### PR TITLE
docs(readme): clean up post-extraction stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 Short-term memory proxy gateway with **proactive memory surfacing** for AI agents.
 
-Sits between your AI agent and upstream MCP servers. Compresses responses to save tokens, caches results, and automatically surfaces relevant memories from memtomem LTM.
+Sits between your AI agent and upstream MCP servers. Compresses responses to save tokens, caches results, and automatically surfaces relevant memories from a memtomem LTM server.
+
+**Built for:**
+- Agents (Claude Code, Cursor, Claude Desktop, etc.) running multiple MCP servers and burning tokens on noisy upstream responses
+- Long-running coding sessions where the agent should *recall* prior decisions instead of re-searching
+- Teams running custom MCP servers that need a proxy layer for compression, caching, and observability — no upstream code changes required
 
 ```
 Agent (Claude Code, Cursor, etc.)
@@ -57,15 +62,13 @@ Agent (Claude Code, Cursor, etc.)
 ## Installation
 
 ```bash
-# Standalone (proxy + compression only)
 pip install memtomem-stm
-
-# With LTM integration (proactive surfacing)
-pip install "memtomem-stm[ltm]"
 
 # With Langfuse tracing
 pip install "memtomem-stm[langfuse]"
 ```
+
+memtomem-stm is independent: it has no Python-level dependency on memtomem core. To enable proactive memory surfacing, point STM at a running memtomem MCP server (or any compatible MCP server) — communication happens entirely through the MCP protocol.
 
 ## Quick Start
 
@@ -103,18 +106,6 @@ Point your AI agent's MCP client config to the STM server:
 ### 3. Use proxied tools
 
 Your agent now sees `fs__read_file`, `gh__search_repositories`, etc. Responses are automatically compressed, cached, and enriched with relevant memories.
-
-### 4. (Optional) Interactive setup via memtomem CLI
-
-If you have the core `memtomem` package installed, run the 8-step wizard:
-
-```bash
-mm stm init
-```
-
-This detects existing MCP client configs (Claude Code, Cursor, Claude Desktop), lets you select servers to proxy, choose compression strategies, enable caching/Langfuse, and writes everything to `~/.memtomem/stm_proxy.json`.
-
-To undo: `mm stm reset` restores original configs and removes STM.
 
 ---
 
@@ -929,7 +920,7 @@ Traces proxy calls for latency analysis and debugging.
 
 | File | Purpose | Managed by |
 |------|---------|------------|
-| `~/.memtomem/stm_proxy.json` | Upstream server config (hot-reloaded) | CLI / `mm stm init` |
+| `~/.memtomem/stm_proxy.json` | Upstream server config (hot-reloaded) | `memtomem-stm-proxy` CLI |
 | `~/.memtomem/proxy_cache.db` | Response cache (SQLite, WAL mode) | ProxyCache |
 | `~/.memtomem/proxy_metrics.db` | Compression metrics history | MetricsStore |
 | `~/.memtomem/stm_feedback.db` | Surfacing events & feedback ratings | FeedbackStore |
@@ -941,14 +932,17 @@ Traces proxy calls for latency analysis and debugging.
 ## Testing
 
 ```bash
-# Run STM tests
-uv run pytest packages/memtomem-stm/tests/ -v
+# Run all tests
+uv run pytest tests/ -v
 
 # Run a specific test file
-uv run pytest packages/memtomem-stm/tests/test_compression.py -v
+uv run pytest tests/test_compression.py -v
+
+# Skip Ollama-dependent tests
+uv run pytest -m "not ollama"
 ```
 
-735 tests covering:
+731 tests covering:
 
 | Test file | Coverage |
 |-----------|----------|


### PR DESCRIPTION
## Summary

Pre-PyPI publish doc pass. The README came along from the monorepo extraction (Phase 3a) with several pieces that no longer reflect reality after STM became its own repo.

## Critical fixes

- **Drop the `[ltm]` extra from install snippet.** The extra was removed in #1 because STM no longer imports `from memtomem.*` (decoupling completed in the core repo's PR #2). Following the install command would currently error out.
- **Drop the entire "(Optional) Interactive setup via memtomem CLI" section** (lines 107-118). `mm stm init` / `mm stm reset` are core-repo CLI commands that no longer exist. STM is independent of memtomem core, so pointing users at a core CLI was both wrong and confusing.
- **Test command** in the Testing section was using the old monorepo layout (`packages/memtomem-stm/tests/...`). Changed to `tests/` + added `-m "not ollama"` for parity with CI.
- **Test count**: 735 → 731 (verified via `pytest --co -q`).

## Should-fix

- Add an explicit **"memtomem-stm is independent"** line right under Installation. The repo split makes this important to communicate upfront so users don't think they need to install both.
- Update the **Data Storage table**: `stm_proxy.json` is managed by the `memtomem-stm-proxy` CLI in this repo, not `mm stm init`.

## Nice-to-have

- Add a **"Built for:"** tagline near the top so PyPI visitors can immediately tell whether STM is for them. Three concrete personas: multi-MCP-server agents burning tokens, long-running coding sessions that need recall, and teams running custom MCP servers.

## Local verification

- `ruff check src` → All checks passed
- `pytest -m "not ollama" -q` → **731 passed in 2.15s**

## Diff stat

```
README.md | 38 ++++++++++++++++----------------------
1 file changed, 16 insertions(+), 22 deletions(-)
```

## Test plan

- [ ] CI lint job passes
- [ ] CI typecheck job runs
- [ ] CI test job passes (731 tests, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)