### PR TITLE
feat(cli): add mms short alias for memtomem-stm-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ memtomem-stm is **independent**: it has no Python-level dependency on memtomem c
 
 ## Quick Start
 
+`mms` is the short alias for `memtomem-stm-proxy` — both commands are identical, use whichever you prefer.
+
 ### 1. Add an upstream MCP server
 
 ```bash
-memtomem-stm-proxy add filesystem \
+mms add filesystem \
   --command npx \
   --args "-y @modelcontextprotocol/server-filesystem /home/user/projects" \
   --prefix fs
@@ -46,8 +48,8 @@ memtomem-stm-proxy add filesystem \
 `--prefix` is required: it's the namespace under which the upstream server's tools will appear (e.g. `fs__read_file`). Repeat for each MCP server you want to proxy.
 
 ```bash
-memtomem-stm-proxy list      # show what you've added
-memtomem-stm-proxy status    # show full config + connectivity
+mms list      # show what you've added
+mms status    # show full config + connectivity
 ```
 
 ### 2. Connect your AI client to STM
@@ -94,7 +96,7 @@ To check what's happening, ask the agent to call `stm_proxy_stats`.
 | [Surfacing](docs/surfacing.md) | Memory surfacing engine, relevance gating, feedback loop, auto-tuning |
 | [Caching](docs/caching.md) | Response cache and auto-indexing |
 | [Configuration](docs/configuration.md) | Environment variables and `stm_proxy.json` reference |
-| [CLI](docs/cli.md) | `memtomem-stm-proxy` commands and the 6 MCP tools |
+| [CLI](docs/cli.md) | `mms` (= `memtomem-stm-proxy`) commands and the 6 MCP tools |
 | [Operations](docs/operations.md) | Safety, privacy, horizontal scaling, observability, on-disk state |
 | [Testing](docs/testing.md) | Test layout and how to run them |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,16 +1,19 @@
 # CLI Reference
 
-memtomem-stm ships two console scripts:
+memtomem-stm ships three console scripts:
 
 | Script | Purpose |
 |--------|---------|
 | `memtomem-stm` | The MCP server itself. Add this to your AI client's MCP config. |
 | `memtomem-stm-proxy` | Management CLI for editing `~/.memtomem/stm_proxy.json`. |
+| `mms` | Short alias for `memtomem-stm-proxy` — identical behavior. |
 
-## `memtomem-stm-proxy`
+The `mms` short form pairs with memtomem core's `mm` CLI: `mm` for long-term memory, `mms` for the STM proxy. Use whichever name you prefer; the docs below use `mms` for brevity.
+
+## `mms` (= `memtomem-stm-proxy`)
 
 ```
-Usage: memtomem-stm-proxy [OPTIONS] COMMAND [ARGS]...
+Usage: mms [OPTIONS] COMMAND [ARGS]...
 
   memtomem-stm proxy gateway management.
 
@@ -26,7 +29,7 @@ All commands accept `--config TEXT` (default `~/.memtomem/stm_proxy.json`).
 ### `add`
 
 ```
-Usage: memtomem-stm-proxy add [OPTIONS] NAME
+Usage: mms add [OPTIONS] NAME
 
 Options:
   --command TEXT                  Executable command (stdio).
@@ -47,32 +50,32 @@ Options:
 
 ```bash
 # Filesystem server
-memtomem-stm-proxy add filesystem \
+mms add filesystem \
   --command npx \
   --args "-y @modelcontextprotocol/server-filesystem /home/user/projects" \
   --prefix fs
 
 # GitHub server with env var
-memtomem-stm-proxy add github \
+mms add github \
   --command npx \
   --args "-y @modelcontextprotocol/server-github" \
   --prefix gh \
   --env GITHUB_TOKEN=ghp_xxx
 
 # SSE transport
-memtomem-stm-proxy add docs \
+mms add docs \
   --transport sse \
   --url https://docs.example.com/mcp \
   --prefix docs
 
 # List configured upstreams
-memtomem-stm-proxy list
+mms list
 
 # Show full status
-memtomem-stm-proxy status
+mms status
 
 # Remove a server
-memtomem-stm-proxy remove github
+mms remove github
 ```
 
 ## MCP Tools (6 + proxied)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ memtomem-stm reads configuration from two sources, in order of precedence:
 1. **Environment variables** — prefix `MEMTOMEM_STM_`, double-underscore (`__`) for nesting
 2. **Config file** — `~/.memtomem/stm_proxy.json` (hot-reloaded; changes take effect on the next tool call without restarting)
 
-For most quick-start scenarios you can ignore the config file entirely and use the [CLI](cli.md) (`memtomem-stm-proxy add ...`) plus a few env vars.
+For most quick-start scenarios you can ignore the config file entirely and use the [CLI](cli.md) (`mms add ...`) plus a few env vars.
 
 ## Environment Variables
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -134,7 +134,7 @@ Traces proxy calls for latency analysis and debugging.
 
 | File | Purpose | Managed by |
 |------|---------|------------|
-| `~/.memtomem/stm_proxy.json` | Upstream server config (hot-reloaded) | `memtomem-stm-proxy` CLI |
+| `~/.memtomem/stm_proxy.json` | Upstream server config (hot-reloaded) | `mms` CLI |
 | `~/.memtomem/proxy_cache.db` | Response cache (SQLite, WAL mode) | ProxyCache |
 | `~/.memtomem/proxy_metrics.db` | Compression metrics history | MetricsStore |
 | `~/.memtomem/stm_feedback.db` | Surfacing events & feedback ratings | FeedbackStore |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ langfuse = ["langfuse>=4.0"]
 [project.scripts]
 memtomem-stm = "memtomem_stm.server:main"
 memtomem-stm-proxy = "memtomem_stm.cli.proxy:cli"
+mms = "memtomem_stm.cli.proxy:cli"
 
 [project.urls]
 Homepage = "https://github.com/memtomem/memtomem"


### PR DESCRIPTION
## Summary

Mirrors memtomem core's convention where `memtomem` has the short alias `mm`. The fully qualified `memtomem-stm-proxy` is awkward to type repeatedly during initial setup; **`mms`** (= `mm` + `s` for stm) keeps the visual pairing with `mm` and is three characters.

Both names are kept — `memtomem-stm-proxy` remains for explicit / script use, `mms` is the short form for the keyboard. Pattern matches core: `memtomem` (long) and `mm` (short) are both first-class.

## pyproject.toml change

```toml
[project.scripts]
memtomem-stm = "memtomem_stm.server:main"
memtomem-stm-proxy = "memtomem_stm.cli.proxy:cli"
+ mms = "memtomem_stm.cli.proxy:cli"
```

## Verified end-to-end

```bash
$ uv pip install -e .
$ mms --help
Usage: mms [OPTIONS] COMMAND [ARGS]...
  memtomem-stm proxy gateway management.
Commands:
  add     Add an upstream MCP server to the proxy configuration.
  list    List configured upstream servers.
  remove  Remove an upstream MCP server from the proxy configuration.
  status  Show proxy gateway configuration and server list.

$ mms add filesystem --command npx --args "-y @modelcontextprotocol/server-filesystem /tmp" --prefix fs --config $TMP
Added server 'filesystem' (prefix=fs)

$ mms list --config $TMP
NAME                 PREFIX     TRANSPORT    COMMAND / URL
----------------------------------------------------------------------
filesystem           fs         stdio        npx -y @modelcontextprotocol/server-filesystem /tmp

$ mms status --config $TMP
Config : .../test.json
Enabled: yes
Servers: 1
  filesystem           prefix=fs  [stdio] npx -y @modelcontextprotocol/server-filesystem /tmp
```

## Doc updates

- **README Quick Start** now uses `mms` (with a one-line note that it's the short alias for the long name)
- **docs/cli.md** introduces both names in the script table and uses `mms` in all examples
- **docs/configuration.md**, **docs/operations.md**: incidental rewrites where the long name appeared

## Local checks

- `ruff check src` → All checks passed
- `pytest -m "not ollama" -q` → **731 passed in 2.16s**

## Test plan

- [ ] CI lint job passes
- [ ] CI typecheck job runs
- [ ] CI test job passes (731 tests, no test changes)
- [ ] After merge + PyPI publish, `pip install memtomem-stm` exposes both `memtomem-stm-proxy` and `mms` on the user's PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)