### PR TITLE
feat(extraction): native regex heuristic for fact extraction

### DIFF
--- a/src/memtomem_stm/proxy/extraction.py
+++ b/src/memtomem_stm/proxy/extraction.py
@@ -60,15 +60,111 @@ def _parse_facts_json(raw: str, *, max_facts: int) -> list[ExtractedFact]:
     return []
 
 
-def _extract_heuristic(text: str, *, max_facts: int) -> list[ExtractedFact]:
-    """Heuristic fallback for fact extraction.
+# ── Heuristic extraction patterns ─────────────────────────────────────
+# Regex-only fact extraction. No external NLP, no core dependency.
 
-    STM no longer imports memtomem core directly; the LLM extractor is the
-    primary path. This stub returns an empty list, so when LLM extraction
-    fails (circuit open, transport error) extraction silently yields no facts.
-    A native STM heuristic can be added later if demand emerges.
+_URL_RE = re.compile(r"https?://[^\s<>\"'`]+", re.IGNORECASE)
+
+_ISO_DATE_RE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+
+_DECISION_RE = re.compile(
+    r"^[\s*\-]*"
+    r"(?:Decision|Decided|Resolved|Conclusion|Agreed|We\s+will|We'll|We\s+chose)"
+    r"[:\s]+(.+)$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+_ACTION_RE = re.compile(
+    r"(?:^|\n)\s*"
+    r"(?:"
+    r"(?:TODO|FIXME|HACK|XXX|ACTION)[:\s]+(.+)|"
+    r"[-*]\s*\[\s*\]\s+(.+)|"
+    r"(?:Action\s+item)[:\s]+(.+)"
+    r")",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# Identifier shapes — kept conservative to limit noise.
+_SNAKE_CASE_RE = re.compile(r"\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b")
+_CAMEL_CASE_RE = re.compile(r"\b[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)+\b")
+_PASCAL_CASE_RE = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]*)+\b")
+
+_QUOTED_CONCEPT_RE = re.compile(r'"([^"\n]{3,80})"')
+
+
+def _extract_heuristic(text: str, *, max_facts: int) -> list[ExtractedFact]:
+    """Regex-based fact extraction with no external dependencies.
+
+    Recognizes the patterns most worth remembering from a tool response:
+      - URLs (http/https)
+      - ISO dates (YYYY-MM-DD)
+      - Decision statements ("Decision: ...", "We will ...", "Resolved: ...")
+      - Action items (TODO/FIXME, "- [ ] ...", "Action item: ...")
+      - Identifiers (snake_case / PascalCase / camelCase)
+      - Quoted concepts (terms in double quotes)
+
+    Used both as the LLM extractor's fallback when the LLM is unavailable
+    (circuit open, transport error) and as a complementary signal in
+    HYBRID strategy where it merges with LLM output.
     """
-    return []
+    if not text or max_facts <= 0:
+        return []
+
+    facts: list[ExtractedFact] = []
+    seen: set[str] = set()
+
+    def _emit(content: str, category: str, confidence: float) -> None:
+        if not content or len(facts) >= max_facts:
+            return
+        key = f"{category}:{content.lower()}"
+        if key in seen:
+            return
+        seen.add(key)
+        facts.append(
+            ExtractedFact(
+                content=content,
+                category=category,
+                confidence=confidence,
+                tags=[category],
+            )
+        )
+
+    # 1. URLs (highest signal)
+    for m in _URL_RE.finditer(text):
+        _emit(m.group(0).rstrip(".,;:)\"'"), "url", 0.95)
+
+    # 2. ISO dates
+    for m in _ISO_DATE_RE.finditer(text):
+        _emit(m.group(0), "date", 0.95)
+
+    # 3. Decision statements
+    for m in _DECISION_RE.finditer(text):
+        value = m.group(1).strip()
+        if len(value) >= 4:
+            _emit(value[:200], "decision", 0.85)
+
+    # 4. Action items
+    for m in _ACTION_RE.finditer(text):
+        value = (m.group(1) or m.group(2) or m.group(3) or "").strip()
+        if len(value) >= 3:
+            _emit(value[:200], "action_item", 0.85)
+
+    # 5. Identifiers (snake_case / PascalCase / camelCase)
+    for pattern, conf in (
+        (_SNAKE_CASE_RE, 0.7),
+        (_PASCAL_CASE_RE, 0.65),
+        (_CAMEL_CASE_RE, 0.6),
+    ):
+        for m in pattern.finditer(text):
+            _emit(m.group(0), "identifier", conf)
+
+    # 6. Quoted concepts (lowest confidence)
+    for m in _QUOTED_CONCEPT_RE.finditer(text):
+        value = m.group(1).strip()
+        if len(value) >= 3:
+            _emit(value, "concept", 0.55)
+
+    return facts
 
 
 class FactExtractor:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -29,10 +29,22 @@ from memtomem_stm.proxy.extraction import (
 
 class TestParseFactsJson:
     def test_valid_json_array(self):
-        raw = json.dumps([
-            {"content": "Python 3.12 is required", "category": "technical", "confidence": 0.9, "tags": ["python"]},
-            {"content": "Deploy on Friday", "category": "decision", "confidence": 0.7, "tags": []},
-        ])
+        raw = json.dumps(
+            [
+                {
+                    "content": "Python 3.12 is required",
+                    "category": "technical",
+                    "confidence": 0.9,
+                    "tags": ["python"],
+                },
+                {
+                    "content": "Deploy on Friday",
+                    "category": "decision",
+                    "confidence": 0.7,
+                    "tags": [],
+                },
+            ]
+        )
         facts = _parse_facts_json(raw, max_facts=10)
         assert len(facts) == 2
         assert facts[0].content == "Python 3.12 is required"
@@ -47,16 +59,20 @@ class TestParseFactsJson:
         assert facts[0].content == "fact one"
 
     def test_max_facts_limit(self):
-        items = [{"content": f"fact {i}", "category": "technical", "confidence": 0.5} for i in range(20)]
+        items = [
+            {"content": f"fact {i}", "category": "technical", "confidence": 0.5} for i in range(20)
+        ]
         raw = json.dumps(items)
         facts = _parse_facts_json(raw, max_facts=5)
         assert len(facts) == 5
 
     def test_missing_content_field_skipped(self):
-        raw = json.dumps([
-            {"category": "technical", "confidence": 0.5},
-            {"content": "valid", "category": "technical", "confidence": 0.8},
-        ])
+        raw = json.dumps(
+            [
+                {"category": "technical", "confidence": 0.5},
+                {"content": "valid", "category": "technical", "confidence": 0.8},
+            ]
+        )
         facts = _parse_facts_json(raw, max_facts=10)
         assert len(facts) == 1
         assert facts[0].content == "valid"
@@ -82,25 +98,136 @@ class TestParseFactsJson:
 
 
 class TestExtractHeuristic:
-    """Heuristic fallback is currently stubbed (returns empty list).
+    """Native regex-based heuristic extraction.
 
-    The previous implementation imported memtomem.tools.entity_extraction,
-    which created an unwanted core dependency. A native STM heuristic is
-    tracked as follow-up work; until then this stub keeps the LLM extractor
-    as the sole extraction path.
+    Replaces the empty stub left after decoupling from
+    memtomem.tools.entity_extraction. Self-contained — no core
+    dependency, no external NLP. Recognizes URLs, ISO dates,
+    decision/action-item lines, identifiers (snake/camel/pascal),
+    and quoted concepts.
     """
 
-    def test_stub_returns_empty(self):
-        text = "Decision: PostgreSQL chosen. Author: John Smith. TODO: ship by Friday."
-        assert _extract_heuristic(text, max_facts=10) == []
-
-    def test_stub_handles_empty_text(self):
+    def test_empty_text_returns_empty(self):
         assert _extract_heuristic("", max_facts=10) == []
 
-    def test_stub_returns_list_type(self):
-        result = _extract_heuristic("any text", max_facts=3)
-        assert isinstance(result, list)
-        assert len(result) <= 3
+    def test_zero_max_facts_returns_empty(self):
+        assert _extract_heuristic("Decision: ship it.", max_facts=0) == []
+
+    def test_no_signal_text_returns_empty(self):
+        # Plain prose with no URLs, identifiers, or marker phrases.
+        assert _extract_heuristic("hello world this is fine", max_facts=10) == []
+
+    def test_extracts_urls(self):
+        text = "See https://example.com/docs and http://api.test.io for details."
+        facts = _extract_heuristic(text, max_facts=10)
+        urls = {f.content for f in facts if f.category == "url"}
+        assert "https://example.com/docs" in urls
+        assert "http://api.test.io" in urls
+
+    def test_strips_trailing_punctuation_from_url(self):
+        text = "Check out https://example.com."
+        facts = _extract_heuristic(text, max_facts=10)
+        urls = [f.content for f in facts if f.category == "url"]
+        assert "https://example.com" in urls
+
+    def test_url_high_confidence(self):
+        facts = _extract_heuristic("https://example.com", max_facts=10)
+        urls = [f for f in facts if f.category == "url"]
+        assert urls and all(f.confidence >= 0.9 for f in urls)
+
+    def test_extracts_iso_dates(self):
+        text = "Released 2026-04-09. Next milestone is 2026-05-01."
+        facts = _extract_heuristic(text, max_facts=10)
+        dates = {f.content for f in facts if f.category == "date"}
+        assert "2026-04-09" in dates
+        assert "2026-05-01" in dates
+
+    def test_extracts_decision_lines(self):
+        text = "Decision: use SQLite for storage.\nResolved: ship Friday."
+        facts = _extract_heuristic(text, max_facts=10)
+        decisions = [f.content for f in facts if f.category == "decision"]
+        assert any("SQLite" in d for d in decisions)
+        assert any("Friday" in d for d in decisions)
+
+    def test_extracts_we_will_decision(self):
+        text = "We will migrate to Postgres next sprint."
+        facts = _extract_heuristic(text, max_facts=10)
+        decisions = [f.content for f in facts if f.category == "decision"]
+        assert any("Postgres" in d for d in decisions)
+
+    def test_extracts_todo_action_items(self):
+        text = "TODO: write tests for the worker pool"
+        facts = _extract_heuristic(text, max_facts=10)
+        actions = [f.content for f in facts if f.category == "action_item"]
+        assert any("write tests" in a for a in actions)
+
+    def test_extracts_checkbox_action_items(self):
+        text = "- [ ] update README\n- [ ] bump version"
+        facts = _extract_heuristic(text, max_facts=10)
+        actions = [f.content for f in facts if f.category == "action_item"]
+        assert any("update README" in a for a in actions)
+        assert any("bump version" in a for a in actions)
+
+    def test_extracts_fixme_action_item(self):
+        text = "FIXME: leak in the worker thread"
+        facts = _extract_heuristic(text, max_facts=10)
+        actions = [f.content for f in facts if f.category == "action_item"]
+        assert any("leak" in a for a in actions)
+
+    def test_extracts_snake_case_identifiers(self):
+        text = "Call get_user_id(user_name) and check api_v2 response."
+        facts = _extract_heuristic(text, max_facts=20)
+        ids = {f.content for f in facts if f.category == "identifier"}
+        assert "get_user_id" in ids
+        assert "user_name" in ids
+        assert "api_v2" in ids
+
+    def test_extracts_camel_case_identifiers(self):
+        text = "Use myHelper() then call getValue() on the response."
+        facts = _extract_heuristic(text, max_facts=20)
+        ids = {f.content for f in facts if f.category == "identifier"}
+        assert "myHelper" in ids
+        assert "getValue" in ids
+
+    def test_extracts_pascal_case_identifiers(self):
+        text = "The MyService class extends BaseHandler in production."
+        facts = _extract_heuristic(text, max_facts=20)
+        ids = {f.content for f in facts if f.category == "identifier"}
+        assert "MyService" in ids
+        assert "BaseHandler" in ids
+
+    def test_pascal_case_skips_single_title_word(self):
+        # Single-Pascal words like "Use" or "Redis" are too noisy to extract.
+        text = "Use Redis for caching."
+        facts = _extract_heuristic(text, max_facts=10)
+        ids = {f.content for f in facts if f.category == "identifier"}
+        assert "Use" not in ids
+        assert "Redis" not in ids
+
+    def test_extracts_quoted_concepts(self):
+        text = 'The term "eventual consistency" comes up often.'
+        facts = _extract_heuristic(text, max_facts=10)
+        concepts = [f.content for f in facts if f.category == "concept"]
+        assert "eventual consistency" in concepts
+
+    def test_dedup_within_category(self):
+        text = "https://example.com appears, then https://example.com again."
+        facts = _extract_heuristic(text, max_facts=10)
+        urls = [f for f in facts if f.category == "url"]
+        assert len(urls) == 1
+
+    def test_max_facts_cap(self):
+        # Many distinct snake_case identifiers — cap should hold.
+        text = " ".join(f"var_{i}_name" for i in range(50))
+        facts = _extract_heuristic(text, max_facts=5)
+        assert len(facts) == 5
+
+    def test_returns_extracted_fact_with_tags(self):
+        text = "TODO: implement caching layer"
+        facts = _extract_heuristic(text, max_facts=10)
+        assert facts
+        assert all(isinstance(f, ExtractedFact) for f in facts)
+        assert all(f.tags == [f.category] for f in facts)
 
 
 # ---------------------------------------------------------------------------
@@ -177,10 +304,14 @@ class TestFactExtractorLLM:
         cfg = ExtractionConfig(enabled=True, min_response_chars=10)
         extractor = FactExtractor(cfg)
 
-        mock_response = json.dumps([
-            {"content": "fact 1", "category": "technical", "confidence": 0.9, "tags": ["test"]},
-        ])
-        with patch.object(extractor, "_call_api", new_callable=AsyncMock, return_value=mock_response):
+        mock_response = json.dumps(
+            [
+                {"content": "fact 1", "category": "technical", "confidence": 0.9, "tags": ["test"]},
+            ]
+        )
+        with patch.object(
+            extractor, "_call_api", new_callable=AsyncMock, return_value=mock_response
+        ):
             facts = await extractor.extract("x" * 100, server="s", tool="t")
 
         assert len(facts) == 1
@@ -190,7 +321,9 @@ class TestFactExtractorLLM:
         cfg = ExtractionConfig(enabled=True, min_response_chars=10)
         extractor = FactExtractor(cfg)
 
-        with patch.object(extractor, "_call_api", new_callable=AsyncMock, side_effect=RuntimeError("API down")):
+        with patch.object(
+            extractor, "_call_api", new_callable=AsyncMock, side_effect=RuntimeError("API down")
+        ):
             text = "Decision: fallback works. " * 20
             facts = await extractor.extract(text, server="s", tool="t")
 
@@ -201,7 +334,9 @@ class TestFactExtractorLLM:
         cfg = ExtractionConfig(enabled=True, min_response_chars=10)
         extractor = FactExtractor(cfg)
 
-        with patch.object(extractor, "_call_api", new_callable=AsyncMock, side_effect=RuntimeError("fail")):
+        with patch.object(
+            extractor, "_call_api", new_callable=AsyncMock, side_effect=RuntimeError("fail")
+        ):
             for _ in range(4):
                 await extractor.extract("x" * 100, server="s", tool="t")
 
@@ -215,10 +350,14 @@ class TestFactExtractorLLM:
         )
         extractor = FactExtractor(cfg)
 
-        mock_response = json.dumps([
-            {"content": "LLM fact", "category": "technical", "confidence": 0.9},
-        ])
-        with patch.object(extractor, "_call_api", new_callable=AsyncMock, return_value=mock_response):
+        mock_response = json.dumps(
+            [
+                {"content": "LLM fact", "category": "technical", "confidence": 0.9},
+            ]
+        )
+        with patch.object(
+            extractor, "_call_api", new_callable=AsyncMock, return_value=mock_response
+        ):
             text = "Decision: Use Redis. LLM fact is separate. " * 10
             facts = await extractor.extract(text, server="s", tool="t")
 


### PR DESCRIPTION
## Summary

- Restores `_extract_heuristic` with a self-contained regex implementation, replacing the empty stub left after STM was decoupled from `memtomem.tools.entity_extraction`
- Six categories: URL, ISO date, decision/action-item lines, identifiers (snake/camel/pascal), quoted concepts — no core dependency, no external NLP
- Makes `HYBRID` strategy meaningful again (LLM + heuristic merge) and gives the LLM extractor a real fallback when the circuit breaker opens

## Why now

This is the first of three follow-ups before v0.1.0 PyPI publish. The decoupling PR (#2) left three features stubbed out so the repo split could land cleanly; we want all of them restored before users see v0.1.0.

## Test plan

- [x] `uv run pytest tests/test_extraction.py -q` — 42 passed (23 → 42, +19 new tests)
- [x] `uv run pytest -q` — 748 passed, no regressions
- [x] `uv run ruff check src` + `uv run ruff format --check src` — clean
- [x] mypy: no new errors (3 pre-existing in `_openai`/`_anthropic`/`_ollama` only, gradual mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)