### PR TITLE
feat(surfacing): restore include_session_context via remote MCP

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -218,12 +218,17 @@ class SurfacingEngine:
             "Surfacing %d memories for %s/%s (query=%s)", len(relevant), server, tool, query[:50]
         )
 
-        # Session context (working memory): temporarily disabled.
-        # The previous in-process implementation called SqliteBackend.scratch_list()
-        # directly. After the remote-only refactor it must go through the MCP
-        # adapter (mem_scratch_get). Tracked as follow-up: see
-        # McpClientSearchAdapter.scratch_list() task.
-        scratch_items = None
+        # Session context (working memory): when enabled, fetch scratchpad
+        # entries via the MCP adapter and inject alongside LTM hits. Failures
+        # are silent — surfacing must still deliver the LTM hits even if
+        # working memory is unavailable.
+        scratch_items: list[dict] | None = None
+        if self._config.include_session_context:
+            try:
+                scratch_items = await self._mcp_adapter.scratch_list()
+            except Exception:
+                logger.debug("Failed to fetch session scratch items", exc_info=True)
+                scratch_items = None
 
         # Generate surfacing ID and record event
         surfacing_id = uuid.uuid4().hex[:12]

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -99,6 +99,89 @@ class McpClientSearchAdapter:
         text = "\n".join(text_parts)
         return self._parse_results(text), None
 
+    async def scratch_list(self) -> list[dict]:
+        """Fetch working memory entries via mem_do(action="scratch_get").
+
+        The remote core's ``mem_scratch_get`` returns a human-readable
+        listing when called with no key. We parse it back into the
+        ``[{"key": ..., "value": ...}, ...]`` shape that
+        :class:`SurfacingFormatter` expects.
+
+        Returns an empty list if the session is not started, the call
+        fails, or working memory is empty — surfacing must always be
+        able to silently skip session-context injection without losing
+        the LTM hits.
+        """
+        if self._session is None:
+            return []
+
+        try:
+            result = await self._session.call_tool(
+                "mem_do",
+                {"action": "scratch_get", "params": {}},
+            )
+        except Exception as exc:
+            logger.debug("MCP mem_do(scratch_get) failed: %s", exc)
+            return []
+
+        text_parts = [c.text for c in result.content if c.type == "text"]
+        if not text_parts:
+            return []
+
+        return self._parse_scratch_list("\n".join(text_parts))
+
+    @staticmethod
+    def _parse_scratch_list(text: str) -> list[dict]:
+        """Parse ``mem_scratch_get`` listing output into entry dicts.
+
+        Expected format from core (mem_scratch_get with key=None)::
+
+            Working memory: 2 entries
+
+              key1: value preview... (expires: 2026-04-09T12:00:00) [promoted]
+              key2: another value...
+
+        Each entry line starts with two leading spaces. The trailing
+        ``...`` marker is stripped (core always appends it after the
+        truncated preview); ``(expires: ...)`` and ``[promoted]`` are
+        captured into optional fields.
+        """
+        if not text or "Working memory is empty" in text:
+            return []
+
+        entries: list[dict] = []
+        for line in text.splitlines():
+            if not line.startswith("  "):
+                continue
+            body = line[2:]
+            key, sep, rest = body.partition(": ")
+            if not sep:
+                continue
+
+            value_part = rest
+            promoted = False
+            if value_part.endswith(" [promoted]"):
+                value_part = value_part[: -len(" [promoted]")]
+                promoted = True
+
+            expires_at: str | None = None
+            expires_match = re.search(r"\s*\(expires:\s*([^)]+)\)\s*$", value_part)
+            if expires_match:
+                expires_at = expires_match.group(1)
+                value_part = value_part[: expires_match.start()]
+
+            if value_part.endswith("..."):
+                value_part = value_part[:-3]
+
+            entry: dict = {"key": key, "value": value_part}
+            if expires_at is not None:
+                entry["expires_at"] = expires_at
+            if promoted:
+                entry["promoted"] = True
+            entries.append(entry)
+
+        return entries
+
     @staticmethod
     def _parse_results(text: str) -> list[RemoteSearchResult]:
         """Parse mem_search formatted output into RemoteSearchResult objects.

--- a/tests/_fake_memtomem_server.py
+++ b/tests/_fake_memtomem_server.py
@@ -1,9 +1,10 @@
 """Tiny stdio MCP server used by integration tests.
 
 Stands in for `memtomem-server` so that STM's McpClientSearchAdapter can be
-exercised end-to-end without depending on a real memtomem installation. The
-server exposes a single tool, `mem_search`, that returns canned content in the
-format the adapter knows how to parse.
+exercised end-to-end without depending on a real memtomem installation. It
+exposes the two tools the adapter actually calls — ``mem_search`` and the
+``mem_do`` meta-tool routing the ``scratch_get`` action — both returning
+canned text in the format the adapter knows how to parse.
 
 Run with: `python <path-to-this-file>`
 """
@@ -28,6 +29,23 @@ async def mem_search(
         "--- [0.87] /notes/api.md ---\n"
         "All API responses include rate limit headers (X-RateLimit-*).\n"
     )
+
+
+@mcp.tool()
+async def mem_do(action: str, params: dict | None = None) -> str:
+    """Stand-in for the core ``mem_do`` meta-tool.
+
+    Only the actions STM actually calls are implemented; everything else
+    returns an unknown-action error matching real core's response.
+    """
+    if action == "scratch_get":
+        return (
+            "Working memory: 2 entries\n"
+            "\n"
+            "  current_task: drafting follow-up 4 implementation plan...\n"
+            "  recent_branch: feat/stm-session-context-restore..."
+        )
+    return f"Error: unknown action '{action}'."
 
 
 if __name__ == "__main__":

--- a/tests/test_remote_ltm_integration.py
+++ b/tests/test_remote_ltm_integration.py
@@ -2,8 +2,8 @@
 
 After the move to remote-only LTM access, STM's surfacing engine reaches the
 LTM exclusively through `McpClientSearchAdapter`, which spawns (or connects
-to) a memtomem MCP server over stdio. This test exercises that path against a
-tiny fake MCP server (_fake_memtomem_server.py) so the integration runs in
+to) a memtomem MCP server over stdio. These tests exercise that path against
+a tiny fake MCP server (_fake_memtomem_server.py) so the integration runs in
 under a second and doesn't require memtomem core to be installed.
 
 What this proves:
@@ -12,6 +12,13 @@ What this proves:
    in-process SearchPipeline fallback path anymore.
 3. The canned hits returned by the child server flow back through the
    adapter, the surfacing pipeline, and into the injected response.
+4. ``include_session_context`` fetches scratchpad entries via the same
+   adapter (``mem_do(action="scratch_get")``) and injects them alongside
+   the LTM hits.
+
+The ``McpClientSearchAdapter._parse_scratch_list`` unit tests at the bottom
+exercise the text-shape edge cases (empty, expired, promoted) that would
+otherwise need a more elaborate fake server fixture per scenario.
 """
 
 from __future__ import annotations
@@ -31,20 +38,24 @@ LONG_RESPONSE = "x" * 200
 VALID_ARGS = {"path": "src/auth.py", "_context_query": "JWT authentication"}
 
 
-@pytest.mark.asyncio
-async def test_surfacing_via_remote_stdio_mcp_server():
-    config = SurfacingConfig(
+def _stdio_config(*, include_session_context: bool = False) -> SurfacingConfig:
+    return SurfacingConfig(
         enabled=True,
         min_response_chars=10,
         cooldown_seconds=0,
         max_surfacings_per_minute=1000,
         auto_tune_enabled=False,
-        include_session_context=False,
+        include_session_context=include_session_context,
         fire_webhook=False,
         feedback_enabled=False,
         ltm_mcp_command=sys.executable,
         ltm_mcp_args=[str(_FAKE_SERVER)],
     )
+
+
+@pytest.mark.asyncio
+async def test_surfacing_via_remote_stdio_mcp_server():
+    config = _stdio_config()
 
     adapter = McpClientSearchAdapter(config)
     await adapter.start()
@@ -57,3 +68,80 @@ async def test_surfacing_via_remote_stdio_mcp_server():
     assert "Relevant Memories" in output, output
     # Canned content from the fake server should land in the surfaced response
     assert "JWT authentication" in output
+
+
+@pytest.mark.asyncio
+async def test_session_context_via_remote_stdio_mcp_server():
+    """include_session_context fetches scratch entries via mem_do(scratch_get)."""
+    config = _stdio_config(include_session_context=True)
+
+    adapter = McpClientSearchAdapter(config)
+    await adapter.start()
+    try:
+        engine = SurfacingEngine(config, mcp_adapter=adapter)
+        output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+    finally:
+        await adapter.stop()
+
+    assert "Relevant Memories" in output, output
+    assert "JWT authentication" in output  # LTM injection still works
+    assert "Working Memory" in output  # session context surfaced alongside
+    assert "current_task" in output
+    assert "drafting follow-up 4" in output
+
+
+# ── McpClientSearchAdapter._parse_scratch_list unit tests ──────────────
+
+
+def test_parse_scratch_list_empty_message():
+    text = "Working memory is empty."
+    assert McpClientSearchAdapter._parse_scratch_list(text) == []
+
+
+def test_parse_scratch_list_blank_text():
+    assert McpClientSearchAdapter._parse_scratch_list("") == []
+
+
+def test_parse_scratch_list_single_entry():
+    text = (
+        "Working memory: 1 entries\n"
+        "\n"
+        "  current_task: drafting follow-up 4 implementation plan..."
+    )
+    entries = McpClientSearchAdapter._parse_scratch_list(text)
+    assert entries == [
+        {"key": "current_task", "value": "drafting follow-up 4 implementation plan"}
+    ]
+
+
+def test_parse_scratch_list_with_expiry_and_promotion():
+    text = (
+        "Working memory: 2 entries\n"
+        "\n"
+        "  api_key: hunter2... (expires: 2026-04-09T12:00:00) [promoted]\n"
+        "  recent_branch: feat/stm-session-context-restore..."
+    )
+    entries = McpClientSearchAdapter._parse_scratch_list(text)
+    assert entries == [
+        {
+            "key": "api_key",
+            "value": "hunter2",
+            "expires_at": "2026-04-09T12:00:00",
+            "promoted": True,
+        },
+        {
+            "key": "recent_branch",
+            "value": "feat/stm-session-context-restore",
+        },
+    ]
+
+
+def test_parse_scratch_list_skips_non_entry_lines():
+    text = (
+        "Working memory: 1 entries\n"
+        "header line\n"
+        "  current_task: actual entry...\n"
+        "trailing footer"
+    )
+    entries = McpClientSearchAdapter._parse_scratch_list(text)
+    assert entries == [{"key": "current_task", "value": "actual entry"}]

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -252,3 +252,62 @@ class TestSurfacingCache:
         out2 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert "cached memory" in out2
         assert adapter.search.call_count == 1  # not called again
+
+
+class TestSessionContextInjection:
+    """Verify include_session_context wires the scratchpad through the MCP adapter."""
+
+    async def test_scratch_items_injected_when_enabled(self):
+        results = [FakeSearchResult(chunk=FakeChunk(content="LTM hit content"), score=0.5)]
+        adapter = _make_mcp_adapter(results)
+        adapter.scratch_list = AsyncMock(
+            return_value=[{"key": "current_task", "value": "running follow-up 4"}]
+        )
+        engine = SurfacingEngine(
+            config=_make_config(include_session_context=True),
+            mcp_adapter=adapter,
+        )
+        output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert "LTM hit content" in output
+        assert "Working Memory" in output
+        assert "current_task" in output
+        adapter.scratch_list.assert_awaited_once()
+
+    async def test_scratch_not_fetched_when_disabled(self):
+        results = [FakeSearchResult(chunk=FakeChunk(content="LTM hit content"), score=0.5)]
+        adapter = _make_mcp_adapter(results)
+        adapter.scratch_list = AsyncMock(return_value=[])
+        engine = SurfacingEngine(
+            config=_make_config(include_session_context=False),
+            mcp_adapter=adapter,
+        )
+        output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert "LTM hit content" in output
+        assert "Working Memory" not in output
+        adapter.scratch_list.assert_not_called()
+
+    async def test_scratch_failure_silent_fallback(self):
+        """LTM injection still happens even if scratch_list raises."""
+        results = [FakeSearchResult(chunk=FakeChunk(content="LTM hit content"), score=0.5)]
+        adapter = _make_mcp_adapter(results)
+        adapter.scratch_list = AsyncMock(side_effect=RuntimeError("scratch broke"))
+        engine = SurfacingEngine(
+            config=_make_config(include_session_context=True),
+            mcp_adapter=adapter,
+        )
+        output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert "LTM hit content" in output
+        assert "Working Memory" not in output
+        adapter.scratch_list.assert_awaited_once()
+
+    async def test_empty_scratch_list_omits_section(self):
+        results = [FakeSearchResult(chunk=FakeChunk(content="LTM hit content"), score=0.5)]
+        adapter = _make_mcp_adapter(results)
+        adapter.scratch_list = AsyncMock(return_value=[])
+        engine = SurfacingEngine(
+            config=_make_config(include_session_context=True),
+            mcp_adapter=adapter,
+        )
+        output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert "LTM hit content" in output
+        assert "Working Memory" not in output


### PR DESCRIPTION
## Summary

- Restores `include_session_context` (Follow-up 4 in `project_stm_next_actions.md`), which was disabled when STM moved to remote-only LTM access — `SurfacingEngine` previously imported `SqliteBackend.scratch_list()` directly, and the broken import left scratchpad injection silently dead.
- Adds `McpClientSearchAdapter.scratch_list()` that calls `mem_do(action="scratch_get")` on the remote core and parses the human-readable listing back into the `{key, value, expires_at?, promoted?}` shape that `SurfacingFormatter` already accepts. Failures and empty working memory return `[]` so surfacing silently falls back to LTM-only injection — the LTM hits are never lost to a working-memory hiccup.
- `SurfacingEngine._do_surface` now fetches scratch entries when `include_session_context` is true, with a `try/except` that logs at debug and continues. The TODO comment is removed.

## Test plan

- [x] `uv run pytest` — 758 passed (4 new engine tests, 1 new stdio integration test, 5 new parser unit tests)
- [x] `uv run ruff check src` + `uv run ruff format --check src` — clean
- [x] `_fake_memtomem_server` extended with a `mem_do(action="scratch_get")` handler so the new end-to-end test exercises the full stdio round trip without depending on real memtomem core
- [x] Verified `SurfacingFormatter`'s existing `scratch_items` contract is unchanged — only the engine wiring and adapter method are new

## Follow-ups left for v0.1.0

- Follow-up 3 (`mem_increment_access` action — cross-repo) is the last item before Phase 4 (PyPI publish). Tracked in the project memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)