### PR TITLE
chore: prep for v0.1.0 publish (lockstep dep + absolute README links)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,25 @@ on:
   pull_request:
     branches: [main]
 
+# Until memtomem is published to PyPI, STM resolves it from a sibling
+# checkout via [tool.uv.sources] path = "../memtomem/packages/memtomem".
+# Each job below checks out memtomem and memtomem-stm side by side and
+# runs from the memtomem-stm working directory so the path resolves.
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: memtomem-stm
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: memtomem/memtomem
+          path: memtomem
+      - uses: actions/checkout@v4
+        with:
+          path: memtomem-stm
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
@@ -20,8 +34,17 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: memtomem-stm
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: memtomem/memtomem
+          path: memtomem
+      - uses: actions/checkout@v4
+        with:
+          path: memtomem-stm
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
@@ -32,8 +55,17 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: memtomem-stm
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: memtomem/memtomem
+          path: memtomem
+      - uses: actions/checkout@v4
+        with:
+          path: memtomem-stm
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"

--- a/README.md
+++ b/README.md
@@ -83,24 +83,24 @@ To check what's happening, ask the agent to call `stm_proxy_stats`.
 
 ## Key Features
 
-- 🗜️ **10 compression strategies** with auto-selection by content type, query-aware budget allocation, and zero-loss progressive delivery → [docs/compression.md](docs/compression.md)
-- 🧠 **Proactive memory surfacing** from a memtomem LTM server, gated by relevance threshold, rate limit, dedup, and circuit breaker → [docs/surfacing.md](docs/surfacing.md)
-- 💾 **Response caching** with TTL and eviction; surfacing re-applied on cache hit so injected memories stay fresh → [docs/caching.md](docs/caching.md)
-- 🔍 **Observability** — Langfuse tracing, RPS, latency percentiles (p50/p95/p99), error classification, per-tool metrics → [docs/operations.md#observability](docs/operations.md#observability)
-- 📈 **Horizontal scaling** — `PendingStore` protocol with InMemory (default) or SQLite-shared backend for multi-instance deployments → [docs/operations.md#horizontal-scaling](docs/operations.md#horizontal-scaling)
-- 🛡️ **Safety** — circuit breaker, retry with backoff, write-tool skip, query cooldown, session/cross-session dedup, sensitive content auto-detection → [docs/operations.md#safety--resilience](docs/operations.md#safety--resilience)
+- 🗜️ **10 compression strategies** with auto-selection by content type, query-aware budget allocation, and zero-loss progressive delivery → [docs/compression.md](https://github.com/memtomem/memtomem-stm/blob/main/docs/compression.md)
+- 🧠 **Proactive memory surfacing** from a memtomem LTM server, gated by relevance threshold, rate limit, dedup, and circuit breaker → [docs/surfacing.md](https://github.com/memtomem/memtomem-stm/blob/main/docs/surfacing.md)
+- 💾 **Response caching** with TTL and eviction; surfacing re-applied on cache hit so injected memories stay fresh → [docs/caching.md](https://github.com/memtomem/memtomem-stm/blob/main/docs/caching.md)
+- 🔍 **Observability** — Langfuse tracing, RPS, latency percentiles (p50/p95/p99), error classification, per-tool metrics → [docs/operations.md#observability](https://github.com/memtomem/memtomem-stm/blob/main/docs/operations.md#observability)
+- 📈 **Horizontal scaling** — `PendingStore` protocol with InMemory (default) or SQLite-shared backend for multi-instance deployments → [docs/operations.md#horizontal-scaling](https://github.com/memtomem/memtomem-stm/blob/main/docs/operations.md#horizontal-scaling)
+- 🛡️ **Safety** — circuit breaker, retry with backoff, write-tool skip, query cooldown, session/cross-session dedup, sensitive content auto-detection → [docs/operations.md#safety--resilience](https://github.com/memtomem/memtomem-stm/blob/main/docs/operations.md#safety--resilience)
 
 ## Documentation
 
 | Guide | Topic |
 |-------|-------|
-| [Pipeline](docs/pipeline.md) | The 4-stage CLEAN → COMPRESS → SURFACE → INDEX flow |
-| [Compression](docs/compression.md) | All 10 strategies, query-aware compression, progressive delivery, model-aware defaults |
-| [Surfacing](docs/surfacing.md) | Memory surfacing engine, relevance gating, feedback loop, auto-tuning |
-| [Caching](docs/caching.md) | Response cache and auto-indexing |
-| [Configuration](docs/configuration.md) | Environment variables and `stm_proxy.json` reference |
-| [CLI](docs/cli.md) | `mms` (= `memtomem-stm-proxy`) commands and the 6 MCP tools |
-| [Operations](docs/operations.md) | Safety, privacy, horizontal scaling, observability, on-disk state |
+| [Pipeline](https://github.com/memtomem/memtomem-stm/blob/main/docs/pipeline.md) | The 4-stage CLEAN → COMPRESS → SURFACE → INDEX flow |
+| [Compression](https://github.com/memtomem/memtomem-stm/blob/main/docs/compression.md) | All 10 strategies, query-aware compression, progressive delivery, model-aware defaults |
+| [Surfacing](https://github.com/memtomem/memtomem-stm/blob/main/docs/surfacing.md) | Memory surfacing engine, relevance gating, feedback loop, auto-tuning |
+| [Caching](https://github.com/memtomem/memtomem-stm/blob/main/docs/caching.md) | Response cache and auto-indexing |
+| [Configuration](https://github.com/memtomem/memtomem-stm/blob/main/docs/configuration.md) | Environment variables and `stm_proxy.json` reference |
+| [CLI](https://github.com/memtomem/memtomem-stm/blob/main/docs/cli.md) | `mms` (= `memtomem-stm-proxy`) commands and the 6 MCP tools |
+| [Operations](https://github.com/memtomem/memtomem-stm/blob/main/docs/operations.md) | Safety, privacy, horizontal scaling, observability, on-disk state |
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "memtomem>=0.1,<0.2",
     "mcp[cli]>=1.26.0",
     "pydantic>=2.10",
     "pydantic-settings>=2.7",
@@ -50,6 +51,12 @@ dev = [
     "ruff>=0.9",
     "mypy>=1.14",
 ]
+
+[tool.uv.sources]
+# Local development against the sibling memtomem checkout. The published
+# wheel still declares the PyPI version range in `[project] dependencies`,
+# so end users get `memtomem` from PyPI while contributors track HEAD.
+memtomem = { path = "../memtomem/packages/memtomem", editable = true }
 
 [tool.ruff]
 target-version = "py312"

--- a/uv.lock
+++ b/uv.lock
@@ -595,6 +595,42 @@ wheels = [
 ]
 
 [[package]]
+name = "memtomem"
+version = "0.1.0"
+source = { editable = "../memtomem/packages/memtomem" }
+dependencies = [
+    { name = "click" },
+    { name = "httpx" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "sqlite-vec" },
+    { name = "watchdog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.1" },
+    { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "kiwipiepy", marker = "extra == 'korean'", specifier = ">=0.18" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "memtomem", extras = ["ollama", "openai", "korean", "code", "web"], marker = "extra == 'all'", editable = "../memtomem/packages/memtomem" },
+    { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.60" },
+    { name = "pydantic", specifier = ">=2.10" },
+    { name = "pydantic-settings", specifier = ">=2.7" },
+    { name = "sqlite-vec", specifier = ">=0.1.6" },
+    { name = "tree-sitter", marker = "extra == 'code'", specifier = ">=0.25" },
+    { name = "tree-sitter-javascript", marker = "extra == 'code'", specifier = ">=0.23" },
+    { name = "tree-sitter-python", marker = "extra == 'code'", specifier = ">=0.23" },
+    { name = "tree-sitter-typescript", marker = "extra == 'code'", specifier = ">=0.23" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.34" },
+    { name = "watchdog", specifier = ">=6.0" },
+]
+provides-extras = ["ollama", "openai", "korean", "code", "web", "all"]
+
+[[package]]
 name = "memtomem-stm"
 version = "0.1.0"
 source = { editable = "." }
@@ -602,6 +638,7 @@ dependencies = [
     { name = "click" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "memtomem" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
@@ -626,6 +663,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "memtomem", editable = "../memtomem/packages/memtomem" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.7" },
 ]
@@ -1183,6 +1221,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1264,6 +1314,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three publish-readiness changes ahead of v0.1.0 to PyPI:

### 1. README docs links → absolute GitHub URLs

13 relative `(docs/...)` markdown links broke when rendered on PyPI (PyPI does not resolve relative paths). Switched all to `https://github.com/memtomem/memtomem-stm/blob/main/docs/...`. Per memory rule `feedback_readme_thin_pattern.md`.

### 2. Lockstep dependency on memtomem core

Declared `memtomem>=0.1,<0.2` in `[project] dependencies`. STM is useless without a memtomem MCP server (the surfacing engine talks to it via stdio), so the install graph should reflect that. The wheel METADATA exposes the PyPI version range as expected:

```
Requires-Dist: memtomem<0.2,>=0.1
```

### 3. Local sibling resolution until memtomem hits PyPI

Until core v0.1.0 is published, `uv sync` cannot resolve `memtomem` from PyPI. Added a `[tool.uv.sources]` entry pointing at the sibling checkout (`../memtomem/packages/memtomem`), and updated the CI workflow to check out memtomem alongside memtomem-stm so the path resolves there too. The path source is a uv-only convention and is **NOT** exported into the built wheel — end users get plain `memtomem>=0.1,<0.2` from PyPI.

Lock file records the source as `editable = \"../memtomem/packages/memtomem\"` (relative, environment-independent). Remove `[tool.uv.sources]` and the CI sibling checkout step once both packages are on PyPI.

### CI workflow

Each of the three jobs (lint, typecheck, test) now:
1. Checks out `memtomem/memtomem` to `memtomem/`
2. Checks out `memtomem-stm` to `memtomem-stm/`
3. Sets `defaults.run.working-directory: memtomem-stm` so all subsequent commands resolve sibling paths

## Test plan

- [x] `uv sync` resolves cleanly via the path source
- [x] `uv run pytest -m \"not ollama\"` → 766 passed (no regression)
- [x] `uv build` succeeds; wheel METADATA exposes `Requires-Dist: memtomem<0.2,>=0.1`
- [x] All 13 relative docs links replaced (`grep -c \"(docs/\" README.md` → 0)

## Companion PR

Pairs with memtomem/memtomem#8 (count sync) for the v0.1.0 publish prep. Neither blocks the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)