### PR TITLE
ci: add release workflow for PyPI publish via Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Publish
+
+# Publishes the memtomem-stm distribution to PyPI (or TestPyPI for dry-runs)
+# via PyPI Trusted Publishers (OIDC). No API tokens are stored.
+#
+# Tag conventions:
+#   v0.1.0          → PyPI                (production)
+#   test-v0.1.0a1   → TestPyPI            (dry run)
+#
+# Both paths share the same `pypi` GitHub environment, gated to tag
+# pushes matching `v*` only (see Settings → Environments → pypi).
+#
+# Until memtomem core hits PyPI, the build job needs the sibling
+# memtomem checkout to satisfy [tool.uv.sources]. Remove the sibling
+# checkout (and the same step in ci.yml) once core is published.
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"        # production
+      - "test-v[0-9]*"   # TestPyPI dry-run
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: memtomem-stm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: memtomem/memtomem
+          path: memtomem
+      - uses: actions/checkout@v4
+        with:
+          path: memtomem-stm
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - name: Build distribution
+        run: uv build
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: memtomem-stm/dist/
+
+  publish:
+    name: Publish to ${{ startsWith(github.ref_name, 'test-') && 'TestPyPI' || 'PyPI' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: ${{ startsWith(github.ref_name, 'test-') && 'https://test.pypi.org/p/memtomem-stm' || 'https://pypi.org/p/memtomem-stm' }}
+    permissions:
+      id-token: write   # required for OIDC token
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        if: ${{ !startsWith(github.ref_name, 'test-') }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to TestPyPI
+        if: ${{ startsWith(github.ref_name, 'test-') }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/release.yml\` that builds memtomem-stm and publishes it to PyPI (or TestPyPI for dry-runs) via PyPI Trusted Publishers (OIDC). No API tokens are stored.

## Tag conventions

| Tag | Target |
|---|---|
| \`v0.1.0\`, \`v0.2.0\`, ... | PyPI (production) |
| \`test-v0.1.0a1\`, \`test-v0.1.0rc1\`, ... | TestPyPI (dry run) |

Both run inside the \`pypi\` GitHub environment, gated to \`v*\` tags only with required reviewer approval.

## Workflow

1. **build** — Sibling-checks-out memtomem core (same pattern as ci.yml), then runs \`uv build\` from memtomem-stm → uploads sdist+wheel as job artifact
2. **publish** — downloads the artifact, dispatches to PyPI or TestPyPI based on tag prefix via \`pypa/gh-action-pypi-publish@release/v1\`

## Sibling memtomem checkout (temporary)

Until memtomem core is published to PyPI, \`[tool.uv.sources]\` resolves the local memtomem dep against \`../memtomem/packages/memtomem\`. The build job replicates the sibling-checkout pattern from ci.yml so \`uv build\` works in CI too.

**Both this checkout step AND the equivalent in ci.yml will be removed in a follow-up PR** once memtomem v0.1.0 is on PyPI. The published wheel METADATA always exposes only \`Requires-Dist: memtomem<0.2,>=0.1\` (independent of how the local build resolved the dep), so end users always pull memtomem from PyPI.

## Verification (after merge + memtomem core PyPI publish)

1. Tag a TestPyPI dry run: \`git tag test-v0.1.0a1 && git push origin test-v0.1.0a1\`
2. Approve the deployment in GitHub (Actions → workflow run → Review deployments)
3. Confirm the package appears at https://test.pypi.org/p/memtomem-stm
4. Tag production: \`git tag v0.1.0 && git push origin v0.1.0\`

## Lockstep order

memtomem core must be on PyPI **before** STM production tag (so end users installing memtomem-stm can resolve the \`memtomem<0.2,>=0.1\` runtime dep). For TestPyPI dry runs, both can publish in any order — TestPyPI dry run only verifies the build+publish path itself, not consumer install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)