### PR TITLE
fix(release): add skip-existing for partial-upload retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: memtomem-stm/dist
+          skip-existing: true
       - name: Publish to TestPyPI
         if: ${{ startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: memtomem-stm/dist
+          skip-existing: true


### PR DESCRIPTION
## Problem

During the second TestPyPI dry-run (\`test-v0.1.0a2\`) the publish step uploaded the wheel successfully but failed on the sdist:

\`\`\`
INFO     memtomem-stm/dist/memtomem_stm-0.1.0-py3-none-any.whl (78.0 KB)
INFO     Response from https://test.pypi.org/legacy/: 200 OK
INFO     Uploading memtomem_stm-0.1.0.tar.gz
INFO     Response: 400 Bad Request
         File already exists ('memtomem_stm-0.1.0.tar.gz', with blake2_256 hash
         '59975fff7132e6b2a53874e00079b66c25aaa08b8378980b2ade0410a3af2e85').
\`\`\`

PyPI/TestPyPI files are immutable. uv build is largely reproducible — the same source produces a byte-identical sdist — so once a partial upload happens (or the same content was uploaded by an earlier attempt), retries hit a 400 conflict because the file's blake2_256 hash already exists server-side.

## Fix

Add \`skip-existing: true\` to both publish steps. \`pypa/gh-action-pypi-publish\` then swallows the 400 and treats existing files as no-ops.

**Production behaviour is unaffected**: on a clean version bump (every \`v*\` tag is a new version), no files exist server-side yet, so \`skip-existing\` has no effect.

## Bonus context

The dry-run confirmed the merged build+publish architecture (#11) works end-to-end — wheel reached TestPyPI with 200 OK. Only the immutable-file conflict on retry remained.

## Test plan

- [ ] After merge + memtomem core fix (memtomem/memtomem#11) merge, push \`test-v0.1.0a3\` → workflow → review deployment → both wheel and sdist either fresh-uploaded or skipped cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)