### PR TITLE
chore: resolve memtomem from PyPI now that core 0.1.0 is published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,25 +6,11 @@ on:
   pull_request:
     branches: [main]
 
-# Until memtomem is published to PyPI, STM resolves it from a sibling
-# checkout via [tool.uv.sources] path = "../memtomem/packages/memtomem".
-# Each job below checks out memtomem and memtomem-stm side by side and
-# runs from the memtomem-stm working directory so the path resolves.
-
 jobs:
   lint:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: memtomem-stm
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: memtomem/memtomem
-          path: memtomem
-      - uses: actions/checkout@v4
-        with:
-          path: memtomem-stm
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
@@ -34,17 +20,8 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: memtomem-stm
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: memtomem/memtomem
-          path: memtomem
-      - uses: actions/checkout@v4
-        with:
-          path: memtomem-stm
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
@@ -55,17 +32,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: memtomem-stm
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: memtomem/memtomem
-          path: memtomem
-      - uses: actions/checkout@v4
-        with:
-          path: memtomem-stm
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,6 @@ name: Publish
 # previous attempt's build artifact. Keeping everything in one job means
 # every (re)run rebuilds locally and avoids the cross-attempt artifact
 # lookup entirely.
-#
-# Until memtomem core is on PyPI, the job needs the sibling memtomem
-# checkout to satisfy [tool.uv.sources]. Both this checkout step AND
-# the equivalent in ci.yml will be removed in a follow-up PR once
-# memtomem v0.1.0 is published.
 
 on:
   push:
@@ -31,9 +26,6 @@ jobs:
   publish:
     name: Build and publish to ${{ startsWith(github.ref_name, 'test-') && 'TestPyPI' || 'PyPI' }}
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: memtomem-stm
     environment:
       name: pypi
       url: ${{ startsWith(github.ref_name, 'test-') && 'https://test.pypi.org/p/memtomem-stm' || 'https://pypi.org/p/memtomem-stm' }}
@@ -41,12 +33,6 @@ jobs:
       id-token: write   # required for OIDC token
     steps:
       - uses: actions/checkout@v4
-        with:
-          repository: memtomem/memtomem
-          path: memtomem
-      - uses: actions/checkout@v4
-        with:
-          path: memtomem-stm
       - uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
@@ -56,12 +42,12 @@ jobs:
         if: ${{ !startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: memtomem-stm/dist
+          packages-dir: dist
           skip-existing: true
       - name: Publish to TestPyPI
         if: ${{ startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          packages-dir: memtomem-stm/dist
+          packages-dir: dist
           skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,6 @@ dev = [
     "mypy>=1.14",
 ]
 
-[tool.uv.sources]
-# Local development against the sibling memtomem checkout. The published
-# wheel still declares the PyPI version range in `[project] dependencies`,
-# so end users get `memtomem` from PyPI while contributors track HEAD.
-memtomem = { path = "../memtomem/packages/memtomem", editable = true }
-
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ wheels = [
 [[package]]
 name = "memtomem"
 version = "0.1.0"
-source = { editable = "../memtomem/packages/memtomem" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "httpx" },
@@ -607,28 +607,10 @@ dependencies = [
     { name = "sqlite-vec" },
     { name = "watchdog" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "click", specifier = ">=8.1" },
-    { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115" },
-    { name = "httpx", specifier = ">=0.28" },
-    { name = "kiwipiepy", marker = "extra == 'korean'", specifier = ">=0.18" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
-    { name = "memtomem", extras = ["ollama", "openai", "korean", "code", "web"], marker = "extra == 'all'", editable = "../memtomem/packages/memtomem" },
-    { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.60" },
-    { name = "pydantic", specifier = ">=2.10" },
-    { name = "pydantic-settings", specifier = ">=2.7" },
-    { name = "sqlite-vec", specifier = ">=0.1.6" },
-    { name = "tree-sitter", marker = "extra == 'code'", specifier = ">=0.25" },
-    { name = "tree-sitter-javascript", marker = "extra == 'code'", specifier = ">=0.23" },
-    { name = "tree-sitter-python", marker = "extra == 'code'", specifier = ">=0.23" },
-    { name = "tree-sitter-typescript", marker = "extra == 'code'", specifier = ">=0.23" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.34" },
-    { name = "watchdog", specifier = ">=6.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/28/dc/4a614958ef1c2f27d11389df90572654acb579b86e220a19d8ddf3e6047f/memtomem-0.1.0.tar.gz", hash = "sha256:0924a474b2ebe34e8c881c2d2644581394314c948db8cad54271eb458369323d", size = 238011, upload-time = "2026-04-10T01:14:05.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/04/43d848692ddefa14bdb38047cdfedfecd17c9f9ef33b047b6de699cada1a/memtomem-0.1.0-py3-none-any.whl", hash = "sha256:03d3ee8cd187762616e1a431bff100030304ed8f65e58db71b45250b66ec5d40", size = 314280, upload-time = "2026-04-10T01:14:03.566Z" },
 ]
-provides-extras = ["ollama", "openai", "korean", "code", "web", "all"]
 
 [[package]]
 name = "memtomem-stm"
@@ -663,7 +645,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
-    { name = "memtomem", editable = "../memtomem/packages/memtomem" },
+    { name = "memtomem", specifier = ">=0.1,<0.2" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.7" },
 ]


### PR DESCRIPTION
## Summary

memtomem 0.1.0 is now live on PyPI: https://pypi.org/p/memtomem

STM no longer needs the temporary \`[tool.uv.sources]\` entry pointing at a sibling checkout. This PR removes all the sibling-resolution scaffolding that was added during the publish-prep phase.

## Changes

- **pyproject.toml**: removed \`[tool.uv.sources]\` section (memtomem path source)
- **ci.yml**: dropped sibling memtomem \`actions/checkout\` step + \`working-directory: memtomem-stm\` from all three jobs (lint/typecheck/test) → back to default repo checkout
- **release.yml**: same sibling checkout removal in the publish job
- **uv.lock**: auto-updated by \`uv sync\` to record memtomem from PyPI:
  \`\`\`
  source = { registry = "https://pypi.org/simple" }
  \`\`\`

## Verification

- [x] \`uv sync\` resolves memtomem from PyPI cleanly
- [x] \`uv run pytest -m \"not ollama\"\` → 766 passed (no regression)
- [x] uv.lock memtomem source switched from \`editable = "../memtomem/packages/memtomem"\` to \`registry = "https://pypi.org/simple"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)