### PR TITLE
fix: correct pyproject Homepage/Repository to point at memtomem-stm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ memtomem-stm-proxy = "memtomem_stm.cli.proxy:cli"
 mms = "memtomem_stm.cli.proxy:cli"
 
 [project.urls]
-Homepage = "https://github.com/memtomem/memtomem"
-Repository = "https://github.com/memtomem/memtomem"
+Homepage = "https://github.com/memtomem/memtomem-stm"
+Repository = "https://github.com/memtomem/memtomem-stm"
+Issues = "https://github.com/memtomem/memtomem-stm/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Problem

The publish-prep PR (#9) accidentally copied the \`Homepage\` and \`Repository\` URLs from memtomem core, so PyPI's "Project links" sidebar on https://pypi.org/p/memtomem-stm was sending visitors to https://github.com/memtomem/memtomem instead of the memtomem-stm repo.

The published 0.1.0 metadata is immutable, so the wrong URLs remain on the 0.1.0 page. This fix takes effect from the **next release**.

## Diff

\`\`\`diff
 [project.urls]
-Homepage = "https://github.com/memtomem/memtomem"
-Repository = "https://github.com/memtomem/memtomem"
+Homepage = "https://github.com/memtomem/memtomem-stm"
+Repository = "https://github.com/memtomem/memtomem-stm"
+Issues = "https://github.com/memtomem/memtomem-stm/issues"
\`\`\`

Also adds the missing \`Issues\` URL.

No version bump — fix lands on main and ships with the next release.

## Companion PR

Pairs with memtomem/memtomem url augment PR (only adds \`Issues\` since core's other URLs were already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)