### PR TITLE
fix: make surfacing feedback DB path configurable via env var

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -42,13 +42,14 @@ Notebook 04 auto-skips subsequent cells when no API key is set — it's safe to 
 
 ## State isolation
 
-Every notebook's first code cell calls `isolate_stm_state()` from `_helpers.py`, which points STM's proxy config, cache, and metrics databases at a fresh temp directory via environment variables:
+Every notebook's first code cell calls `isolate_stm_state()` from `_helpers.py`, which points STM's proxy config, cache, metrics, and surfacing feedback databases at a fresh temp directory via environment variables:
 
 - `MEMTOMEM_STM_PROXY__CONFIG_PATH`
 - `MEMTOMEM_STM_PROXY__CACHE__DB_PATH`
 - `MEMTOMEM_STM_PROXY__METRICS__DB_PATH`
+- `MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH`
 
-One caveat: STM's surfacing feedback database (`~/.memtomem/stm_feedback.db`) currently has a hardcoded path and is **not** isolated. Notebook 03 writes to it, but the rows age out after 7 days via STM's built-in dedup TTL. If you need stricter isolation for notebook 03, delete `~/.memtomem/stm_feedback.db` before running it.
+All four notebooks — including notebook 03's surfacing demo — are fully hermetic. Your real `~/.memtomem/` is untouched.
 
 ## Files
 

--- a/notebooks/_helpers.py
+++ b/notebooks/_helpers.py
@@ -68,9 +68,11 @@ def fake_ltm_path() -> Path:
 def isolate_stm_state(prefix: str = "mms_nb_", *, enable_surfacing: bool = False) -> Path:
     """Create an isolated tempdir and point STM's state there via env vars.
 
-    Sets ``MEMTOMEM_STM_PROXY__CONFIG_PATH``, ``...CACHE__DB_PATH``, and
-    ``...METRICS__DB_PATH`` so that nothing the notebook does touches the
-    user's real ``~/.memtomem/`` directory.
+    Sets ``MEMTOMEM_STM_PROXY__CONFIG_PATH``, ``...CACHE__DB_PATH``,
+    ``...METRICS__DB_PATH``, and ``MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH``
+    so that nothing the notebook does touches the user's real
+    ``~/.memtomem/`` directory — including the surfacing feedback store
+    that holds cross-session dedup state.
 
     Parameters
     ----------
@@ -93,6 +95,7 @@ def isolate_stm_state(prefix: str = "mms_nb_", *, enable_surfacing: bool = False
     os.environ["MEMTOMEM_STM_PROXY__CONFIG_PATH"] = str(config_path)
     os.environ["MEMTOMEM_STM_PROXY__CACHE__DB_PATH"] = str(tmp / "proxy_cache.db")
     os.environ["MEMTOMEM_STM_PROXY__METRICS__DB_PATH"] = str(tmp / "proxy_metrics.db")
+    os.environ["MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH"] = str(tmp / "stm_feedback.db")
     if not enable_surfacing:
         os.environ["MEMTOMEM_STM_SURFACING__ENABLED"] = "false"
     return config_path

--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from pydantic import BaseModel
 
 from memtomem_stm.proxy.config import MODEL_CONTEXT_WINDOWS
@@ -26,6 +28,11 @@ class SurfacingConfig(BaseModel):
     """
 
     enabled: bool = True
+    feedback_db_path: Path = Path("~/.memtomem/stm_feedback.db")
+    """Path to the SQLite store for surfacing events, feedback, and
+    ``seen_memories`` cross-session dedup. Configurable so tests and
+    notebooks can isolate state into a tempdir via
+    ``MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH``."""
     ltm_mcp_command: str = "memtomem-server"
     ltm_mcp_args: list[str] = []
     min_score: float = 0.02

--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -18,7 +18,8 @@ class FeedbackTracker:
 
     def __init__(self, config: SurfacingConfig, db_path: Path | None = None) -> None:
         self._config = config
-        self._store = FeedbackStore(db_path or Path("~/.memtomem/stm_feedback.db").expanduser())
+        resolved = db_path if db_path is not None else config.feedback_db_path.expanduser()
+        self._store = FeedbackStore(resolved)
         self._store.initialize()
 
     @property


### PR DESCRIPTION
## Summary

- Adds `SurfacingConfig.feedback_db_path` field so the store path can be overridden via `MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH` env var (through pydantic-settings nested delimiter)
- `FeedbackTracker.__init__` now defaults to `config.feedback_db_path.expanduser()` instead of a hardcoded literal; explicit `db_path` arg still wins so existing test call sites are unaffected
- Updates `notebooks/_helpers.py isolate_stm_state()` to set the new env var alongside the other isolation knobs → notebook 03 is now fully hermetic (previously leaked rows into `~/.memtomem/stm_feedback.db`)
- Removes the corresponding caveat from `notebooks/README.md`

## Context

Discovered while building the tutorial notebooks that just landed in #TBD. `stm_feedback.db` was the only STM state store whose path was hardcoded — the proxy config, cache, and metrics stores all respect `MEMTOMEM_STM_PROXY__*` env vars. The surfacing feedback DB (holding cross-session dedup state in `seen_memories`) leaked into user state for every integration test and notebook run, and dedup suppression persisted for 7 days via `SurfacingConfig.dedup_ttl_seconds`.

4-line src change, fully backward-compatible.

## Test plan

- [x] `uv run pytest -m "not ollama"` — **800 passed** in 3.86s. All existing `FeedbackTracker` call sites in tests pass an explicit `db_path` and are unaffected.
- [x] `uv run pytest --nbmake notebooks/0[123]_*.ipynb --nbmake-timeout=180` — **3 passed** in 15.97s
- [x] `uv run ruff check src notebooks/_helpers.py` — All checks passed
- [x] `uv run mypy src` — Success, no issues in 34 source files
- [x] **Empirical isolation**: counted `seen_memories` and `surfacing_events` rows in `~/.memtomem/stm_feedback.db` before and after a full notebook 03 nbmake run. Both counts unchanged → 0 rows leaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)