### PR TITLE
fix: harden tests fake LTM against content-hash dedup

### DIFF
--- a/notebooks/03_memory_surfacing.ipynb
+++ b/notebooks/03_memory_surfacing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3322f992",
+   "id": "dfab34eb",
    "metadata": {},
    "source": [
     "# 03 — Memory surfacing with a fake LTM\n",
@@ -15,9 +15,10 @@
     "\n",
     "This notebook shows surfacing end-to-end **without requiring\n",
     "a real `memtomem-server`** — we point STM at\n",
-    "`tests/_fake_memtomem_server.py`, which is the stub the\n",
-    "integration tests use. It returns canned memories so the\n",
-    "output is deterministic.\n",
+    "`notebooks/_fixtures/fake_ltm.py`, a notebook-local stub\n",
+    "that returns canned memories with per-call UUIDs so repeated\n",
+    "runs stay deterministic and aren't silently suppressed by\n",
+    "STM's cross-session dedup.\n",
     "\n",
     "**You will learn:**\n",
     "\n",
@@ -32,7 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bcb3a3d3",
+   "id": "ed1b8f0a",
    "metadata": {},
    "source": [
     "## 1. Isolate state and point surfacing at the fake LTM"
@@ -41,7 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffa09971",
+   "id": "6c130fa6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d65b67c",
+   "id": "533181e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c98824b",
+   "id": "fa5a3cdc",
    "metadata": {},
    "source": [
     "> **Note:** In a real setup you would replace the fake LTM\n",
@@ -102,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b499cde",
+   "id": "0eaf06d8",
    "metadata": {},
    "source": [
     "## 2. Register a small upstream and talk to it via STM"
@@ -111,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37e4f4f9",
+   "id": "738c1335",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0fd8c647",
+   "id": "de87ec6b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a44264ba",
+   "id": "5594b508",
    "metadata": {},
    "source": [
     "## 3. What just happened\n",
@@ -167,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb934304",
+   "id": "524134b5",
    "metadata": {},
    "source": [
     "## 4. Send feedback"
@@ -176,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c29c38ce",
+   "id": "18a4758e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad681c13",
+   "id": "a27f1210",
    "metadata": {},
    "source": [
     "Over time, `\"helpful\"` feedback raises the confidence of the\n",
@@ -213,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ca50d2a",
+   "id": "b8735156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27a56a97",
+   "id": "835faf6a",
    "metadata": {},
    "source": [
     "## Where to next\n",

--- a/notebooks/_build_notebooks.py
+++ b/notebooks/_build_notebooks.py
@@ -429,9 +429,10 @@ def build_nb03() -> None:
 
             This notebook shows surfacing end-to-end **without requiring
             a real `memtomem-server`** — we point STM at
-            `tests/_fake_memtomem_server.py`, which is the stub the
-            integration tests use. It returns canned memories so the
-            output is deterministic.
+            `notebooks/_fixtures/fake_ltm.py`, a notebook-local stub
+            that returns canned memories with per-call UUIDs so repeated
+            runs stay deterministic and aren't silently suppressed by
+            STM's cross-session dedup.
 
             **You will learn:**
 

--- a/notebooks/_helpers.py
+++ b/notebooks/_helpers.py
@@ -102,12 +102,17 @@ def isolate_stm_state(prefix: str = "mms_nb_", *, enable_surfacing: bool = False
 
 
 def configure_fake_ltm() -> Path:
-    """Point STM's surfacing engine at ``tests/_fake_memtomem_server.py``.
+    """Point STM's surfacing engine at ``notebooks/_fixtures/fake_ltm.py``.
 
     Used by notebook 03 so that surfacing can be demonstrated without the
-    user needing a real ``memtomem-server`` on their PATH. Also lowers the
-    ``min_response_chars`` threshold so that small tutorial tool responses
-    actually trigger surfacing.
+    user needing a real ``memtomem-server`` on their PATH. The fixture is
+    a notebook-local fake (distinct from ``tests/_fake_memtomem_server.py``)
+    that embeds a fresh UUID in each memory chunk — STM's cross-session
+    dedup keys on ``sha256(content)`` so a fixed-content fake would appear
+    broken on repeated notebook runs. See ``fake_ltm.py``'s module docstring
+    for the full rationale. Also lowers the ``min_response_chars``
+    threshold so that small tutorial tool responses actually trigger
+    surfacing.
 
     Must be called **after** :func:`isolate_stm_state` (with
     ``enable_surfacing=True``) and **before** :func:`stm_session`.

--- a/tests/_fake_memtomem_server.py
+++ b/tests/_fake_memtomem_server.py
@@ -7,10 +7,23 @@ exposes the two tools the adapter actually calls — ``mem_search`` and the
 actions — both returning canned text in the format the adapter knows how
 to parse.
 
+**Content must vary per call.** STM's cross-session dedup keys on
+``sha256(content)[:16]`` (see
+``src/memtomem_stm/surfacing/mcp_client.py:34``), so a fixture returning
+identical content across calls gets silently suppressed after the first
+run if the test exercises the ``FeedbackTracker`` path. The current
+integration tests pass ``feedback_enabled=False`` and dodge this, but we
+embed per-call UUIDs anyway so the fixture stays safe to drop into a
+future test that *does* hit the dedup path. Assertions here are all
+substring checks (``"JWT authentication"``, ``"current_task"``) so the
+UUID suffixes are invisible to callers.
+
 Run with: `python <path-to-this-file>`
 """
 
 from __future__ import annotations
+
+import uuid
 
 from mcp.server.fastmcp import FastMCP
 
@@ -23,12 +36,19 @@ async def mem_search(
     top_k: int | None = None,
     namespace: str | list[str] | None = None,
 ) -> str:
-    """Return canned search hits in the format McpClientSearchAdapter parses."""
+    """Return canned search hits in the format McpClientSearchAdapter parses.
+
+    Each call embeds a fresh UUID in both the source path and the body
+    text so ``sha256(content)`` dedup never collapses repeated calls.
+    See the module docstring for the full rationale.
+    """
+    auth_tag = uuid.uuid4().hex[:8]
+    api_tag = uuid.uuid4().hex[:8]
     return (
-        "--- [0.92] /notes/auth.md ---\n"
-        "JWT authentication uses HS256 with rotating secrets every 24 hours.\n"
-        "--- [0.87] /notes/api.md ---\n"
-        "All API responses include rate limit headers (X-RateLimit-*).\n"
+        f"--- [0.92] /notes/auth-{auth_tag}.md ---\n"
+        f"JWT authentication uses HS256 with rotating secrets every 24 hours. [run={auth_tag}]\n"
+        f"--- [0.87] /notes/api-{api_tag}.md ---\n"
+        f"All API responses include rate limit headers (X-RateLimit-*). [run={api_tag}]\n"
     )
 
 


### PR DESCRIPTION
## Summary

- Add per-call UUID tagging to `tests/_fake_memtomem_server.py` so it can't be silently suppressed by STM's `sha256(content)[:16]` cross-session dedup when dropped into a test that exercises the `FeedbackTracker` path. Matches the pattern already used by `notebooks/_fixtures/fake_ltm.py`.
- Fix three spots that claimed `configure_fake_ltm()` targets `tests/_fake_memtomem_server.py` when it actually uses `notebooks/_fixtures/fake_ltm.py`: the helper docstring, the nb03 markdown source, and the regenerated nb03 itself.
- Document the dedup gotcha in the tests fixture's module docstring so future readers don't have to rediscover it.

Follow-up to #15 which shipped the `stm_feedback.db` path configurability — the two items were tracked together as "STM testability gaps."

## Test plan

- [x] `pytest tests/test_remote_ltm_integration.py` — 8/8 passed (substring assertions unaffected by UUID suffixes)
- [x] `pytest tests/test_surfacing_engine.py tests/test_feedback.py tests/test_cross_session_dedup.py tests/test_formatter.py tests/test_stm_integration.py` — 67/67 passed
- [x] `pytest --ignore=tests/bench` — 800/800 passed
- [ ] Reviewer sanity-check the nb03 markdown rebuild looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)