### PR TITLE
docs(readme): align License section wording with parent memtomem

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@ CI runs the same three commands on every PR via `.github/workflows/ci.yml`. Mypy
 
 ## License
 
-[Apache License 2.0](LICENSE). Contributions are accepted under the terms of the [Contributor License Agreement](CLA.md), which allows DAPADA Inc. to distribute the Work under Apache-2.0 or any other license terms.
+[Apache License 2.0](LICENSE). Contributions are accepted under the terms of the [Contributor License Agreement](CLA.md).


### PR DESCRIPTION
## Summary
Drop the `...which allows DAPADA Inc. to distribute the Work under Apache-2.0 or any other license terms` clarifier from the README License section so it matches the minimal wording used in parent `memtomem/memtomem`.

The catch-all future-licensing right remains fully documented in `CLA.md` Section 4(e) — this change only removes the README-level surfacing, not the legal basis.

### Why
- **README License sections are a one-line summary, not partial legal disclosure.** Surfacing only the catch-all clause while hiding the other Section 4 items (OSI / source-available / proprietary / dual) reads as adversarial without being informative.
- **First-impression cost.** The phrase can read as "this project is planning to go commercial" to casual contributors and evaluators scanning the README. The CLA signing flow already forces explicit "read and agree", so the disclosure is not lost — just moved to the place where it belongs.
- **One source of truth.** Keeps both repos aligned so future wording changes only need one place.

## Test plan
- [ ] CI (`ruff`, `pytest -m "not ollama"`) stays green — docs only
- [ ] `README.md` License section now matches parent `memtomem/memtomem` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)