### PR TITLE
feat(proxy): compression ratio guard and strategy metric

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -948,6 +948,13 @@ class ProxyManager:
         _clean_ms = (_time.monotonic() - _t0) * 1000
 
         # ── Stage 2: COMPRESS (or PROGRESSIVE) ──
+        # ``effective_compression`` is the strategy actually used (with AUTO
+        # already resolved). ``ratio_violation`` is set by the post-compression
+        # guard below when the compressor cut more than ``min_result_retention``
+        # allows — it feeds into metrics for auditing R4 after the fact.
+        effective_compression: CompressionStrategy = tc.compression
+        ratio_violation = False
+
         if tc.compression == CompressionStrategy.PROGRESSIVE and tc.progressive:
             pcfg = tc.progressive
             if len(cleaned) <= pcfg.chunk_size:
@@ -966,6 +973,7 @@ class ProxyManager:
             # This is the SINGLE place where retention is enforced — compressors trust max_chars.
             effective_max_chars = tc.max_chars
             min_retention = getattr(cfg_snap, "min_result_retention", 0.65)
+            dynamic = 0.0  # effective retention floor applied to this call (0 = unset)
             if min_retention > 0:
                 n = len(cleaned)
                 # Scale: short content (< 1KB) gets ~90% retention, large (10KB+) gets base
@@ -981,10 +989,17 @@ class ProxyManager:
                 if effective_max_chars < min_budget:
                     effective_max_chars = min_budget
 
+            # Resolve AUTO early so downstream metrics know which strategy ran.
+            # ``_apply_compression`` still handles AUTO internally for callers
+            # that pass it directly, but resolving here lets us record the
+            # effective strategy without threading a return tuple.
+            if effective_compression == CompressionStrategy.AUTO:
+                effective_compression = auto_select_strategy(cleaned, max_chars=effective_max_chars)
+
             _t0 = _time.monotonic()
             compressed = await self._apply_compression(
                 cleaned,
-                tc.compression,
+                effective_compression,
                 effective_max_chars,
                 tc.selective,
                 tc.llm,
@@ -994,6 +1009,39 @@ class ProxyManager:
                 context_query=context_query,
             )
             _compress_ms = (_time.monotonic() - _t0) * 1000
+
+            # ── Compression ratio guard (R4 defense) ──
+            # Flag calls where the compressor cut below the dynamic retention
+            # floor. This catches both deliberate ``min_result_retention=0``
+            # bypass configs and compressors that overshoot their char budget.
+            # PROGRESSIVE is excluded above — it is zero-loss by construction.
+            cleaned_len = len(cleaned)
+            if cleaned_len > 0 and dynamic > 0:
+                compressed_ratio = len(compressed) / cleaned_len
+                if compressed_ratio < dynamic:
+                    ratio_violation = True
+                    logger.warning(
+                        "Compression ratio violation for %s/%s: %.3f < %.3f "
+                        "(strategy=%s, cleaned=%d, compressed=%d)",
+                        server,
+                        tool,
+                        compressed_ratio,
+                        dynamic,
+                        effective_compression.value,
+                        cleaned_len,
+                        len(compressed),
+                    )
+                if compressed_ratio < 0.20:
+                    logger.error(
+                        "Heavy compression applied for %s/%s: ratio=%.3f "
+                        "(strategy=%s, cleaned=%d, compressed=%d) — review config",
+                        server,
+                        tool,
+                        compressed_ratio,
+                        effective_compression.value,
+                        cleaned_len,
+                        len(compressed),
+                    )
 
             # Record metrics BEFORE surfacing (surfacing adds content, not compresses)
             compressed_chars_for_metrics = len(compressed)
@@ -1072,6 +1120,8 @@ class ProxyManager:
                 compress_ms=_compress_ms,
                 surface_ms=_surface_ms,
                 surfaced_chars=len(surfaced),
+                compression_strategy=effective_compression.value,
+                ratio_violation=ratio_violation,
             )
         )
 

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -68,6 +68,19 @@ class CallMetrics:
     is_error: bool = False
     error_category: ErrorCategory | None = None
     error_code: int | None = None
+    # Compression fidelity tracking
+    #
+    # ``compression_strategy`` records the *effective* strategy used for this
+    # call (with AUTO already resolved to a concrete strategy). ``None`` means
+    # the strategy is unknown or the call did not go through compression
+    # (e.g., cached hits that bypass the pipeline).
+    #
+    # ``ratio_violation`` is set True when the compressed length falls below
+    # the dynamic ``min_result_retention`` budget enforced in ProxyManager.
+    # This flags calls where compression cut more than the configured floor
+    # — useful for auditing R4 (min_retention bypass) after the fact.
+    compression_strategy: str | None = None
+    ratio_violation: bool = False
 
 
 class RPSTracker:

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -60,6 +60,12 @@ class MetricsStore:
             "error_category": "ALTER TABLE proxy_metrics ADD COLUMN error_category TEXT DEFAULT NULL",
             "error_code": "ALTER TABLE proxy_metrics ADD COLUMN error_code INTEGER DEFAULT NULL",
             "trace_id": "ALTER TABLE proxy_metrics ADD COLUMN trace_id TEXT DEFAULT NULL",
+            "compression_strategy": (
+                "ALTER TABLE proxy_metrics ADD COLUMN compression_strategy TEXT DEFAULT NULL"
+            ),
+            "ratio_violation": (
+                "ALTER TABLE proxy_metrics ADD COLUMN ratio_violation INTEGER NOT NULL DEFAULT 0"
+            ),
         }
         for col, ddl in migrations.items():
             if col not in existing:
@@ -79,8 +85,9 @@ class MetricsStore:
             self._db.execute(
                 "INSERT INTO proxy_metrics "
                 "(server, tool, original_chars, compressed_chars, cleaned_chars, "
-                "is_error, error_category, error_code, trace_id, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "is_error, error_category, error_code, trace_id, "
+                "compression_strategy, ratio_violation, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     metrics.server,
                     metrics.tool,
@@ -91,6 +98,8 @@ class MetricsStore:
                     metrics.error_category.value if metrics.error_category else None,
                     metrics.error_code,
                     metrics.trace_id,
+                    metrics.compression_strategy,
+                    int(metrics.ratio_violation),
                     now,
                 ),
             )

--- a/tests/test_compression_ratio_guard.py
+++ b/tests/test_compression_ratio_guard.py
@@ -1,0 +1,281 @@
+"""Tests for the compression ratio guard (P0-2).
+
+Covers:
+- CallMetrics defaults for the new compression_strategy / ratio_violation fields
+- MetricsStore schema migration for the two new columns (fresh + legacy DB)
+- MetricsStore.record persistence of the new fields
+- ProxyManager.call_tool integration: AUTO resolution is recorded, and the
+  ratio guard flags calls where the compressor cut below the dynamic
+  min_result_retention floor.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ProxyConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
+from memtomem_stm.proxy.metrics import CallMetrics, TokenTracker
+from memtomem_stm.proxy.metrics_store import MetricsStore
+
+
+# ── CallMetrics compression fields ───────────────────────────────────────
+
+
+class TestCallMetricsCompressionFields:
+    def test_defaults(self):
+        m = CallMetrics(server="s", tool="t", original_chars=100, compressed_chars=50)
+        assert m.compression_strategy is None
+        assert m.ratio_violation is False
+
+    def test_explicit_values(self):
+        m = CallMetrics(
+            server="s",
+            tool="t",
+            original_chars=100,
+            compressed_chars=50,
+            compression_strategy="truncate",
+            ratio_violation=True,
+        )
+        assert m.compression_strategy == "truncate"
+        assert m.ratio_violation is True
+
+
+# ── MetricsStore migration ───────────────────────────────────────────────
+
+
+class TestMetricsStoreCompressionMigration:
+    def test_fresh_db_has_compression_columns(self, tmp_path):
+        store = MetricsStore(tmp_path / "fresh.db")
+        store.initialize()
+        cols = {row[1] for row in store._db.execute("PRAGMA table_info(proxy_metrics)")}
+        assert "compression_strategy" in cols
+        assert "ratio_violation" in cols
+        store.close()
+
+    def test_legacy_db_gets_migrated(self, tmp_path):
+        """Pre-existing DB without the new columns should be upgraded."""
+        db_path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE proxy_metrics ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "server TEXT NOT NULL, tool TEXT NOT NULL, "
+            "original_chars INTEGER NOT NULL, compressed_chars INTEGER NOT NULL, "
+            "cleaned_chars INTEGER NOT NULL DEFAULT 0, created_at REAL NOT NULL)"
+        )
+        conn.commit()
+        conn.close()
+
+        store = MetricsStore(db_path)
+        store.initialize()
+        cols = {row[1] for row in store._db.execute("PRAGMA table_info(proxy_metrics)")}
+        assert "compression_strategy" in cols
+        assert "ratio_violation" in cols
+        store.close()
+
+    def test_migration_is_idempotent(self, tmp_path):
+        """Running initialize twice must not fail or duplicate columns."""
+        db_path = tmp_path / "idempotent.db"
+        store = MetricsStore(db_path)
+        store.initialize()
+        store.close()
+
+        # Second open on the already-migrated DB should be a no-op.
+        store2 = MetricsStore(db_path)
+        store2.initialize()
+        cols = {row[1] for row in store2._db.execute("PRAGMA table_info(proxy_metrics)")}
+        assert "compression_strategy" in cols
+        assert "ratio_violation" in cols
+        store2.close()
+
+    def test_record_persists_compression_fields(self, tmp_path):
+        store = MetricsStore(tmp_path / "record.db")
+        store.initialize()
+        store.record(
+            CallMetrics(
+                server="srv",
+                tool="tool",
+                original_chars=10000,
+                compressed_chars=500,
+                cleaned_chars=10000,
+                compression_strategy="truncate",
+                ratio_violation=True,
+            )
+        )
+        row = store._db.execute(
+            "SELECT compression_strategy, ratio_violation FROM proxy_metrics"
+        ).fetchone()
+        assert row == ("truncate", 1)
+        store.close()
+
+    def test_record_success_defaults(self, tmp_path):
+        """A call recorded without the new fields should default to NULL / 0."""
+        store = MetricsStore(tmp_path / "defaults.db")
+        store.initialize()
+        store.record(
+            CallMetrics(
+                server="srv",
+                tool="tool",
+                original_chars=100,
+                compressed_chars=100,
+                cleaned_chars=100,
+            )
+        )
+        row = store._db.execute(
+            "SELECT compression_strategy, ratio_violation FROM proxy_metrics"
+        ).fetchone()
+        assert row == (None, 0)
+        store.close()
+
+
+# ── ProxyManager ratio guard ─────────────────────────────────────────────
+
+
+def _text_content(text: str):
+    return SimpleNamespace(type="text", text=text)
+
+
+def _make_result(text: str):
+    return SimpleNamespace(content=[_text_content(text)], isError=False)
+
+
+def _make_manager_with_store(
+    tmp_path: Path,
+    *,
+    min_retention: float = 0.65,
+    compression: CompressionStrategy = CompressionStrategy.TRUNCATE,
+    max_result_chars: int = 50000,
+) -> tuple[ProxyManager, MetricsStore]:
+    """Build a ProxyManager wired to a real MetricsStore so tests can read
+    persisted rows directly — closer to production than summary dicts."""
+    store = MetricsStore(tmp_path / "metrics.db")
+    store.initialize()
+    server_cfg = UpstreamServerConfig(
+        prefix="test",
+        compression=compression,
+        max_result_chars=max_result_chars,
+        max_retries=0,
+        reconnect_delay_seconds=0.0,
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={"srv": server_cfg},
+        min_result_retention=min_retention,
+    )
+    tracker = TokenTracker(metrics_store=store)
+    mgr = ProxyManager(proxy_cfg, tracker)
+    session = AsyncMock()
+    mgr._connections["srv"] = UpstreamConnection(
+        name="srv",
+        config=server_cfg,
+        session=session,
+        tools=[],
+    )
+    return mgr, store
+
+
+def _latest_row(store: MetricsStore) -> dict:
+    row = store._db.execute(
+        "SELECT server, tool, cleaned_chars, compressed_chars, "
+        "compression_strategy, ratio_violation "
+        "FROM proxy_metrics ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    return {
+        "server": row[0],
+        "tool": row[1],
+        "cleaned_chars": row[2],
+        "compressed_chars": row[3],
+        "compression_strategy": row[4],
+        "ratio_violation": row[5],
+    }
+
+
+@pytest.mark.asyncio
+class TestProxyManagerRatioGuard:
+    async def test_records_effective_strategy(self, tmp_path):
+        """Calls that pass compression should record the concrete strategy."""
+        mgr, store = _make_manager_with_store(tmp_path)
+        mgr._connections["srv"].session.call_tool.return_value = _make_result("ok")
+        await mgr.call_tool("srv", "tool", {})
+        row = _latest_row(store)
+        assert row["compression_strategy"] == "truncate"
+        assert row["ratio_violation"] == 0
+        store.close()
+
+    async def test_auto_is_resolved_before_metrics(self, tmp_path):
+        """AUTO should be resolved to a concrete strategy before recording.
+
+        A tiny response fits the budget, so auto_select_strategy returns
+        NONE — that is what the metrics row should reflect, not 'auto'.
+        """
+        mgr, store = _make_manager_with_store(tmp_path, compression=CompressionStrategy.AUTO)
+        mgr._connections["srv"].session.call_tool.return_value = _make_result("small response")
+        await mgr.call_tool("srv", "tool", {})
+        row = _latest_row(store)
+        assert row["compression_strategy"] == "none"
+        assert row["ratio_violation"] == 0
+        store.close()
+
+    async def test_violation_flagged_when_compressor_overshoots(self, tmp_path):
+        """If the compressor returns far less than the dynamic floor,
+        the guard should flag ratio_violation on the recorded call.
+
+        We stub _apply_compression to simulate a compressor that ignores
+        its char budget — this is exactly the R4 failure mode observed in
+        proxy_metrics.db (§2a of the diagnosis)."""
+        mgr, store = _make_manager_with_store(tmp_path, min_retention=0.65, max_result_chars=500)
+        # ~15KB upstream → cleaned length >= 10000 → dynamic = 0.65
+        large_text = "content paragraph. " * 800  # ~15200 chars
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(large_text)
+        # Return something far below the retention floor
+        mgr._apply_compression = AsyncMock(return_value="x" * 100)
+
+        await mgr.call_tool("srv", "tool", {})
+
+        row = _latest_row(store)
+        assert row["cleaned_chars"] > 10000
+        assert row["compressed_chars"] == 100
+        assert row["ratio_violation"] == 1
+        assert row["compression_strategy"] == "truncate"
+        store.close()
+
+    async def test_no_violation_when_compressor_respects_budget(self, tmp_path):
+        """Compressor staying within the dynamic floor should not trip
+        the guard."""
+        mgr, store = _make_manager_with_store(tmp_path, min_retention=0.65, max_result_chars=50000)
+        large_text = "content paragraph. " * 800  # ~15200 chars
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(large_text)
+        # Simulate a compressor that keeps ~80% of the content — above the
+        # 0.65 floor, so no violation should fire.
+        kept = int(len(large_text) * 0.8)
+        mgr._apply_compression = AsyncMock(return_value=large_text[:kept])
+
+        await mgr.call_tool("srv", "tool", {})
+
+        row = _latest_row(store)
+        assert row["ratio_violation"] == 0
+        store.close()
+
+    async def test_min_retention_zero_disables_guard(self, tmp_path):
+        """min_result_retention=0 means the operator opted out of the floor;
+        the guard must not flag anything, even for extreme compression."""
+        mgr, store = _make_manager_with_store(tmp_path, min_retention=0.0, max_result_chars=500)
+        large_text = "content paragraph. " * 800
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(large_text)
+        mgr._apply_compression = AsyncMock(return_value="x" * 10)
+
+        await mgr.call_tool("srv", "tool", {})
+
+        row = _latest_row(store)
+        assert row["ratio_violation"] == 0
+        store.close()


### PR DESCRIPTION
## Summary

- Diagnosis of `~/.memtomem/proxy_metrics.db` (2026-04-06..11, n=16) found a real case of R4 (min_result_retention bypass): `docfix/get_document` cut 18,680 cleaned chars down to 1,540 — **ratio 0.082**, reproduced twice — far below the 0.65 floor, with no runtime signal and no way to ask *which strategy* did it because the schema never recorded it.
- Adds a post-compression ratio guard in `ProxyManager.call_tool` that compares `len(compressed) / len(cleaned)` against the dynamic retention floor already used for budgeting. Below the floor: `warning` log with server/tool/strategy/sizes. Below 0.20: `error` log (`heavy compression applied — review config`). `PROGRESSIVE` is excluded by construction (zero-loss).
- Records `compression_strategy` (with `AUTO` resolved upfront) and `ratio_violation` on every call via two new columns on `proxy_metrics` + matching `CallMetrics` fields. Migration is idempotent on legacy DBs. Now the "which strategy is cutting how much" question is one SQL away.

## Test plan

- [x] `uv run pytest tests/test_compression_ratio_guard.py -q` — 12 new tests: `CallMetrics` defaults, schema migration (fresh + legacy + idempotent re-open), `record()` persistence with and without the new fields, and `ProxyManager.call_tool` integration (records the effective strategy, resolves `AUTO` before metrics, flags ratio violations when the compressor overshoots its budget, no-violation happy path, `min_result_retention=0` opt-out).
- [x] `uv run pytest tests/test_error_metrics.py -q` — regression on adjacent migration tests, 25 passed.
- [x] `uv run pytest -m "not ollama" -q` — full CI-filtered suite, 816 passed.
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src` — no issues (advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)