### PR TITLE
feat(proxy): stm_compression_feedback learning loop

### DIFF
--- a/src/memtomem_stm/proxy/compression_feedback.py
+++ b/src/memtomem_stm/proxy/compression_feedback.py
@@ -1,0 +1,92 @@
+"""Thin tracker orchestrating ``CompressionFeedbackStore`` writes.
+
+The tracker validates input, resolves the ``trace_id`` when the caller
+omits one (best-effort lookup against ``MetricsStore``), and exposes a
+stable API for the MCP tool layer. It deliberately does **not** modify
+``ProxyManager`` — feedback collection is a learning loop that lives on
+the side of the main request path.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from memtomem_stm.proxy.compression_feedback_store import (
+    TRACE_LOOKUP_WINDOW_SECONDS,
+    CompressionFeedbackStore,
+    is_valid_kind,
+    valid_kinds,
+)
+from memtomem_stm.proxy.metrics_store import MetricsStore
+
+logger = logging.getLogger(__name__)
+
+
+class CompressionFeedbackTracker:
+    """Orchestrates ``CompressionFeedbackStore`` writes and trace lookup.
+
+    Instantiated when proxy is enabled *and* ``compression_feedback.enabled``
+    is true. Owns the feedback store connection; the ``MetricsStore`` is
+    borrowed read-only for the optional ``trace_id`` correlation and is
+    not closed by this class.
+    """
+
+    def __init__(
+        self,
+        db_path: Path,
+        metrics_store: MetricsStore | None = None,
+    ) -> None:
+        self._store = CompressionFeedbackStore(db_path.expanduser())
+        self._store.initialize()
+        self._metrics_store = metrics_store
+
+    @property
+    def store(self) -> CompressionFeedbackStore:
+        return self._store
+
+    def close(self) -> None:
+        self._store.close()
+
+    def record(
+        self,
+        server: str,
+        tool: str,
+        missing: str,
+        kind: str = "other",
+        trace_id: str | None = None,
+    ) -> str:
+        """Persist a feedback report and return a user-facing status string.
+
+        When ``trace_id`` is omitted we ask the metrics store for the
+        freshest matching ``(server, tool)`` row within
+        ``TRACE_LOOKUP_WINDOW_SECONDS``. If nothing is found the report
+        is still stored with ``trace_id=NULL`` — the feedback itself is
+        useful even when the analytical join back to ``proxy_metrics``
+        isn't available.
+        """
+        if not server or not tool:
+            return "Error: server and tool are required"
+        if not missing:
+            return "Error: missing description is required"
+        if not is_valid_kind(kind):
+            return f"Error: kind must be one of {valid_kinds()}"
+
+        resolved_trace = trace_id
+        if resolved_trace is None and self._metrics_store is not None:
+            try:
+                resolved_trace = self._metrics_store.lookup_recent_trace_id(
+                    server, tool, TRACE_LOOKUP_WINDOW_SECONDS
+                )
+            except Exception:
+                logger.warning("trace_id lookup failed", exc_info=True)
+                resolved_trace = None
+
+        self._store.record(server, tool, kind, missing, resolved_trace)
+
+        if resolved_trace is not None:
+            return f"Compression feedback recorded ({kind}, trace_id={resolved_trace})"
+        return f"Compression feedback recorded ({kind}, trace_id unresolved)"
+
+    def get_stats(self, tool: str | None = None) -> dict:
+        return self._store.get_stats(tool)

--- a/src/memtomem_stm/proxy/compression_feedback_store.py
+++ b/src/memtomem_stm/proxy/compression_feedback_store.py
@@ -1,0 +1,167 @@
+"""SQLite persistence for ``stm_compression_feedback`` reports.
+
+This store captures agent-reported information loss from compressed proxy
+responses. It is a **learning signal**, not a safety net — writes here do
+not repair the current turn; they feed future auto-tuning and manual
+audits via ``stm_compression_stats``.
+
+The store shares its SQLite file with surfacing feedback
+(``~/.memtomem/stm_feedback.db`` by default). SQLite WAL journaling makes
+two connections to the same file safe for concurrent read/write, and the
+table namespaces are disjoint so the two subsystems don't conflict.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# Window for best-effort ``trace_id`` correlation when the caller does not
+# supply one. Too narrow misses correlations in multi-turn conversations;
+# too wide risks attaching a feedback report to the wrong prior call with
+# the same ``(server, tool)`` pair. 30 minutes covers a typical chat
+# session without running far enough to collide with an unrelated task.
+# Constant rather than config: the right value is not tool-specific and
+# tuning it rarely helps in practice.
+TRACE_LOOKUP_WINDOW_SECONDS: float = 1800.0
+
+
+# Accepted ``kind`` buckets for a feedback report. Intentionally small —
+# free-form narrative belongs in ``missing``; ``kind`` exists to enable
+# per-category rollups in ``get_stats``. Future: add ``"expired"`` for
+# R2 (SELECTIVE/HYBRID TTL expiry) once enough reports land in ``other``
+# to justify a dedicated bucket.
+_VALID_KINDS: frozenset[str] = frozenset(
+    {
+        "truncated",
+        "missing_example",
+        "missing_metadata",
+        "wrong_topic",
+        "other",
+    }
+)
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS compression_feedback (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    server      TEXT    NOT NULL,
+    tool        TEXT    NOT NULL,
+    trace_id    TEXT,
+    kind        TEXT    NOT NULL,
+    missing     TEXT    NOT NULL,
+    created_at  REAL    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cfb_tool ON compression_feedback(tool);
+CREATE INDEX IF NOT EXISTS idx_cfb_trace ON compression_feedback(trace_id);
+CREATE INDEX IF NOT EXISTS idx_cfb_created ON compression_feedback(created_at);
+"""
+
+
+def is_valid_kind(kind: str) -> bool:
+    return kind in _VALID_KINDS
+
+
+def valid_kinds() -> list[str]:
+    return sorted(_VALID_KINDS)
+
+
+class CompressionFeedbackStore:
+    """SQLite store for agent-reported compression feedback.
+
+    Opens its own connection to ``db_path`` — safe to share the file
+    with other stores (e.g. surfacing ``FeedbackStore``) because SQLite
+    WAL journaling permits multiple concurrent connections and the
+    tables are disjoint.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._db: sqlite3.Connection | None = None
+        self._lock = threading.Lock()
+
+    def initialize(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self._db = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._db.execute("PRAGMA busy_timeout=3000")
+        self._db.executescript(_SCHEMA)
+        self._db.commit()
+
+    def close(self) -> None:
+        if self._db:
+            self._db.close()
+            self._db = None
+
+    def record(
+        self,
+        server: str,
+        tool: str,
+        kind: str,
+        missing: str,
+        trace_id: str | None,
+    ) -> None:
+        """Persist a feedback row. ``kind`` is assumed already validated."""
+        if self._db is None:
+            return
+        with self._lock:
+            self._db.execute(
+                "INSERT INTO compression_feedback "
+                "(server, tool, trace_id, kind, missing, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (server, tool, trace_id, kind, missing, time.time()),
+            )
+            self._db.commit()
+
+    def get_stats(self, tool: str | None = None) -> dict:
+        """Return counts for ``stm_compression_stats``.
+
+        Shape::
+
+            {
+                "total_feedback": int,
+                "by_kind": {kind: count},
+                "by_tool": {tool_name: count},  # empty when tool filter is set
+            }
+
+        When ``tool`` is provided, ``by_tool`` is returned as an empty
+        dict so callers can rely on the key always being present without
+        having to branch on the filter.
+        """
+        if self._db is None:
+            return {"total_feedback": 0, "by_kind": {}, "by_tool": {}}
+
+        if tool is not None:
+            kind_rows = self._db.execute(
+                "SELECT kind, COUNT(*) FROM compression_feedback WHERE tool = ? GROUP BY kind",
+                (tool,),
+            ).fetchall()
+            total = self._db.execute(
+                "SELECT COUNT(*) FROM compression_feedback WHERE tool = ?",
+                (tool,),
+            ).fetchone()[0]
+            return {
+                "total_feedback": total,
+                "by_kind": {r[0]: r[1] for r in kind_rows},
+                "by_tool": {},
+            }
+
+        kind_rows = self._db.execute(
+            "SELECT kind, COUNT(*) FROM compression_feedback GROUP BY kind"
+        ).fetchall()
+        tool_rows = self._db.execute(
+            "SELECT tool, COUNT(*) FROM compression_feedback GROUP BY tool"
+        ).fetchall()
+        total = sum(r[1] for r in kind_rows)
+        return {
+            "total_feedback": total,
+            "by_kind": {r[0]: r[1] for r in kind_rows},
+            "by_tool": {r[0]: r[1] for r in tool_rows},
+        }

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -205,6 +205,20 @@ class MetricsConfig(BaseModel):
     max_history: int = Field(default=10000, gt=0)
 
 
+class CompressionFeedbackConfig(BaseModel):
+    """Configuration for the stm_compression_feedback learning loop.
+
+    Collection-only in this release: reports are persisted for later
+    inspection via ``stm_compression_stats`` and for future auto-tuning.
+    Shares the user-wide ``~/.memtomem/stm_feedback.db`` file with
+    surfacing feedback (different tables; WAL mode makes concurrent
+    access safe).
+    """
+
+    enabled: bool = True
+    db_path: Path = Path("~/.memtomem/stm_feedback.db")
+
+
 # Static context window sizes (tokens) for known model families.
 # Used by ProxyConfig.effective_max_result_chars() to scale compression budget.
 # Prefix-matched: "claude-sonnet-4-20250514" matches "claude-sonnet-4".
@@ -287,6 +301,9 @@ class ProxyConfig(BaseModel):
     auto_index: AutoIndexConfig = Field(default_factory=AutoIndexConfig)
     extraction: ExtractionConfig = Field(default_factory=ExtractionConfig)
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
+    compression_feedback: CompressionFeedbackConfig = Field(
+        default_factory=CompressionFeedbackConfig
+    )
 
     def effective_max_result_chars(self) -> int:
         """Compute max_result_chars scaled by consumer model's context window.

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -129,3 +129,32 @@ class MetricsStore:
             }
             for r in rows
         ]
+
+    def lookup_recent_trace_id(
+        self,
+        server: str,
+        tool: str,
+        within_seconds: float,
+    ) -> str | None:
+        """Return the ``trace_id`` of the freshest ``(server, tool)`` row
+        recorded within the last ``within_seconds`` seconds, or ``None``
+        if the store is closed or nothing matches.
+
+        Best-effort correlation helper used by ``stm_compression_feedback``
+        when the caller omits an explicit ``trace_id``. The window should
+        stay narrow enough (see ``TRACE_LOOKUP_WINDOW_SECONDS`` in
+        ``compression_feedback_store``) that we don't attach a feedback
+        report to an unrelated historical call with the same ``(server,
+        tool)`` pair.
+        """
+        if self._db is None:
+            return None
+        cutoff = time.time() - within_seconds
+        row = self._db.execute(
+            "SELECT trace_id FROM proxy_metrics "
+            "WHERE server = ? AND tool = ? AND created_at >= ? "
+            "AND trace_id IS NOT NULL "
+            "ORDER BY created_at DESC LIMIT 1",
+            (server, tool, cutoff),
+        ).fetchone()
+        return row[0] if row else None

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -12,6 +12,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 
 from memtomem_stm.config import STMConfig
+from memtomem_stm.proxy.compression_feedback import CompressionFeedbackTracker
 from memtomem_stm.proxy.config import ProxyConfig
 from memtomem_stm.proxy.manager import ProxyManager
 from memtomem_stm.proxy.metrics import TokenTracker
@@ -30,6 +31,7 @@ class STMContext:
     tracker: TokenTracker
     surfacing_engine: SurfacingEngine | None
     feedback_tracker: FeedbackTracker | None
+    compression_feedback_tracker: CompressionFeedbackTracker | None
 
 
 CtxType = Context[ServerSession, STMContext]
@@ -57,6 +59,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
     surfacing_engine: SurfacingEngine | None = None
     mcp_adapter = None
     feedback_tracker: FeedbackTracker | None = None
+    compression_feedback_tracker: CompressionFeedbackTracker | None = None
     langfuse_client = None
     tracker = TokenTracker()
 
@@ -69,6 +72,22 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             )
             metrics_store.initialize()
         tracker = TokenTracker(metrics_store=metrics_store)
+
+        # Compression feedback tracker — learning loop for agent-reported
+        # information loss. Reads ``metrics_store`` read-only for
+        # best-effort trace_id correlation when the caller omits it.
+        if config.proxy.compression_feedback.enabled:
+            try:
+                compression_feedback_tracker = CompressionFeedbackTracker(
+                    config.proxy.compression_feedback.db_path,
+                    metrics_store=metrics_store,
+                )
+            except Exception:
+                logger.warning(
+                    "Compression feedback tracker init failed — tool will be disabled",
+                    exc_info=True,
+                )
+                compression_feedback_tracker = None
 
         # Surfacing engine — LTM access is always remote-only via the
         # MCP client adapter. The adapter spawns (or connects to) a memtomem
@@ -153,6 +172,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
         tracker=tracker,
         surfacing_engine=surfacing_engine,
         feedback_tracker=feedback_tracker,
+        compression_feedback_tracker=compression_feedback_tracker,
     )
     try:
         yield ctx
@@ -170,6 +190,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             (proxy_cache, "proxy_cache"),
             (metrics_store, "metrics_store"),
             (feedback_tracker, "feedback_tracker"),
+            (compression_feedback_tracker, "compression_feedback_tracker"),
         ]:
             if resource is not None:
                 try:
@@ -456,6 +477,101 @@ async def stm_surfacing_stats(
         helpful = stats["by_rating"].get("helpful", 0)
         pct = round(helpful / stats["total_feedback"] * 100, 1)
         lines.append(f"\nHelpfulness: {pct}%")
+
+    if tool:
+        lines.append(f"\n(filtered by tool: {tool})")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tool: stm_compression_feedback
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def stm_compression_feedback(
+    server: str,
+    tool: str,
+    missing: str,
+    kind: str = "other",
+    trace_id: str | None = None,
+    ctx: CtxType = None,  # type: ignore[assignment]
+) -> str:
+    """Report missing information from a compressed proxy response.
+
+    Use this after a prior ``stm_proxy_*`` call returned a response whose
+    compression stripped something you needed for downstream work. This
+    is a *learning signal* — it does not repair the current turn. Reports
+    accumulate for later inspection via ``stm_compression_stats`` and
+    will feed future auto-tuning of compression strategies per tool.
+
+    Args:
+        server: Upstream server name (e.g. ``"docfix"``).
+        tool:   Upstream tool name (e.g. ``"get_document"``).
+        missing: Free-form description of what was missing
+                 (e.g. ``"example code for Query.select"``).
+        kind:   One of ``"truncated"``, ``"missing_example"``,
+                ``"missing_metadata"``, ``"wrong_topic"``, ``"other"``.
+        trace_id: Optional. If omitted, the server correlates to the most
+                  recent matching ``(server, tool)`` call within the last
+                  30 minutes; if no match, the report is stored with a
+                  NULL ``trace_id``.
+    """
+    app = _get_ctx(ctx)
+    if app.compression_feedback_tracker is None:
+        return "Compression feedback tracking is not enabled."
+    return app.compression_feedback_tracker.record(
+        server=server,
+        tool=tool,
+        missing=missing,
+        kind=kind,
+        trace_id=trace_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: stm_compression_stats
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def stm_compression_stats(
+    tool: str | None = None,
+    ctx: CtxType = None,  # type: ignore[assignment]
+) -> str:
+    """Show compression feedback counts.
+
+    Reports the total number of ``stm_compression_feedback`` calls, the
+    breakdown by ``kind``, and (when no tool filter is passed) the
+    breakdown by tool.
+
+    Args:
+        tool: Optional filter by upstream tool name.
+    """
+    app = _get_ctx(ctx)
+    if app.compression_feedback_tracker is None:
+        return "Compression feedback tracking is not enabled."
+
+    stats = app.compression_feedback_tracker.get_stats(tool)
+
+    lines = [
+        "Compression Feedback Stats",
+        "==========================",
+        f"Total feedback: {stats['total_feedback']}",
+    ]
+
+    if stats["by_kind"]:
+        lines.append("\nBy kind:")
+        for kind_name, count in sorted(stats["by_kind"].items()):
+            lines.append(f"  {kind_name}: {count}")
+
+    if not tool and stats["by_tool"]:
+        lines.append("\nBy tool:")
+        for tool_name, count in sorted(
+            stats["by_tool"].items(), key=lambda kv: kv[1], reverse=True
+        ):
+            lines.append(f"  {tool_name}: {count}")
 
     if tool:
         lines.append(f"\n(filtered by tool: {tool})")

--- a/tests/test_compression_feedback.py
+++ b/tests/test_compression_feedback.py
@@ -1,0 +1,420 @@
+"""Tests for CompressionFeedbackStore, CompressionFeedbackTracker, and
+the ``lookup_recent_trace_id`` helper on MetricsStore.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.proxy.compression_feedback import CompressionFeedbackTracker
+from memtomem_stm.proxy.compression_feedback_store import (
+    TRACE_LOOKUP_WINDOW_SECONDS,
+    CompressionFeedbackStore,
+    is_valid_kind,
+    valid_kinds,
+)
+from memtomem_stm.proxy.metrics import CallMetrics
+from memtomem_stm.proxy.metrics_store import MetricsStore
+from memtomem_stm.surfacing.feedback_store import FeedbackStore
+
+
+# ---------------------------------------------------------------------------
+# Schema + kind registry
+# ---------------------------------------------------------------------------
+
+
+class TestKindRegistry:
+    def test_valid_kinds_sorted_and_complete(self):
+        assert valid_kinds() == [
+            "missing_example",
+            "missing_metadata",
+            "other",
+            "truncated",
+            "wrong_topic",
+        ]
+
+    def test_is_valid_kind(self):
+        assert is_valid_kind("truncated") is True
+        assert is_valid_kind("missing_example") is True
+        assert is_valid_kind("other") is True
+        assert is_valid_kind("expired") is False
+        assert is_valid_kind("") is False
+
+
+# ---------------------------------------------------------------------------
+# CompressionFeedbackStore
+# ---------------------------------------------------------------------------
+
+
+class TestCompressionFeedbackStore:
+    def test_record_and_get_stats_empty(self, tmp_path: Path):
+        store = CompressionFeedbackStore(tmp_path / "cfb.db")
+        store.initialize()
+        try:
+            stats = store.get_stats()
+            assert stats == {"total_feedback": 0, "by_kind": {}, "by_tool": {}}
+        finally:
+            store.close()
+
+    def test_record_persists_single_row(self, tmp_path: Path):
+        store = CompressionFeedbackStore(tmp_path / "cfb.db")
+        store.initialize()
+        try:
+            store.record(
+                server="docfix",
+                tool="get_document",
+                kind="truncated",
+                missing="example for Query.select",
+                trace_id="abc123",
+            )
+            stats = store.get_stats()
+            assert stats["total_feedback"] == 1
+            assert stats["by_kind"] == {"truncated": 1}
+            assert stats["by_tool"] == {"get_document": 1}
+        finally:
+            store.close()
+
+    def test_get_stats_aggregates_by_kind_and_tool(self, tmp_path: Path):
+        store = CompressionFeedbackStore(tmp_path / "cfb.db")
+        store.initialize()
+        try:
+            store.record("docfix", "get_document", "truncated", "m1", None)
+            store.record("docfix", "get_document", "missing_example", "m2", None)
+            store.record("docfix", "search", "wrong_topic", "m3", None)
+            store.record("next", "docs", "truncated", "m4", None)
+
+            stats = store.get_stats()
+            assert stats["total_feedback"] == 4
+            assert stats["by_kind"] == {
+                "truncated": 2,
+                "missing_example": 1,
+                "wrong_topic": 1,
+            }
+            assert stats["by_tool"] == {
+                "get_document": 2,
+                "search": 1,
+                "docs": 1,
+            }
+        finally:
+            store.close()
+
+    def test_get_stats_filtered_by_tool(self, tmp_path: Path):
+        store = CompressionFeedbackStore(tmp_path / "cfb.db")
+        store.initialize()
+        try:
+            store.record("docfix", "get_document", "truncated", "m1", None)
+            store.record("docfix", "get_document", "missing_example", "m2", None)
+            store.record("docfix", "search", "wrong_topic", "m3", None)
+
+            stats = store.get_stats(tool="get_document")
+            assert stats["total_feedback"] == 2
+            assert stats["by_kind"] == {"truncated": 1, "missing_example": 1}
+            # by_tool is intentionally empty when a tool filter is set,
+            # so callers can always ``stats["by_tool"]`` without branching.
+            assert stats["by_tool"] == {}
+        finally:
+            store.close()
+
+    def test_coexists_with_surfacing_feedback_store(self, tmp_path: Path):
+        """Opening both stores on the same DB file must not conflict."""
+        db_path = tmp_path / "stm_feedback.db"
+
+        surfacing = FeedbackStore(db_path)
+        surfacing.initialize()
+        compression = CompressionFeedbackStore(db_path)
+        compression.initialize()
+
+        try:
+            surfacing.record_surfacing(
+                "surf1", "docfix", "search", "query", ["m1"], [0.9]
+            )
+            compression.record(
+                "docfix", "search", "other", "compression report", None
+            )
+
+            # Both subsystems see only their own rows.
+            surf_stats = surfacing.get_tool_feedback_summary()
+            assert surf_stats["total_surfacings"] == 1
+            cfb_stats = compression.get_stats()
+            assert cfb_stats["total_feedback"] == 1
+        finally:
+            compression.close()
+            surfacing.close()
+
+    def test_close_is_idempotent(self, tmp_path: Path):
+        store = CompressionFeedbackStore(tmp_path / "cfb.db")
+        store.initialize()
+        store.close()
+        store.close()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# MetricsStore.lookup_recent_trace_id
+# ---------------------------------------------------------------------------
+
+
+def _record_metric(
+    store: MetricsStore,
+    server: str,
+    tool: str,
+    trace_id: str | None,
+) -> None:
+    store.record(
+        CallMetrics(
+            server=server,
+            tool=tool,
+            original_chars=100,
+            compressed_chars=50,
+            cleaned_chars=80,
+            trace_id=trace_id,
+        )
+    )
+
+
+def _backdate_last_row(db_path: Path, delta_seconds: float) -> None:
+    """Push the most recent proxy_metrics row's ``created_at`` into the past."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        now = time.time()
+        conn.execute(
+            "UPDATE proxy_metrics SET created_at = ? "
+            "WHERE id = (SELECT MAX(id) FROM proxy_metrics)",
+            (now - delta_seconds,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestMetricsStoreLookup:
+    def test_empty_store_returns_none(self, tmp_path: Path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        try:
+            assert store.lookup_recent_trace_id("docfix", "get_document", 1800.0) is None
+        finally:
+            store.close()
+
+    def test_finds_most_recent_matching(self, tmp_path: Path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        try:
+            _record_metric(store, "docfix", "get_document", "old_trace")
+            _record_metric(store, "docfix", "get_document", "new_trace")
+            assert (
+                store.lookup_recent_trace_id("docfix", "get_document", 1800.0)
+                == "new_trace"
+            )
+        finally:
+            store.close()
+
+    def test_filters_by_server_and_tool(self, tmp_path: Path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        try:
+            _record_metric(store, "docfix", "get_document", "doc_trace")
+            _record_metric(store, "docfix", "search", "search_trace")
+            _record_metric(store, "next", "get_document", "next_trace")
+            assert (
+                store.lookup_recent_trace_id("docfix", "get_document", 1800.0)
+                == "doc_trace"
+            )
+            assert (
+                store.lookup_recent_trace_id("docfix", "search", 1800.0)
+                == "search_trace"
+            )
+        finally:
+            store.close()
+
+    def test_skips_rows_with_null_trace_id(self, tmp_path: Path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        try:
+            _record_metric(store, "docfix", "get_document", "first")
+            _record_metric(store, "docfix", "get_document", None)
+            # Freshest row has NULL trace_id; lookup must fall back to the
+            # previous row rather than returning NULL.
+            assert (
+                store.lookup_recent_trace_id("docfix", "get_document", 1800.0)
+                == "first"
+            )
+        finally:
+            store.close()
+
+    def test_filters_by_window(self, tmp_path: Path):
+        db_path = tmp_path / "metrics.db"
+        store = MetricsStore(db_path)
+        store.initialize()
+        try:
+            _record_metric(store, "docfix", "get_document", "stale")
+            # Push the row far enough into the past that a 30-minute window
+            # will not see it.
+            _backdate_last_row(db_path, delta_seconds=3600.0)
+            assert (
+                store.lookup_recent_trace_id(
+                    "docfix", "get_document", TRACE_LOOKUP_WINDOW_SECONDS
+                )
+                is None
+            )
+        finally:
+            store.close()
+
+
+# ---------------------------------------------------------------------------
+# CompressionFeedbackTracker
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def metrics_store(tmp_path: Path) -> MetricsStore:
+    store = MetricsStore(tmp_path / "metrics.db")
+    store.initialize()
+    yield store
+    store.close()
+
+
+class TestCompressionFeedbackTracker:
+    def test_invalid_kind_rejected(self, tmp_path: Path):
+        tracker = CompressionFeedbackTracker(tmp_path / "cfb.db")
+        try:
+            result = tracker.record(
+                server="docfix",
+                tool="get_document",
+                missing="x",
+                kind="bogus",
+            )
+            assert "kind must be one of" in result
+            # The bogus call must not have persisted anything.
+            assert tracker.get_stats()["total_feedback"] == 0
+        finally:
+            tracker.close()
+
+    def test_missing_fields_rejected(self, tmp_path: Path):
+        tracker = CompressionFeedbackTracker(tmp_path / "cfb.db")
+        try:
+            assert "server and tool" in tracker.record(
+                server="", tool="x", missing="m"
+            )
+            assert "server and tool" in tracker.record(
+                server="x", tool="", missing="m"
+            )
+            assert "missing description" in tracker.record(
+                server="x", tool="y", missing=""
+            )
+            assert tracker.get_stats()["total_feedback"] == 0
+        finally:
+            tracker.close()
+
+    def test_explicit_trace_id_persisted(self, tmp_path: Path):
+        tracker = CompressionFeedbackTracker(tmp_path / "cfb.db")
+        try:
+            result = tracker.record(
+                server="docfix",
+                tool="get_document",
+                missing="example code",
+                kind="missing_example",
+                trace_id="explicit_trace",
+            )
+            assert "explicit_trace" in result
+            stats = tracker.get_stats()
+            assert stats["by_kind"] == {"missing_example": 1}
+        finally:
+            tracker.close()
+
+    def test_trace_id_lookup_within_window(
+        self, tmp_path: Path, metrics_store: MetricsStore
+    ):
+        _record_metric(metrics_store, "docfix", "get_document", "live_trace")
+
+        tracker = CompressionFeedbackTracker(
+            tmp_path / "cfb.db", metrics_store=metrics_store
+        )
+        try:
+            result = tracker.record(
+                server="docfix",
+                tool="get_document",
+                missing="headings only",
+                kind="truncated",
+            )
+            # The tracker echoes the resolved trace_id in its status string.
+            assert "live_trace" in result
+        finally:
+            tracker.close()
+
+    def test_trace_id_lookup_outside_window_stores_null(
+        self, tmp_path: Path, metrics_store: MetricsStore
+    ):
+        metrics_db = tmp_path / "metrics.db"
+        _record_metric(metrics_store, "docfix", "get_document", "stale_trace")
+        _backdate_last_row(metrics_db, delta_seconds=3600.0)
+
+        tracker = CompressionFeedbackTracker(
+            tmp_path / "cfb.db", metrics_store=metrics_store
+        )
+        try:
+            result = tracker.record(
+                server="docfix",
+                tool="get_document",
+                missing="headings only",
+                kind="truncated",
+            )
+            assert "unresolved" in result
+        finally:
+            tracker.close()
+
+    def test_trace_id_lookup_different_tool_stores_null(
+        self, tmp_path: Path, metrics_store: MetricsStore
+    ):
+        _record_metric(metrics_store, "docfix", "get_document", "wrong_tool")
+
+        tracker = CompressionFeedbackTracker(
+            tmp_path / "cfb.db", metrics_store=metrics_store
+        )
+        try:
+            result = tracker.record(
+                server="docfix",
+                tool="search",  # different tool
+                missing="x",
+                kind="other",
+            )
+            assert "unresolved" in result
+        finally:
+            tracker.close()
+
+    def test_record_without_metrics_store_stores_null(self, tmp_path: Path):
+        tracker = CompressionFeedbackTracker(tmp_path / "cfb.db")
+        try:
+            result = tracker.record(
+                server="docfix",
+                tool="get_document",
+                missing="x",
+                kind="other",
+            )
+            assert "unresolved" in result
+        finally:
+            tracker.close()
+
+    def test_get_stats_passthrough(self, tmp_path: Path):
+        tracker = CompressionFeedbackTracker(tmp_path / "cfb.db")
+        try:
+            tracker.record(
+                server="docfix", tool="get_document", missing="x", kind="truncated"
+            )
+            tracker.record(
+                server="docfix", tool="search", missing="y", kind="wrong_topic"
+            )
+
+            all_stats = tracker.get_stats()
+            assert all_stats["total_feedback"] == 2
+            assert all_stats["by_tool"] == {"get_document": 1, "search": 1}
+
+            filtered = tracker.get_stats(tool="search")
+            assert filtered["total_feedback"] == 1
+            assert filtered["by_kind"] == {"wrong_topic": 1}
+            assert filtered["by_tool"] == {}
+        finally:
+            tracker.close()

--- a/tests/test_qa_round3.py
+++ b/tests/test_qa_round3.py
@@ -449,14 +449,18 @@ class TestFeedbackTrackerPosition:
         tree = ast.parse(source)
 
         # Simple text check: "if mcp_adapter is not None:" should appear
-        # before "FeedbackTracker" in the code
+        # before the surfacing FeedbackTracker constructor in the code.
+        # We match "= FeedbackTracker(" (with leading "= ") so that the
+        # unrelated CompressionFeedbackTracker init — which lives on the
+        # metrics side of the lifespan and correctly runs outside the
+        # adapter guard — does not trip this assertion.
         lines = source.split("\n")
         adapter_check_line = None
         feedback_line = None
         for i, line in enumerate(lines):
             if "if mcp_adapter is not None:" in line and adapter_check_line is None:
                 adapter_check_line = i
-            if "FeedbackTracker(" in line and feedback_line is None:
+            if "= FeedbackTracker(" in line and feedback_line is None:
                 feedback_line = i
 
         assert adapter_check_line is not None


### PR DESCRIPTION
## Summary

- New MCP tool `stm_compression_feedback(server, tool, missing, kind="other", trace_id=None)` lets an agent that discovers mid-task that a prior compressed proxy response was missing something (stripped example code, dropped section, wrong topic bias) report it after the fact. This is a **learning signal**, not a safety net — it does not repair the current turn. The ratio guard in #20 carries the real-time safety role; this PR is the complementary "the agent noticed later" path called out in diagnostic §7.
- Backed by a new `compression_feedback` SQLite table living in the same `~/.memtomem/stm_feedback.db` file that surfacing feedback already uses. WAL journaling makes two store classes on one file safe; tables are disjoint. A second MCP tool `stm_compression_stats` mirrors `stm_surfacing_stats` for inspection (totals / by_kind / by_tool).
- `trace_id` is optional. When omitted, the tracker falls back to `MetricsStore.lookup_recent_trace_id` which returns the freshest `(server, tool)` row recorded within a **30-minute** window (`TRACE_LOOKUP_WINDOW_SECONDS` constant, not config — the right value is not per-tool and a wider window risks attaching feedback to an unrelated historical call with the same pair). If nothing matches, the row is stored with `trace_id=NULL` — the feedback itself is still useful even without the analytical join.
- Accepted `kind` values intentionally small: `truncated`, `missing_example`, `missing_metadata`, `wrong_topic`, `other`. Free-form narrative goes in `missing`; `kind` exists for per-category rollups. A future `expired` bucket for R2 (SELECTIVE/HYBRID TTL) can be added once reports accumulate in `other`.
- Auto-tuner integration is deferred on purpose. Reports have to land first before any heuristic can be designed against them, and the diagnostic explicitly classifies this as a learning signal — the safety role is the ratio guard.

## Trace-id join interaction with #20

Analytically complementary, functionally independent:

- **This PR** works standalone against today's `proxy_metrics` schema — all it needs is the existing `trace_id` column.
- **After #20 merges**, `compression_feedback JOIN proxy_metrics ON trace_id` gains a new dimension: the `compression_strategy` column #20 adds lets you answer "which effective strategy is each complaint coming from" in a single SQL query. Until then the join still works, just without the strategy breakdown.

No merge-order constraint in either direction.

## Test plan

- [x] `uv run pytest tests/test_compression_feedback.py -q` — 21 new tests: kind registry, store persist/empty/by-kind/by-tool/filtered, surfacing + compression store coexistence on one DB file, `lookup_recent_trace_id` empty/most-recent/server+tool filter/null-trace skip/window cutoff, tracker kind validation, missing-field validation, explicit-trace path, in-window lookup, out-of-window → unresolved, different-tool → unresolved, no-metrics-store → unresolved, `get_stats` passthrough.
- [x] `uv run pytest -m "not ollama" -q` — full CI-filtered suite, **825 passed** (was 804 on origin/main; +21 new).
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src` — clean (advisory).
- [x] Adjusts `tests/test_qa_round3.py::TestFeedbackTrackerPosition` to match `"= FeedbackTracker("` (with leading `= `) instead of the bare `FeedbackTracker(` substring. The unrelated `CompressionFeedbackTracker` init correctly lives outside the `mcp_adapter` guard on the metrics side of lifespan; the old loose match was tripping on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)