### PR TITLE
feat(proxy): ratio guard fallback via boundary-aware truncate

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1010,38 +1010,46 @@ class ProxyManager:
             )
             _compress_ms = (_time.monotonic() - _t0) * 1000
 
-            # ── Compression ratio guard (R4 defense) ──
-            # Flag calls where the compressor cut below the dynamic retention
-            # floor. This catches both deliberate ``min_result_retention=0``
-            # bypass configs and compressors that overshoot their char budget.
+            # ── Compression ratio guard (R4 defense + fallback) ──
+            # When the compressor cuts below the dynamic retention floor,
+            # re-compress via boundary-aware TruncateCompressor at the full
+            # effective budget. This preserves heading/code-fence/SQL
+            # boundaries (M5) without changing the agent protocol — the
+            # response stays a single text block, just with more content.
             # PROGRESSIVE is excluded above — it is zero-loss by construction.
             cleaned_len = len(cleaned)
+            metrics_strategy = effective_compression.value
             if cleaned_len > 0 and dynamic > 0:
                 compressed_ratio = len(compressed) / cleaned_len
                 if compressed_ratio < dynamic:
                     ratio_violation = True
-                    logger.warning(
-                        "Compression ratio violation for %s/%s: %.3f < %.3f "
-                        "(strategy=%s, cleaned=%d, compressed=%d)",
-                        server,
-                        tool,
-                        compressed_ratio,
-                        dynamic,
-                        effective_compression.value,
-                        cleaned_len,
-                        len(compressed),
-                    )
-                if compressed_ratio < 0.20:
-                    logger.error(
-                        "Heavy compression applied for %s/%s: ratio=%.3f "
-                        "(strategy=%s, cleaned=%d, compressed=%d) — review config",
-                        server,
-                        tool,
-                        compressed_ratio,
-                        effective_compression.value,
-                        cleaned_len,
-                        len(compressed),
-                    )
+                    # SELECTIVE returns a compact TOC by design — the agent
+                    # retrieves full content via stm_proxy_select_chunks.
+                    # Replacing the TOC would break the two-phase protocol.
+                    if effective_compression == CompressionStrategy.SELECTIVE:
+                        logger.warning(
+                            "Compression ratio below floor for %s/%s: %.3f < %.3f "
+                            "(strategy=selective — no fallback, TOC is intentionally compact)",
+                            server,
+                            tool,
+                            compressed_ratio,
+                            dynamic,
+                        )
+                    else:
+                        original_strategy = effective_compression.value
+                        compressed = TruncateCompressor(scorer=self._relevance_scorer).compress(
+                            cleaned, max_chars=effective_max_chars
+                        )
+                        metrics_strategy = f"{original_strategy}→truncate_fallback"
+                        logger.warning(
+                            "Ratio guard fallback for %s/%s: %s (ratio %.3f→%.3f, budget=%d)",
+                            server,
+                            tool,
+                            metrics_strategy,
+                            compressed_ratio,
+                            len(compressed) / cleaned_len if cleaned_len else 0,
+                            effective_max_chars,
+                        )
 
             # Record metrics BEFORE surfacing (surfacing adds content, not compresses)
             compressed_chars_for_metrics = len(compressed)
@@ -1120,7 +1128,7 @@ class ProxyManager:
                 compress_ms=_compress_ms,
                 surface_ms=_surface_ms,
                 surfaced_chars=len(surfaced),
-                compression_strategy=effective_compression.value,
+                compression_strategy=metrics_strategy,
                 ratio_violation=ratio_violation,
             )
         )

--- a/tests/test_compression_ratio_guard.py
+++ b/tests/test_compression_ratio_guard.py
@@ -226,13 +226,14 @@ class TestProxyManagerRatioGuard:
         assert row["ratio_violation"] == 0
         store.close()
 
-    async def test_violation_flagged_when_compressor_overshoots(self, tmp_path):
-        """If the compressor returns far less than the dynamic floor,
-        the guard should flag ratio_violation on the recorded call.
+    async def test_violation_triggers_truncate_fallback(self, tmp_path):
+        """When the compressor overshoots, the ratio guard falls back to
+        boundary-aware TruncateCompressor at the effective budget.
 
-        We stub _apply_compression to simulate a compressor that ignores
-        its char budget — this is exactly the R4 failure mode observed in
-        proxy_metrics.db (§2a of the diagnosis)."""
+        The fallback output should contain substantially more content
+        than the original compression, and the strategy should record
+        the ``"{original}→truncate_fallback"`` transition so SQL queries
+        can track fallback frequency."""
         mgr, store = _make_manager_with_store(tmp_path, min_retention=0.65, max_result_chars=500)
         # ~15KB upstream → cleaned length >= 10000 → dynamic = 0.65
         large_text = "content paragraph. " * 800  # ~15200 chars
@@ -244,9 +245,32 @@ class TestProxyManagerRatioGuard:
 
         row = _latest_row(store)
         assert row["cleaned_chars"] > 10000
-        assert row["compressed_chars"] == 100
+        # Fallback should produce substantially more than the 100-char stub.
+        # effective_max_chars = max(500, ~15200 * 0.65) ≈ 9880
+        assert row["compressed_chars"] > 5000
         assert row["ratio_violation"] == 1
-        assert row["compression_strategy"] == "truncate"
+        assert "→truncate_fallback" in row["compression_strategy"]
+        store.close()
+
+    async def test_fallback_preserves_heading_boundaries(self, tmp_path):
+        """Fallback via TruncateCompressor should cut at heading
+        boundaries rather than mid-sentence when the input is markdown."""
+        mgr, store = _make_manager_with_store(tmp_path, min_retention=0.65, max_result_chars=500)
+        sections = []
+        for i in range(20):
+            sections.append(f"\n## Section {i}\n\n{'Detail text paragraph. ' * 30}")
+        markdown_text = "".join(sections)  # ~14K chars, 20 headings
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(markdown_text)
+        mgr._apply_compression = AsyncMock(return_value="x" * 50)
+
+        result = await mgr.call_tool("srv", "tool", {})
+
+        # The returned text should contain heading markers — TruncateCompressor
+        # cuts at section boundaries and appends remaining section titles.
+        assert "## Section" in result
+        row = _latest_row(store)
+        assert "→truncate_fallback" in row["compression_strategy"]
+        assert row["ratio_violation"] == 1
         store.close()
 
     async def test_no_violation_when_compressor_respects_budget(self, tmp_path):


### PR DESCRIPTION
## Summary

- When the P0-2 ratio guard detects a violation (compressor output < `min_result_retention` floor), the guard now **re-compresses via `TruncateCompressor`** at the full effective budget instead of just logging. This fills the gap between what the compressor produced and what the budget allows, using boundary-aware truncation (heading/code-fence/SQL boundaries per M5).
- The strategy is recorded as `"{original}→truncate_fallback"` in `proxy_metrics.compression_strategy`, making fallback frequency directly queryable: `WHERE compression_strategy LIKE '%→truncate_fallback'`.
- Two multi-phase strategies are **excluded from fallback** (but still flag `ratio_violation` for auditing):
  - **PROGRESSIVE** — already excluded from the guard entirely (zero-loss by construction)
  - **SELECTIVE** — compact TOC is intentional; replacing it would break the `stm_proxy_select_chunks` two-phase protocol

## Motivation (live data, today)

`proxy_metrics.db` showed docs-langchain hybrid calls where the budget was 18.2K but the compressor only produced 13K (ratio 0.468). The compressor treats the budget as a *ceiling*, not a *floor* — when the content's heading structure ends early, hybrid returns short. The ratio guard caught this (P0-2 working as designed), but the truncated response went through unchanged. With this PR, the guard also corrects.

Before: `hybrid | 28595 → 13375 | ratio 0.468 | violation=1`
After:  `hybrid→truncate_fallback | 28595 → ~18587 | ratio ≈0.65 | violation=1`

## Test plan

- [x] `test_violation_triggers_truncate_fallback` — stubbed compressor returns 100 chars from 15K input; fallback produces >5000 chars, strategy records `→truncate_fallback`
- [x] `test_fallback_preserves_heading_boundaries` — markdown input with 20 headings; fallback output contains `## Section` markers (not raw-sliced)
- [x] `test_selective_pipeline_returns_toc` — SELECTIVE strategy is excluded from fallback; TOC JSON passes through unchanged
- [x] `test_no_violation_when_compressor_respects_budget` — no fallback fires (unchanged)
- [x] `test_min_retention_zero_disables_guard` — no fallback fires (unchanged)
- [x] Full suite: **838 passed**, ruff/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)