### PR TITLE
fix: add asyncio.TimeoutError to MCP client transport errors

### DIFF
--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -205,7 +206,7 @@ class McpClientSearchAdapter:
             self._stack = None
             self._session = None
 
-    _TRANSPORT_ERRORS = (OSError, ConnectionError, EOFError, BrokenPipeError)
+    _TRANSPORT_ERRORS = (OSError, ConnectionError, EOFError, BrokenPipeError, asyncio.TimeoutError)
 
     async def _reconnect(self) -> None:
         """Tear down and re-establish the MCP connection."""

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 from dataclasses import dataclass
@@ -427,3 +428,21 @@ class TestMcpClientSearchAdapter:
         results, stats = await adapter.search("query")
         assert results == []
         assert stats is None
+
+    @pytest.mark.asyncio
+    async def test_search_timeout_triggers_reconnect(self) -> None:
+        """asyncio.TimeoutError is treated as a transport error, triggering reconnect."""
+        from memtomem_stm.surfacing.config import SurfacingConfig
+
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+
+        mock_session = AsyncMock()
+        mock_session.call_tool.side_effect = asyncio.TimeoutError()
+        adapter._session = mock_session
+
+        adapter._reconnect = AsyncMock(side_effect=ConnectionError("reconnect failed"))  # type: ignore[method-assign]
+
+        results, stats = await adapter.search("query")
+        assert results == []
+        # Reconnect was attempted (TimeoutError treated as transport error)
+        adapter._reconnect.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Add `asyncio.TimeoutError` to `McpClientSearchAdapter._TRANSPORT_ERRORS` so transient timeouts trigger reconnection instead of being treated as permanent failures
- Aligns with `ProxyManager`'s existing retry logic which already includes `asyncio.TimeoutError`

## Problem
When the upstream MCP server is slow, `asyncio.TimeoutError` fell through to the generic `except Exception` branch — no reconnect, stale session persists, surfacing silently degrades.

## Test plan
- [x] New test `test_search_timeout_triggers_reconnect` confirms `asyncio.TimeoutError` triggers `_reconnect()`
- [x] All 1044 existing tests pass
- [x] `ruff check` + `ruff format --check` clean

Closes #46