### PR TITLE
fix: wrap session.initialize() with configurable timeout

### DIFF
--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -198,6 +198,7 @@ class UpstreamServerConfig(BaseModel):
     max_retries: int = Field(default=3, ge=0)
     reconnect_delay_seconds: float = Field(default=1.0, ge=0.0)
     max_reconnect_delay_seconds: float = Field(default=30.0, ge=0.0)
+    connect_timeout_seconds: float = Field(default=30.0, gt=0.0)
     max_description_chars: int = Field(default=200, gt=0)
     strip_schema_descriptions: bool = False
 

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -193,7 +193,7 @@ class ProxyManager:
         streams = await self._stack.enter_async_context(transport_ctx)
         read, write = streams[0], streams[1]
         session = await self._stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
+        await asyncio.wait_for(session.initialize(), timeout=cfg.connect_timeout_seconds)
 
         result = await session.list_tools()
         valid_tools = []
@@ -225,7 +225,7 @@ class ProxyManager:
         streams = await conn_stack.enter_async_context(transport_ctx)
         read, write = streams[0], streams[1]
         session = await conn_stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
+        await asyncio.wait_for(session.initialize(), timeout=cfg.connect_timeout_seconds)
         result = await session.list_tools()
 
         conn.session = session

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -160,3 +160,57 @@ class TestStop:
 
         mock_stack.aclose.assert_awaited_once()
         assert len(mgr._connections) == 0
+
+
+# ── connect timeout ─────────────────────────────────────────────────────
+
+
+class TestConnectTimeout:
+    async def test_connect_server_times_out_on_slow_initialize(self):
+        """_connect_server raises TimeoutError when session.initialize() exceeds timeout."""
+        cfg = UpstreamServerConfig(prefix="slow", connect_timeout_seconds=0.05)
+        mgr = _make_manager(servers={"slow": cfg})
+
+        # Initialize _stack without actually connecting
+        with patch.object(mgr, "_connect_server", new_callable=AsyncMock):
+            await mgr.start()
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        async def _slow_init():
+            await asyncio.sleep(10)
+
+        mock_session.initialize = _slow_init
+
+        mock_transport = AsyncMock()
+        mock_transport.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+        mock_transport.__aexit__ = AsyncMock(return_value=False)
+
+        import pytest as _pt
+
+        with (
+            patch.object(mgr, "_open_transport", return_value=mock_transport),
+            patch("memtomem_stm.proxy.manager.ClientSession", return_value=mock_session),
+        ):
+            with _pt.raises(asyncio.TimeoutError):
+                await mgr._connect_server("slow", cfg, set())
+
+    async def test_start_logs_timeout_and_continues(self, caplog):
+        """start() catches TimeoutError from _connect_server and continues."""
+        mgr = _make_manager(
+            servers={
+                "ok": UpstreamServerConfig(prefix="ok"),
+                "slow": UpstreamServerConfig(prefix="slow"),
+            }
+        )
+
+        async def _conditional_connect(name, cfg, seen):
+            if name == "slow":
+                raise asyncio.TimeoutError()
+
+        with patch.object(mgr, "_connect_server", side_effect=_conditional_connect):
+            await mgr.start()
+
+        assert "Failed to connect to upstream server 'slow'" in caplog.text


### PR DESCRIPTION
## Summary
- Add `connect_timeout_seconds` field to `UpstreamServerConfig` (default 30s)
- Wrap `session.initialize()` in both `_connect_server` and `_reconnect_server` with `asyncio.wait_for()`
- `TimeoutError` propagates into existing error handlers — startup logs and continues, retry loop treats it as retryable

## Problem
`session.initialize()` had no timeout. A single unresponsive upstream could block startup entirely or stall the reconnect loop indefinitely.

## Test plan
- [x] `test_connect_server_times_out_on_slow_initialize` — verifies `TimeoutError` raised when initialize hangs
- [x] `test_start_logs_timeout_and_continues` — verifies startup resilience
- [x] All 1044 existing tests pass
- [x] `ruff check` + `ruff format --check` clean

Closes #41