### PR TITLE
fix: defensive numeric parsing for untrusted external input (#66)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,8 @@ export MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__SCORER=bm25           # "bm25" or "
 export MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__EMBEDDING_PROVIDER=ollama
 export MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__EMBEDDING_MODEL=nomic-embed-text
 export MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__EMBEDDING_BASE_URL=http://localhost:11434
+# When embedding_provider is "openai", set OPENAI_API_KEY:
+# export OPENAI_API_KEY=sk-...
 
 # Extraction (Stage 4b — auto fact extraction)
 export MEMTOMEM_STM_PROXY__EXTRACTION__ENABLED=false
@@ -194,7 +196,6 @@ Full example with all options:
     "scorer": "bm25",
     "embedding_provider": "ollama",
     "embedding_model": "nomic-embed-text",
-    "embedding_base_url": "http://localhost:11434",
     "embedding_timeout": 10.0
   },
   "extraction": {

--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -90,7 +90,7 @@ The injection mode is configurable: `prepend` (default), `append`, or `section`.
 | `cache_ttl_seconds` | `60.0` | Internal surfacing result cache TTL |
 | `circuit_max_failures` | `3` | Consecutive failures before circuit breaker opens |
 | `circuit_reset_seconds` | `60.0` | Seconds before half-open probe after circuit opens |
-| `auto_tune_enabled` | `true` | Enable automatic `min_score` adjustment from feedback |
+| `auto_tune_enabled` | `true` | Auto-adjust `min_score` from feedback: >60% `not_relevant` raises it (stricter), <20% lowers it (more inclusive) |
 | `auto_tune_min_samples` | `20` | Minimum feedback entries before adjusting per-tool score |
 | `auto_tune_score_increment` | `0.002` | Step size for `min_score` adjustments |
 | `feedback_enabled` | `true` | Enable the feedback recording and `stm_surfacing_feedback` tool |

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -279,7 +279,11 @@ _EMBEDDING_PROVIDER_DEFAULTS: dict[str, str] = {
 
 
 class RelevanceScorerConfig(BaseModel):
-    """Configuration for query-aware relevance scoring."""
+    """Configuration for query-aware relevance scoring.
+
+    When ``embedding_provider`` is ``"openai"``, the ``OPENAI_API_KEY``
+    environment variable must be set for authentication.
+    """
 
     scorer: str = "bm25"
     """Scorer type: "bm25" (default, zero-latency) or "embedding" (semantic)."""

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -272,6 +272,12 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
 }
 
 
+_EMBEDDING_PROVIDER_DEFAULTS: dict[str, str] = {
+    "ollama": "http://localhost:11434",
+    "openai": "https://api.openai.com",
+}
+
+
 class RelevanceScorerConfig(BaseModel):
     """Configuration for query-aware relevance scoring."""
 
@@ -281,10 +287,20 @@ class RelevanceScorerConfig(BaseModel):
     """Embedding provider: "ollama" or "openai". Only used when scorer="embedding"."""
     embedding_model: str = "nomic-embed-text"
     """Embedding model name. Only used when scorer="embedding"."""
-    embedding_base_url: str = "http://localhost:11434"
-    """Embedding API base URL. Only used when scorer="embedding"."""
+    embedding_base_url: str | None = None
+    """Embedding API base URL. Defaults to the provider's standard endpoint
+    (Ollama → http://localhost:11434, OpenAI → https://api.openai.com).
+    Only used when scorer="embedding"."""
     embedding_timeout: float = 10.0
     """Embedding API timeout in seconds."""
+
+    @model_validator(mode="after")
+    def _apply_provider_default_url(self) -> "RelevanceScorerConfig":
+        if self.embedding_base_url is None:
+            self.embedding_base_url = _EMBEDDING_PROVIDER_DEFAULTS.get(
+                self.embedding_provider, "http://localhost:11434"
+            )
+        return self
 
 
 class ProxyConfig(BaseModel):

--- a/src/memtomem_stm/proxy/extraction.py
+++ b/src/memtomem_stm/proxy/extraction.py
@@ -18,6 +18,7 @@ from memtomem_stm.proxy.config import (
     LLMProvider,
 )
 from memtomem_stm.utils.circuit_breaker import CircuitBreaker
+from memtomem_stm.utils.numeric import safe_float
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ def _parse_facts_json(raw: str, *, max_facts: int) -> list[ExtractedFact]:
                         ExtractedFact(
                             content=str(item["content"]).strip(),
                             category=str(item.get("category", "technical")),
-                            confidence=float(item.get("confidence", 0.5)),
+                            confidence=safe_float(item.get("confidence", 0.5), 0.5),
                             tags=[str(t) for t in item.get("tags", [])],
                         )
                     )

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -125,7 +125,8 @@ class ProxyManager:
         self._llm_compressor: LLMCompressor | None = None
         self._llm_compressor_cfg: LLMCompressorConfig | None = None
         self._llm_compressor_lock = asyncio.Lock()
-        self._relevance_scorer = self._create_scorer(config)
+        self._relevance_scorer_instance = self._create_scorer(config)
+        self._relevance_scorer_cfg = config.relevance_scorer
         self._background_tasks: set[asyncio.Task] = set()
 
     async def start(self) -> None:
@@ -263,6 +264,15 @@ class ProxyManager:
     @property
     def _config(self) -> ProxyConfig:
         return self._config_loader.get()
+
+    @property
+    def _relevance_scorer(self) -> "RelevanceScorer":
+        """Return the cached scorer, recreating if config changed via hot-reload."""
+        current_cfg = self._config.relevance_scorer
+        if current_cfg != self._relevance_scorer_cfg:
+            self._relevance_scorer_instance = self._create_scorer(self._config)
+            self._relevance_scorer_cfg = current_cfg
+        return self._relevance_scorer_instance
 
     # Delegates to proxy.tool_metadata module (backward-compatible)
     _truncate_description = staticmethod(truncate_description)

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -122,6 +122,9 @@ class ProxyManager:
         self._extractor_lock = asyncio.Lock()
         self._progressive_store: ProgressiveStoreAdapter | None = None
         self._progressive_lock = asyncio.Lock()
+        self._llm_compressor: LLMCompressor | None = None
+        self._llm_compressor_cfg: LLMCompressorConfig | None = None
+        self._llm_compressor_lock = asyncio.Lock()
         self._relevance_scorer = self._create_scorer(config)
         self._background_tasks: set[asyncio.Task] = set()
 
@@ -241,6 +244,9 @@ class ProxyManager:
             await asyncio.gather(*self._background_tasks, return_exceptions=True)
         self._background_tasks.clear()
         # Close httpx clients
+        if self._llm_compressor is not None:
+            await self._llm_compressor.close()
+            self._llm_compressor = None
         if self._extractor is not None:
             await self._extractor.close()
         for conn in self._connections.values():
@@ -469,9 +475,14 @@ class ProxyManager:
 
         if compression == CompressionStrategy.LLM_SUMMARY:
             if llm_cfg is not None:
-                comp = LLMCompressor(llm_cfg)
-                result = await comp.compress(text, max_chars=max_chars)
-                return result, comp.last_fallback
+                async with self._llm_compressor_lock:
+                    if self._llm_compressor is None or self._llm_compressor_cfg != llm_cfg:
+                        if self._llm_compressor is not None:
+                            await self._llm_compressor.close()
+                        self._llm_compressor = LLMCompressor(llm_cfg)
+                        self._llm_compressor_cfg = llm_cfg
+                result = await self._llm_compressor.compress(text, max_chars=max_chars)
+                return result, self._llm_compressor.last_fallback
             logger.warning(
                 "LLM_SUMMARY requested for %s/%s but no llm config found; falling back to truncate",
                 server,

--- a/src/memtomem_stm/proxy/pending_store.py
+++ b/src/memtomem_stm/proxy/pending_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import threading
 import time
@@ -11,6 +12,8 @@ from pathlib import Path
 from typing import Protocol
 
 from memtomem_stm.proxy.compression import PendingSelection
+
+logger = logging.getLogger(__name__)
 
 
 class PendingStore(Protocol):
@@ -132,8 +135,16 @@ class SQLitePendingStore:
             )
         if row is None:
             return None
+        try:
+            chunks = json.loads(row[0])
+        except json.JSONDecodeError:
+            logger.warning(
+                "Corrupted chunks_json in pending_selections for key=%s; treating as miss",
+                key,
+            )
+            return None
         return PendingSelection(
-            chunks=json.loads(row[0]),
+            chunks=chunks,
             format=row[1],
             created_at=row[2],
             total_chars=row[3],

--- a/src/memtomem_stm/proxy/progressive.py
+++ b/src/memtomem_stm/proxy/progressive.py
@@ -7,10 +7,13 @@ it in chunks on demand — like Claude Code reads files 150 lines at a time.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass
 
 from memtomem_stm.proxy.compression import PendingSelection
+
+logger = logging.getLogger(__name__)
 
 _HEADING_RE = re.compile(r"(?:^|\n)#{1,6}\s+(.+)")
 
@@ -62,9 +65,21 @@ class ProgressiveStoreAdapter:
         sel = self._store.get(key)
         if sel is None or sel.format != "progressive":
             return None
-        meta = json.loads(sel.chunks.get("__meta__", "{}"))
+        content = sel.chunks.get("__content__")
+        if content is None:
+            logger.warning(
+                "Progressive entry missing __content__ for key=%s; treating as miss", key
+            )
+            return None
+        try:
+            meta = json.loads(sel.chunks.get("__meta__", "{}"))
+        except json.JSONDecodeError:
+            logger.warning(
+                "Corrupted __meta__ JSON for progressive key=%s; using defaults", key
+            )
+            meta = {}
         return ProgressiveResponse(
-            content=sel.chunks["__content__"],
+            content=content,
             total_chars=sel.total_chars,
             total_lines=meta.get("total_lines", 0),
             content_type=meta.get("content_type", "text"),

--- a/src/memtomem_stm/proxy/progressive.py
+++ b/src/memtomem_stm/proxy/progressive.py
@@ -74,9 +74,7 @@ class ProgressiveStoreAdapter:
         try:
             meta = json.loads(sel.chunks.get("__meta__", "{}"))
         except json.JSONDecodeError:
-            logger.warning(
-                "Corrupted __meta__ JSON for progressive key=%s; using defaults", key
-            )
+            logger.warning("Corrupted __meta__ JSON for progressive key=%s; using defaults", key)
             meta = {}
         return ProgressiveResponse(
             content=content,

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -187,6 +187,11 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             await proxy_manager.stop()
         except Exception:
             logger.warning("Failed to stop proxy manager", exc_info=True)
+        if surfacing_engine is not None:
+            try:
+                await surfacing_engine.stop()
+            except Exception:
+                logger.warning("Failed to stop surfacing engine", exc_info=True)
         for resource, name in [
             (proxy_cache, "proxy_cache"),
             (metrics_store, "metrics_store"),

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -351,6 +351,14 @@ class SurfacingEngine:
         if exc is not None:
             logger.warning("Webhook fire-and-forget task failed: %s", exc)
 
+    async def stop(self) -> None:
+        """Cancel and drain pending background tasks (webhooks)."""
+        for task in self._background_tasks:
+            task.cancel()
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        self._background_tasks.clear()
+
     def _maybe_cleanup_expired(self) -> None:
         """Run cleanup_expired() at most once per cleanup interval.
 

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import itertools
 import logging
 import time
 import uuid
@@ -57,13 +56,16 @@ class SurfacingEngine:
             max_failures=config.circuit_max_failures,
             reset_timeout=config.circuit_reset_seconds,
         )
-        # Track memory IDs surfaced — seeded from persistent store for cross-session dedup.
+        # Track memory IDs surfaced — insertion-ordered dict for FIFO eviction.
+        # Seeded from persistent store for cross-session dedup.
         # Cap at 10k entries to prevent unbounded growth in long sessions.
-        self._surfaced_ids: set[str] = set()
+        self._surfaced_ids: dict[str, None] = {}
         self._surfaced_ids_max = 10000
         if feedback_tracker is not None and config.dedup_ttl_seconds > 0:
             try:
-                self._surfaced_ids = feedback_tracker.store.get_seen_ids(config.dedup_ttl_seconds)
+                self._surfaced_ids = dict.fromkeys(
+                    feedback_tracker.store.get_seen_ids(config.dedup_ttl_seconds)
+                )
                 if self._surfaced_ids:
                     logger.debug(
                         "Loaded %d seen memory IDs for cross-session dedup",
@@ -298,13 +300,13 @@ class SurfacingEngine:
         # Record surfaced IDs to suppress repeats (in-memory + persistent)
         new_ids = [str(r.chunk.id) for r in relevant]
         for mid in new_ids:
-            self._surfaced_ids.add(mid)
-        # Prune if exceeded cap (drop oldest half via snapshot to avoid
-        # RuntimeError from modifying a set during iteration).
+            self._surfaced_ids[mid] = None
+        # Prune if exceeded cap — evict oldest (first-inserted) entries.
         if len(self._surfaced_ids) > self._surfaced_ids_max:
             excess = len(self._surfaced_ids) - self._surfaced_ids_max // 2
-            to_remove = list(itertools.islice(self._surfaced_ids, excess))
-            self._surfaced_ids -= set(to_remove)
+            keys = list(self._surfaced_ids)[:excess]
+            for k in keys:
+                del self._surfaced_ids[k]
         if self._feedback_tracker is not None:
             try:
                 self._feedback_tracker.store.mark_surfaced(new_ids)

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -16,6 +16,7 @@ from mcp import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
 
 from memtomem_stm.surfacing.config import SurfacingConfig
+from memtomem_stm.utils.numeric import safe_float
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +135,7 @@ class StructuredResultParser(ResultParser):
                 )
             result = RemoteSearchResult(
                 content=content[:500],
-                score=float(item.get("score", 0.0)),
+                score=safe_float(item.get("score", 0.0), 0.0),
                 source=item.get("source", "unknown"),
                 namespace=item.get("namespace", "default"),
             )

--- a/src/memtomem_stm/utils/numeric.py
+++ b/src/memtomem_stm/utils/numeric.py
@@ -1,0 +1,25 @@
+"""Numeric parsing helpers for untrusted external input."""
+
+from __future__ import annotations
+
+import math
+
+
+def safe_float(value: object, default: float = 0.0, *, reject_nonfinite: bool = True) -> float:
+    """Coerce ``value`` to a finite float, falling back to ``default`` on failure.
+
+    Defends against malformed LLM output and untrusted external JSON. Unlike
+    raw ``float()``:
+
+    - Catches ``TypeError``/``ValueError`` from non-convertible inputs.
+    - Rejects ``nan``/``inf``/``-inf`` when ``reject_nonfinite=True`` (default),
+      which plain ``float()`` accepts silently and propagates through
+      comparison/sort logic as undefined behavior.
+    """
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    if reject_nonfinite and not math.isfinite(result):
+        return default
+    return result

--- a/tests/test_context_extractor.py
+++ b/tests/test_context_extractor.py
@@ -84,6 +84,32 @@ class TestHeuristicExtraction:
         assert result is None
 
 
+class TestEdgeCases:
+    """Edge cases for extract_query — inputs realistic from LLM tool calls."""
+
+    def test_all_underscore_prefixed_keys_falls_back(self):
+        """When every key starts with _, heuristic yields nothing → tool name."""
+        result = _extract(
+            "search_docs",
+            {"_context_query": "", "_internal": "data", "_trace": "abc123"},
+            min_query_tokens=1,
+        )
+        assert result == "search docs"
+
+    def test_only_short_values_falls_back(self):
+        """Values with len <= 2 are skipped; only tool name remains."""
+        result = _extract("read_file", {"q": "ab", "x": "no"}, min_query_tokens=1)
+        assert result == "read file"
+
+    def test_non_string_context_query_falls_through(self):
+        """_context_query that is not a str should be ignored."""
+        result = _extract(
+            "search_tool",
+            {"_context_query": 42, "topic": "authentication patterns in the codebase"},
+        )
+        assert "authentication patterns" in result
+
+
 class TestIsIdentifier:
     def test_uuid(self):
         assert ContextExtractor._is_identifier("550e8400-e29b-41d4-a716-446655440000")

--- a/tests/test_pending_store.py
+++ b/tests/test_pending_store.py
@@ -144,6 +144,22 @@ class TestSQLitePendingStore:
         assert result.chunks == {"x": "data"}
         store2.close()
 
+    def test_get_returns_none_on_corrupted_json(self, tmp_path, caplog):
+        """Corrupted chunks_json should be treated as a cache miss, not crash."""
+        store = self._make_store(tmp_path)
+        # Bypass put() and insert invalid JSON directly
+        store._get_db().execute(
+            "INSERT INTO pending_selections "
+            "(key, chunks_json, format, created_at, total_chars) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("bad", "{not valid json", "markdown", time.time(), 10),
+        )
+        store._get_db().commit()
+        with caplog.at_level("WARNING"):
+            assert store.get("bad") is None
+        assert any("Corrupted chunks_json" in r.message for r in caplog.records)
+        store.close()
+
     def test_concurrent_access(self, tmp_path):
         """Multiple threads can put/get without errors."""
         store = self._make_store(tmp_path)

--- a/tests/test_progressive.py
+++ b/tests/test_progressive.py
@@ -197,6 +197,44 @@ class TestProgressiveStoreAdapter:
         store = ProgressiveStoreAdapter(InMemoryPendingStore())
         assert store.get("nonexistent") is None
 
+    def test_missing_content_key_returns_none(self, caplog):
+        """Entry without __content__ should be treated as miss, not crash."""
+        backing = InMemoryPendingStore()
+        # Inject a progressive-format entry missing __content__
+        backing.put(
+            "broken",
+            PendingSelection(
+                chunks={"__meta__": "{}"},  # no __content__
+                format="progressive",
+                created_at=time.monotonic(),
+                total_chars=0,
+            ),
+        )
+        store = ProgressiveStoreAdapter(backing)
+        with caplog.at_level("WARNING"):
+            assert store.get("broken") is None
+        assert any("missing __content__" in r.message for r in caplog.records)
+
+    def test_corrupted_meta_uses_defaults(self, caplog):
+        """Corrupted __meta__ JSON should log and fall back to defaults."""
+        backing = InMemoryPendingStore()
+        backing.put(
+            "bad_meta",
+            PendingSelection(
+                chunks={"__content__": "hello", "__meta__": "{not json"},
+                format="progressive",
+                created_at=time.monotonic(),
+                total_chars=5,
+            ),
+        )
+        store = ProgressiveStoreAdapter(backing)
+        with caplog.at_level("WARNING"):
+            got = store.get("bad_meta")
+        assert got is not None
+        assert got.content == "hello"
+        assert got.content_type == "text"  # default
+        assert any("Corrupted __meta__ JSON" in r.message for r in caplog.records)
+
     def test_touch_does_not_error(self):
         store = ProgressiveStoreAdapter(InMemoryPendingStore())
         resp = ProgressiveResponse(

--- a/tests/test_qa_round3.py
+++ b/tests/test_qa_round3.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import itertools
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -37,7 +36,7 @@ class TestSurfacedIdsPruning:
     """Verify set pruning does not raise RuntimeError."""
 
     def test_pruning_no_runtime_error(self):
-        """Fill _surfaced_ids beyond max, trigger pruning via snapshot approach."""
+        """Fill _surfaced_ids beyond max, trigger pruning via dict-based FIFO."""
         from memtomem_stm.surfacing.engine import SurfacingEngine
 
         config = MagicMock()
@@ -54,30 +53,51 @@ class TestSurfacedIdsPruning:
         engine = SurfacingEngine(config, mcp_adapter=adapter)
         engine._surfaced_ids_max = 100
 
-        # Fill beyond max
+        # Fill beyond max (insertion-ordered dict)
         for i in range(150):
-            engine._surfaced_ids.add(f"id-{i}")
+            engine._surfaced_ids[f"id-{i}"] = None
 
         # Simulate the pruning logic (same code as engine.py)
         if len(engine._surfaced_ids) > engine._surfaced_ids_max:
             excess = len(engine._surfaced_ids) - engine._surfaced_ids_max // 2
-            to_remove = list(itertools.islice(engine._surfaced_ids, excess))
-            engine._surfaced_ids -= set(to_remove)
+            keys = list(engine._surfaced_ids)[:excess]
+            for k in keys:
+                del engine._surfaced_ids[k]
 
         assert len(engine._surfaced_ids) <= engine._surfaced_ids_max
 
     def test_pruning_reduces_to_half_max(self):
-        """After pruning, the set should be at max_size // 2."""
-        ids: set[str] = set()
+        """After pruning, the dict should be at max_size // 2."""
+        ids: dict[str, None] = {}
         max_size = 100
         for i in range(150):
-            ids.add(f"id-{i}")
+            ids[f"id-{i}"] = None
 
         excess = len(ids) - max_size // 2
-        to_remove = list(itertools.islice(ids, excess))
-        ids -= set(to_remove)
+        keys = list(ids)[:excess]
+        for k in keys:
+            del ids[k]
 
         assert len(ids) == max_size // 2
+
+    def test_pruning_evicts_oldest_entries(self):
+        """Pruning should evict the first-inserted entries (FIFO order)."""
+        ids: dict[str, None] = {}
+        max_size = 10
+        for i in range(15):
+            ids[f"id-{i}"] = None
+
+        excess = len(ids) - max_size // 2
+        keys = list(ids)[:excess]
+        for k in keys:
+            del ids[k]
+
+        # Newest entries (id-10 through id-14) should survive
+        for i in range(10, 15):
+            assert f"id-{i}" in ids
+        # Oldest entries (id-0 through id-9) should be evicted
+        for i in range(10):
+            assert f"id-{i}" not in ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_safe_float.py
+++ b/tests/test_safe_float.py
@@ -1,0 +1,65 @@
+"""Unit tests for ``memtomem_stm.utils.numeric.safe_float``."""
+
+from __future__ import annotations
+
+import math
+
+from memtomem_stm.utils.numeric import safe_float
+
+
+class TestSafeFloatFinite:
+    def test_passes_through_plain_float(self):
+        assert safe_float(1.5) == 1.5
+
+    def test_passes_through_int(self):
+        assert safe_float(3) == 3.0
+
+    def test_coerces_numeric_string(self):
+        assert safe_float("2.5") == 2.5
+
+    def test_coerces_scientific_notation(self):
+        assert safe_float("1e-3") == 0.001
+
+    def test_coerces_negative(self):
+        assert safe_float("-0.25") == -0.25
+
+
+class TestSafeFloatFallback:
+    def test_malformed_string_returns_default(self):
+        assert safe_float("not-a-number", 0.5) == 0.5
+
+    def test_mixed_dots_returns_default(self):
+        assert safe_float("1.2.3", 0.5) == 0.5
+
+    def test_none_returns_default(self):
+        assert safe_float(None, 0.0) == 0.0
+
+    def test_list_returns_default(self):
+        assert safe_float([1.0, 2.0], 0.1) == 0.1
+
+    def test_default_default_is_zero(self):
+        assert safe_float("nope") == 0.0
+
+
+class TestSafeFloatNonFiniteRejection:
+    def test_string_nan_rejected_by_default(self):
+        assert safe_float("nan", 0.5) == 0.5
+
+    def test_string_inf_rejected_by_default(self):
+        assert safe_float("inf", 0.5) == 0.5
+
+    def test_string_neg_inf_rejected_by_default(self):
+        assert safe_float("-inf", 0.5) == 0.5
+
+    def test_float_nan_rejected_by_default(self):
+        assert safe_float(float("nan"), 0.5) == 0.5
+
+    def test_float_inf_rejected_by_default(self):
+        assert safe_float(float("inf"), 0.5) == 0.5
+
+    def test_nonfinite_allowed_when_opted_in(self):
+        result = safe_float("nan", 0.5, reject_nonfinite=False)
+        assert math.isnan(result)
+
+        result = safe_float("inf", 0.5, reject_nonfinite=False)
+        assert math.isinf(result)

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -542,3 +542,39 @@ class TestMaybeCleanupExpired:
         # Should not crash — cleanup error is swallowed
         assert "mem" in output
         tracker.store.cleanup_expired.assert_called_once()
+
+
+class TestSurfacingEngineStop:
+    """Verify stop() drains background webhook tasks cleanly."""
+
+    async def test_stop_cancels_pending_background_tasks(self):
+        """Pending tasks are cancelled and drained."""
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter([]),
+        )
+
+        async def never_completes():
+            await asyncio.sleep(100)
+
+        t1 = asyncio.create_task(never_completes())
+        t2 = asyncio.create_task(never_completes())
+        engine._background_tasks.add(t1)
+        engine._background_tasks.add(t2)
+
+        await engine.stop()
+
+        assert t1.cancelled()
+        assert t2.cancelled()
+        assert len(engine._background_tasks) == 0
+
+    async def test_stop_is_idempotent_with_no_tasks(self):
+        """stop() with no pending tasks is a no-op and does not raise."""
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter([]),
+        )
+
+        await engine.stop()
+        await engine.stop()  # second call should also be safe
+        assert len(engine._background_tasks) == 0

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 
@@ -436,3 +437,108 @@ class TestFeedbackBoost:
 
         assert "not enabled" in result
         adapter.increment_access.assert_not_called()
+
+
+class TestMaybeCleanupExpired:
+    """Integration: _maybe_cleanup_expired() scheduling from surface()."""
+
+    def _make_tracker(self):
+        tracker = MagicMock()
+        tracker.store = MagicMock()
+        tracker.store.get_seen_ids = MagicMock(return_value=set())
+        tracker.store.mark_surfaced = MagicMock()
+        tracker.store.cleanup_expired = MagicMock(return_value=0)
+        tracker.store.record_surfacing_event = MagicMock()
+        return tracker
+
+    async def test_cleanup_called_once_per_interval(self):
+        """Two surface() calls within the interval → cleanup runs only once."""
+        tracker = self._make_tracker()
+        results = [FakeSearchResult(chunk=FakeChunk(content="mem"), score=0.5)]
+        engine = SurfacingEngine(
+            config=_make_config(dedup_ttl_seconds=3600),
+            mcp_adapter=_make_mcp_adapter(results),
+            feedback_tracker=tracker,
+        )
+        # Set last_cleanup to the past so first call triggers cleanup
+        engine._last_cleanup = time.monotonic() - 7200
+
+        await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert tracker.store.cleanup_expired.call_count == 1
+
+        # Second call within interval — should NOT trigger cleanup again
+        engine._cache.clear()
+        await engine.surface(
+            "s", "read_file",
+            {"path": "/other", "_context_query": "different query for testing"},
+            LONG_RESPONSE,
+        )
+        assert tracker.store.cleanup_expired.call_count == 1
+
+    async def test_cleanup_fires_again_after_interval(self):
+        """Advance the clock past the interval → cleanup runs again."""
+        tracker = self._make_tracker()
+        results = [FakeSearchResult(chunk=FakeChunk(content="mem"), score=0.5)]
+        engine = SurfacingEngine(
+            config=_make_config(dedup_ttl_seconds=3600),
+            mcp_adapter=_make_mcp_adapter(results),
+            feedback_tracker=tracker,
+        )
+        engine._last_cleanup = time.monotonic() - 7200
+
+        await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert tracker.store.cleanup_expired.call_count == 1
+
+        # Simulate clock advancing past the 1-hour interval
+        engine._last_cleanup = time.monotonic() - 7200
+        engine._cache.clear()
+        await engine.surface(
+            "s", "read_file",
+            {"path": "/z", "_context_query": "another query for clock test"},
+            LONG_RESPONSE,
+        )
+        assert tracker.store.cleanup_expired.call_count == 2
+
+    async def test_cleanup_skipped_when_ttl_zero(self):
+        """dedup_ttl_seconds=0 disables cleanup entirely."""
+        tracker = self._make_tracker()
+        results = [FakeSearchResult(chunk=FakeChunk(content="mem"), score=0.5)]
+        engine = SurfacingEngine(
+            config=_make_config(dedup_ttl_seconds=0),
+            mcp_adapter=_make_mcp_adapter(results),
+            feedback_tracker=tracker,
+        )
+        engine._last_cleanup = time.monotonic() - 7200
+
+        await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        tracker.store.cleanup_expired.assert_not_called()
+
+    async def test_cleanup_skipped_when_no_tracker(self):
+        """No feedback_tracker → cleanup never fires."""
+        results = [FakeSearchResult(chunk=FakeChunk(content="mem"), score=0.5)]
+        engine = SurfacingEngine(
+            config=_make_config(dedup_ttl_seconds=3600),
+            mcp_adapter=_make_mcp_adapter(results),
+            feedback_tracker=None,
+        )
+        engine._last_cleanup = time.monotonic() - 7200
+
+        await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        # No tracker → no cleanup call possible
+
+    async def test_cleanup_exception_does_not_break_surface(self):
+        """cleanup_expired() raising should be caught, surface() continues."""
+        tracker = self._make_tracker()
+        tracker.store.cleanup_expired = MagicMock(side_effect=RuntimeError("DB locked"))
+        results = [FakeSearchResult(chunk=FakeChunk(content="mem"), score=0.5)]
+        engine = SurfacingEngine(
+            config=_make_config(dedup_ttl_seconds=3600),
+            mcp_adapter=_make_mcp_adapter(results),
+            feedback_tracker=tracker,
+        )
+        engine._last_cleanup = time.monotonic() - 7200
+
+        output = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        # Should not crash — cleanup error is swallowed
+        assert "mem" in output
+        tracker.store.cleanup_expired.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #66.

- Introduces `memtomem_stm.utils.numeric.safe_float(value, default, *, reject_nonfinite=True)` — coerces to float, catches `TypeError`/`ValueError`, rejects `NaN`/`Inf` by default (which plain `float()` accepts silently).
- Applies it at the two call sites identified in the issue:
  - `proxy/extraction.py:52` — confidence from LLM output (was: `float("nan")` slipped through as NaN and broke downstream sort/filter).
  - `surfacing/mcp_client.py:137` — score from remote core (was: malformed numeric string raised `ValueError` and broke the entire response parse).
- Unit tests in `tests/test_safe_float.py` cover finite passthrough, malformed-string fallback, explicit `NaN`/`Inf` rejection, and the opt-in `reject_nonfinite=False` escape hatch.

## Commits

1. `fix:` — the defensive parsing change (the actual #66 fix).
2. `chore:` — a one-line pre-existing `ruff format` drift in `progressive.py` left over from PR #64/#65. Unrelated to this issue but was blocking CI on all branches, so it is fixed here to unblock the PR. Reviewers can skip this commit.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1081 passed
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run mypy src/memtomem_stm/utils/numeric.py src/memtomem_stm/proxy/extraction.py src/memtomem_stm/surfacing/mcp_client.py` — clean
- [ ] CI green on PR