### PR TITLE
fix: preserve input order when embedding provider omits "index" field (#68)

### DIFF
--- a/src/memtomem_stm/proxy/relevance.py
+++ b/src/memtomem_stm/proxy/relevance.py
@@ -185,8 +185,11 @@ class EmbeddingScorer:
         )
         resp.raise_for_status()
         data = resp.json()["data"]
-        # Sort by index to ensure order matches input
-        data.sort(key=lambda x: x["index"])
+        # Sort by "index" when the provider populates it (official OpenAI).
+        # OpenAI-compatible servers — Ollama's compat layer, LiteLLM, LM Studio —
+        # often omit the field, in which case we trust the input order.
+        if data and all("index" in d for d in data):
+            data.sort(key=lambda x: x["index"])
         return [d["embedding"] for d in data]
 
 

--- a/tests/test_query_aware.py
+++ b/tests/test_query_aware.py
@@ -164,6 +164,85 @@ class TestRelevanceScorerProtocol:
         assert third_len >= first_len
 
 
+# ── EmbeddingScorer OpenAI response parsing (#68) ──────────────────────
+
+
+class TestEmbeddingOpenAIResponseParsing:
+    """Provider compatibility for ``EmbeddingScorer._embed_openai``.
+
+    Official OpenAI populates ``index`` on every embedding object. Many
+    OpenAI-compatible servers (Ollama's compat layer, LiteLLM, LM Studio)
+    omit it. Sorting by a missing ``index`` used to raise ``KeyError`` and
+    fail the entire request.
+    """
+
+    def _make_scorer(self):
+        from memtomem_stm.proxy.relevance import EmbeddingScorer
+
+        return EmbeddingScorer(
+            provider="openai",
+            model="text-embedding-3-small",
+            base_url="https://api.openai.com",
+        )
+
+    def _mock_response(self, payload: dict):
+        from unittest.mock import MagicMock
+
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value=payload)
+        return resp
+
+    def test_official_openai_response_sorts_by_index(self):
+        """Out-of-order items are sorted back by 'index'."""
+        scorer = self._make_scorer()
+        payload = {
+            "data": [
+                {"index": 2, "embedding": [0.2, 0.2]},
+                {"index": 0, "embedding": [0.0, 0.0]},
+                {"index": 1, "embedding": [0.1, 0.1]},
+            ]
+        }
+        with patch("httpx.post", return_value=self._mock_response(payload)):
+            result = scorer._embed_openai(None, ["a", "b", "c"])
+        assert result == [[0.0, 0.0], [0.1, 0.1], [0.2, 0.2]]
+
+    def test_ollama_compat_response_without_index_preserves_order(self):
+        """Provider omits 'index' entirely — input order is trusted, no KeyError."""
+        scorer = self._make_scorer()
+        payload = {
+            "data": [
+                {"embedding": [1.0, 1.0]},
+                {"embedding": [2.0, 2.0]},
+                {"embedding": [3.0, 3.0]},
+            ]
+        }
+        with patch("httpx.post", return_value=self._mock_response(payload)):
+            result = scorer._embed_openai(None, ["a", "b", "c"])
+        assert result == [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]
+
+    def test_partial_index_preserves_input_order(self):
+        """Mixed response (some items missing 'index') falls back to input order
+        rather than raising KeyError during sort."""
+        scorer = self._make_scorer()
+        payload = {
+            "data": [
+                {"index": 0, "embedding": [0.0, 0.0]},
+                {"embedding": [1.0, 1.0]},  # missing "index"
+                {"index": 2, "embedding": [2.0, 2.0]},
+            ]
+        }
+        with patch("httpx.post", return_value=self._mock_response(payload)):
+            result = scorer._embed_openai(None, ["a", "b", "c"])
+        assert result == [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]]
+
+    def test_empty_data_returns_empty_list(self):
+        scorer = self._make_scorer()
+        with patch("httpx.post", return_value=self._mock_response({"data": []})):
+            result = scorer._embed_openai(None, [])
+        assert result == []
+
+
 # ── TruncateCompressor with context_query ─────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #68.

`EmbeddingScorer._embed_openai` sorted the response by the `"index"` field on every embedding object. Official OpenAI populates this field, but many OpenAI-compatible servers (Ollama compat layer, LiteLLM, LM Studio, self-hosted) omit it — sorting raised `KeyError` and broke the entire embedding request.

**Fix** (2 lines): sort by `"index"` only when every item populates it; otherwise trust input order.

```python
if data and all("index" in d for d in data):
    data.sort(key=lambda x: x["index"])
return [d["embedding"] for d in data]
```

This covers:
- Official OpenAI: all items have `index` → sort happens as before
- Ollama-compat / LiteLLM / LM Studio: no items have `index` → trust input order
- Mixed responses (defensive): fall back to input order rather than `KeyError`

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1095 passed (4 new in `TestEmbeddingOpenAIResponseParsing`)
- [x] `uv run ruff check src tests/test_query_aware.py` — clean
- [x] `uv run ruff format --check src` — clean
- [x] `uv run mypy src/memtomem_stm/proxy/relevance.py` — clean
- New tests cover: sorted-by-index, no-index (compat), partial-index (mixed), empty-data
- [ ] CI green on PR