### PR TITLE
fix: guarantee backward search room in _find_boundary for small spans (#69)

### DIFF
--- a/src/memtomem_stm/proxy/progressive.py
+++ b/src/memtomem_stm/proxy/progressive.py
@@ -215,7 +215,8 @@ class ProgressiveChunker:
             return len(text)
 
         span = target - floor_offset
-        floor = max(floor_offset, target - int(span * 0.2))
+        # max(1, ...) keeps span<=4 from collapsing int(span*0.2) to 0.
+        floor = max(floor_offset, target - max(1, int(span * 0.2)))
 
         # Paragraph boundary
         for i in range(target, floor - 1, -1):

--- a/tests/test_progressive.py
+++ b/tests/test_progressive.py
@@ -59,6 +59,45 @@ class TestProgressiveChunkerBoundary:
         # Should still produce a result without error
         assert "has_more=True" in result
 
+    def test_find_boundary_small_span_detects_paragraph_at_target_minus_one(self):
+        """Regression for #69: span<=4 collapsed floor to target, skipping \\n\\n
+        at target-1. The search now has at least 1 step of backward room."""
+        # target=3, floor_offset=0, span=3. \n\n starts at index 2.
+        text = "ab\n\ncd"
+        assert ProgressiveChunker._find_boundary(text, 3, floor_offset=0) == 2
+
+    def test_find_boundary_small_span_does_not_regress(self):
+        """span<=4 should still find line/word boundaries and fall back cleanly."""
+        # No natural boundary within the span — hard cut at target.
+        assert ProgressiveChunker._find_boundary("abcdef", 4, floor_offset=0) == 4
+        # span=0 (target == floor_offset) is a no-op and must not raise.
+        assert ProgressiveChunker._find_boundary("abc", 0, floor_offset=0) == 0
+
+    def test_small_chunk_size_sequential_integrity(self):
+        """Regression for #69: chunk_size=10 progressive reads must reproduce
+        the full content. Previously the small-span boundary no-op could cause
+        overshoots that broke offset arithmetic."""
+        text = "First.\n\nSecond.\n\nThird.\n\nFourth.\n\nFifth."
+        chunker = ProgressiveChunker(chunk_size=10)
+
+        parts: list[str] = []
+        result = chunker.first_chunk(text, "key1")
+        content = result.split("\n---\n")[0]
+        parts.append(content)
+        offset = len(content)
+
+        for _ in range(50):  # safety bound
+            result = chunker.read_chunk(text, offset)
+            if "no more content" in result:
+                break
+            content = result.split("\n---\n")[0]
+            parts.append(content)
+            offset += len(content)
+            if "has_more=False" in result:
+                break
+
+        assert "".join(parts) == text
+
 
 # ---------------------------------------------------------------------------
 # ProgressiveChunker — first_chunk metadata


### PR DESCRIPTION
## Summary

- `progressive._find_boundary` used `floor = max(floor_offset, target - int(span * 0.2))`. For `span <= 4`, `int(span * 0.2)` rounds down to `0`, so `floor == target` and the three backward-search loops collapse to a single position — making the boundary refinement a no-op and missing natural breaks at `target - 1` (most notably a `\n\n` paragraph boundary).
- Clamp the step to at least 1 so the search always has room to look back one character: `floor = max(floor_offset, target - max(1, int(span * 0.2)))`.

## Trigger

Reachable whenever progressive chunking works at a small span:

- Short fragments at content boundaries in `read_chunk`.
- User-configured small `chunk_size` with tiny input.
- Edge cases in `_find_boundary` on cursor continuations.

## Test plan

- [x] New unit test: `_find_boundary("ab\n\ncd", target=3)` must detect `\n\n` at index 2 (previously returned 4).
- [x] No-regression checks for non-boundary hard-cut and `span == 0`.
- [x] End-to-end integrity: `chunk_size=10` sequential reads reproduce the full input exactly.
- [x] `uv run pytest -m "not ollama"` — 1098 passed.
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.

Closes #69.