### PR TITLE
fix: bound per-server/tool counters in TokenTracker (#70)

### DIFF
--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -5,15 +5,63 @@ from __future__ import annotations
 import logging
 import math
 import time as _time
-from collections import defaultdict, deque
+from collections import OrderedDict, defaultdict, deque
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from memtomem_stm.proxy.metrics_store import MetricsStore
 
 logger = logging.getLogger(__name__)
+
+# LRU cap for per-(server|tool) aggregate counters. Bounds worst-case memory on
+# long-lived daemons or multi-tenant gateways where upstream names churn.
+MAX_TRACKED_KEYS = 10_000
+
+
+class _BoundedCounterDict:
+    """LRU-bounded counter map with defaultdict-style lazy insertion.
+
+    Bounds memory for long-lived trackers. When the size exceeds *max_size*,
+    the least-recently-touched key is evicted. Both ``__getitem__`` and
+    ``__setitem__`` count as a touch.
+    """
+
+    def __init__(self, factory: Callable[[], Any], max_size: int = MAX_TRACKED_KEYS) -> None:
+        self._data: OrderedDict[str, Any] = OrderedDict()
+        self._factory = factory
+        self._max_size = max_size
+
+    def __getitem__(self, key: str) -> Any:
+        if key in self._data:
+            self._data.move_to_end(key)
+            return self._data[key]
+        value = self._factory()
+        self._data[key] = value
+        if len(self._data) > self._max_size:
+            self._data.popitem(last=False)
+        return value
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = value
+        if len(self._data) > self._max_size:
+            self._data.popitem(last=False)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def items(self):
+        return self._data.items()
 
 
 class ErrorCategory(StrEnum):
@@ -114,7 +162,12 @@ class RPSTracker:
 class TokenTracker:
     """Aggregate proxy call metrics (in-memory + optional persistent store)."""
 
-    def __init__(self, metrics_store: MetricsStore | None = None) -> None:
+    def __init__(
+        self,
+        metrics_store: MetricsStore | None = None,
+        *,
+        max_tracked_keys: int = MAX_TRACKED_KEYS,
+    ) -> None:
         self._total_calls = 0
         self._total_original = 0
         self._total_compressed = 0
@@ -128,17 +181,20 @@ class TokenTracker:
         self._cache_misses = 0
         self._reconnects = 0
         self._metrics_store = metrics_store
-        self._by_server: dict[str, dict[str, int]] = defaultdict(
-            lambda: {"calls": 0, "original_chars": 0, "compressed_chars": 0}
+        self._by_server = _BoundedCounterDict(
+            lambda: {"calls": 0, "original_chars": 0, "compressed_chars": 0},
+            max_size=max_tracked_keys,
         )
-        self._by_tool: dict[str, dict[str, int]] = defaultdict(
-            lambda: {"calls": 0, "original_chars": 0, "compressed_chars": 0}
+        self._by_tool = _BoundedCounterDict(
+            lambda: {"calls": 0, "original_chars": 0, "compressed_chars": 0},
+            max_size=max_tracked_keys,
         )
         self._rps_tracker = RPSTracker()
         # Error tracking
         self._total_errors = 0
+        # _errors_by_category is bounded by the ErrorCategory enum — safe as defaultdict.
         self._errors_by_category: dict[str, int] = defaultdict(int)
-        self._errors_by_server: dict[str, int] = defaultdict(int)
+        self._errors_by_server = _BoundedCounterDict(int, max_size=max_tracked_keys)
         # Progressive delivery tracking
         self._progressive_first_chunks = 0
         self._progressive_continuations = 0

--- a/tests/test_metrics_bounds.py
+++ b/tests/test_metrics_bounds.py
@@ -1,0 +1,125 @@
+"""Tests for TokenTracker memory bounds (issue #70).
+
+Long-lived daemons and multi-tenant gateways can see churn in upstream
+server/tool names. The per-key aggregation maps must not grow without bound.
+"""
+
+from __future__ import annotations
+
+from memtomem_stm.proxy.metrics import (
+    MAX_TRACKED_KEYS,
+    CallMetrics,
+    ErrorCategory,
+    TokenTracker,
+    _BoundedCounterDict,
+)
+
+
+class TestBoundedCounterDict:
+    def test_lazy_insertion_with_factory(self):
+        d = _BoundedCounterDict(lambda: {"calls": 0}, max_size=5)
+        d["a"]["calls"] += 1
+        assert d["a"]["calls"] == 1
+
+    def test_evicts_oldest_past_max_size(self):
+        d = _BoundedCounterDict(int, max_size=3)
+        for key in ("a", "b", "c", "d"):
+            d[key] = 1
+        assert len(d) == 3
+        assert "a" not in d  # oldest inserted → evicted
+        assert {"b", "c", "d"} == set(iter(d))
+
+    def test_getitem_is_a_touch(self):
+        """Re-accessing a key should protect it from eviction (LRU)."""
+        d = _BoundedCounterDict(int, max_size=3)
+        d["a"] = 1
+        d["b"] = 1
+        d["c"] = 1
+        _ = d["a"]  # touch a → most recently used
+        d["d"] = 1  # evicts the LRU, which is now 'b'
+        assert "a" in d
+        assert "b" not in d
+        assert "c" in d
+        assert "d" in d
+
+    def test_setitem_is_a_touch(self):
+        d = _BoundedCounterDict(int, max_size=3)
+        d["a"] = 1
+        d["b"] = 1
+        d["c"] = 1
+        d["a"] = 2  # touch a
+        d["d"] = 1  # evicts 'b'
+        assert "a" in d and d["a"] == 2
+        assert "b" not in d
+
+    def test_increment_pattern_preserves_counts_until_eviction(self):
+        """Typical `d[k] += 1` pattern must work across repeated updates."""
+        d = _BoundedCounterDict(int, max_size=10)
+        for _ in range(5):
+            d["server"] += 1
+        assert d["server"] == 5
+
+    def test_eviction_happens_inside_getitem_for_new_key(self):
+        """Creating a new key via __getitem__ must also respect max_size."""
+        d = _BoundedCounterDict(lambda: {"n": 0}, max_size=2)
+        d["a"]["n"] = 1
+        d["b"]["n"] = 2
+        d["c"]["n"] = 3  # triggers __getitem__ path with new key
+        assert len(d) == 2
+        assert "a" not in d
+
+
+class TestTokenTrackerBounds:
+    def _metrics(self, server: str, tool: str = "t") -> CallMetrics:
+        return CallMetrics(
+            server=server, tool=tool, original_chars=10, compressed_chars=5
+        )
+
+    def test_by_server_respects_max_tracked_keys(self):
+        tracker = TokenTracker(max_tracked_keys=5)
+        for i in range(20):
+            tracker.record(self._metrics(f"srv{i}"))
+        summary = tracker.get_summary()
+        # Totals aggregate every call, per-server map is bounded.
+        assert summary["total_calls"] == 20
+        assert len(summary["by_server"]) == 5
+
+    def test_by_tool_respects_max_tracked_keys(self):
+        tracker = TokenTracker(max_tracked_keys=5)
+        for i in range(20):
+            tracker.record(self._metrics("srv", tool=f"tool{i}"))
+        # by_tool is internal; verify via attribute access for this test.
+        assert len(tracker._by_tool) == 5
+        # Aggregate totals remain accurate even after eviction.
+        assert tracker.get_summary()["total_calls"] == 20
+
+    def test_errors_by_server_respects_max_tracked_keys(self):
+        tracker = TokenTracker(max_tracked_keys=5)
+        for i in range(20):
+            m = CallMetrics(
+                server=f"srv{i}",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.PROTOCOL,
+            )
+            tracker.record_error(m)
+        assert len(tracker._errors_by_server) == 5
+        assert tracker.get_summary()["total_errors"] == 20
+
+    def test_default_max_is_10k(self):
+        assert MAX_TRACKED_KEYS == 10_000
+        tracker = TokenTracker()  # default cap
+        assert tracker._by_server._max_size == 10_000
+        assert tracker._by_tool._max_size == 10_000
+        assert tracker._errors_by_server._max_size == 10_000
+
+    def test_existing_server_counts_accumulate(self):
+        """LRU does not reset counts for keys that stay resident."""
+        tracker = TokenTracker(max_tracked_keys=100)
+        for _ in range(3):
+            tracker.record(self._metrics("stable"))
+        summary = tracker.get_summary()
+        assert summary["by_server"]["stable"]["calls"] == 3
+        assert summary["by_server"]["stable"]["original_chars"] == 30


### PR DESCRIPTION
## Summary

- `TokenTracker` kept three per-key `defaultdict` aggregation maps — `_by_server`, `_by_tool`, `_errors_by_server` — keyed by upstream server/tool names. On long-lived daemons, multi-tenant gateways, or sandboxes that generate tool names dynamically these grow without bound, and `get_summary()` slows down linearly with every distinct key ever observed.
- Introduce a small `_BoundedCounterDict` (OrderedDict-backed LRU with `defaultdict`-style lazy insertion) and apply it to the three affected maps. Default cap is **10 000 keys per map**, configurable via `TokenTracker(max_tracked_keys=...)`.
- `_errors_by_category` remains a plain `defaultdict(int)` since it is already bounded by the `ErrorCategory` enum.
- Totals (`total_calls`, `total_errors`, `total_original_chars`, …) continue to aggregate every call — only the per-key breakdown is subject to LRU eviction.

## Test plan

- [x] New `tests/test_metrics_bounds.py`:
  - `_BoundedCounterDict` LRU eviction order (both `__getitem__` and `__setitem__` count as touches).
  - `TokenTracker` respects `max_tracked_keys` for `_by_server`, `_by_tool`, `_errors_by_server`.
  - Totals remain accurate across 20 records with a cap of 5.
  - Resident keys' aggregated counts are preserved.
  - Default cap is 10 000.
- [x] `uv run pytest -m "not ollama"` — 1106 passed.
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src/memtomem_stm/proxy/metrics.py` — clean.

Closes #70.