### PR TITLE
test: lock in RelevanceScorer hot-reload behavior (#62)

### DIFF
--- a/tests/test_proxy_manager.py
+++ b/tests/test_proxy_manager.py
@@ -11,6 +11,7 @@ from memtomem_stm.proxy.config import (
     CleaningConfig,
     CompressionStrategy,
     ProxyConfig,
+    RelevanceScorerConfig,
     SelectiveConfig,
     ToolOverrideConfig,
     UpstreamServerConfig,
@@ -215,3 +216,79 @@ class TestToolConfigFrozen:
         )
         with pytest.raises(AttributeError):
             tc.compression = CompressionStrategy.TRUNCATE
+
+
+# ── RelevanceScorer hot-reload (regression for #62) ─────────────────────
+
+
+class TestRelevanceScorerHotReload:
+    def _make_manager(self, scorer_cfg: RelevanceScorerConfig, tmp_path) -> ProxyManager:
+        cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={},
+            relevance_scorer=scorer_cfg,
+        )
+        return ProxyManager(cfg, TokenTracker())
+
+    def test_cached_when_config_unchanged(self, tmp_path):
+        """Repeated access with no config change returns the same scorer instance."""
+        mgr = self._make_manager(RelevanceScorerConfig(scorer="bm25"), tmp_path)
+        first = mgr._relevance_scorer
+        second = mgr._relevance_scorer
+        assert first is second
+
+    def test_recreated_when_scorer_type_changes(self, tmp_path):
+        """Hot-reloading the scorer type must rebuild the instance."""
+        mgr = self._make_manager(RelevanceScorerConfig(scorer="bm25"), tmp_path)
+        before = mgr._relevance_scorer
+
+        new_cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={},
+            relevance_scorer=RelevanceScorerConfig(
+                scorer="embedding",
+                embedding_provider="ollama",
+                embedding_model="nomic-embed-text",
+            ),
+        )
+        mgr._config_loader.seed(new_cfg)
+
+        after = mgr._relevance_scorer
+        assert after is not before
+
+    def test_recreated_when_embedding_model_changes(self, tmp_path):
+        """Changing the embedding model on an embedding scorer must rebuild."""
+        mgr = self._make_manager(
+            RelevanceScorerConfig(scorer="embedding", embedding_model="nomic-embed-text"),
+            tmp_path,
+        )
+        before = mgr._relevance_scorer
+
+        new_cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={},
+            relevance_scorer=RelevanceScorerConfig(
+                scorer="embedding",
+                embedding_model="mxbai-embed-large",
+            ),
+        )
+        mgr._config_loader.seed(new_cfg)
+
+        after = mgr._relevance_scorer
+        assert after is not before
+
+    def test_not_recreated_when_unrelated_field_changes(self, tmp_path):
+        """Changing unrelated proxy config (e.g. upstream_servers) must not rebuild the scorer."""
+        scorer_cfg = RelevanceScorerConfig(scorer="bm25")
+        mgr = self._make_manager(scorer_cfg, tmp_path)
+        before = mgr._relevance_scorer
+
+        new_cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={"srv": UpstreamServerConfig(prefix="test")},
+            relevance_scorer=scorer_cfg,
+        )
+        mgr._config_loader.seed(new_cfg)
+
+        after = mgr._relevance_scorer
+        assert after is before


### PR DESCRIPTION
## Summary

Issue #62 reported that `ProxyManager._relevance_scorer` was frozen at `__init__` time and did not observe hot-reload changes to scorer type, embedding provider, model, or base URL. **The fix already landed on \`main\` in commit 288ceb9**, which replaced the attribute with a property that diffs the cached \`RelevanceScorerConfig\` against the current config and rebuilds when they differ. The issue remained open only because it was never linked to a PR.

This PR adds regression coverage so the behavior cannot silently regress.

## Invariants locked in

1. Repeated access with no config change returns the same scorer instance (caching works).
2. Changing the scorer type (\`bm25\` → \`embedding\`) rebuilds.
3. Changing the embedding model on an existing embedding scorer rebuilds.
4. Unrelated proxy config changes (e.g. \`upstream_servers\`) do not rebuild the scorer.

## Test plan

- [x] \`uv run pytest tests/test_proxy_manager.py -k HotReload\` — 4 new tests pass.
- [x] \`uv run pytest -m "not ollama"\` — 1099 passed, no regressions.
- [x] \`uv run ruff check src && uv run ruff format --check src\` — clean.

Closes #62.