### PR TITLE
chore(cla): record ayushi-wq signature for PR #87

### DIFF
--- a/signatures/v1/cla.json
+++ b/signatures/v1/cla.json
@@ -15,6 +15,14 @@
       "created_at": "2026-04-14T06:28:35Z",
       "repoId": 1205834997,
       "pullRequestNo": 39
+    },
+    {
+      "name": "ayushi-wq",
+      "id": 179132370,
+      "comment_id": 4245704490,
+      "created_at": "2026-04-14T16:56:52Z",
+      "repoId": 1205834997,
+      "pullRequestNo": 87
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Manually add ayushi-wq's CLA signature entry to `signatures/v1/cla.json` so PR #87 can unblock.

## Why this is manual
CLAAssistant bot tried to commit the signature automatically but hit branch protection on `main`:

```
##[error]Could not update the JSON file: Could not update file:
Changes must be made through a pull request. 3 of 3 required status checks are expected.
```

The bot still edited the PR comment to "All contributors have signed ✅" (false-positive), but the workflow exited 1, so the `CLAAssistant` check remains failing on #87.

A root-cause fix (admin PAT as secret for contributor-assistant, or ruleset bypass) will be tracked separately.

## Signing evidence
- User: `ayushi-wq` (id `179132370`)
- Comment: <https://github.com/memtomem/memtomem-stm/pull/87#issuecomment-4245704490>
- Content: "I have read the CLA Document and I hereby sign the CLA"
- Signed at: `2026-04-14T16:56:52Z`

## Test plan
- [ ] After merge, comment `recheck` on PR #87 and confirm `CLAAssistant` turns green.