### PR TITLE
ci(cla): wire PERSONAL_ACCESS_TOKEN so CLAAssistant can commit signatures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,12 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT from an admin account. The built-in GITHUB_TOKEN cannot push
+          # to `main` because branch protection requires status checks + a PR
+          # review, and GITHUB_TOKEN is not an admin actor. `enforce_admins`
+          # is false on this repo, so an admin PAT bypasses protection and
+          # lets the bot commit the signature JSON directly. See #89.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/v1/cla.json'
           path-to-document: 'https://github.com/memtomem/memtomem-stm/blob/main/CLA.md'


### PR DESCRIPTION
Closes #89 once the secret is in place and the e2e test passes.

## Summary
- Add `PERSONAL_ACCESS_TOKEN` env var to the CLAAssistant step.
- Inline comment documents why the built-in `GITHUB_TOKEN` is not enough.

## Why
`contributor-assistant/github-action` commits the updated `signatures/v1/cla.json` to `main` directly. The built-in `GITHUB_TOKEN` is not an admin actor, so branch protection on `main` (`required_status_checks: [lint, test, notebooks]` + 1 approving review) rejects the push. `enforce_admins` is `false`, so an admin PAT can bypass protection and let the commit through. See #89 for full context including the failing run from PR #87.

## Prerequisites before merging this PR

This PR only references `secrets.PERSONAL_ACCESS_TOKEN` — the secret itself still needs to be created. **Do not merge until all three are done:**

1. Generate a fine-grained PAT from the `memtomem` admin account:
   - Resource: `memtomem/memtomem-stm` only
   - Repository permissions: `Contents: write`, `Pull requests: write`
   - Expiry: longest allowed; note expiry on a calendar
2. Add the secret:
   ```bash
   gh secret set PERSONAL_ACCESS_TOKEN --repo memtomem/memtomem-stm
   ```
3. Verify: `gh secret list --repo memtomem/memtomem-stm` shows `PERSONAL_ACCESS_TOKEN`.

If the secret is absent when the bot runs, `${{ secrets.PERSONAL_ACCESS_TOKEN }}` expands to an empty string and the action falls back to `GITHUB_TOKEN` — i.e. the same broken behavior as today. Merging early is not unsafe, just ineffective.

## Test plan

- [ ] `PERSONAL_ACCESS_TOKEN` secret created and visible in `gh secret list`.
- [ ] Open a throwaway PR from a second account (e.g. `pandas-studio`) that has not yet signed the CLA.
- [ ] Post the sign comment on that PR.
- [ ] Confirm `signatures/v1/cla.json` gets a new entry committed to `main` **automatically** (no manual PR needed) and the `CLAAssistant` check turns green.
- [ ] Close the throwaway PR without merging; leave the signature entry in place.

## Not included here

- Scheduled workflow to alert on PAT expiry — can be added as a follow-up if a calendar reminder feels fragile.
- GitHub App migration — tracked as a separate follow-up issue referenced from #89.