### PR TITLE
ci(cla): pin remote-* inputs so PERSONAL_ACCESS_TOKEN actually gets used

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,6 +30,13 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/v1/cla.json'
+          # Pin the action's `isRemoteRepoOrOrgConfigured` branch to true even
+          # though signatures live in this same repo. Without these inputs the
+          # action ignores PERSONAL_ACCESS_TOKEN and uses GITHUB_TOKEN, which
+          # cannot bypass branch protection on `main`. See #89 for the source-
+          # code analysis (src/persistence/persistence.ts).
+          remote-organization-name: memtomem
+          remote-repository-name: memtomem-stm
           path-to-document: 'https://github.com/memtomem/memtomem-stm/blob/main/CLA.md'
           branch: 'main'
           allowlist: dependabot[bot],memtomem


### PR DESCRIPTION
Follow-on to #90. Discovered during the e2e test in #89: PR #90's `PERSONAL_ACCESS_TOKEN` wiring was correct but the action was ignoring it.

## Root cause

`contributor-assistant/github-action` only uses `PERSONAL_ACCESS_TOKEN` when `remote-organization-name` or `remote-repository-name` is set. Source ([persistence.ts](https://github.com/contributor-assistant/github-action/blob/v2.6.1/src/persistence/persistence.ts)):

\`\`\`ts
const octokitInstance =
  isRemoteRepoOrOrgConfigured() ? getPATOctokit() : getDefaultOctokitClient()

function isRemoteRepoOrOrgConfigured(): boolean {
  return !!(input.getRemoteRepoName() || input.getRemoteOrgName())
}
\`\`\`

With both inputs empty (the default for "store signatures in this same repo"), the action falls back to `GITHUB_TOKEN` regardless of whether `PERSONAL_ACCESS_TOKEN` is set. Branch protection then rejects the push, exactly as before #90.

## Fix

Set `remote-organization-name` and `remote-repository-name` to this repo's own coordinates. The action treats it as "remote", flips to PAT octokit, but ends up calling the same GitHub API endpoint — just authenticated as the PAT owner instead of `github-actions[bot]`. PAT bypasses branch protection because the PAT owner has admin role.

## Test plan

PR #92 stays open as the e2e harness:

- [ ] Merge this PR.
- [ ] Comment `recheck` on PR #92.
- [ ] Verify the bot commits a `pandas-studio` entry to `signatures/v1/cla.json` on `main` automatically (no manual PR).
- [ ] Verify CLAAssistant check on PR #92 turns green.
- [ ] Close PR #92, delete its branch and the `.cla-e2e-marker.md` file.

If this works, #89 is resolved. If it still fails, escalate to GitHub App migration (#91).