### PR TITLE
feat(relevance): extend BM25 tokenizer to Cyrillic/Arabic/Devanagari/Thai

### DIFF
--- a/src/memtomem_stm/proxy/relevance.py
+++ b/src/memtomem_stm/proxy/relevance.py
@@ -31,7 +31,18 @@ class BM25Scorer:
     basic suffix stemming. Zero external dependencies.
     """
 
-    _TOKEN_RE = re.compile(r"[a-zA-Z0-9\uac00-\ud7a3\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff_]+")
+    _TOKEN_RE = re.compile(
+        r"[a-zA-Z0-9"
+        r"\uac00-\ud7a3"  # Korean (Hangul syllables)
+        r"\u3040-\u309f"  # Hiragana
+        r"\u30a0-\u30ff"  # Katakana
+        r"\u4e00-\u9fff"  # CJK Unified Ideographs
+        r"\u0400-\u04ff"  # Cyrillic
+        r"\u0600-\u06ff"  # Arabic
+        r"\u0900-\u097f"  # Devanagari
+        r"\u0e00-\u0e7f"  # Thai
+        r"_]+"
+    )
     _SUFFIX_RE = re.compile(r"(ing|ed|ly|tion|ness|ment|ies|es|s)$")
     _HEADING_WEIGHT = 3.0
 

--- a/tests/test_query_aware.py
+++ b/tests/test_query_aware.py
@@ -77,6 +77,35 @@ class TestBM25Scorer:
         scores = scorer.score_sections("caching", sections)
         assert scores[0] > scores[1]
 
+    @pytest.mark.parametrize(
+        "query,matching_body,non_matching_body",
+        [
+            # Cyrillic (Russian)
+            ("кэширование", "Redis кэширование данных.", "PostgreSQL ACID транзакции."),
+            # Arabic
+            ("التخزين", "Redis التخزين المؤقت.", "قاعدة البيانات PostgreSQL."),
+            # Devanagari (Hindi)
+            ("कैशिंग", "Redis कैशिंग रणनीति.", "PostgreSQL डेटाबेस."),
+            # Thai
+            ("แคช", "Redis แคช ข้อมูล.", "ฐานข้อมูล PostgreSQL."),
+        ],
+    )
+    def test_non_ascii_scripts_tokenize(self, query, matching_body, non_matching_body):
+        """BM25 tokenizer recognizes Cyrillic, Arabic, Devanagari, and Thai.
+
+        Prior to the tokenizer Unicode expansion these scripts produced zero
+        tokens → BM25 score of 0.0 regardless of content, silently degrading
+        query-aware compression for multilingual users.
+        """
+        sections = [
+            ("## A", matching_body),
+            ("## B", non_matching_body),
+        ]
+        scorer = BM25Scorer()
+        scores = scorer.score_sections(query, sections)
+        assert scores[0] > 0.0
+        assert scores[0] > scores[1]
+
 
 # ── RelevanceScorer Protocol & Factory ─────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Extend `BM25Scorer._TOKEN_RE` with Cyrillic, Arabic, Devanagari, and Thai ranges so non-ASCII scripts actually produce tokens.
- Add parametrized tests proving matching vs. non-matching sections score correctly in each script.

## Why
Previously `_TOKEN_RE` only covered Latin/digits/Korean/Hiragana/Katakana/CJK. Text in the other major scripts produced zero tokens → BM25 score of 0.0 regardless of content. This silently degraded query-aware compression and surfacing for multilingual users (issue #49).

## Test plan
- [x] `uv run pytest tests/test_query_aware.py -v` passes (27 tests)
- [x] `uv run ruff check` + `ruff format --check` clean on changed files
- [x] Parametrized tests cover each new script (Cyrillic, Arabic, Devanagari, Thai)

Closes #49