### PR TITLE
refactor(surfacing): switch SurfacingCache to insertion-ordered FIFO eviction

### DIFF
--- a/src/memtomem_stm/surfacing/cache.py
+++ b/src/memtomem_stm/surfacing/cache.py
@@ -12,6 +12,10 @@ class SurfacingCache:
 
     Keyed by query hash. Avoids repeated LTM searches when the same
     tool is called with similar arguments in quick succession.
+
+    Eviction is insertion-ordered FIFO (matching ``InMemoryPendingStore``):
+    overflow drops the first-inserted entry in O(1). Expiry is handled
+    lazily on ``get()``.
     """
 
     def __init__(self, ttl: float = 60.0, max_entries: int = 200) -> None:
@@ -31,22 +35,17 @@ class SurfacingCache:
         return results
 
     def set(self, query: str, results: list[Any]) -> None:
-        if len(self._cache) >= self._max_entries:
-            self._evict()
-        self._cache[self._hash(query)] = (time.monotonic(), results)
+        key = self._hash(query)
+        # Re-insert to move an existing key to the tail (preserves FIFO order).
+        if key in self._cache:
+            del self._cache[key]
+        while len(self._cache) >= self._max_entries:
+            oldest_key = next(iter(self._cache))
+            del self._cache[oldest_key]
+        self._cache[key] = (time.monotonic(), results)
 
     def clear(self) -> None:
         self._cache.clear()
-
-    def _evict(self) -> None:
-        now = time.monotonic()
-        expired = [k for k, (ts, _) in self._cache.items() if now - ts > self._ttl]
-        for k in expired:
-            del self._cache[k]
-        # If still over limit, remove oldest
-        while len(self._cache) >= self._max_entries:
-            oldest = min(self._cache, key=lambda k: self._cache[k][0])
-            del self._cache[oldest]
 
     @staticmethod
     def _hash(query: str) -> str:

--- a/tests/test_surfacing_cache.py
+++ b/tests/test_surfacing_cache.py
@@ -42,15 +42,39 @@ class TestSurfacingCacheEviction:
         # Should have evicted oldest entries
         assert len(cache._cache) <= 3
 
-    def test_expired_entries_evicted_first(self):
+    def test_fifo_eviction_drops_first_inserted(self):
+        """Overflow drops the first-inserted entry, not an arbitrary one."""
+        cache = SurfacingCache(ttl=60.0, max_entries=3)
+        cache.set("q1", ["r1"])
+        cache.set("q2", ["r2"])
+        cache.set("q3", ["r3"])
+        cache.set("q4", ["r4"])  # evicts q1
+        assert cache.get("q1") is None
+        assert cache.get("q2") == ["r2"]
+        assert cache.get("q3") == ["r3"]
+        assert cache.get("q4") == ["r4"]
+
+    def test_reinsert_refreshes_order(self):
+        """Setting an existing key moves it to the tail (youngest position)."""
+        cache = SurfacingCache(ttl=60.0, max_entries=3)
+        cache.set("q1", ["r1"])
+        cache.set("q2", ["r2"])
+        cache.set("q3", ["r3"])
+        cache.set("q1", ["r1_new"])  # re-insert moves q1 to tail
+        cache.set("q4", ["r4"])  # evicts q2 (now the oldest), not q1
+        assert cache.get("q1") == ["r1_new"]
+        assert cache.get("q2") is None
+        assert cache.get("q3") == ["r3"]
+        assert cache.get("q4") == ["r4"]
+
+    def test_expired_entries_evicted_lazily_on_get(self):
+        """Expired entries are removed on get() rather than scanned on set()."""
         cache = SurfacingCache(ttl=0.01, max_entries=3)
         cache.set("old1", ["r1"])
-        cache.set("old2", ["r2"])
         time.sleep(0.02)
-        # These should evict expired entries
-        cache.set("new1", ["r3"])
-        cache.set("new2", ["r4"])
-        assert cache.get("new1") == ["r3"]
+        # Lazy expiry: get() returns None and deletes the entry in place
+        assert cache.get("old1") is None
+        assert "old1" not in {k for k in cache._cache}
 
 
 class TestSurfacingCacheClear:


### PR DESCRIPTION
## Summary
- Replace `SurfacingCache._evict()` scan + `min(...)` with Python 3.7+ insertion-ordered dict FIFO (O(1) per eviction via `next(iter(...))`).
- Move expiry to lazy check on `get()` — same pattern `InMemoryPendingStore` already uses.
- Re-inserting an existing key now moves it to the tail so age resets correctly.

## Why
The prior `_evict()` was O(n) per set when over capacity and duplicated logic we already have in `InMemoryPendingStore`. No user-visible impact at default `max_entries=200`, but the pattern is fragile if anyone tunes up the cap (issue #78).

## Test plan
- [x] `uv run pytest tests/test_surfacing_cache.py tests/test_surfacing_engine.py` — 42 passed
- [x] New tests cover FIFO eviction order, re-insert order refresh, lazy expiry via get()
- [x] `ruff check` + `ruff format --check` clean on changed files

Closes #78