### PR TITLE
perf(sqlite): centralize PRAGMA tuning across all long-lived stores

### DIFF
--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from memtomem_stm.utils.sqlite_tuning import tune_connection
+
 logger = logging.getLogger(__name__)
 
 _CREATE_TABLE = """
@@ -62,8 +64,7 @@ class ProxyCache:
             self._db_path.chmod(0o600)
         except OSError:
             pass
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA busy_timeout=3000")
+        tune_connection(self._db)
         self._db.execute(_CREATE_TABLE)
         self._db.execute(_CREATE_INDEX)
         self._db.commit()

--- a/src/memtomem_stm/proxy/compression_feedback_store.py
+++ b/src/memtomem_stm/proxy/compression_feedback_store.py
@@ -19,6 +19,8 @@ import threading
 import time
 from pathlib import Path
 
+from memtomem_stm.utils.sqlite_tuning import tune_connection
+
 logger = logging.getLogger(__name__)
 
 
@@ -90,8 +92,7 @@ class CompressionFeedbackStore:
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         self._db = sqlite3.connect(str(self._db_path), check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA busy_timeout=3000")
+        tune_connection(self._db)
         self._db.executescript(_SCHEMA)
         self._db.commit()
 

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 
 from memtomem_stm.proxy.metrics import CallMetrics
+from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +44,7 @@ class MetricsStore:
             self._db_path.chmod(0o600)
         except OSError:
             pass
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA busy_timeout=3000")
+        tune_connection(self._db)
         self._db.execute(_CREATE)
         self._db.execute(_INDEX)
         self._db.commit()

--- a/src/memtomem_stm/proxy/pending_store.py
+++ b/src/memtomem_stm/proxy/pending_store.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Protocol
 
 from memtomem_stm.proxy.compression import PendingSelection
+from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +87,7 @@ class SQLitePendingStore:
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         self._db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
-        self._db.execute("PRAGMA journal_mode=WAL")
+        tune_connection(self._db)
         self._db.execute(
             """CREATE TABLE IF NOT EXISTS pending_selections (
                 key TEXT PRIMARY KEY,

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -9,6 +9,8 @@ import threading
 import time
 from pathlib import Path
 
+from memtomem_stm.utils.sqlite_tuning import tune_connection
+
 logger = logging.getLogger(__name__)
 
 _SCHEMA = """
@@ -54,8 +56,7 @@ class FeedbackStore:
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         self._db = sqlite3.connect(str(self._db_path), check_same_thread=False)
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA busy_timeout=3000")
+        tune_connection(self._db)
         self._db.executescript(_SCHEMA)
 
     def close(self) -> None:

--- a/src/memtomem_stm/utils/sqlite_tuning.py
+++ b/src/memtomem_stm/utils/sqlite_tuning.py
@@ -1,0 +1,32 @@
+"""Shared PRAGMA tuning for long-lived SQLite stores.
+
+Every STM-owned SQLite connection opens under WAL and picks up the same
+baseline tuning: ``synchronous=NORMAL`` (saves one fsync per commit vs.
+``FULL`` — WAL is safe under ``NORMAL``; the worst case is losing the
+last committed transaction on OS-level power loss, acceptable for
+cache/metrics/feedback stores), a 64 MB page cache (default ~2 MB
+thrashes under moderate read load), and in-memory temp tables.
+
+Centralized so all stores share the same durability tradeoff and any
+future tuning lands in one place.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+BUSY_TIMEOUT_MS = 3000
+# Negative cache_size values are in KiB per SQLite docs; 64000 KiB = 64 MB.
+CACHE_SIZE_KIB = -64000
+
+
+def tune_connection(conn: sqlite3.Connection) -> None:
+    """Apply the standard STM PRAGMA tuning to ``conn``.
+
+    Idempotent — safe to call again on the same connection.
+    """
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute(f"PRAGMA cache_size={CACHE_SIZE_KIB}")
+    conn.execute("PRAGMA temp_store=MEMORY")

--- a/tests/test_sqlite_tuning.py
+++ b/tests/test_sqlite_tuning.py
@@ -1,0 +1,73 @@
+"""Tests for the shared SQLite PRAGMA tuning helper.
+
+Asserts that ``tune_connection`` actually applies the documented
+PRAGMAs (not just no-ops) so any future regression in the helper
+is caught immediately.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from memtomem_stm.utils.sqlite_tuning import (
+    BUSY_TIMEOUT_MS,
+    CACHE_SIZE_KIB,
+    tune_connection,
+)
+
+
+def _pragma(conn: sqlite3.Connection, name: str) -> object:
+    row = conn.execute(f"PRAGMA {name}").fetchone()
+    return row[0] if row else None
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def test_sets_wal_journal_mode(conn):
+    tune_connection(conn)
+    # SQLite returns "memory" for in-memory DBs even under WAL request,
+    # but non-memory DBs return "wal". Just check the call did not error
+    # and we can still query mode.
+    mode = _pragma(conn, "journal_mode")
+    assert mode in {"wal", "memory"}
+
+
+def test_sets_busy_timeout(conn):
+    tune_connection(conn)
+    assert _pragma(conn, "busy_timeout") == BUSY_TIMEOUT_MS
+
+
+def test_sets_synchronous_normal(conn):
+    tune_connection(conn)
+    # PRAGMA synchronous: 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA
+    assert _pragma(conn, "synchronous") == 1
+
+
+def test_sets_cache_size(conn):
+    tune_connection(conn)
+    assert _pragma(conn, "cache_size") == CACHE_SIZE_KIB
+
+
+def test_sets_temp_store_memory(conn):
+    tune_connection(conn)
+    # PRAGMA temp_store: 0=DEFAULT, 1=FILE, 2=MEMORY
+    assert _pragma(conn, "temp_store") == 2
+
+
+def test_idempotent(conn):
+    """Calling twice leaves PRAGMAs in the same state."""
+    tune_connection(conn)
+    tune_connection(conn)
+    assert _pragma(conn, "busy_timeout") == BUSY_TIMEOUT_MS
+    assert _pragma(conn, "synchronous") == 1
+    assert _pragma(conn, "cache_size") == CACHE_SIZE_KIB
+    assert _pragma(conn, "temp_store") == 2


### PR DESCRIPTION
## Summary
- Add `utils.sqlite_tuning.tune_connection()` applying `journal_mode=WAL`, `busy_timeout=3000`, `synchronous=NORMAL`, `cache_size=-64000` (64 MB), `temp_store=MEMORY`.
- Wire it into all five long-lived SQLite stores: proxy cache, metrics, compression feedback, pending selections, surfacing feedback.
- Add direct tests verifying each PRAGMA is actually applied and the helper is idempotent.

## Why
Existing stores set only `journal_mode=WAL` + `busy_timeout` independently. Three extra PRAGMAs matter for a daemon (issue #77):

- **`synchronous=NORMAL`** — saves one fsync per commit; safe under WAL (worst case loses the last committed transaction on OS-level power loss, acceptable for cache/metrics/feedback).
- **`cache_size=-64000`** — 64 MB page cache; default ~2 MB thrashes under moderate read load.
- **`temp_store=MEMORY`** — keeps sort/join scratch space off disk.

Centralized so all stores share the same durability tradeoff and future tuning lands in one place.

## Scope notes
- Skipped the "config override for users who need different tradeoffs" sub-proposal from the issue — adds complexity we haven't been asked for. Easy to add later once someone actually needs different tradeoffs.

## Test plan
- [x] `uv run pytest -m "not ollama"` — 1128 passed
- [x] New tests in `tests/test_sqlite_tuning.py` verify each PRAGMA value directly via `PRAGMA <name>` query
- [x] `ruff check` + `ruff format --check` clean

Closes #77