### PR TITLE
refactor(logging): demote expected-fallback warnings away from exc_info traces

### DIFF
--- a/src/memtomem_stm/proxy/compression_feedback.py
+++ b/src/memtomem_stm/proxy/compression_feedback.py
@@ -79,7 +79,11 @@ class CompressionFeedbackTracker:
                     server, tool, TRACE_LOOKUP_WINDOW_SECONDS
                 )
             except Exception:
-                logger.warning("trace_id lookup failed", exc_info=True)
+                # Expected fallback: trace_id is a best-effort correlation,
+                # not a hard requirement — the report still lands with
+                # trace_id=None. Demoted from warning to avoid treating a
+                # benign metrics-store query failure as an actionable error.
+                logger.debug("trace_id lookup failed", exc_info=True)
                 resolved_trace = None
 
         self._store.record(server, tool, kind, missing, resolved_trace)

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -802,7 +802,11 @@ class ProxyManager:
                     try:
                         await self._reconnect_server(server)
                     except Exception:
-                        logger.warning("Post-protocol-error reconnect failed", exc_info=True)
+                        # Expected fallback: the primary error is already being
+                        # re-raised and carries the actionable trace. The
+                        # reconnect attempt here is best-effort for the NEXT
+                        # call — a failure is noise for current operators.
+                        logger.debug("Post-protocol-error reconnect failed", exc_info=True)
                     raise
 
                 if attempt >= cfg.max_retries:
@@ -826,7 +830,10 @@ class ProxyManager:
                     try:
                         await self._reconnect_server(server)
                     except Exception:
-                        logger.warning("Post-failure reconnect failed", exc_info=True)
+                        # Same reasoning as the protocol-error path above:
+                        # the primary failure is being re-raised, the
+                        # reconnect attempt is just pre-emptive cleanup.
+                        logger.debug("Post-failure reconnect failed", exc_info=True)
                     raise
                 logger.warning(
                     "Tool call %s/%s failed (attempt %d/%d): %s",

--- a/src/memtomem_stm/proxy/relevance.py
+++ b/src/memtomem_stm/proxy/relevance.py
@@ -129,9 +129,13 @@ class EmbeddingScorer:
 
         try:
             return self._score_via_embedding(query, sections)
-        except Exception:
+        except Exception as exc:
+            # Expected fallback path (Ollama offline, network hiccup, timeout):
+            # we already have a working BM25 scorer and fallback_count surfaces
+            # the rate. Full stack on every hit buries real errors in log-
+            # aggregation pipelines, so log the exception message only.
             self.fallback_count += 1
-            logger.warning("EmbeddingScorer failed, falling back to BM25", exc_info=True)
+            logger.warning("EmbeddingScorer failed, falling back to BM25: %s", exc)
             return self._fallback.score_sections(query, sections)
 
     def _score_via_embedding(self, query: str, sections: list[tuple[str, str]]) -> list[float]:


### PR DESCRIPTION
## Summary
Audited every `exc_info=True` site in `src/` and demoted the four that are expected-fallback paths, keeping the other ~22 as actionable warnings. Each demoted site gets an inline comment explaining the classification so intent survives future edits.

## Changes
- **`relevance.py:134`** — `EmbeddingScorer` falling back to BM25 is the textbook expected fallback (Ollama offline / transient network). Drop `exc_info`, include exception message inline. `fallback_count` already tracks rate.
- **`manager.py:805`** — "Post-protocol-error reconnect failed": demote to debug. The primary error is being re-raised with its own trace; the reconnect is best-effort cleanup for the next call.
- **`manager.py:829`** — "Post-failure reconnect failed": same reasoning.
- **`compression_feedback.py:82`** — `trace_id` lookup is a best-effort correlation; feedback still records with `trace_id=None` on failure. Demote to debug.

All ~22 other sites stay at `warning + exc_info` — they're genuine errors (DB write failures, startup/shutdown errors, top-level surfacing failures, FastMCP API incompatibility, fact extraction failures) where a trace is actionable.

## Why
Per issue #71 guiding principle: stack traces in logs should mean "something is wrong." Expected fallbacks producing traces condition operators to ignore traces and devalue the signal when a real error finally does appear. Langfuse / Sentry pipelines also generate false-positive alerts on these.

## Test plan
- [x] `uv run pytest -m "not ollama"` — 1122 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] Classification documented inline at each demoted site

Closes #71