### PR TITLE
docs: document OPENAI_API_KEY requirement for OpenAI embedding provider

### DIFF
--- a/docs/compression.md
+++ b/docs/compression.md
@@ -271,6 +271,8 @@ When an agent provides `_context_query` in tool arguments, compression allocates
 
 `RelevanceScorer` protocol (`proxy/relevance.py`) enables custom scorer implementations. `EmbeddingScorer` uses sync httpx to call embedding APIs with automatic BM25 fallback on error.
 
+> **OpenAI provider requires `OPENAI_API_KEY`.** When `embedding_provider: "openai"`, `EmbeddingScorer` reads the API key from the `OPENAI_API_KEY` environment variable. Missing or empty keys produce HTTP 401 from the OpenAI endpoint and trigger the BM25 fallback. Ollama (the default) needs no key.
+
 ## Per-Server and Per-Tool Overrides
 
 ```json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,8 +50,10 @@ export MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__SCORER=bm25           # "bm25" or "
 export MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__EMBEDDING_PROVIDER=ollama
 export MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__EMBEDDING_MODEL=nomic-embed-text
 export MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__EMBEDDING_BASE_URL=http://localhost:11434
-# When embedding_provider is "openai", set OPENAI_API_KEY:
-# export OPENAI_API_KEY=sk-...
+
+# Required when embedding_provider="openai" — the scorer reads this from the
+# environment and falls back to BM25 with an HTTP 401 if missing.
+export OPENAI_API_KEY=sk-...
 
 # Extraction (Stage 4b — auto fact extraction)
 export MEMTOMEM_STM_PROXY__EXTRACTION__ENABLED=false


### PR DESCRIPTION
## Summary

- `EmbeddingScorer._embed_openai()` reads `OPENAI_API_KEY` from `os.environ`; missing/empty key produces HTTP 401 and the scorer falls back to BM25. This was only documented inside the `RelevanceScorerConfig` docstring, leaving `docs/configuration.md` and `docs/compression.md` readers without a signal.
- `docs/configuration.md`: promote the env-var comment to a real `export` with a short note on the fallback behaviour.
- `docs/compression.md`: add a prose note under **Query-Aware Compression** next to the scorer comparison table.

Closes #56

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src`
- [x] Manually reviewed markdown rendering