### PR TITLE
docs: clarify auto-tune feedback direction in surfacing docs

### DIFF
--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -222,12 +222,15 @@ stm_surfacing_feedback(surfacing_id="ghi789", rating="already_known")
 
 Valid ratings: `helpful`, `not_relevant`, `already_known`.
 
-When auto-tuning is enabled (default), STM adjusts `min_score` per tool based on feedback:
+When auto-tuning is enabled (default), STM adjusts `min_score` per tool based on feedback. In plain terms: **`not_relevant` ratings push `min_score` up** (surfacing becomes more selective), while a run of **`helpful`/`already_known` ratings pushes it down** (surfacing becomes more inclusive) because they keep the `not_relevant` ratio low. Concretely:
 
 | Feedback ratio | Action |
 |----------------|--------|
 | > 60% `not_relevant` | Raise `min_score` by +0.002 (surface fewer, more relevant) |
 | < 20% `not_relevant` | Lower `min_score` by -0.002 (surface more) |
+| 20–60% `not_relevant` | Hold current `min_score` |
+
+Adjustment step is `auto_tune_score_increment` (default `0.002`) and the tuned score is clamped to `[0.005, 0.05]`.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Summary

- The **Feedback & Auto-Tuning** section in `docs/surfacing.md` previously showed the `not_relevant`-ratio thresholds, but did not state in plain English which way `helpful` ratings push `min_score`. Readers had to reason through the ratio logic to predict the direction.
- Add a one-sentence explanation (helpful/already_known → lower; not_relevant → higher).
- Surface the **20–60 %** hold band as an explicit table row (previously only in the mermaid diagram).
- Restate the adjustment step (`auto_tune_score_increment`, default `0.002`) and the clamp range `[0.005, 0.05]` right next to the table.

Closes #57

## Test plan

- [x] Manually reviewed markdown rendering
- [x] No code changes; lint/test unaffected