### PR TITLE
fix(config): add pydantic Field/Literal constraints to prevent unsafe values

### DIFF
--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-from pydantic import BaseModel
 
 from memtomem_stm.proxy.config import ProxyConfig
 from memtomem_stm.surfacing.config import SurfacingConfig
@@ -22,6 +20,15 @@ class LangfuseConfig(BaseModel):
     host: str = ""
     sampling_rate: float = Field(default=1.0, ge=0.0, le=1.0)
     """Fraction of proxy calls to trace (0.0–1.0).  Default 1.0 = all."""
+
+    @model_validator(mode="after")
+    def _require_keys_when_enabled(self) -> "LangfuseConfig":
+        if self.enabled and not (self.public_key and self.secret_key):
+            raise ValueError(
+                "LangfuseConfig.enabled=true requires both public_key and secret_key "
+                "to be set (non-empty)."
+            )
+        return self
 
 
 class STMConfig(BaseSettings):

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -6,7 +6,7 @@ import json
 import logging
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -52,7 +52,7 @@ class LLMCompressorConfig(BaseModel):
         "Summarize the following content concisely, preserving all key information. "
         "Keep the summary under {max_chars} characters."
     )
-    max_tokens: int = 500
+    max_tokens: int = Field(default=500, gt=0)
 
 
 class CleaningConfig(BaseModel):
@@ -73,15 +73,15 @@ class HybridConfig(BaseModel):
 class SelectiveConfig(BaseModel):
     max_pending: int = Field(default=100, gt=0)
     pending_ttl_seconds: float = Field(default=300.0, ge=0.0)
-    json_depth: int = 1
-    min_section_chars: int = 50
-    pending_store: str = "memory"  # "memory" | "sqlite"
+    json_depth: int = Field(default=1, gt=0)
+    min_section_chars: int = Field(default=50, ge=0)
+    pending_store: Literal["memory", "sqlite"] = "memory"
     pending_store_path: Path = Path("~/.memtomem/pending_selections.db")
 
 
 class AutoIndexConfig(BaseModel):
     enabled: bool = False
-    min_chars: int = 2000
+    min_chars: int = Field(default=2000, ge=0)
     memory_dir: Path = Path("~/.memtomem/proxy_index")
     namespace: str = "proxy-{server}"
 
@@ -127,13 +127,13 @@ class ExtractionConfig(BaseModel):
     enabled: bool = False
     strategy: ExtractionStrategy = ExtractionStrategy.LLM
     llm: LLMCompressorConfig | None = None
-    max_facts: int = 10
-    min_response_chars: int = 500
-    dedup_threshold: float = 0.92
+    max_facts: int = Field(default=10, gt=0)
+    min_response_chars: int = Field(default=500, ge=0)
+    dedup_threshold: float = Field(default=0.92, ge=0.0, le=1.0)
     memory_dir: Path = Path("~/.memtomem/extracted_facts")
     namespace: str = "facts-{server}"
     background: bool = True
-    max_input_chars: int = 20000
+    max_input_chars: int = Field(default=20000, gt=0)
 
     def effective_llm(self) -> LLMCompressorConfig:
         """Return user-provided LLM config or the default (Ollama qwen3:4b)."""
@@ -295,7 +295,7 @@ class RelevanceScorerConfig(BaseModel):
     """Embedding API base URL. Defaults to the provider's standard endpoint
     (Ollama → http://localhost:11434, OpenAI → https://api.openai.com).
     Only used when scorer="embedding"."""
-    embedding_timeout: float = 10.0
+    embedding_timeout: float = Field(default=10.0, gt=0.0)
     """Embedding API timeout in seconds."""
 
     @model_validator(mode="after")

--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from memtomem_stm.proxy.config import MODEL_CONTEXT_WINDOWS
 
@@ -15,8 +16,8 @@ class ToolSurfacingConfig(BaseModel):
     enabled: bool = True
     query_template: str = ""
     namespace: str | None = None
-    min_score: float | None = None
-    max_results: int | None = None
+    min_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    max_results: int | None = Field(default=None, gt=0)
 
 
 class SurfacingConfig(BaseModel):
@@ -35,12 +36,12 @@ class SurfacingConfig(BaseModel):
     ``MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH``."""
     ltm_mcp_command: str = "memtomem-server"
     ltm_mcp_args: list[str] = []
-    min_score: float = 0.02
-    max_results: int = 3
-    min_query_tokens: int = 3
-    cooldown_seconds: float = 5.0
-    timeout_seconds: float = 3.0
-    injection_mode: str = "prepend"  # prepend | append | section
+    min_score: float = Field(default=0.02, ge=0.0, le=1.0)
+    max_results: int = Field(default=3, gt=0)
+    min_query_tokens: int = Field(default=3, gt=0)
+    cooldown_seconds: float = Field(default=5.0, ge=0.0)
+    timeout_seconds: float = Field(default=3.0, gt=0.0)
+    injection_mode: Literal["prepend", "append", "section"] = "prepend"
     section_header: str = "## Relevant Memories"
     default_namespace: str | None = None
     exclude_tools: list[str] = []
@@ -54,21 +55,23 @@ class SurfacingConfig(BaseModel):
     ]
     context_tools: dict[str, ToolSurfacingConfig] = {}
     feedback_enabled: bool = True
-    max_surfacings_per_minute: int = 15
-    cache_ttl_seconds: float = 60.0
-    circuit_max_failures: int = 3
-    circuit_reset_seconds: float = 60.0
+    max_surfacings_per_minute: int = Field(default=15, gt=0)
+    cache_ttl_seconds: float = Field(default=60.0, ge=0.0)
+    circuit_max_failures: int = Field(default=3, ge=0)
+    circuit_reset_seconds: float = Field(default=60.0, gt=0.0)
     auto_tune_enabled: bool = True
-    auto_tune_min_samples: int = 20
-    auto_tune_score_increment: float = 0.002
-    min_response_chars: int = 5000
+    auto_tune_min_samples: int = Field(default=20, gt=0)
+    auto_tune_score_increment: float = Field(default=0.002, gt=0.0)
+    min_response_chars: int = Field(default=5000, ge=0)
     include_session_context: bool = True
     fire_webhook: bool = True
-    max_injection_chars: int = 3000
-    context_window_size: int = 0  # 0=disabled; >0 expands ±N adjacent chunks
-    dedup_ttl_seconds: float = 604800.0  # 7 days
+    max_injection_chars: int = Field(default=3000, gt=0)
+    context_window_size: int = Field(default=0, ge=0)
+    """0=disabled; >0 expands ±N adjacent chunks."""
+    dedup_ttl_seconds: float = Field(default=604800.0, ge=0.0)
+    """7 days default; 0 disables cross-session dedup."""
     consumer_model: str = ""
-    result_format: str = "compact"
+    result_format: Literal["compact", "structured"] = "compact"
     """Parser format for mem_search output. ``compact`` is the legacy
     core format (``[rank] score | source``). ``structured`` selects the
     machine-parseable JSON format (``{"results": [...]}``) with automatic

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -1,0 +1,137 @@
+"""Tests that unsafe config values are rejected by pydantic validators."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from memtomem_stm.config import LangfuseConfig
+from memtomem_stm.proxy.config import (
+    AutoIndexConfig,
+    ExtractionConfig,
+    LLMCompressorConfig,
+    RelevanceScorerConfig,
+    SelectiveConfig,
+)
+from memtomem_stm.surfacing.config import SurfacingConfig
+
+
+class TestProxyNumericConstraints:
+    def test_llm_compressor_rejects_nonpositive_max_tokens(self) -> None:
+        with pytest.raises(ValidationError):
+            LLMCompressorConfig(max_tokens=0)
+        with pytest.raises(ValidationError):
+            LLMCompressorConfig(max_tokens=-10)
+
+    def test_selective_json_depth_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            SelectiveConfig(json_depth=0)
+        with pytest.raises(ValidationError):
+            SelectiveConfig(json_depth=-1)
+        SelectiveConfig(json_depth=1)  # minimum valid
+
+    def test_selective_min_section_chars_nonnegative(self) -> None:
+        with pytest.raises(ValidationError):
+            SelectiveConfig(min_section_chars=-1)
+        SelectiveConfig(min_section_chars=0)  # zero allowed (passthrough)
+
+    def test_selective_pending_store_literal_rejects_typo(self) -> None:
+        with pytest.raises(ValidationError):
+            SelectiveConfig(pending_store="memry")  # type: ignore[arg-type]
+        SelectiveConfig(pending_store="memory")
+        SelectiveConfig(pending_store="sqlite")
+
+    def test_extraction_rejects_invalid_ranges(self) -> None:
+        with pytest.raises(ValidationError):
+            ExtractionConfig(max_facts=0)
+        with pytest.raises(ValidationError):
+            ExtractionConfig(min_response_chars=-1)
+        with pytest.raises(ValidationError):
+            ExtractionConfig(dedup_threshold=1.5)
+        with pytest.raises(ValidationError):
+            ExtractionConfig(dedup_threshold=-0.1)
+        with pytest.raises(ValidationError):
+            ExtractionConfig(max_input_chars=0)
+
+    def test_auto_index_min_chars_nonnegative(self) -> None:
+        with pytest.raises(ValidationError):
+            AutoIndexConfig(min_chars=-100)
+        AutoIndexConfig(min_chars=0)  # zero = index everything
+
+    def test_relevance_scorer_embedding_timeout_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            RelevanceScorerConfig(embedding_timeout=0.0)
+        with pytest.raises(ValidationError):
+            RelevanceScorerConfig(embedding_timeout=-1.0)
+
+
+class TestSurfacingNumericConstraints:
+    def test_surfacing_min_score_range(self) -> None:
+        with pytest.raises(ValidationError):
+            SurfacingConfig(min_score=-0.01)
+        with pytest.raises(ValidationError):
+            SurfacingConfig(min_score=1.5)
+
+    def test_surfacing_timeouts_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            SurfacingConfig(timeout_seconds=0.0)
+        with pytest.raises(ValidationError):
+            SurfacingConfig(timeout_seconds=-1.0)
+        with pytest.raises(ValidationError):
+            SurfacingConfig(circuit_reset_seconds=0.0)
+
+    def test_surfacing_cooldown_nonnegative(self) -> None:
+        with pytest.raises(ValidationError):
+            SurfacingConfig(cooldown_seconds=-1.0)
+        SurfacingConfig(cooldown_seconds=0.0)  # 0 disables cooldown
+
+    def test_surfacing_auto_tune_increment_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            SurfacingConfig(auto_tune_score_increment=0.0)
+        with pytest.raises(ValidationError):
+            SurfacingConfig(auto_tune_score_increment=-0.01)
+
+    def test_surfacing_counts_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            SurfacingConfig(max_results=0)
+        with pytest.raises(ValidationError):
+            SurfacingConfig(max_surfacings_per_minute=0)
+        with pytest.raises(ValidationError):
+            SurfacingConfig(max_injection_chars=0)
+        with pytest.raises(ValidationError):
+            SurfacingConfig(min_query_tokens=0)
+
+    def test_surfacing_context_window_nonnegative(self) -> None:
+        with pytest.raises(ValidationError):
+            SurfacingConfig(context_window_size=-1)
+        SurfacingConfig(context_window_size=0)  # 0 disables
+
+    def test_surfacing_injection_mode_literal(self) -> None:
+        with pytest.raises(ValidationError):
+            SurfacingConfig(injection_mode="postpend")  # type: ignore[arg-type]
+        for mode in ("prepend", "append", "section"):
+            SurfacingConfig(injection_mode=mode)  # type: ignore[arg-type]
+
+    def test_surfacing_result_format_literal(self) -> None:
+        with pytest.raises(ValidationError):
+            SurfacingConfig(result_format="json")  # type: ignore[arg-type]
+        SurfacingConfig(result_format="compact")
+        SurfacingConfig(result_format="structured")
+
+
+class TestLangfuseInterdepValidator:
+    def test_enabled_requires_both_keys(self) -> None:
+        with pytest.raises(ValidationError, match="public_key and secret_key"):
+            LangfuseConfig(enabled=True)
+        with pytest.raises(ValidationError, match="public_key and secret_key"):
+            LangfuseConfig(enabled=True, public_key="pk-lf-x")
+        with pytest.raises(ValidationError, match="public_key and secret_key"):
+            LangfuseConfig(enabled=True, secret_key="sk-lf-x")
+
+    def test_enabled_with_both_keys_ok(self) -> None:
+        cfg = LangfuseConfig(enabled=True, public_key="pk-lf-x", secret_key="sk-lf-x")
+        assert cfg.enabled is True
+
+    def test_disabled_allows_empty_keys(self) -> None:
+        cfg = LangfuseConfig(enabled=False)
+        assert cfg.public_key == ""


### PR DESCRIPTION
## Summary

Several pydantic models silently accepted values that break at runtime (negative timeouts passed to `httpx` / `asyncio.wait_for`, thresholds outside `[0, 1]` passed to similarity dedup, `Literal`-typo strings falling through to default branches, Langfuse `enabled=true` with empty auth keys).

This mirrors the existing pattern already used by `HybridConfig` / `ProgressiveConfig` / `ToolOverrideConfig` and extends it to the remaining config classes.

## Changes

- **`proxy/config.py`**
  - `LLMCompressorConfig.max_tokens`: `gt=0`
  - `SelectiveConfig`: `json_depth` `gt=0`, `min_section_chars` `ge=0`, `pending_store` → `Literal["memory", "sqlite"]`
  - `AutoIndexConfig.min_chars`: `ge=0`
  - `ExtractionConfig`: `max_facts` `gt=0`, `min_response_chars` `ge=0`, `dedup_threshold` `[0.0, 1.0]`, `max_input_chars` `gt=0`
  - `RelevanceScorerConfig.embedding_timeout`: `gt=0.0`
- **`surfacing/config.py`**
  - `SurfacingConfig`: `min_score` `[0.0, 1.0]`; positive-only for `max_results`, `max_surfacings_per_minute`, `max_injection_chars`, `min_query_tokens`, `timeout_seconds`, `auto_tune_score_increment`, `auto_tune_min_samples`, `circuit_reset_seconds`; non-negative for `cooldown_seconds`, `cache_ttl_seconds`, `circuit_max_failures`, `min_response_chars`, `context_window_size`, `dedup_ttl_seconds`; `injection_mode` → `Literal[prepend|append|section]`; `result_format` → `Literal[compact|structured]`
  - `ToolSurfacingConfig`: `min_score` `[0.0, 1.0]`, `max_results` `gt=0`
- **`config.py`**
  - `LangfuseConfig`: `@model_validator(mode="after")` rejects `enabled=true` with empty `public_key` or `secret_key` — previously passed validation and the Langfuse SDK errored on auth only at the first trace attempt.
- **`tests/test_config_constraints.py`** — 18 cases covering representative rejections + the Langfuse interdep.

## Background

Discovered in a round-1 config-invariant audit (same pattern as open issue #44, which stays open for the `reconnect_delay_seconds ≤ max_reconnect_delay_seconds` pair validator that needs a custom `@model_validator` rather than a `Field(...)` annotation).

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — pass
- [x] `uv run pytest -m "not ollama"` — **1217 passed** (1199 existing + 18 new)
- [x] No behavior change for valid configs — all previously-passing tests still green