### PR TITLE
perf: hoist hot-path regex compilation to module level

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -30,13 +30,19 @@ logger = logging.getLogger(__name__)
 QueryRelevanceScorer = BM25Scorer
 
 
+_HEADINGS_RE = re.compile(r"(?:^|\n)#{1,6}\s")
+_CODE_FENCE_RE = re.compile(r"```")
+_LIST_ITEM_RE = re.compile(r"(?:^|\n)\s*[-*]\s")
+_LINK_RE = re.compile(r"\[.*?\]\(.*?\)")
+
+
 def _content_summary(text: str) -> str:
     """Count structural elements in the original text for truncation metadata."""
     counts: list[str] = []
-    headings = len(re.findall(r"(?:^|\n)#{1,6}\s", text))
-    code_blocks = len(re.findall(r"```", text)) // 2
-    list_items = len(re.findall(r"(?:^|\n)\s*[-*]\s", text))
-    links = len(re.findall(r"\[.*?\]\(.*?\)", text))
+    headings = len(_HEADINGS_RE.findall(text))
+    code_blocks = len(_CODE_FENCE_RE.findall(text)) // 2
+    list_items = len(_LIST_ITEM_RE.findall(text))
+    links = len(_LINK_RE.findall(text))
     if headings:
         counts.append(f"{headings} headings")
     if code_blocks:

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -48,6 +48,13 @@ class ResultParser:
         raise NotImplementedError
 
 
+_BLOCK_SPLIT_RE = re.compile(r"^(?=\[\d+\]\s+\d+\.?\d*\s*\|)", flags=re.MULTILINE)
+_HEADER_RE = re.compile(r"\[(\d+)\]\s+(\d+\.?\d*)\s*\|(.+)")
+_NS_RE = re.compile(r"\[([^\]]+)\]\s*(.*)")
+_RANK_SUFFIX_RE = re.compile(r"\s*\[\d+/\d+\]\s*$")
+_FIRST_TOKEN_RE = re.compile(r"(\S+)")
+
+
 class CompactResultParser(ResultParser):
     """Parse core's compact format: ``[rank] score | source > hierarchy``."""
 
@@ -56,7 +63,7 @@ class CompactResultParser(ResultParser):
         if not text or not text.strip():
             return results
 
-        blocks = re.split(r"^(?=\[\d+\]\s+\d+\.?\d*\s*\|)", text, flags=re.MULTILINE)
+        blocks = _BLOCK_SPLIT_RE.split(text)
 
         for block in blocks:
             block = block.strip()
@@ -65,23 +72,23 @@ class CompactResultParser(ResultParser):
 
             first_line, _, rest = block.partition("\n")
 
-            header_match = re.match(r"\[(\d+)\]\s+(\d+\.?\d*)\s*\|(.+)", first_line)
+            header_match = _HEADER_RE.match(first_line)
             if not header_match:
                 continue
 
             score = float(header_match.group(2))
             remainder = header_match.group(3).strip()
 
-            ns_match = re.match(r"\[([^\]]+)\]\s*(.*)", remainder)
+            ns_match = _NS_RE.match(remainder)
             if ns_match:
                 namespace = ns_match.group(1)
                 remainder = ns_match.group(2)
             else:
                 namespace = "default"
 
-            remainder = re.sub(r"\s*\[\d+/\d+\]\s*$", "", remainder)
+            remainder = _RANK_SUFFIX_RE.sub("", remainder)
 
-            source_match = re.match(r"(\S+)", remainder)
+            source_match = _FIRST_TOKEN_RE.match(remainder)
             source = source_match.group(1) if source_match else "unknown"
 
             content = rest.strip() if rest else ""


### PR DESCRIPTION
## Summary

Two utilities on the compression / surfacing hot path compiled regex patterns **inline on every call**:

- ``compression._content_summary`` — 4 ``re.findall`` calls with literal patterns (headings, code fences, list items, links). Invoked for every compressed response's truncation metadata.
- ``CompactResultParser.parse`` — 5 inline ``re.split`` / ``re.match`` / ``re.sub`` calls. Invoked once per mem_search response.

Both sites already had module-level siblings elsewhere in the same modules (``TruncateCompressor._HEADING_RE`` etc.), so the pattern is consistent with local style.

## Changes

- `src/memtomem_stm/proxy/compression.py`: added `_HEADINGS_RE`, `_CODE_FENCE_RE`, `_LIST_ITEM_RE`, `_LINK_RE` at module level; `_content_summary` uses the cached objects.
- `src/memtomem_stm/surfacing/mcp_client.py`: added `_BLOCK_SPLIT_RE`, `_HEADER_RE`, `_NS_RE`, `_RANK_SUFFIX_RE`, `_FIRST_TOKEN_RE`; `CompactResultParser.parse` uses them.

## Verification

- [x] ``uv run ruff check src && uv run ruff format --check src``
- [x] ``uv run pytest -m "not ollama"`` — **1199 passed** (no behavior change)
- [x] All regex flags preserved (e.g. `re.MULTILINE` on `_BLOCK_SPLIT_RE`)