### PR TITLE
fix(surfacing): cap _boosted_event_ids growth with FIFO eviction

### DIFF
--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -190,6 +190,7 @@ Surfacing tracks which memory IDs have already been shown so the same content do
 | Layer | Storage | Purpose | Eviction |
 |-------|---------|---------|----------|
 | In-memory `_surfaced_ids` | Insertion-ordered `dict` on the `SurfacingEngine` | Skip IDs already surfaced in this process | Bulk prune to ~5,000 entries when size exceeds **10,000** (FIFO — oldest insertions go first) |
+| In-memory `_boosted_event_ids` | Insertion-ordered `dict` on the `SurfacingEngine` | Ensure each surfacing event's `access_count` boost fires exactly once, even across repeated `helpful` ratings | Bulk prune to ~5,000 when size exceeds **10,000** (same FIFO as `_surfaced_ids`) |
 | Persistent `seen_memories` | SQLite row in `stm_feedback.db` | Skip IDs surfaced in a prior session within `dedup_ttl_seconds` | TTL-based (default 7 days; `0` disables) |
 
 The in-memory set is **seeded from `seen_memories`** on startup so dedup survives restarts within the TTL, and every new surfacing writes to both layers via `FeedbackStore.mark_surfaced(ids)`.

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -75,8 +75,10 @@ class SurfacingEngine:
                 logger.warning("Failed to load cross-session seen IDs", exc_info=True)
         # In-memory boost guard — at most one mem_do(increment_access) call
         # per surfacing event, even if the agent fires multiple "helpful"
-        # ratings for it.
-        self._boosted_event_ids: set[str] = set()
+        # ratings for it. Insertion-ordered dict for FIFO eviction; cap at
+        # 10k matches the sibling _surfaced_ids bound.
+        self._boosted_event_ids: dict[str, None] = {}
+        self._boosted_event_ids_max = 10000
         self._background_tasks: set[asyncio.Task] = set()
         # Opportunistic cleanup: run cleanup_expired at most once per hour
         self._cleanup_interval = 3600.0
@@ -177,7 +179,12 @@ class SurfacingEngine:
                         },
                     ):
                         await self._mcp_adapter.increment_access(target_ids)
-                    self._boosted_event_ids.add(surfacing_id)
+                    self._boosted_event_ids[surfacing_id] = None
+                    # Prune if exceeded cap — evict oldest (first-inserted) entries.
+                    if len(self._boosted_event_ids) > self._boosted_event_ids_max:
+                        excess = len(self._boosted_event_ids) - self._boosted_event_ids_max // 2
+                        for k in list(self._boosted_event_ids)[:excess]:
+                            del self._boosted_event_ids[k]
             except Exception:
                 logger.debug(
                     "Failed to boost access_count for surfacing %s",

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -430,6 +430,27 @@ class TestFeedbackBoost:
 
         adapter.increment_access.assert_not_called()
 
+    async def test_boosted_event_ids_fifo_cap_evicts_oldest(self):
+        """When ``_boosted_event_ids`` exceeds its cap, oldest entries evict first."""
+        adapter = _make_mcp_adapter([])
+        adapter.increment_access = AsyncMock()
+        tracker = self._make_tracker(["mid-A"])
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+        engine._boosted_event_ids_max = 10  # shrink for test speed
+
+        for i in range(15):
+            await engine.handle_feedback(f"sid-cap-{i}", "helpful", memory_id="mid-A")
+
+        # Overflow triggers bulk prune to half the cap (~5 entries remain).
+        assert len(engine._boosted_event_ids) <= 10
+        # Oldest (first-inserted) entries should be gone; newest retained.
+        assert "sid-cap-0" not in engine._boosted_event_ids
+        assert "sid-cap-14" in engine._boosted_event_ids
+
     async def test_no_tracker_returns_disabled_message(self):
         adapter = _make_mcp_adapter([])
         adapter.increment_access = AsyncMock()


### PR DESCRIPTION
## Summary

``SurfacingEngine._boosted_event_ids`` recorded every surfacing event that had already consumed its access-count boost. It grew one entry per ``helpful`` rating for the life of the process and was never pruned. PR #55 capped the sibling ``_surfaced_ids`` set at 10k with FIFO eviction; this matching cap was missed.

## Changes

- `src/memtomem_stm/surfacing/engine.py`: ``set[str]`` → ``dict[str, None]`` for insertion-order iteration; cap at 10,000; bulk prune to ~5,000 on overflow. Existing membership tests via ``"sid" in engine._boosted_event_ids`` continue to work unchanged.
- `tests/test_surfacing_engine.py`: new ``test_boosted_event_ids_fifo_cap_evicts_oldest`` exercises the prune path with ``_boosted_event_ids_max=10``. All four existing boost-guard tests pass unmodified.
- `docs/surfacing.md`: "Session & Cross-Session Dedup" gains a row for the boost-guard layer alongside ``_surfaced_ids`` and ``seen_memories``.

Closes #110

## Test plan

- [x] ``uv run ruff check src && uv run ruff format --check src``
- [x] ``uv run pytest tests/test_surfacing_engine.py tests/test_remote_ltm_integration.py -q`` — 45 passed (was 44; added 1)
- [x] Full suite ``uv run pytest -m "not ollama"`` — green