### PR TITLE
fix(proxy): tolerate spec-noncompliant upstream result.content=None

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -853,10 +853,13 @@ class ProxyManager:
                     logger.error("Reconnect to '%s' failed: %s", server, reconnect_exc)
                     raise
 
-        # Separate text and non-text content
+        # Separate text and non-text content. ``result.content`` is required by
+        # the MCP spec to be a list, but spec-noncompliant upstreams have been
+        # observed returning ``None`` — guard so we degrade to "[empty response]"
+        # via the existing empty-text-parts path instead of raising TypeError.
         text_parts: list[str] = []
         non_text_content: list = []
-        for content in result.content:
+        for content in result.content or []:
             if content.type == "text":
                 text_parts.append(content.text)
             else:

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -392,6 +392,19 @@ class TestEdgeResponses:
         result = await mgr.call_tool("srv", "tool", {})
         assert result == "[empty response]"
 
+    async def test_none_content_degrades_to_empty(self):
+        """Spec-noncompliant upstream returning ``content=None`` must not crash.
+
+        The MCP spec requires ``content`` to be a list, but resilient proxies
+        should degrade rather than raise ``TypeError`` from ``for c in None``.
+        """
+        mgr = _make_manager()
+        session = _get_session(mgr)
+        session.call_tool.return_value = SimpleNamespace(content=None, isError=False)
+
+        result = await mgr.call_tool("srv", "tool", {})
+        assert result == "[empty response]"
+
     async def test_non_text_content_passthrough(self):
         mgr = _make_manager()
         session = _get_session(mgr)
@@ -407,9 +420,7 @@ class TestEdgeResponses:
         session = _get_session(mgr)
         text = _text_content("hello world")
         img = SimpleNamespace(type="image", data="png")
-        session.call_tool.return_value = SimpleNamespace(
-            content=[text, img], isError=False
-        )
+        session.call_tool.return_value = SimpleNamespace(content=[text, img], isError=False)
 
         result = await mgr.call_tool("srv", "tool", {})
         assert isinstance(result, list)


### PR DESCRIPTION
## Summary

MCP spec requires ``CallToolResult.content`` to be a list. In practice some upstream servers (and especially fakes / wrappers) return ``None`` when the tool produced no output. The ``for content in result.content`` loop then raises ``TypeError: 'NoneType' object is not iterable`` and the failure propagates back to the agent as a hard error before the metrics row is even recorded.

Guard with ``result.content or []`` so the empty-text-parts path takes over and returns ``"[empty response]"``, matching existing behaviour for ``content=[]``.

## Changes

- `src/memtomem_stm/proxy/manager.py`: one-line guard on the content iteration at line 859, plus a comment noting the spec / observed behaviour gap.
- `tests/test_proxy_error_paths.py`: new ``test_none_content_degrades_to_empty`` mirrors the existing ``test_empty_response`` case.

## Test plan

- [x] ``uv run ruff check src && uv run ruff format --check src``
- [x] ``uv run pytest tests/test_proxy_error_paths.py`` — 33 passed (was 32; added 1)