### PR TITLE
fix(cli): write stm_proxy.json atomically (temp + os.replace)

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shlex
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -42,13 +44,34 @@ def _load(config_path: Path) -> dict[str, Any]:
 
 
 def _save(config_path: Path, data: dict[str, Any]) -> None:
+    """Write the proxy config atomically.
+
+    Writes to a sibling temp file then ``os.replace``s onto the target.
+    A running proxy's hot-reload watcher would otherwise be able to read
+    a half-written JSON file in the gap between truncate and write
+    (``Path.write_text`` is not atomic), surfacing as a parse-error log
+    + a fall-through to the previous config.
+    """
     resolved = config_path.expanduser().resolve()
     resolved.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    resolved.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=resolved.name + ".",
+        suffix=".tmp",
+        dir=str(resolved.parent),
+    )
+    tmp = Path(tmp_path)
     try:
-        resolved.chmod(0o600)
-    except OSError:
-        pass
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            pass
+        os.replace(tmp, resolved)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -15,6 +15,7 @@ home directory is touched.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -280,6 +281,67 @@ class TestAddValidation:
         )
         assert result.exit_code == 1
         assert "blocked for security reasons" in result.output
+
+
+class TestAtomicSave:
+    """Direct exercises of ``_save``'s atomic-rename behaviour.
+
+    A torn write would otherwise let the proxy's hot-reload watcher read
+    a half-written JSON file (the previous ``Path.write_text`` path was
+    truncate-then-write).
+    """
+
+    def test_save_writes_payload_and_leaves_no_temp_file(self, tmp_path: Path) -> None:
+        from memtomem_stm.cli.proxy import _save
+
+        target = tmp_path / "stm_proxy.json"
+        _save(target, {"enabled": True, "upstream_servers": {}})
+
+        assert target.exists()
+        assert json.loads(target.read_text(encoding="utf-8")) == {
+            "enabled": True,
+            "upstream_servers": {},
+        }
+        # No leftover sibling temp files (mkstemp prefix matches target name)
+        leftover = list(tmp_path.glob("stm_proxy.json.*.tmp"))
+        assert leftover == []
+
+    def test_save_overwrites_existing_atomically(self, tmp_path: Path) -> None:
+        from memtomem_stm.cli.proxy import _save
+
+        target = tmp_path / "stm_proxy.json"
+        target.write_text('{"enabled": false, "upstream_servers": {}}\n', encoding="utf-8")
+        old_inode = target.stat().st_ino
+
+        _save(target, {"enabled": True, "upstream_servers": {}})
+
+        # Content updated
+        assert json.loads(target.read_text(encoding="utf-8"))["enabled"] is True
+        # On POSIX, atomic rename replaces the file (new inode); the old
+        # inode is unlinked. Skip strict inode check on platforms where
+        # this is not guaranteed (Windows), but assert content correctness
+        # everywhere.
+        if hasattr(os, "fsync"):  # POSIX
+            new_inode = target.stat().st_ino
+            assert new_inode != old_inode
+
+    def test_save_cleans_up_temp_on_failure(self, tmp_path: Path, monkeypatch) -> None:
+        """If ``os.replace`` fails, the sibling temp file must be removed."""
+        from memtomem_stm.cli.proxy import _save
+
+        target = tmp_path / "stm_proxy.json"
+
+        def boom(*_a, **_kw):  # pragma: no cover - patched per test
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr("memtomem_stm.cli.proxy.os.replace", boom)
+
+        with pytest.raises(OSError, match="simulated rename"):
+            _save(target, {"enabled": True})
+
+        leftover = list(tmp_path.glob("stm_proxy.json.*.tmp"))
+        assert leftover == []
+        assert not target.exists()  # original was never written
 
 
 class TestAddPersistence:


### PR DESCRIPTION
## Summary

``_save`` in ``cli/proxy.py`` previously called ``Path.write_text`` directly, which internally does open-truncate-then-write. The proxy's hot-reload watcher (``mtime`` based) can fire in the gap between truncate and write completion and read a half-written file. The downstream parser catches the ``json.JSONDecodeError`` and keeps the previous config, so the user sees a transient warning log rather than data loss — but the CLI's documented "atomic" feel is broken.

## Fix

Canonical write-to-temp-then-rename:

1. Write to a sibling ``stm_proxy.json.<rand>.tmp`` (same parent → same filesystem → ``os.replace`` is atomic on POSIX).
2. ``chmod 0o600`` on the temp before rename so the final file is never visible at a permissive mode.
3. ``os.replace`` onto the target.
4. On any exception, unlink the temp before re-raising.

## Tests

- ``test_save_writes_payload_and_leaves_no_temp_file``
- ``test_save_overwrites_existing_atomically`` (new inode check on POSIX)
- ``test_save_cleans_up_temp_on_failure`` (monkeypatched ``os.replace``)

## Test plan

- [x] ``uv run ruff check src && uv run ruff format --check src``
- [x] ``uv run pytest -m "not ollama"`` — **1202 passed**