### PR TITLE
fix(config): honour env > file > defaults precedence end to end

### DIFF
--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,52 @@ from typing import Any
 from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
+
+
+_PROXY_ENV_PREFIX = "MEMTOMEM_STM_PROXY__"
+
+
+def collect_proxy_env_overrides(environ: dict[str, str] | None = None) -> dict[str, Any]:
+    """Build a nested dict from ``MEMTOMEM_STM_PROXY__*`` env vars.
+
+    Used to layer env-set proxy fields on top of the JSON config file so the
+    documented precedence (env > file > defaults) holds end-to-end. Without
+    this, the file-load path in ``server.py`` would clobber every env-set
+    field except ``MEMTOMEM_STM_PROXY__ENABLED``.
+
+    The returned dict mirrors the JSON config shape — nested by ``__``
+    delimiters, lower-cased — and pydantic's coercion handles type
+    conversion at validation time.
+    """
+    env = environ if environ is not None else dict(os.environ)
+    overrides: dict[str, Any] = {}
+    for key, val in env.items():
+        if not key.startswith(_PROXY_ENV_PREFIX):
+            continue
+        path = [p.lower() for p in key[len(_PROXY_ENV_PREFIX) :].split("__") if p]
+        if not path:
+            continue
+        cursor = overrides
+        for part in path[:-1]:
+            existing = cursor.get(part)
+            if not isinstance(existing, dict):
+                existing = {}
+                cursor[part] = existing
+            cursor = existing
+        cursor[path[-1]] = val
+    return overrides
+
+
+def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge *overrides* on top of *base*; returns a new dict."""
+    out = dict(base)
+    for k, v in overrides.items():
+        existing = out.get(k)
+        if isinstance(v, dict) and isinstance(existing, dict):
+            out[k] = _deep_merge(existing, v)
+        else:
+            out[k] = v
+    return out
 
 
 class CompressionStrategy(StrEnum):
@@ -357,12 +404,27 @@ class ProxyConfig(BaseModel):
         return min(model_budget, self.default_max_result_chars)
 
     @staticmethod
-    def load_from_file(path: Path) -> ProxyConfig | None:
-        """Load config from *path*.  Returns ``None`` on parse/validation error
-        (distinct from file-not-found which returns a default ``ProxyConfig``)."""
+    def load_from_file(
+        path: Path, env_overrides: dict[str, Any] | None = None
+    ) -> ProxyConfig | None:
+        """Load config from *path*. Returns ``None`` on parse/validation error
+        (distinct from file-not-found which returns a default ``ProxyConfig``).
+
+        When *env_overrides* is supplied it is deep-merged on top of the file
+        contents so env-set fields win over file-set fields, matching the
+        ``env > file > defaults`` precedence documented in
+        ``docs/configuration.md``.
+        """
         resolved = path.expanduser().resolve()
         if not resolved.exists():
             logger.debug("Proxy config file not found: %s", resolved)
+            if env_overrides:
+                try:
+                    return ProxyConfig.model_validate(env_overrides)
+                except Exception as exc:
+                    logger.warning(
+                        "Env-only proxy config failed validation: %s — using defaults", exc
+                    )
             return ProxyConfig()
         # Warn if config is group/world-readable (may contain API keys)
         try:
@@ -377,6 +439,8 @@ class ProxyConfig(BaseModel):
             pass
         try:
             data: dict[str, Any] = json.loads(resolved.read_text(encoding="utf-8"))
+            if env_overrides:
+                data = _deep_merge(data, env_overrides)
             return ProxyConfig.model_validate(data)
         except (json.JSONDecodeError, Exception) as exc:
             logger.warning("Failed to parse proxy config %s: %s", resolved, exc)
@@ -384,12 +448,18 @@ class ProxyConfig(BaseModel):
 
 
 class ProxyConfigLoader:
-    """mtime-based hot-reload for proxy config file."""
+    """mtime-based hot-reload for proxy config file.
 
-    def __init__(self, path: Path) -> None:
+    Env overrides captured at construction time are re-applied on every
+    reload so ``MEMTOMEM_STM_PROXY__*`` settings continue to win over file
+    contents after the agent edits ``stm_proxy.json`` at runtime.
+    """
+
+    def __init__(self, path: Path, env_overrides: dict[str, Any] | None = None) -> None:
         self._path = path.expanduser().resolve()
         self._cached: ProxyConfig | None = None
         self._mtime: float = 0.0
+        self._env_overrides = env_overrides or {}
 
     def seed(self, config: ProxyConfig) -> None:
         self._cached = config
@@ -404,9 +474,12 @@ class ProxyConfigLoader:
         except OSError:
             if self._cached is not None:
                 return self._cached
-            return ProxyConfig.load_from_file(self._path) or ProxyConfig()
+            return (
+                ProxyConfig.load_from_file(self._path, env_overrides=self._env_overrides)
+                or ProxyConfig()
+            )
         if mtime != self._mtime or self._cached is None:
-            loaded = ProxyConfig.load_from_file(self._path)
+            loaded = ProxyConfig.load_from_file(self._path, env_overrides=self._env_overrides)
             if loaded is not None:
                 self._cached = loaded
             else:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -107,8 +107,9 @@ class ProxyManager:
         index_engine: FileIndexer | None = None,
         surfacing_engine: SurfacingEngine | None = None,
         cache: ProxyCache | None = None,
+        env_overrides: dict[str, Any] | None = None,
     ) -> None:
-        self._config_loader = ProxyConfigLoader(config.config_path)
+        self._config_loader = ProxyConfigLoader(config.config_path, env_overrides=env_overrides)
         self._config_loader.seed(config)
         self.tracker = tracker
         self._index_engine = index_engine

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -13,7 +13,7 @@ from mcp.server.session import ServerSession
 
 from memtomem_stm.config import STMConfig
 from memtomem_stm.proxy.compression_feedback import CompressionFeedbackTracker
-from memtomem_stm.proxy.config import ProxyConfig
+from memtomem_stm.proxy.config import ProxyConfig, collect_proxy_env_overrides
 from memtomem_stm.proxy.manager import ProxyManager
 from memtomem_stm.proxy.metrics import TokenTracker
 from memtomem_stm.surfacing.engine import SurfacingEngine
@@ -41,13 +41,18 @@ CtxType = Context[ServerSession, STMContext]
 @asynccontextmanager
 async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
     config = STMConfig()
+    proxy_env_overrides = collect_proxy_env_overrides()
 
-    # Merge JSON config file if env var MEMTOMEM_STM_PROXY__ENABLED was not
-    # explicitly set.  The CLI writes "enabled": true to the JSON file, but
-    # STMConfig (pydantic-settings) only reads env vars, so without this
-    # merge the proxy would be silently disabled after a normal Quick Start.
+    # Load JSON config file and overlay env vars on top so the documented
+    # precedence (env > file > defaults) holds. The CLI writes
+    # ``"enabled": true`` to the JSON file, so a normal Quick Start enables
+    # the proxy without requiring ``MEMTOMEM_STM_PROXY__ENABLED``. Without
+    # the env overlay every other env-set field would be silently clobbered
+    # by the file values.
     if not os.environ.get("MEMTOMEM_STM_PROXY__ENABLED"):
-        file_cfg = ProxyConfig.load_from_file(config.proxy.config_path)
+        file_cfg = ProxyConfig.load_from_file(
+            config.proxy.config_path, env_overrides=proxy_env_overrides
+        )
         if file_cfg is not None:
             config.proxy = file_cfg
 
@@ -146,6 +151,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
         tracker,
         surfacing_engine=surfacing_engine,
         cache=proxy_cache,
+        env_overrides=proxy_env_overrides,
     )
 
     if config.proxy.enabled:

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -1,0 +1,152 @@
+"""Tests for env-var > file > defaults precedence in ProxyConfig loading.
+
+Locks in the fix for #106: env-set ``MEMTOMEM_STM_PROXY__*`` fields must
+win over file values both at startup and on hot-reload.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.proxy.config import (
+    ProxyConfig,
+    ProxyConfigLoader,
+    _deep_merge,
+    collect_proxy_env_overrides,
+)
+
+
+class TestCollectProxyEnvOverrides:
+    def test_top_level_field(self) -> None:
+        env = {"MEMTOMEM_STM_PROXY__DEFAULT_MAX_RESULT_CHARS": "9999"}
+        assert collect_proxy_env_overrides(env) == {"default_max_result_chars": "9999"}
+
+    def test_nested_field_via_double_underscore(self) -> None:
+        env = {"MEMTOMEM_STM_PROXY__CACHE__ENABLED": "true"}
+        assert collect_proxy_env_overrides(env) == {"cache": {"enabled": "true"}}
+
+    def test_deeply_nested_field(self) -> None:
+        env = {
+            "MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__EMBEDDING_PROVIDER": "openai",
+            "MEMTOMEM_STM_PROXY__RELEVANCE_SCORER__EMBEDDING_MODEL": "text-embedding-3-small",
+        }
+        assert collect_proxy_env_overrides(env) == {
+            "relevance_scorer": {
+                "embedding_provider": "openai",
+                "embedding_model": "text-embedding-3-small",
+            }
+        }
+
+    def test_unrelated_env_vars_ignored(self) -> None:
+        env = {
+            "PATH": "/usr/bin",
+            "MEMTOMEM_STM_SURFACING__ENABLED": "true",  # surfacing prefix, not proxy
+            "MEMTOMEM_STM_PROXY__ENABLED": "true",
+        }
+        assert collect_proxy_env_overrides(env) == {"enabled": "true"}
+
+    def test_empty_when_no_proxy_env(self) -> None:
+        assert collect_proxy_env_overrides({"FOO": "bar"}) == {}
+
+
+class TestDeepMerge:
+    def test_overrides_replace_scalars(self) -> None:
+        assert _deep_merge({"a": 1, "b": 2}, {"a": 9}) == {"a": 9, "b": 2}
+
+    def test_nested_dicts_merge_recursively(self) -> None:
+        base = {"cache": {"enabled": False, "ttl": 60}}
+        env = {"cache": {"enabled": True}}
+        assert _deep_merge(base, env) == {"cache": {"enabled": True, "ttl": 60}}
+
+    def test_overrides_replace_dict_with_scalar(self) -> None:
+        assert _deep_merge({"x": {"a": 1}}, {"x": "scalar"}) == {"x": "scalar"}
+
+
+class TestLoadFromFileWithEnvOverrides:
+    def test_env_wins_when_field_in_both(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 16000}))
+
+        cfg = ProxyConfig.load_from_file(
+            cfg_file, env_overrides={"default_max_result_chars": "9999"}
+        )
+
+        assert cfg is not None
+        assert cfg.default_max_result_chars == 9999
+
+    def test_file_value_kept_when_no_env_override(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 16000}))
+
+        cfg = ProxyConfig.load_from_file(cfg_file, env_overrides={})
+
+        assert cfg is not None
+        assert cfg.default_max_result_chars == 16000
+
+    def test_env_overrides_when_file_missing(self, tmp_path: Path) -> None:
+        cfg = ProxyConfig.load_from_file(
+            tmp_path / "nonexistent.json",
+            env_overrides={"default_max_result_chars": "7777"},
+        )
+
+        assert cfg is not None
+        assert cfg.default_max_result_chars == 7777
+
+    def test_nested_env_override_merges_with_file(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"cache": {"enabled": True, "default_ttl_seconds": 3600.0}}))
+
+        cfg = ProxyConfig.load_from_file(
+            cfg_file, env_overrides={"cache": {"default_ttl_seconds": "60"}}
+        )
+
+        assert cfg is not None
+        assert cfg.cache.enabled is True  # from file
+        assert cfg.cache.default_ttl_seconds == 60.0  # env override
+
+
+class TestProxyConfigLoaderRespectsEnvOnReload:
+    def test_env_overrides_survive_hot_reload(self, tmp_path: Path) -> None:
+        """The original bug: hot-reload of stm_proxy.json discards env overrides."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 16000}))
+
+        loader = ProxyConfigLoader(cfg_file, env_overrides={"default_max_result_chars": "9999"})
+        first = loader.get()
+        assert first.default_max_result_chars == 9999
+
+        # Edit file with a new (file-only) value; env override must still win.
+        time.sleep(0.01)  # ensure mtime ticks
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 32000}))
+
+        # Force mtime detection
+        loader._mtime = -1.0  # noqa: SLF001 — direct test of reload behaviour
+        second = loader.get()
+        assert second.default_max_result_chars == 9999  # env override held
+
+    def test_env_override_only_used_when_field_in_env(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 16000}))
+
+        loader = ProxyConfigLoader(cfg_file, env_overrides={})
+        cfg = loader.get()
+
+        assert cfg.default_max_result_chars == 16000
+
+    def test_loader_without_env_overrides_uses_pure_file(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 12345}))
+
+        loader = ProxyConfigLoader(cfg_file)  # no env_overrides arg
+        assert loader.get().default_max_result_chars == 12345
+
+
+def test_collect_uses_real_environ_when_arg_omitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMTOMEM_STM_PROXY__DEFAULT_MAX_RESULT_CHARS", "4242")
+    monkeypatch.delenv("MEMTOMEM_STM_PROXY__ENABLED", raising=False)
+    out = collect_proxy_env_overrides()
+    assert out.get("default_max_result_chars") == "4242"


### PR DESCRIPTION
## Summary

``docs/configuration.md`` promises env vars win over the JSON config file, but the startup path only honoured ``MEMTOMEM_STM_PROXY__ENABLED`` — every other ``MEMTOMEM_STM_PROXY__*`` env var was silently clobbered by ``config.proxy = file_cfg`` at ``server.py:52``. Hot-reload was worse: ``ProxyConfigLoader.get()`` re-loaded the file with no env awareness, so a post-startup ``mms add`` flush of ``stm_proxy.json`` wiped the env state again.

## Fix

- New helper `collect_proxy_env_overrides()` walks `os.environ` for `MEMTOMEM_STM_PROXY__*` keys and returns the same nested dict shape as the JSON config.
- New `_deep_merge()` helper used to overlay env overrides on top of file contents.
- `ProxyConfig.load_from_file` accepts optional `env_overrides` and applies the merge before validation; the file-missing path also honours env overrides instead of returning pure defaults.
- `ProxyConfigLoader` accepts `env_overrides` at construction and re-applies them on every reload, so subsequent `mms add` writes do not regress env-set fields.
- `ProxyManager.__init__` forwards `env_overrides` into the loader; `server.py` collects overrides once at startup and passes them through both code paths.

No docs change — ``docs/configuration.md`` already claims this behaviour; the code now matches the contract.

Closes #106

## Test plan

- [x] ``uv run ruff check src && uv run ruff format --check src``
- [x] ``uv run pytest -m "not ollama"`` — **1215 passed** (1199 existing + 16 new in `tests/test_env_overrides.py`)
- [x] New tests cover: helper extraction (5 cases), deep merge (3), `load_from_file` with overrides (4), `ProxyConfigLoader` hot-reload survival (3), and a real-environ smoke test