### PR TITLE
fix(metrics): record INTERNAL_ERROR row when pipeline raises

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -167,7 +167,7 @@ By server:
 Surfacing: enabled (min_score=0.02)
 ```
 
-- **Error classification** — errors are categorized as `transport`, `timeout`, `protocol`, `upstream_error`, or `programming`. Each failed call records the category and code for debugging.
+- **Error classification** — errors are categorized as `transport`, `timeout`, `protocol`, `upstream_error`, `programming`, or `internal_error`. The `internal_error` category covers exceptions raised inside the CLEAN/COMPRESS/SURFACE/INDEX pipeline after the upstream call already returned (rare in practice — most strategies fall back internally — but recording these guarantees no failed call is invisible). Each failed call records the category and code for debugging.
 - **Trace IDs** — every proxy call generates a unique `trace_id` (16-char hex) for correlating logs and metrics.
 
 Metrics are persisted to SQLite (`~/.memtomem/proxy_metrics.db`, max 10K entries) with error category and trace_id columns.

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -99,6 +99,19 @@ class UpstreamConnection:
     stack: AsyncExitStack | None = None
 
 
+def _mark_recorded(exc: BaseException) -> None:
+    """Tag *exc* so the outer ``call_tool`` wrapper does not double-record it.
+
+    The pipeline records its own typed metrics rows for upstream / transport /
+    timeout / protocol errors. The ``call_tool`` outer wrapper catches anything
+    else as ``INTERNAL_ERROR``; this marker keeps the two paths from racing.
+    """
+    try:
+        exc._stm_metrics_recorded = True  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        pass
+
+
 class ProxyManager:
     def __init__(
         self,
@@ -701,7 +714,30 @@ class ProxyManager:
             "proxy_call",
             metadata={"server": server, "tool": tool, "trace_id": trace_id},
         ):
-            return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id)
+            try:
+                return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id)
+            except Exception as exc:
+                # Upstream/transport/timeout/protocol errors are already
+                # recorded inside _call_tool_inner via record_error(); a raise
+                # that escapes to here means a CLEAN/COMPRESS/SURFACE/INDEX
+                # stage threw after the upstream call had already returned.
+                # Without this guard the metrics row was silently skipped,
+                # leaving operators blind to in-pipeline failures.
+                if not getattr(exc, "_stm_metrics_recorded", False):
+                    try:
+                        self.tracker.record_error(
+                            CallMetrics(
+                                server=server,
+                                tool=tool,
+                                original_chars=0,
+                                compressed_chars=0,
+                                trace_id=trace_id,
+                                error_category=ErrorCategory.INTERNAL_ERROR,
+                            )
+                        )
+                    except Exception:
+                        logger.debug("Failed to record INTERNAL_ERROR metrics row", exc_info=True)
+                raise
 
     async def _call_tool_inner(
         self,
@@ -779,6 +815,7 @@ class ProxyManager:
                             trace_id=trace_id,
                         )
                     )
+                    _mark_recorded(exc)
                     raise
 
                 # Protocol errors (bad params, unknown method) — don't retry,
@@ -799,6 +836,7 @@ class ProxyManager:
                             trace_id=trace_id,
                         )
                     )
+                    _mark_recorded(exc)
                     try:
                         await self._reconnect_server(server)
                     except Exception:
@@ -826,6 +864,7 @@ class ProxyManager:
                             trace_id=trace_id,
                         )
                     )
+                    _mark_recorded(exc)
                     # Reconnect before raising so the NEXT call starts fresh
                     try:
                         await self._reconnect_server(server)
@@ -895,7 +934,9 @@ class ProxyManager:
             # proxied response instead of silently converting to a normal result.
             from mcp.server.fastmcp.exceptions import ToolError
 
-            raise ToolError(original_text)
+            tool_err = ToolError(original_text)
+            _mark_recorded(tool_err)
+            raise tool_err
 
         # Resolve effective settings (using config snapshot)
         tc = self._resolve_tool_config(server, tool, proxy_cfg=cfg_snap)

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -72,6 +72,7 @@ class ErrorCategory(StrEnum):
     PROTOCOL = "protocol"  # JSON-RPC errors (-32600..-32603)
     UPSTREAM_ERROR = "upstream_error"  # result.isError=True from upstream
     PROGRAMMING = "programming"  # TypeError, AttributeError, etc.
+    INTERNAL_ERROR = "internal_error"  # raised inside the COMPRESS/SURFACE/INDEX pipeline
 
 
 def _percentile(sorted_vals: list[float], p: float) -> float:

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -407,9 +407,7 @@ class TestEdgeResponses:
         session = _get_session(mgr)
         text = _text_content("hello world")
         img = SimpleNamespace(type="image", data="png")
-        session.call_tool.return_value = SimpleNamespace(
-            content=[text, img], isError=False
-        )
+        session.call_tool.return_value = SimpleNamespace(content=[text, img], isError=False)
 
         result = await mgr.call_tool("srv", "tool", {})
         assert isinstance(result, list)
@@ -435,6 +433,75 @@ class TestSurfacingFailure:
         result = await mgr.call_tool("srv", "tool", {})
         # Should get the text back, not an exception
         assert "hello world" in result
+
+
+# ── Pipeline-stage exceptions: must surface in proxy_metrics as INTERNAL_ERROR ─
+
+
+class TestPipelineExceptionMetrics:
+    async def test_compress_failure_records_internal_error(self):
+        """If a COMPRESS-stage exception escapes _call_tool_inner, the outer
+        wrapper must record an INTERNAL_ERROR metrics row before re-raising
+        — otherwise operators are blind to in-pipeline failures."""
+        from memtomem_stm.proxy.metrics import ErrorCategory
+
+        mgr = _make_manager()
+        session = _get_session(mgr)
+        session.call_tool.return_value = _make_result("hello world")
+
+        # Force the compression stage to raise after upstream succeeds
+        with patch.object(
+            mgr, "_apply_compression", new_callable=AsyncMock, side_effect=RuntimeError("boom")
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await mgr.call_tool("srv", "tool", {})
+
+        # An INTERNAL_ERROR row must be present
+        assert mgr.tracker._errors_by_category[ErrorCategory.INTERNAL_ERROR.value] == 1
+        # And no double-count from typed paths
+        for cat in (
+            ErrorCategory.TRANSPORT,
+            ErrorCategory.TIMEOUT,
+            ErrorCategory.PROTOCOL,
+            ErrorCategory.UPSTREAM_ERROR,
+            ErrorCategory.PROGRAMMING,
+        ):
+            assert mgr.tracker._errors_by_category[cat.value] == 0
+
+    async def test_typed_upstream_error_not_double_recorded(self):
+        """A transport error already records its own row; the outer wrapper
+        must not add a second INTERNAL_ERROR row."""
+        from memtomem_stm.proxy.metrics import ErrorCategory
+
+        mgr = _make_manager(max_retries=0)
+        session = _get_session(mgr)
+        session.call_tool.side_effect = ConnectionError("down")
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            with pytest.raises(ConnectionError):
+                await mgr.call_tool("srv", "tool", {})
+
+        # Exactly one row, classified TRANSPORT — not INTERNAL_ERROR
+        assert mgr.tracker._errors_by_category[ErrorCategory.TRANSPORT.value] == 1
+        assert mgr.tracker._errors_by_category[ErrorCategory.INTERNAL_ERROR.value] == 0
+
+    async def test_upstream_iserror_not_double_recorded(self):
+        """A result.isError=True path raises ToolError after recording an
+        UPSTREAM_ERROR row; the outer wrapper must not add INTERNAL_ERROR."""
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        from memtomem_stm.proxy.metrics import ErrorCategory
+
+        mgr = _make_manager()
+        session = _get_session(mgr)
+        session.call_tool.return_value = _make_result("oops", is_error=True)
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            with pytest.raises(ToolError):
+                await mgr.call_tool("srv", "tool", {})
+
+        assert mgr.tracker._errors_by_category[ErrorCategory.UPSTREAM_ERROR.value] == 1
+        assert mgr.tracker._errors_by_category[ErrorCategory.INTERNAL_ERROR.value] == 0
 
 
 # ── Context query stripping ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The CLEAN / COMPRESS / SURFACE / INDEX pipeline stages run after the upstream call already succeeded, but exceptions thrown inside them propagated all the way out of ``_call_tool_inner`` without ever calling ``tracker.record_error`` — the success-path ``tracker.record(...)`` at the bottom of the function only fires on normal return.

Operators reading ``proxy_metrics.db`` therefore could not see in-pipeline failures even though the matching Langfuse span shows the exception. In practice most compressors fall back internally so the gap is small, but the contract in ``docs/operations.md`` ("every failed call records the category and code") was broken.

## Fix

- Wrap the inner call inside ``call_tool`` with a ``try / except`` that records a CallMetrics row tagged ``ErrorCategory.INTERNAL_ERROR`` before re-raising.
- Avoid double-counting: every existing typed-error site (PROGRAMMING / PROTOCOL / TIMEOUT / TRANSPORT / UPSTREAM_ERROR) now tags its exception with ``_stm_metrics_recorded = True`` via a new ``_mark_recorded`` helper; the outer wrapper skips already-recorded exceptions.
- New ``ErrorCategory.INTERNAL_ERROR`` enum value.
- ``docs/operations.md`` updated to list the new category alongside the existing five.

Closes #107

## Test plan

- [x] ``uv run ruff check src && uv run ruff format --check src``
- [x] ``uv run pytest -m "not ollama"`` — **1202 passed** (1199 existing + 3 new)
- [x] New tests cover the COMPRESS-failure path AND assert no double-counting on typed paths (TRANSPORT + UPSTREAM_ERROR cases)