### PR TITLE
fix(proxy,surfacing): complete None-content defense missed by #114

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -911,7 +911,11 @@ class ProxyManager:
                 if remaining <= 0:
                     oversize = True
                     break
-                text = content.text
+                # ``content.text or ""`` tolerates spec-noncompliant upstreams
+                # that return ``None`` for a TextContent's ``text`` field.
+                # MCP spec requires ``text: str`` but mirrors the same gap
+                # that PR #114 fixed for ``result.content`` itself.
+                text = content.text or ""
                 if len(text) > remaining:
                     text_parts.append(text[:remaining])
                     total_chars += remaining

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -281,7 +281,9 @@ class McpClientSearchAdapter:
             return [], None
 
         # Parse text response into results
-        text_parts = [c.text for c in result.content if c.type == "text"]
+        # ``result.content or []`` tolerates spec-noncompliant upstreams that
+        # return ``None`` instead of an empty list (mirrors PR #114 in proxy).
+        text_parts = [c.text for c in (result.content or []) if c.type == "text"]
         if not text_parts:
             return [], None
 
@@ -354,7 +356,9 @@ class McpClientSearchAdapter:
             logger.debug("MCP mem_do(scratch_get) failed: %s", exc)
             return []
 
-        text_parts = [c.text for c in result.content if c.type == "text"]
+        # ``result.content or []`` tolerates spec-noncompliant upstreams that
+        # return ``None`` instead of an empty list (mirrors PR #114 in proxy).
+        text_parts = [c.text for c in (result.content or []) if c.type == "text"]
         if not text_parts:
             return []
 

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -250,3 +250,39 @@ class TestNegotiationDowngradeAffectsParsing:
         assert len(results) == 1
         assert results[0].score == 0.42
         assert "Hello from compact" in results[0].chunk.content
+
+
+# ── Spec-noncompliant ``result.content=None`` from upstream ──────────────
+
+
+class TestNoneContentDefense:
+    """PR #114 fixed ``result.content=None`` in ``proxy/manager.py``; the
+    surfacing client kept the same unguarded iteration in ``search`` and
+    ``scratch_list`` and would crash with ``TypeError`` instead of returning
+    an empty result. Both paths must degrade silently — surfacing is always
+    allowed to skip on missing data."""
+
+    @pytest.mark.asyncio
+    async def test_search_returns_empty_when_content_is_none(self):
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+        bad = MagicMock()
+        bad.content = None
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=bad)
+        adapter._session = mock_session
+
+        results, stats = await adapter.search("anything")
+        assert results == []
+        assert stats is None
+
+    @pytest.mark.asyncio
+    async def test_scratch_list_returns_empty_when_content_is_none(self):
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+        bad = MagicMock()
+        bad.content = None
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=bad)
+        adapter._session = mock_session
+
+        entries = await adapter.scratch_list()
+        assert entries == []

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -405,6 +405,27 @@ class TestEdgeResponses:
         result = await mgr.call_tool("srv", "tool", {})
         assert result == "[empty response]"
 
+    async def test_text_field_none_degrades(self):
+        """Spec-noncompliant upstream returning ``TextContent.text=None`` must not crash.
+
+        Mirrors ``test_none_content_degrades_to_empty`` one level down: the MCP
+        spec requires ``TextContent.text`` to be ``str``, but the same upstream
+        servers that produce ``content=None`` also occasionally produce a
+        TextContent whose ``text`` field is ``None``. Without the ``or ""``
+        guard, ``len(text)`` raises ``TypeError`` and the failure propagates
+        before the metrics row is recorded — the same failure mode #114 fixed
+        for ``content`` itself.
+        """
+        mgr = _make_manager()
+        session = _get_session(mgr)
+        none_text = SimpleNamespace(type="text", text=None)
+        session.call_tool.return_value = SimpleNamespace(content=[none_text], isError=False)
+
+        # Should not raise; concrete return value is implementation-defined
+        # (the empty text passes through compression as an empty payload).
+        result = await mgr.call_tool("srv", "tool", {})
+        assert isinstance(result, str)
+
     async def test_non_text_content_passthrough(self):
         mgr = _make_manager()
         session = _get_session(mgr)


### PR DESCRIPTION
## Summary

Follow-up to #114, which guarded `result.content=None` only in
`proxy/manager.py`. Two adjacent paths kept the same unguarded
iteration and would still raise `TypeError` from spec-noncompliant
upstreams:

- **`surfacing/mcp_client.py:284, 357`** — `search()` and
  `scratch_list()` iterate `result.content` directly. Both docstrings
  promise an empty list on failure, but `content=None` raised through
  to the surfacing engine (which assumes the adapter never raises).
- **`proxy/manager.py:914`** — even with #114's outer `or []`, reading
  `content.text` crashes `len(text)` one line later when a TextContent
  has `text=None`. The same upstream class produces both shapes in
  practice.

Mirrors #114's pattern: `or []` for the iterable, `or ""` for the
inner string.

## Test plan

- [x] `tests/test_proxy_error_paths.py::TestEdgeResponses::test_text_field_none_degrades` — new
- [x] `tests/test_mcp_client_reconnect.py::TestNoneContentDefense::test_search_returns_empty_when_content_is_none` — new
- [x] `tests/test_mcp_client_reconnect.py::TestNoneContentDefense::test_scratch_list_returns_empty_when_content_is_none` — new
- [x] `uv run pytest tests/test_proxy_error_paths.py tests/test_mcp_client_reconnect.py tests/test_proxy_manager.py tests/test_proxy_manager_pipeline.py -m "not ollama"` — 87 passed
- [x] `uv run ruff check src tests` and `uv run ruff format --check src` — clean
- [x] `uv run mypy src` — pre-existing `manager.py:362` warning unrelated to this change

## Notes

- `mcp_client.py:209` (version negotiation) was reviewed and **not**
  changed: it sits inside an outer `try/except Exception` that already
  degrades silently. Touching it would broaden scope without fixing a
  user-visible failure.