### PR TITLE
fix(proxy): guard cache.set so a write failure can't drop the response

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1270,14 +1270,25 @@ class ProxyManager:
         )
 
         # ── Cache store (pre-surfacing content so memories stay fresh on hit) ──
+        # Cache writes are an optional fast-path: a SQLite lock timeout, disk
+        # full, or any other store error must NOT propagate to the agent and
+        # discard a successful upstream response. Log and continue.
         if self._cache is not None and not non_text_content:
-            self._cache.set(
-                server,
-                tool,
-                upstream_args,
-                compressed,
-                ttl_seconds=cfg_snap.cache.default_ttl_seconds,
-            )
+            try:
+                self._cache.set(
+                    server,
+                    tool,
+                    upstream_args,
+                    compressed,
+                    ttl_seconds=cfg_snap.cache.default_ttl_seconds,
+                )
+            except Exception:
+                logger.warning(
+                    "Cache store failed for %s/%s — response unaffected",
+                    server,
+                    tool,
+                    exc_info=True,
+                )
 
         # Combine compressed text with preserved non-text content
         if non_text_content:

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -627,3 +627,22 @@ class TestCacheWithErrors:
         assert result == "cached result"
         session.call_tool.assert_not_called()
         assert mgr.tracker.get_summary()["cache_hits"] == 1
+
+    async def test_cache_set_failure_does_not_break_response(self):
+        """A failing ``cache.set`` (SQLite lock timeout, disk full, etc.)
+        must not discard a successful upstream response. Cache writes are
+        an optional fast-path, not a correctness dependency: a swallowed
+        warning is the expected behaviour."""
+        mgr = _make_manager()
+        session = _get_session(mgr)
+        session.call_tool.return_value = _make_result("hello world")
+
+        cache = MagicMock()
+        cache.get.return_value = None  # miss → upstream is consulted
+        cache.set.side_effect = RuntimeError("simulated SQLite lock timeout")
+        mgr._cache = cache
+
+        # Must not raise — response returns normally.
+        result = await mgr.call_tool("srv", "tool", {})
+        assert "hello world" in result
+        cache.set.assert_called_once()


### PR DESCRIPTION
## Summary

`_call_tool_inner` calls `self._cache.set(...)` after a successful
upstream + compress + surface pipeline, but the call was unguarded.
A SQLite `OperationalError` (lock timeout, WAL trouble, disk full)
would propagate all the way up through `call_tool` and the agent
would see a hard failure even though the response was already on the
stack ready to return.

The cache layer is an optional fast-path: its job is to make repeat
calls cheap, not to gate correctness. Wrap the `set` in
`try/except Exception` and log a warning. The next call simply hits
upstream again — the same behaviour that would happen if the cache
were disabled, which is by design always safe.

## Test plan

- [x] `tests/test_proxy_error_paths.py::TestCacheWithErrors::test_cache_set_failure_does_not_break_response` — new
- [x] `uv run pytest tests/test_proxy_error_paths.py tests/test_proxy_manager.py tests/test_proxy_manager_pipeline.py tests/test_surfacing_cache.py -m "not ollama"` — 86 passed
- [x] `uv run ruff check src tests` and `uv run ruff format --check src` — clean

## Notes

This pairs with #119 (None-content defense) and #115 (atomic config
write) as the third piece of "boundary failures must not corrupt the
happy path" hardening.