### PR TITLE
refactor(utils): centralise atomic_write_text + apply to memory_ops

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import shlex
 import sys
-import tempfile
 from pathlib import Path
 from typing import Any
 
 import click
+
+from memtomem_stm.utils.fileio import atomic_write_text
 
 _PREFIX_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
 
@@ -46,32 +46,15 @@ def _load(config_path: Path) -> dict[str, Any]:
 def _save(config_path: Path, data: dict[str, Any]) -> None:
     """Write the proxy config atomically.
 
-    Writes to a sibling temp file then ``os.replace``s onto the target.
-    A running proxy's hot-reload watcher would otherwise be able to read
-    a half-written JSON file in the gap between truncate and write
-    (``Path.write_text`` is not atomic), surfacing as a parse-error log
-    + a fall-through to the previous config.
+    Delegates to :func:`atomic_write_text` so the temp + ``os.replace``
+    pattern stays in one place (see PR #115 for the original failure
+    mode: a running proxy's mtime-based hot-reload would otherwise read
+    a half-written JSON file in the gap between truncate and write).
+    ``mode=0o600`` keeps the rendered file out of a permissive listing
+    even if the parent directory is shared.
     """
-    resolved = config_path.expanduser().resolve()
-    resolved.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
-    fd, tmp_path = tempfile.mkstemp(
-        prefix=resolved.name + ".",
-        suffix=".tmp",
-        dir=str(resolved.parent),
-    )
-    tmp = Path(tmp_path)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(payload)
-        try:
-            tmp.chmod(0o600)
-        except OSError:
-            pass
-        os.replace(tmp, resolved)
-    except Exception:
-        tmp.unlink(missing_ok=True)
-        raise
+    atomic_write_text(config_path, payload, mode=0o600)
 
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}

--- a/src/memtomem_stm/proxy/memory_ops.py
+++ b/src/memtomem_stm/proxy/memory_ops.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from memtomem_stm.proxy.config import AutoIndexConfig, ExtractionConfig
 from memtomem_stm.proxy.extraction import ExtractedFact, FactExtractor
+from memtomem_stm.utils.fileio import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,9 @@ async def auto_index_response(
         f"{intent_section}"
         f"## Content\n\n{text}\n"
     )
-    file_path.write_text(md_content, encoding="utf-8")
+    # Atomic so the auto-indexer (called next) can't observe a partial file
+    # if the writer is killed mid-flush. Caller has already mkdir'd memory_dir.
+    atomic_write_text(file_path, md_content, ensure_parent=False)
 
     ns = ai_cfg.namespace.format(server=server, tool=tool)
 
@@ -128,7 +131,8 @@ async def extract_and_store(
             fname = f"{server}__{safe_tool}__fact__{ts}__{i:02d}.md"
             file_path = memory_dir / fname
             md_content = format_fact_md(fact, server, tool, arguments)
-            file_path.write_text(md_content, encoding="utf-8")
+            # Atomic so a kill between write and index_file leaves no partial.
+            atomic_write_text(file_path, md_content, ensure_parent=False)
 
             if index_engine is None:
                 continue

--- a/src/memtomem_stm/utils/fileio.py
+++ b/src/memtomem_stm/utils/fileio.py
@@ -1,0 +1,70 @@
+"""Filesystem helpers shared across the proxy.
+
+The current owner is ``atomic_write_text`` — see PR #115 for the original
+``_save`` it was extracted from. Centralising the temp + ``os.replace``
+pattern keeps the third re-implementation of it from showing up.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(
+    path: Path,
+    content: str,
+    *,
+    encoding: str = "utf-8",
+    mode: int | None = None,
+    ensure_parent: bool = True,
+    parent_mode: int = 0o700,
+) -> None:
+    """Atomically write ``content`` to ``path``.
+
+    Writes to a sibling temp file in the same directory (so the rename is
+    atomic on POSIX — same filesystem) and ``os.replace``\\ s onto the
+    target. Concurrent readers either see the previous contents or the
+    new ones, never a partially-written file. The proxy's hot-reload
+    watcher (mtime-based) and the auto-indexer both rely on this; a
+    half-written read produces a JSONDecodeError or a corrupt index entry
+    that is hard to attribute back to the writer.
+
+    Failure during the temp write removes the temp and re-raises, so the
+    target is left untouched.
+
+    :param path: Destination path. ``~`` is expanded and the path is
+        resolved before the write so callers can pass user-relative paths.
+    :param content: Text payload.
+    :param encoding: Text encoding (default ``utf-8``).
+    :param mode: If set, ``chmod`` is applied to the temp file *before*
+        the rename so the final file is never observable at a permissive
+        mode. Use ``0o600`` for sensitive configs.
+    :param ensure_parent: When True (default), create missing parent
+        directories with ``parent_mode``. Pass False when the caller has
+        already prepared the parent and does not want its mode rewritten.
+    :param parent_mode: Mode for created parent directories. Only used
+        when ``ensure_parent`` is True.
+    """
+    resolved = path.expanduser().resolve()
+    if ensure_parent:
+        resolved.parent.mkdir(parents=True, exist_ok=True, mode=parent_mode)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=resolved.name + ".",
+        suffix=".tmp",
+        dir=str(resolved.parent),
+    )
+    tmp = Path(tmp_path)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as f:
+            f.write(content)
+        if mode is not None:
+            try:
+                tmp.chmod(mode)
+            except OSError:
+                pass
+        os.replace(tmp, resolved)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -334,7 +334,9 @@ class TestAtomicSave:
         def boom(*_a, **_kw):  # pragma: no cover - patched per test
             raise OSError("simulated rename failure")
 
-        monkeypatch.setattr("memtomem_stm.cli.proxy.os.replace", boom)
+        # ``_save`` was migrated to delegate to ``utils.fileio.atomic_write_text``;
+        # the rename now happens there, so patch the helper's ``os.replace``.
+        monkeypatch.setattr("memtomem_stm.utils.fileio.os.replace", boom)
 
         with pytest.raises(OSError, match="simulated rename"):
             _save(target, {"enabled": True})

--- a/tests/test_utils_fileio.py
+++ b/tests/test_utils_fileio.py
@@ -1,0 +1,216 @@
+"""Tests for ``memtomem_stm.utils.fileio.atomic_write_text``.
+
+Codifies the contract the proxy depends on: callers (CLI ``_save``,
+``memory_ops.auto_index_response`` and ``extract_and_store``) need both
+crash-safety (no partial file ever observable on the target path) and
+proper cleanup of the temp file on failure.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.utils.fileio import atomic_write_text
+
+
+class TestAtomicWriteText:
+    def test_basic_write(self, tmp_path: Path):
+        target = tmp_path / "out.txt"
+        atomic_write_text(target, "hello")
+        assert target.read_text(encoding="utf-8") == "hello"
+
+    def test_overwrite_existing(self, tmp_path: Path):
+        target = tmp_path / "out.txt"
+        target.write_text("old", encoding="utf-8")
+        atomic_write_text(target, "new")
+        assert target.read_text(encoding="utf-8") == "new"
+
+    def test_unicode_round_trip(self, tmp_path: Path):
+        target = tmp_path / "out.txt"
+        payload = "한글 + emoji 🚀 + accents éàü"
+        atomic_write_text(target, payload)
+        assert target.read_text(encoding="utf-8") == payload
+
+    def test_mode_applied(self, tmp_path: Path):
+        target = tmp_path / "secret.json"
+        atomic_write_text(target, "{}", mode=0o600)
+        # Bottom 9 bits = permission bits.
+        assert (target.stat().st_mode & 0o777) == 0o600
+
+    def test_no_mode_inherits_mkstemp_default(self, tmp_path: Path):
+        """When ``mode`` is None we don't ``chmod`` — the file keeps the
+        mode ``tempfile.mkstemp`` assigned, which is ``0o600`` on POSIX.
+        This is intentional: even non-sensitive callers (e.g.
+        ``memory_ops``) get a private file by default rather than a
+        permissive one. Document the contract here so the next person
+        reading "mode=None" doesn't assume it means "system default"."""
+        target = tmp_path / "out.txt"
+        atomic_write_text(target, "x")
+        # On POSIX, ``mkstemp`` always opens the file at 0o600. We only
+        # assert the upper bits aren't more permissive — a future change
+        # that loosens the default would trip this.
+        bits = target.stat().st_mode & 0o077
+        assert bits == 0, f"unexpected world/group bits: {oct(bits)}"
+
+    def test_ensure_parent_creates_missing_dirs(self, tmp_path: Path):
+        target = tmp_path / "deep" / "nested" / "file.txt"
+        atomic_write_text(target, "x")
+        assert target.read_text(encoding="utf-8") == "x"
+
+    def test_ensure_parent_false_requires_existing_parent(self, tmp_path: Path):
+        target = tmp_path / "missing-dir" / "file.txt"
+        with pytest.raises(FileNotFoundError):
+            atomic_write_text(target, "x", ensure_parent=False)
+
+    def test_replace_failure_leaves_target_untouched_and_cleans_temp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """If ``os.replace`` raises mid-write (simulated disk full), the
+        original file must be intact and no leftover ``.tmp`` may remain."""
+        target = tmp_path / "out.txt"
+        target.write_text("original", encoding="utf-8")
+
+        def boom(*args, **kwargs):
+            raise OSError("simulated disk full")
+
+        monkeypatch.setattr("memtomem_stm.utils.fileio.os.replace", boom)
+
+        with pytest.raises(OSError, match="simulated disk full"):
+            atomic_write_text(target, "new")
+
+        assert target.read_text(encoding="utf-8") == "original"
+        leftovers = list(target.parent.glob(target.name + ".*.tmp"))
+        assert leftovers == [], f"tempfile not cleaned up: {leftovers}"
+
+    def test_concurrent_reader_never_sees_partial(self, tmp_path: Path):
+        """A reader looping ``read_text`` while a writer flips the same path
+        between two distinct payloads must only ever observe a complete
+        payload, never a truncation or in-flight write. This is the actual
+        property the indexer/hot-reload watcher relies on."""
+        target = tmp_path / "race.txt"
+        small = "small"
+        big = "B" * 50_000  # large enough that a non-atomic write would split
+        target.write_text(small, encoding="utf-8")
+
+        seen: list[str] = []
+        stop = threading.Event()
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    seen.append(target.read_text(encoding="utf-8"))
+                except FileNotFoundError:
+                    pass
+
+        t = threading.Thread(target=reader)
+        t.start()
+        try:
+            for _ in range(40):
+                atomic_write_text(target, big)
+                atomic_write_text(target, small)
+        finally:
+            stop.set()
+            t.join()
+
+        # Every observation must be one of the two complete payloads.
+        bad = [s for s in seen if s not in (small, big)]
+        assert not bad, f"observed {len(bad)} partial reads, e.g. len={len(bad[0])}"
+
+
+class TestSaveProxyConfigStillAtomic:
+    """Regression for PR #115: the CLI's ``_save`` was migrated to use
+    ``atomic_write_text`` — the externally-observable behaviour
+    (``stm_proxy.json`` ends up with mode 0o600 and JSON content) must
+    not have drifted.
+    """
+
+    def test_save_writes_json_at_mode_0o600(self, tmp_path: Path):
+        from memtomem_stm.cli.proxy import _save
+
+        target = tmp_path / "stm_proxy.json"
+        _save(target, {"enabled": True, "upstream_servers": {"x": {"prefix": "x"}}})
+
+        assert (target.stat().st_mode & 0o777) == 0o600
+        assert "upstream_servers" in target.read_text(encoding="utf-8")
+        # No leftover tempfile.
+        assert list(target.parent.glob("stm_proxy.json.*.tmp")) == []
+
+    def test_save_overwrite_does_not_duplicate(self, tmp_path: Path):
+        from memtomem_stm.cli.proxy import _save
+
+        target = tmp_path / "stm_proxy.json"
+        _save(target, {"enabled": True, "upstream_servers": {}})
+        _save(target, {"enabled": False, "upstream_servers": {"y": {"prefix": "y"}}})
+
+        body = target.read_text(encoding="utf-8")
+        assert '"enabled": false' in body
+        assert '"y"' in body
+        # First payload is fully replaced (no merged JSON, no leftover keys).
+        assert '"enabled": true' not in body
+
+    def test_save_failure_preserves_old_content(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from memtomem_stm.cli.proxy import _save
+
+        target = tmp_path / "stm_proxy.json"
+        _save(target, {"enabled": True, "upstream_servers": {}})
+        original = target.read_text(encoding="utf-8")
+
+        monkeypatch.setattr(
+            "memtomem_stm.utils.fileio.os.replace",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+
+        with pytest.raises(OSError):
+            _save(target, {"enabled": False, "upstream_servers": {"z": {"prefix": "z"}}})
+
+        assert target.read_text(encoding="utf-8") == original
+
+
+class TestMemoryOpsUsesAtomicWrite:
+    """``auto_index_response`` and ``extract_and_store`` write Markdown
+    files that the auto-indexer immediately reads — a partial file would
+    poison the index. Verify both paths now route through
+    ``atomic_write_text`` (no leftover ``.tmp`` fragments after a normal
+    write, no truncated-then-flushed window)."""
+
+    @pytest.mark.asyncio
+    async def test_auto_index_response_writes_atomically(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from memtomem_stm.proxy.config import AutoIndexConfig
+        from memtomem_stm.proxy.memory_ops import auto_index_response
+
+        # Stub indexer
+        class _Stats:
+            indexed_chunks = 0
+
+        class _Indexer:
+            async def index_file(self, *_a, **_k):
+                return _Stats()
+
+        cfg = AutoIndexConfig(
+            enabled=True,
+            memory_dir=tmp_path / "mem",
+            namespace="ns/{server}/{tool}",
+        )
+        (tmp_path / "mem").mkdir()
+
+        await auto_index_response(
+            index_engine=_Indexer(),
+            ai_cfg=cfg,
+            server="srv",
+            tool="t",
+            arguments={"q": "x"},
+            text="payload",
+            agent_summary="ok",
+        )
+
+        files = list((tmp_path / "mem").iterdir())
+        assert any(f.suffix == ".md" for f in files), files
+        # No tempfile residue from the atomic write.
+        assert not any(f.name.endswith(".tmp") for f in files), files


### PR DESCRIPTION
## Summary

PR #115 added the temp + `os.replace` pattern to the CLI's `_save` to
stop the proxy's mtime hot-reload from reading a half-written
`stm_proxy.json`. `proxy/memory_ops.py` had the same shape of writer in
two places (`auto_index_response` and `extract_and_store`) but still
called `Path.write_text` — and the auto-indexer reads each file
immediately after the writer flushes, so a kill or lock event between
write and `index_file` would leave the indexer pointing at a partial
Markdown body.

Extract the pattern to `memtomem_stm.utils.fileio.atomic_write_text`
and route both call sites through it. The CLI `_save` is now a
five-liner that just renders JSON and forwards. Without the helper, the
next caller that needed an atomic write would have made it three
implementations of the same thing.

## Surface area

| Path | Change |
| ---- | ------ |
| `src/memtomem_stm/utils/fileio.py` | **new** — `atomic_write_text(path, content, *, encoding, mode, ensure_parent, parent_mode)` |
| `src/memtomem_stm/cli/proxy.py` | `_save` now delegates; drops `os` + `tempfile` imports |
| `src/memtomem_stm/proxy/memory_ops.py` | `auto_index_response` and `extract_and_store` write through helper (`ensure_parent=False`) |

## Test plan

- [x] `tests/test_utils_fileio.py` — new, covers basic write, unicode, overwrite, mode 0o600, default mkstemp mode, `ensure_parent` toggling, `os.replace` failure cleanup, and a concurrent-reader-never-sees-partial check on a 50k payload
- [x] `tests/cli/test_proxy_cli.py::TestAtomicSave` — existing #115 tests still pass; `test_save_cleans_up_temp_on_failure` was patched to monkeypatch `utils.fileio.os.replace` (the rename moved with the helper)
- [x] `uv run pytest tests/ -m "not ollama" --ignore=tests/bench` — 1283 passed
- [x] `uv run ruff check src tests` and `uv run ruff format --check src` — clean
- [x] `uv run mypy src` — pre-existing `manager.py:362` warning unrelated to this change

## Notes

The helper deliberately leaves `mode=None` callers at `mkstemp`'s 0o600
default rather than applying the system umask. That is documented in
the test (`test_no_mode_inherits_mkstemp_default`) so the next reader
doesn't assume `mode=None` means "system default".