### PR TITLE
test(circuit_breaker): tolerate float residue in at-boundary reset check

### DIFF
--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -169,7 +169,14 @@ class TestCircuitBreakerProperties:
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = cb._opened_at + 10.0
             result = cb.time_until_reset
-            assert result == 0.0
+            # ``time_until_reset`` computes ``reset_timeout - (now - opened_at)``.
+            # ``opened_at`` is a real ``time.monotonic()`` value (often ~1e5-1e9
+            # seconds on CI runners), so ``(opened_at + 10.0) - opened_at`` loses
+            # a few low bits and the result is ``~1e-14`` rather than bit-exact
+            # ``0.0``. The contract here is "not positive, effectively zero" —
+            # pick a tolerance several orders of magnitude below any observable
+            # reset window.
+            assert result is not None and abs(result) < 1e-9
 
     def test_backward_compat_failure_alias(self):
         cb = CircuitBreaker(max_failures=2)


### PR DESCRIPTION
## Summary

`test_time_until_reset_at_boundary` mocks `time.monotonic()` to return
`cb._opened_at + 10.0` and asserts `time_until_reset == 0.0`. The
computation inside `time_until_reset` is
`reset_timeout - (now - opened_at)`; `opened_at` is a real monotonic
value (~1e5-1e9 seconds on a CI runner), so
`(opened_at + 10.0) - opened_at` drops a few low bits and the
subtraction leaves `~1e-14` rather than bit-exact zero.

The test then fails with `assert 1.4210854715202004e-14 == 0.0` on
runs where the runner's monotonic clock lands in an unfavourable
range. This is exactly what happened on the CI run for PR #119 while
unrelated PRs #120 and #121 — same base branch, same test — happened
to pass.

Replace the exact compare with an `abs(result) < 1e-9` tolerance
(several orders of magnitude below any observable reset window). The
semantic assertion "`time_until_reset` is effectively zero at the
boundary" is unchanged.

## Test plan

- [x] `uv run pytest tests/test_circuit_breaker.py -v` — 20 passed
- [x] `uv run ruff check tests/test_circuit_breaker.py` and `uv run ruff format --check tests/test_circuit_breaker.py` — clean
- [x] No production code touched — only the test assertion is relaxed

## Notes

After this lands, #119 will be rebased onto main so its CI picks up
the fix and reruns. #120 / #121 are unaffected.