### PR TITLE
fix(config): reject empty api_key for openai/anthropic at load time

### DIFF
--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -101,6 +101,22 @@ class LLMCompressorConfig(BaseModel):
     )
     max_tokens: int = Field(default=500, gt=0)
 
+    @model_validator(mode="after")
+    def _require_api_key_for_hosted_providers(self) -> LLMCompressorConfig:
+        if self.provider not in (LLMProvider.OPENAI, LLMProvider.ANTHROPIC):
+            return self
+        if self.api_key:
+            return self
+        env_var = "OPENAI_API_KEY" if self.provider == LLMProvider.OPENAI else "ANTHROPIC_API_KEY"
+        env_val = os.environ.get(env_var, "").strip()
+        if env_val:
+            self.api_key = env_val
+            return self
+        raise ValueError(
+            f"api_key is required for provider='{self.provider.value}' "
+            f"(set api_key in config or the {env_var} environment variable)"
+        )
+
 
 class CleaningConfig(BaseModel):
     enabled: bool = True

--- a/src/memtomem_stm/proxy/relevance.py
+++ b/src/memtomem_stm/proxy/relevance.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import re
 from typing import Protocol
 
@@ -127,10 +128,19 @@ class EmbeddingScorer:
         base_url: str = "http://localhost:11434",
         timeout: float = 10.0,
     ) -> None:
+        api_key = ""
+        if provider == "openai":
+            api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+            if not api_key:
+                raise ValueError(
+                    "OPENAI_API_KEY environment variable is required when "
+                    "EmbeddingScorer provider='openai'"
+                )
         self._provider = provider
         self._model = model
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
+        self._api_key = api_key
         self._fallback = BM25Scorer()
         self.fallback_count: int = 0
 
@@ -186,16 +196,13 @@ class EmbeddingScorer:
         return resp.json()["embeddings"]
 
     def _embed_openai(self, httpx_mod: object, texts: list[str]) -> list[list[float]]:
-        import os
-
         import httpx as _httpx
 
-        api_key = os.environ.get("OPENAI_API_KEY", "")
         url = self._base_url + "/v1/embeddings"
         resp = _httpx.post(
             url,
             json={"model": self._model, "input": texts, "encoding_format": "float"},
-            headers={"Authorization": f"Bearer {api_key}"},
+            headers={"Authorization": f"Bearer {self._api_key}"},
             timeout=self._timeout,
         )
         resp.raise_for_status()

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -10,6 +10,7 @@ from memtomem_stm.proxy.config import (
     AutoIndexConfig,
     ExtractionConfig,
     LLMCompressorConfig,
+    LLMProvider,
     RelevanceScorerConfig,
     SelectiveConfig,
 )
@@ -63,6 +64,54 @@ class TestProxyNumericConstraints:
             RelevanceScorerConfig(embedding_timeout=0.0)
         with pytest.raises(ValidationError):
             RelevanceScorerConfig(embedding_timeout=-1.0)
+
+
+class TestLLMCompressorApiKey:
+    """``provider=openai|anthropic`` with empty ``api_key`` used to send a
+    malformed ``Bearer `` header and silently fall back to truncate; validate
+    at config-load time instead so misconfiguration is loud."""
+
+    def test_openai_empty_api_key_rejected_when_env_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
+            LLMCompressorConfig(provider=LLMProvider.OPENAI)
+
+    def test_anthropic_empty_api_key_rejected_when_env_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with pytest.raises(ValidationError, match="ANTHROPIC_API_KEY"):
+            LLMCompressorConfig(provider=LLMProvider.ANTHROPIC)
+
+    def test_openai_env_fallback_populates_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        cfg = LLMCompressorConfig(provider=LLMProvider.OPENAI)
+        assert cfg.api_key == "sk-from-env"
+
+    def test_anthropic_env_fallback_populates_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-from-env")
+        cfg = LLMCompressorConfig(provider=LLMProvider.ANTHROPIC)
+        assert cfg.api_key == "ant-from-env"
+
+    def test_explicit_api_key_bypasses_env_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        cfg = LLMCompressorConfig(provider=LLMProvider.OPENAI, api_key="sk-explicit")
+        assert cfg.api_key == "sk-explicit"
+
+    def test_ollama_does_not_require_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        cfg = LLMCompressorConfig(provider=LLMProvider.OLLAMA)
+        assert cfg.api_key == ""
+
+    def test_whitespace_only_env_treated_as_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "   ")
+        with pytest.raises(ValidationError, match="OPENAI_API_KEY"):
+            LLMCompressorConfig(provider=LLMProvider.OPENAI)
 
 
 class TestSurfacingNumericConstraints:

--- a/tests/test_query_aware.py
+++ b/tests/test_query_aware.py
@@ -160,6 +160,22 @@ class TestRelevanceScorerProtocol:
         scorer.score_sections("another query", sections)
         assert scorer.fallback_count == 2
 
+    def test_openai_provider_requires_api_key_env(self, monkeypatch):
+        """Missing OPENAI_API_KEY at construction raises loudly so the misconfig
+        does not get swallowed by the silent BM25 fallback in score_sections."""
+        from memtomem_stm.proxy.relevance import EmbeddingScorer
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+            EmbeddingScorer(provider="openai", model="text-embedding-3-small")
+
+    def test_openai_provider_accepts_env_api_key(self, monkeypatch):
+        from memtomem_stm.proxy.relevance import EmbeddingScorer
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        scorer = EmbeddingScorer(provider="openai", model="text-embedding-3-small")
+        assert scorer._api_key == "sk-test"
+
     def test_custom_scorer_in_truncate(self):
         """TruncateCompressor accepts a custom scorer."""
 
@@ -204,6 +220,10 @@ class TestEmbeddingOpenAIResponseParsing:
     omit it. Sorting by a missing ``index`` used to raise ``KeyError`` and
     fail the entire request.
     """
+
+    @pytest.fixture(autouse=True)
+    def _openai_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     def _make_scorer(self):
         from memtomem_stm.proxy.relevance import EmbeddingScorer


### PR DESCRIPTION
## Summary

- Empty `api_key` with `provider=openai|anthropic` used to send malformed `Authorization: Bearer ` / `x-api-key: ""`, drawing a 401 that compression silently swallowed into truncate fallback. Since #102 demoted expected-fallback warnings, operators had no signal that LLM compression was misconfigured.
- `LLMCompressorConfig` now validates at load time: raises `ValidationError` when provider is openai/anthropic and `api_key` is empty, with env-var fallback to `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`.
- `EmbeddingScorer(provider="openai")` now validates `OPENAI_API_KEY` at `__init__` and caches it, so misconfig fails loudly at scorer construction instead of masking behind the silent BM25 fallback in `score_sections`.
- Ollama is unaffected (no api_key required). Configs that set `api_key` explicitly work unchanged.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run pytest -m "not ollama"` — 1296 passed
- [x] New `TestLLMCompressorApiKey` covers:
  - openai/anthropic empty api_key + no env → ValidationError
  - openai/anthropic empty api_key + env set → auto-populated
  - explicit api_key bypasses env check
  - ollama does not require api_key
  - whitespace-only env treated as missing
- [x] New `EmbeddingScorer` tests cover missing-env rejection and env-populated success
- [x] Existing `TestEmbeddingOpenAIResponseParsing` patched with autouse fixture to `monkeypatch.setenv("OPENAI_API_KEY", "test-key")` — HTTP-mock tests still pass