### PR TITLE
fix(server): guard FeedbackTracker init so SQLite failure degrades, not crashes

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -117,7 +117,14 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
 
             if mcp_adapter is not None:
                 if config.surfacing.feedback_enabled:
-                    feedback_tracker = FeedbackTracker(config.surfacing)
+                    try:
+                        feedback_tracker = FeedbackTracker(config.surfacing)
+                    except Exception:
+                        logger.warning(
+                            "FeedbackTracker init failed — surfacing feedback disabled",
+                            exc_info=True,
+                        )
+                        feedback_tracker = None
 
                 surfacing_engine = SurfacingEngine(
                     config.surfacing,

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -365,3 +365,56 @@ class TestLifespan:
             async with app_lifespan(mcp) as _ctx:
                 # ProxyManager.start() should NOT be called when proxy is disabled
                 mock_pm_instance.start.assert_not_awaited()
+
+    async def test_feedback_tracker_init_failure_degrades_gracefully(self):
+        """FeedbackTracker raising at init should log and fall back to
+        feedback_tracker=None — learning-loop feature must not crash the
+        server. Mirrors the CompressionFeedbackTracker guard pattern."""
+        from memtomem_stm.server import app_lifespan, mcp
+
+        mock_pm_instance = MagicMock()
+        mock_pm_instance.start = AsyncMock()
+        mock_pm_instance.stop = AsyncMock()
+        mock_pm_instance.get_proxy_tools.return_value = []
+
+        mock_adapter = MagicMock()
+        mock_adapter.start = AsyncMock()
+        mock_adapter.stop = AsyncMock()
+
+        captured_engine_kwargs: dict = {}
+
+        def _capture_engine(*_args, **kwargs):
+            captured_engine_kwargs.update(kwargs)
+            engine = MagicMock()
+            engine.stop = AsyncMock()
+            return engine
+
+        with (
+            patch("memtomem_stm.server.STMConfig") as MockConfig,
+            patch("memtomem_stm.server.ProxyManager", return_value=mock_pm_instance),
+            patch(
+                "memtomem_stm.surfacing.mcp_client.McpClientSearchAdapter",
+                return_value=mock_adapter,
+            ),
+            patch(
+                "memtomem_stm.server.FeedbackTracker",
+                side_effect=RuntimeError("disk full"),
+            ),
+            patch("memtomem_stm.server.SurfacingEngine", side_effect=_capture_engine),
+        ):
+            mock_cfg = MockConfig.return_value
+            mock_cfg.proxy = MagicMock()
+            mock_cfg.proxy.enabled = True
+            mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
+            mock_cfg.proxy.metrics.enabled = False
+            mock_cfg.proxy.compression_feedback.enabled = False
+            mock_cfg.proxy.cache.enabled = False
+            mock_cfg.surfacing = MagicMock()
+            mock_cfg.surfacing.enabled = True
+            mock_cfg.surfacing.feedback_enabled = True
+            mock_cfg.langfuse = MagicMock()
+            mock_cfg.langfuse.enabled = False
+
+            async with app_lifespan(mcp) as ctx:
+                assert ctx.feedback_tracker is None
+                assert captured_engine_kwargs.get("feedback_tracker") is None


### PR DESCRIPTION
## Summary

- `FeedbackTracker(config.surfacing)` in `app_lifespan` opens a SQLite DB inside `__init__` (`FeedbackStore.initialize()`). If the DB path is unwritable — bad permissions, full disk, stale lock — the unguarded construction crashes server startup entirely.
- Adjacent init blocks (`CompressionFeedbackTracker` at lines 86-96, `McpClientSearchAdapter.start()` at 102-116) already degrade gracefully with `try/except` → `None`. Follow the same pattern here.
- Core paths (`MetricsStore.initialize()`, `ProxyCache.initialize()`) intentionally stay fail-fast — running the proxy without observability or forcing every request to hit upstream is worse than not starting. Surfacing feedback is a learning loop, not core, so degrading is the right choice.
- `SurfacingEngine` already null-checks `feedback_tracker` on every read/write (`engine.py` lines 47, 64, 160, 294, 317, 376), so passing `None` is a supported degraded mode.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run pytest -m "not ollama"` — 1288 passed
- [x] New `test_feedback_tracker_init_failure_degrades_gracefully` patches `FeedbackTracker` to raise `RuntimeError("disk full")` and verifies:
  - `app_lifespan` enters without crashing
  - `ctx.feedback_tracker is None`
  - `SurfacingEngine` is still constructed with `feedback_tracker=None`