### PR TITLE
fix(extraction): guard LLM provider responses against empty/malformed payloads

### DIFF
--- a/src/memtomem_stm/proxy/extraction.py
+++ b/src/memtomem_stm/proxy/extraction.py
@@ -282,7 +282,15 @@ class FactExtractor:
             },
         )
         resp.raise_for_status()
-        return resp.json()["choices"][0]["message"]["content"]
+        data = resp.json()
+        choices = data.get("choices") or []
+        if not choices:
+            raise ValueError("OpenAI response has empty 'choices' (likely quota or content filter)")
+        message = choices[0].get("message") or {}
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise ValueError("OpenAI response missing 'choices[0].message.content'")
+        return content
 
     async def _anthropic(self, text: str, system_prompt: str) -> str:
         assert self._client is not None
@@ -305,7 +313,16 @@ class FactExtractor:
             },
         )
         resp.raise_for_status()
-        return resp.json()["content"][0]["text"]
+        data = resp.json()
+        content = data.get("content") or []
+        if not content:
+            raise ValueError(
+                "Anthropic response has empty 'content' (likely empty completion or filter)"
+            )
+        text_block = content[0].get("text")
+        if not isinstance(text_block, str):
+            raise ValueError("Anthropic response missing 'content[0].text'")
+        return text_block
 
     async def _ollama(self, text: str, system_prompt: str) -> str:
         assert self._client is not None
@@ -324,7 +341,12 @@ class FactExtractor:
             timeout=60,
         )
         resp.raise_for_status()
-        return resp.json()["message"]["content"]
+        data = resp.json()
+        message = data.get("message") or {}
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise ValueError("Ollama response missing 'message.content'")
+        return content
 
     async def close(self) -> None:
         if self._client:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -380,6 +380,167 @@ class TestFactExtractorLLM:
 
         assert captured_text is not None
         assert len(captured_text) <= 100
+
+
+# ---------------------------------------------------------------------------
+# Provider response defense (mirrors compression.py guards from #114/#119)
+# ---------------------------------------------------------------------------
+
+
+def _mock_http_response(payload: dict) -> MagicMock:
+    """Build an httpx-like response whose ``.json()`` returns ``payload``."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=payload)
+    return resp
+
+
+def _make_extractor(provider: LLMProvider) -> FactExtractor:
+    """FactExtractor with the given provider. api_key satisfies PR #123 validator;
+    system_prompt uses the ``{max_facts}`` placeholder that ``_call_api`` expects
+    (the compressor-config default uses ``{max_chars}`` and would KeyError here)."""
+    llm_cfg = LLMCompressorConfig(
+        provider=provider,
+        api_key="test-key",
+        system_prompt="Extract up to {max_facts} facts as JSON.",
+    )
+    cfg = ExtractionConfig(
+        enabled=True,
+        strategy=ExtractionStrategy.LLM,
+        llm=llm_cfg,
+        min_response_chars=10,
+    )
+    return FactExtractor(cfg)
+
+
+class TestOpenAIResponseDefense:
+    """OpenAI content filter / quota returns ``{"choices": []}`` with 200 OK.
+    Previously crashed with IndexError; now raises ValueError which the
+    ``_extract_llm`` caller catches and falls back to heuristic extraction."""
+
+    async def test_valid_response_returns_content(self):
+        extractor = _make_extractor(LLMProvider.OPENAI)
+        payload = {"choices": [{"message": {"content": '[{"content": "fact"}]'}}]}
+        with patch.object(
+            extractor._client, "post", AsyncMock(return_value=_mock_http_response(payload))
+        ):
+            result = await extractor._openai("text", "prompt")
+        assert result == '[{"content": "fact"}]'
+
+    async def test_empty_choices_raises_valueerror(self):
+        extractor = _make_extractor(LLMProvider.OPENAI)
+        with patch.object(
+            extractor._client,
+            "post",
+            AsyncMock(return_value=_mock_http_response({"choices": []})),
+        ):
+            with pytest.raises(ValueError, match="empty 'choices'"):
+                await extractor._openai("text", "prompt")
+
+    async def test_missing_content_raises_valueerror(self):
+        extractor = _make_extractor(LLMProvider.OPENAI)
+        payload = {"choices": [{"message": {}}]}  # no "content" key
+        with patch.object(
+            extractor._client, "post", AsyncMock(return_value=_mock_http_response(payload))
+        ):
+            with pytest.raises(ValueError, match="choices\\[0\\].message.content"):
+                await extractor._openai("text", "prompt")
+
+    async def test_non_dict_root_raises_valueerror(self):
+        """Some proxies return a bare error string or array on 200 OK."""
+        extractor = _make_extractor(LLMProvider.OPENAI)
+        with patch.object(
+            extractor._client,
+            "post",
+            AsyncMock(return_value=_mock_http_response({"error": "rate limited"})),
+        ):
+            with pytest.raises(ValueError, match="empty 'choices'"):
+                await extractor._openai("text", "prompt")
+
+
+class TestAnthropicResponseDefense:
+    """Anthropic safety filter returns ``{"content": []}`` with 200 OK."""
+
+    async def test_valid_response_returns_text(self):
+        extractor = _make_extractor(LLMProvider.ANTHROPIC)
+        payload = {"content": [{"text": '[{"content": "fact"}]'}]}
+        with patch.object(
+            extractor._client, "post", AsyncMock(return_value=_mock_http_response(payload))
+        ):
+            result = await extractor._anthropic("text", "prompt")
+        assert result == '[{"content": "fact"}]'
+
+    async def test_empty_content_raises_valueerror(self):
+        extractor = _make_extractor(LLMProvider.ANTHROPIC)
+        with patch.object(
+            extractor._client,
+            "post",
+            AsyncMock(return_value=_mock_http_response({"content": []})),
+        ):
+            with pytest.raises(ValueError, match="empty 'content'"):
+                await extractor._anthropic("text", "prompt")
+
+    async def test_missing_text_raises_valueerror(self):
+        extractor = _make_extractor(LLMProvider.ANTHROPIC)
+        payload = {"content": [{"type": "tool_use"}]}  # no "text" field
+        with patch.object(
+            extractor._client, "post", AsyncMock(return_value=_mock_http_response(payload))
+        ):
+            with pytest.raises(ValueError, match="content\\[0\\].text"):
+                await extractor._anthropic("text", "prompt")
+
+
+class TestOllamaResponseDefense:
+    """Ollama returns malformed responses when the model errors mid-generation
+    or when called with a wrong endpoint shape."""
+
+    async def test_valid_response_returns_content(self):
+        extractor = _make_extractor(LLMProvider.OLLAMA)
+        payload = {"message": {"role": "assistant", "content": '[{"content": "fact"}]'}}
+        with patch.object(
+            extractor._client, "post", AsyncMock(return_value=_mock_http_response(payload))
+        ):
+            result = await extractor._ollama("text", "prompt")
+        assert result == '[{"content": "fact"}]'
+
+    async def test_missing_message_raises_valueerror(self):
+        extractor = _make_extractor(LLMProvider.OLLAMA)
+        with patch.object(
+            extractor._client,
+            "post",
+            AsyncMock(return_value=_mock_http_response({"done": True})),
+        ):
+            with pytest.raises(ValueError, match="message.content"):
+                await extractor._ollama("text", "prompt")
+
+    async def test_non_string_content_raises_valueerror(self):
+        """Ollama occasionally emits ``content: null`` for tool-only turns."""
+        extractor = _make_extractor(LLMProvider.OLLAMA)
+        payload = {"message": {"content": None}}
+        with patch.object(
+            extractor._client, "post", AsyncMock(return_value=_mock_http_response(payload))
+        ):
+            with pytest.raises(ValueError, match="message.content"):
+                await extractor._ollama("text", "prompt")
+
+
+class TestExtractLlmFallsBackOnValueError:
+    """End-to-end: malformed provider response → ValueError → heuristic fallback.
+    Ensures the caller (_extract_llm) treats the new ValueError the same as
+    a transport error and doesn't regress into returning ``[]`` silently."""
+
+    async def test_empty_choices_triggers_heuristic_fallback(self):
+        extractor = _make_extractor(LLMProvider.OPENAI)
+        with patch.object(
+            extractor._client,
+            "post",
+            AsyncMock(return_value=_mock_http_response({"choices": []})),
+        ):
+            text = "Decision: Use Redis for caching. " * 20
+            facts = await extractor.extract(text, server="s", tool="t")
+
+        assert isinstance(facts, list)
+        assert extractor._cb.failure_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`FactExtractor._openai/_anthropic/_ollama` used raw subscript chains (`resp.json()["choices"][0]["message"]["content"]`) that raise `IndexError`/`KeyError` when a provider returns 200 OK with an empty or schema-shifted body. Real triggers: OpenAI content filters (`choices: []`), Anthropic safety blocks (`content: []`), quota/error payloads shaped as `{"error": "..."}`, Ollama tool-only turns where `message.content` is `null`.

The caller `_extract_llm` already catches `Exception` and falls back to heuristic extraction, so the agent never saw a crash — but the warning line only showed `type(exc).__name__`, surfacing as `KeyError: 'choices'` and masking the actual failure mode (quota vs safety filter vs schema drift).

Mirror the defensive pattern `LLMCompressor` grew in #114/#119: `.get()` chains + `ValueError` with a provider-specific message. Caller stays unchanged because its `except Exception` branch at `extraction.py:230` already logs the exception message.

## Design note

`extraction` is a result-returning path, not a strategy chain like compression. Returning `""` on malformed response would cause `_parse_facts_json("")` to yield `[]` and skip the heuristic fallback (worse UX). Raising `ValueError` routes through the existing caller's `except Exception` → heuristic path, which is the designed safety net, and also increments the circuit breaker so a persistently broken endpoint stops being called.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run pytest -m \"not ollama\"` — 1308 passed (11 new)
- [x] New tests per provider (`TestOpenAIResponseDefense`, `TestAnthropicResponseDefense`, `TestOllamaResponseDefense`):
  - valid response returns content
  - empty `choices` / `content` array → `ValueError`
  - missing leaf key → `ValueError`
  - OpenAI: error-shaped root (`{"error": "..."}`) → `ValueError`
  - Ollama: `message.content: null` → `ValueError`
- [x] `TestExtractLlmFallsBackOnValueError` confirms the caller catches the new `ValueError` and increments `circuit_breaker.failure_count`, so the heuristic fallback runs as designed