### PR TITLE
fix(stores): close SQLite connection if init-time tuning/schema fails

### DIFF
--- a/src/memtomem_stm/proxy/compression_feedback_store.py
+++ b/src/memtomem_stm/proxy/compression_feedback_store.py
@@ -91,10 +91,15 @@ class CompressionFeedbackStore:
 
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        self._db = sqlite3.connect(str(self._db_path), check_same_thread=False)
-        tune_connection(self._db)
-        self._db.executescript(_SCHEMA)
-        self._db.commit()
+        db = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        try:
+            tune_connection(db)
+            db.executescript(_SCHEMA)
+            db.commit()
+        except Exception:
+            db.close()
+            raise
+        self._db = db
 
     def close(self) -> None:
         if self._db:

--- a/src/memtomem_stm/proxy/pending_store.py
+++ b/src/memtomem_stm/proxy/pending_store.py
@@ -86,18 +86,23 @@ class SQLitePendingStore:
 
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        self._db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
-        tune_connection(self._db)
-        self._db.execute(
-            """CREATE TABLE IF NOT EXISTS pending_selections (
-                key TEXT PRIMARY KEY,
-                chunks_json TEXT NOT NULL,
-                format TEXT NOT NULL,
-                created_at REAL NOT NULL,
-                total_chars INTEGER NOT NULL
-            )"""
-        )
-        self._db.commit()
+        db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
+        try:
+            tune_connection(db)
+            db.execute(
+                """CREATE TABLE IF NOT EXISTS pending_selections (
+                    key TEXT PRIMARY KEY,
+                    chunks_json TEXT NOT NULL,
+                    format TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    total_chars INTEGER NOT NULL
+                )"""
+            )
+            db.commit()
+        except Exception:
+            db.close()
+            raise
+        self._db = db
 
     def close(self) -> None:
         if self._db:

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -55,9 +55,14 @@ class FeedbackStore:
 
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        self._db = sqlite3.connect(str(self._db_path), check_same_thread=False)
-        tune_connection(self._db)
-        self._db.executescript(_SCHEMA)
+        db = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        try:
+            tune_connection(db)
+            db.executescript(_SCHEMA)
+        except Exception:
+            db.close()
+            raise
+        self._db = db
 
     def close(self) -> None:
         if self._db:

--- a/tests/test_sqlite_init_cleanup.py
+++ b/tests/test_sqlite_init_cleanup.py
@@ -1,0 +1,58 @@
+"""Init-time SQLite connection must be closed if tuning/schema setup fails.
+
+If the new connection is left open, repeated init failures (e.g. a
+transient ``sqlite3`` corruption) accumulate file descriptors and a stale
+write lock, eventually preventing recovery on restart. Each store must
+close the in-progress connection and leave ``self._db is None`` so the
+store reports as un-initialized rather than half-initialized.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from memtomem_stm.proxy.compression_feedback_store import CompressionFeedbackStore
+from memtomem_stm.proxy.pending_store import SQLitePendingStore
+from memtomem_stm.surfacing.feedback_store import FeedbackStore
+
+
+_CASES: list[tuple[str, type[Any], str]] = [
+    ("memtomem_stm.surfacing.feedback_store", FeedbackStore, "feedback.db"),
+    (
+        "memtomem_stm.proxy.compression_feedback_store",
+        CompressionFeedbackStore,
+        "cfb.db",
+    ),
+    ("memtomem_stm.proxy.pending_store", SQLitePendingStore, "pending.db"),
+]
+
+
+@pytest.mark.parametrize("module_path, store_cls, filename", _CASES)
+def test_initialize_releases_connection_on_tune_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    module_path: str,
+    store_cls: type[Any],
+    filename: str,
+) -> None:
+    mod = importlib.import_module(module_path)
+
+    def boom(_db: Any) -> None:
+        raise RuntimeError("simulated tune_connection failure")
+
+    monkeypatch.setattr(mod, "tune_connection", boom)
+
+    store = store_cls(tmp_path / filename)
+    with pytest.raises(RuntimeError, match="simulated tune_connection failure"):
+        store.initialize()
+
+    assert store._db is None
+
+    monkeypatch.setattr(mod, "tune_connection", lambda _db: None)
+    store.initialize()
+    assert store._db is not None
+    store.close()


### PR DESCRIPTION
## Summary
- Three SQLite stores (`FeedbackStore`, `CompressionFeedbackStore`, `SQLitePendingStore`) opened a connection and immediately called `tune_connection()` + `executescript()` outside any guard. If either raised, the freshly-opened connection was leaked because it was never assigned to `self._db` (so `close()` couldn't reach it) yet the underlying file handle and write lock stayed.
- Repeated retries — `FeedbackTracker.__init__` was hardened in #124 to log-and-continue on init failure and may be retried — would accumulate FDs and a stale lock, eventually preventing recovery.
- Open the connection into a local, do setup inside `try/except` that closes the local on failure, then assign to `self._db` only after success. The store now reports as un-initialized (`self._db is None`) rather than half-initialized.

## Test plan
- [x] New parametrized test `tests/test_sqlite_init_cleanup.py` monkeypatches `tune_connection` to raise, asserts `store._db is None` after the exception, and verifies a subsequent retry succeeds (3 stores covered).
- [x] `uv run pytest tests/test_feedback.py tests/test_compression_feedback.py tests/test_pending_store.py tests/test_sqlite_init_cleanup.py -q` — 61 passed.
- [x] `uv run ruff check src tests/test_sqlite_init_cleanup.py && uv run ruff format --check ...` — clean.