### PR TITLE
fix(config): keep previous mtime when proxy config parse fails

### DIFF
--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -508,7 +508,11 @@ class ProxyConfigLoader:
             loaded = ProxyConfig.load_from_file(self._path, env_overrides=self._env_overrides)
             if loaded is not None:
                 self._cached = loaded
+                self._mtime = mtime
             else:
+                # Don't advance _mtime on parse failure: the next get() must
+                # retry instead of treating the broken file as up-to-date,
+                # otherwise a fix that lands within filesystem mtime
+                # granularity (or before any other write) would be ignored.
                 logger.warning("Proxy config parse failed; keeping previous config")
-            self._mtime = mtime
         return self._cached  # type: ignore[return-value]

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 
 
@@ -62,6 +63,34 @@ class TestProxyConfigLoader:
         seeded = ProxyConfig(enabled=True)
         loader.seed(seeded)
         assert loader.get() is seeded  # same object, not re-parsed
+
+    def test_parse_failure_does_not_block_subsequent_reload(self, tmp_path):
+        """If a fix lands within filesystem mtime granularity after a parse
+        failure, the next get() must still pick it up — the loader must not
+        treat the broken file's mtime as "already seen".
+        """
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"enabled": False}))
+        loader = ProxyConfigLoader(cfg_file)
+
+        assert loader.get().enabled is False
+
+        # Write broken JSON (its mtime differs so the loader notices).
+        time.sleep(0.05)
+        cfg_file.write_text("{ not valid json")
+        broken_mtime = cfg_file.stat().st_mtime
+
+        # Parse fails — the loader must keep the previously cached good config.
+        assert loader.get().enabled is False
+
+        # Simulate a fix that lands at the same mtime as the broken write
+        # (e.g., a rapid in-place edit on a coarse-grained filesystem).
+        cfg_file.write_text(json.dumps({"enabled": True}))
+        os.utime(cfg_file, (broken_mtime, broken_mtime))
+
+        # Without the fix, the loader stored broken_mtime when parsing failed
+        # and now sees the same mtime → skips reload → returns stale config.
+        assert loader.get().enabled is True
 
 
 # ── MetricsStore persistence ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `ProxyConfigLoader.get()` advanced `self._mtime` unconditionally — even when `load_from_file()` returned `None` because the file failed to parse. The next call compared the file's current mtime against that broken-state mtime and skipped reload, so a fix written at the same mtime (rapid in-place edit on a coarse-grained filesystem, or any same-second recovery) was silently ignored.
- Move `self._mtime = mtime` inside the `if loaded is not None:` branch so a parse failure leaves the mtime untouched and the next `get()` retries.

## Test plan
- [x] New `test_parse_failure_does_not_block_subsequent_reload` simulates the scenario with `os.utime` (good → broken → good-with-broken's-mtime) and asserts the loader picks up the fix. Verified by reasoning that without the patch, the loader would see `mtime == self._mtime` and return the stale cached config.
- [x] `uv run pytest tests/test_config_persistence.py -q` — 26 passed.
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.