### PR TITLE
fix(mcp_client): aclose stack if start() fails after entering contexts

### DIFF
--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -179,17 +179,30 @@ class McpClientSearchAdapter:
 
     async def start(self) -> None:
         """Connect to the memtomem MCP server."""
-        self._stack = AsyncExitStack()
-        params = StdioServerParameters(
-            command=self._config.ltm_mcp_command,
-            args=self._config.ltm_mcp_args,
-        )
-        transport = stdio_client(params)
-        streams = await self._stack.enter_async_context(transport)
-        self._session = await self._stack.enter_async_context(ClientSession(streams[0], streams[1]))
-        await self._session.initialize()
-        logger.info("MCP client connected to memtomem server: %s", self._config.ltm_mcp_command)
-        await self._negotiate_format()
+        stack = AsyncExitStack()
+        self._stack = stack
+        try:
+            params = StdioServerParameters(
+                command=self._config.ltm_mcp_command,
+                args=self._config.ltm_mcp_args,
+            )
+            transport = stdio_client(params)
+            streams = await stack.enter_async_context(transport)
+            self._session = await stack.enter_async_context(ClientSession(streams[0], streams[1]))
+            await self._session.initialize()
+            logger.info("MCP client connected to memtomem server: %s", self._config.ltm_mcp_command)
+            await self._negotiate_format()
+        except BaseException:
+            # Roll back any contexts we entered (transport subprocess, session
+            # streams) so a failed start — common during reconnect storms —
+            # doesn't leak file descriptors and child processes across retries.
+            try:
+                await stack.aclose()
+            except Exception:
+                logger.debug("Error during MCP client start() cleanup", exc_info=True)
+            self._stack = None
+            self._session = None
+            raise
 
     async def _negotiate_format(self) -> None:
         """Downgrade to compact if core doesn't advertise structured support.

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -286,3 +286,57 @@ class TestNoneContentDefense:
 
         entries = await adapter.scratch_list()
         assert entries == []
+
+
+# ── start() cleanup on failure ───────────────────────────────────────────
+
+
+class TestStartCleansUpOnFailure:
+    """If `start()` fails after entering the transport+session contexts (e.g.
+    `session.initialize()` raises against an unreachable server), the
+    AsyncExitStack must be aclosed so the spawned subprocess and stdio streams
+    aren't leaked across reconnect retries — otherwise repeated transient
+    failures pile up file descriptors and zombie processes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_initialize_failure_unwinds_stack_and_clears_state(self, monkeypatch):
+        from memtomem_stm.surfacing import mcp_client as mod
+
+        transport_exited = asyncio.Event()
+        session_exited = asyncio.Event()
+
+        class FakeTransport:
+            async def __aenter__(self):
+                return (MagicMock(), MagicMock())
+
+            async def __aexit__(self, *args):
+                transport_exited.set()
+                return None
+
+        class FakeSession:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                session_exited.set()
+                return None
+
+            async def initialize(self):
+                raise ConnectionError("simulated init failure")
+
+        monkeypatch.setattr(mod, "stdio_client", lambda _params: FakeTransport())
+        monkeypatch.setattr(mod, "ClientSession", FakeSession)
+
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+
+        with pytest.raises(ConnectionError, match="simulated init failure"):
+            await adapter.start()
+
+        assert transport_exited.is_set(), "transport context must be aclosed on init failure"
+        assert session_exited.is_set(), "session context must be aclosed on init failure"
+        assert adapter._stack is None
+        assert adapter._session is None


### PR DESCRIPTION
## Summary
- `McpClientSearchAdapter.start()` entered the transport (`stdio_client`) and session (`ClientSession`) into an `AsyncExitStack`, then called `session.initialize()`. If `initialize()` raised — common when the upstream server is briefly unreachable during reconnect — the exception propagated without unwinding the stack, leaving the spawned subprocess and stdio streams dangling.
- Repeated reconnect attempts compound the leak: each failed `start()` adds another zombie subprocess plus its file descriptors. With #124's degraded-not-crashed init flow, retries are now realistic.
- Wrap the body in `try/except BaseException`, `aclose` the stack, and clear `self._stack` / `self._session` before re-raising. `BaseException` ensures task cancellation also triggers cleanup (`asyncio.CancelledError` is not a subclass of `Exception`).

## Test plan
- [x] New `TestStartCleansUpOnFailure::test_initialize_failure_unwinds_stack_and_clears_state` monkeypatches `stdio_client` and `ClientSession` with fakes whose `__aexit__` flips an `asyncio.Event`. After a simulated `initialize()` failure, both events are set and `_stack` / `_session` are reset to `None`.
- [x] `uv run pytest tests/test_mcp_client_reconnect.py -v` — 13 passed (12 existing + 1 new).
- [x] Full suite: `uv run pytest -m "not ollama" -q` — 1309 passed.
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.