### PR TITLE
fix(proxy): aclose conn_stack if _reconnect_server fails after enter

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -239,12 +239,22 @@ class ProxyManager:
                 logger.debug("Failed to close previous stack for '%s'", name, exc_info=True)
 
         conn_stack = AsyncExitStack()
-        transport_ctx = self._open_transport(cfg)
-        streams = await conn_stack.enter_async_context(transport_ctx)
-        read, write = streams[0], streams[1]
-        session = await conn_stack.enter_async_context(ClientSession(read, write))
-        await asyncio.wait_for(session.initialize(), timeout=cfg.connect_timeout_seconds)
-        result = await session.list_tools()
+        try:
+            transport_ctx = self._open_transport(cfg)
+            streams = await conn_stack.enter_async_context(transport_ctx)
+            read, write = streams[0], streams[1]
+            session = await conn_stack.enter_async_context(ClientSession(read, write))
+            await asyncio.wait_for(session.initialize(), timeout=cfg.connect_timeout_seconds)
+            result = await session.list_tools()
+        except BaseException:
+            # Roll back any contexts we entered (transport subprocess, session
+            # streams). Without this, a failed reconnect leaks file descriptors
+            # and child processes across retry storms.
+            try:
+                await conn_stack.aclose()
+            except Exception:
+                logger.debug("Error during reconnect cleanup for '%s'", name, exc_info=True)
+            raise
 
         conn.session = session
         conn.stack = conn_stack

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -323,6 +323,60 @@ class TestReconnectFailure:
         assert session.call_tool.call_count == 2
 
 
+# ── Reconnect cleans up partial stack on failure ────────────────────────
+
+
+class TestReconnectServerCleansUpOnFailure:
+    """If `_reconnect_server()` fails after entering the new transport+session
+    contexts (e.g. `session.initialize()` raises against an unreachable server),
+    the partially-entered AsyncExitStack must be aclosed so the new subprocess
+    and stdio streams aren't leaked across retry storms — otherwise repeated
+    transient failures pile up file descriptors and zombie processes.
+    """
+
+    async def test_initialize_failure_unwinds_stack(self, monkeypatch):
+        from memtomem_stm.proxy import manager as mod
+
+        transport_exited = asyncio.Event()
+        session_exited = asyncio.Event()
+
+        class FakeTransport:
+            async def __aenter__(self):
+                return (MagicMock(), MagicMock())
+
+            async def __aexit__(self, *args):
+                transport_exited.set()
+                return None
+
+        class FakeSession:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                session_exited.set()
+                return None
+
+            async def initialize(self):
+                raise ConnectionError("simulated init failure")
+
+        mgr = _make_manager()
+        original_session = _get_session(mgr)
+        monkeypatch.setattr(mod, "ClientSession", FakeSession)
+        monkeypatch.setattr(mgr, "_open_transport", lambda cfg: FakeTransport())
+
+        with pytest.raises(ConnectionError, match="simulated init failure"):
+            await mgr._reconnect_server("srv")
+
+        assert transport_exited.is_set(), "transport context must be aclosed on init failure"
+        assert session_exited.is_set(), "session context must be aclosed on init failure"
+        # Connection state must not be partially mutated on failure.
+        assert mgr._connections["srv"].session is original_session
+        assert mgr._connections["srv"].stack is None
+
+
 # ── Zero retries configuration ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `_reconnect_server` creates a new `AsyncExitStack`, enters the transport + `ClientSession` contexts, then awaits `session.initialize()` and `session.list_tools()`. If any of those raise, the partially-entered stack was orphaned — file descriptors and stdio subprocess children leaked across retry storms.
- Wrap the enter/initialize/list_tools block in `try/except BaseException` that `aclose()`s `conn_stack` before re-raising. Mirrors the pattern shipped in `McpClientSearchAdapter.start()` via #129.
- `conn.session`/`conn.stack` are left untouched on failure, so the caller's retry loop sees the original exception rather than a cleanup-path secondary.

## Test plan
- [x] New `TestReconnectServerCleansUpOnFailure::test_initialize_failure_unwinds_stack` fakes transport/session context managers, raises from `initialize()`, and asserts both `__aexit__` methods ran and `conn` state is untouched.
- [x] `uv run pytest tests/test_proxy_error_paths.py tests/test_proxy_manager_lifecycle.py` — 52 passed.
- [x] `uv run ruff check src && uv run ruff format --check src`.