### PR TITLE
fix(surfacing): close boost-guard race in handle_feedback

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -163,6 +163,11 @@ class SurfacingEngine:
         result = self._feedback_tracker.record_feedback(surfacing_id, rating, memory_id)
 
         if rating == "helpful" and surfacing_id not in self._boosted_event_ids:
+            # Claim the guard optimistically BEFORE the increment_access
+            # await so a concurrent "helpful" for the same surfacing_id
+            # observes the claim and short-circuits. Rolled back on failure
+            # so the documented "retry on failure" behavior is preserved.
+            self._boosted_event_ids[surfacing_id] = None
             try:
                 if memory_id:
                     target_ids: list[str] = [memory_id]
@@ -179,13 +184,17 @@ class SurfacingEngine:
                         },
                     ):
                         await self._mcp_adapter.increment_access(target_ids)
-                    self._boosted_event_ids[surfacing_id] = None
                     # Prune if exceeded cap — evict oldest (first-inserted) entries.
                     if len(self._boosted_event_ids) > self._boosted_event_ids_max:
                         excess = len(self._boosted_event_ids) - self._boosted_event_ids_max // 2
                         for k in list(self._boosted_event_ids)[:excess]:
                             del self._boosted_event_ids[k]
+                else:
+                    # No memories to boost — release the guard so a later
+                    # call with a resolvable memory_id can retry.
+                    self._boosted_event_ids.pop(surfacing_id, None)
             except Exception:
+                self._boosted_event_ids.pop(surfacing_id, None)
                 logger.debug(
                     "Failed to boost access_count for surfacing %s",
                     surfacing_id,

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -430,6 +430,36 @@ class TestFeedbackBoost:
 
         adapter.increment_access.assert_not_called()
 
+    async def test_concurrent_helpful_for_same_surfacing_id_boosts_once(self):
+        """Two concurrent ``handle_feedback`` calls for the same ``surfacing_id``
+        must fire a single ``increment_access`` RPC — the class docstring and
+        ``_boosted_event_ids`` guard promise "at most one per surfacing event"
+        even under concurrency. Without claiming the guard before the await,
+        both coroutines observe an empty guard, both await ``increment_access``,
+        and the boost is double-counted in core."""
+        adapter = _make_mcp_adapter([])
+
+        async def slow_increment(_ids):
+            await asyncio.sleep(0.01)
+
+        adapter.increment_access = AsyncMock(side_effect=slow_increment)
+        tracker = self._make_tracker(["mid-A"])
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        await asyncio.gather(
+            engine.handle_feedback("sid-concurrent", "helpful", memory_id="mid-A"),
+            engine.handle_feedback("sid-concurrent", "helpful", memory_id="mid-A"),
+        )
+
+        assert adapter.increment_access.await_count == 1, (
+            "Dedup guard violated under concurrency: "
+            f"increment_access awaited {adapter.increment_access.await_count} times"
+        )
+
     async def test_boosted_event_ids_fifo_cap_evicts_oldest(self):
         """When ``_boosted_event_ids`` exceeds its cap, oldest entries evict first."""
         adapter = _make_mcp_adapter([])


### PR DESCRIPTION
## Summary

- ``handle_feedback`` documents that a "helpful" rating for the same ``surfacing_id`` fires at most one ``increment_access`` RPC. Sequential dedup was covered, but under concurrency two coroutines could both see ``_boosted_event_ids`` empty at the check (L165), both ``await`` ``increment_access`` (L181), and both record the event at L182 — double-counting the ranking boost in core.
- Claim the guard optimistically before the await so a concurrent caller for the same ``surfacing_id`` short-circuits. Roll it back on exception or when no memories resolve, preserving the "retry on failure" invariant locked in by ``test_boost_failure_does_not_break_feedback``.
- No behavior change in the sequential path.

## Test plan
- [x] New ``test_concurrent_helpful_for_same_surfacing_id_boosts_once`` runs two ``asyncio.gather``-parallel "helpful" calls and asserts a single ``increment_access`` RPC.
- [x] Reproduced the bug on main: new test fails (await_count == 2). Fix flips it to 1.
- [x] Existing ``TestFeedbackBoost`` suite (sequential dedup, failure rollback, empty memories, FIFO cap) still passes.
- [x] ``uv run pytest -m "not ollama"`` — 1314 passed.
- [x] ``uv run ruff check src && uv run ruff format --check src``.