### PR TITLE
fix(surfacing): claim _surfaced_ids before awaiting to close dedup race

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -272,6 +272,22 @@ class SurfacingEngine:
             )
             return response_text
 
+        # Record in-memory surfaced IDs EAGERLY — before any await — so a
+        # concurrent ``_do_surface`` for an overlapping memory observes the
+        # claim at L261 and excludes it. Without this, the await at
+        # ``scratch_list`` below opens an interleaving window where both
+        # coroutines build ``relevant`` including the same memory and
+        # violate the documented session-dedup invariant.
+        new_ids = [str(r.chunk.id) for r in relevant]
+        for mid in new_ids:
+            self._surfaced_ids[mid] = None
+        # Prune if exceeded cap — evict oldest (first-inserted) entries.
+        if len(self._surfaced_ids) > self._surfaced_ids_max:
+            excess = len(self._surfaced_ids) - self._surfaced_ids_max // 2
+            keys = list(self._surfaced_ids)[:excess]
+            for k in keys:
+                del self._surfaced_ids[k]
+
         self._gate.record_surfacing(query)
         logger.info(
             "Surfacing %d memories for %s/%s (query=%s)", len(relevant), server, tool, query[:50]
@@ -298,22 +314,14 @@ class SurfacingEngine:
                     server=server,
                     tool=tool,
                     query=query,
-                    memory_ids=[str(r.chunk.id) for r in relevant],
+                    memory_ids=new_ids,
                     scores=[r.score for r in relevant],
                 )
             except Exception:
                 logger.warning("Failed to record surfacing event", exc_info=True)
 
-        # Record surfaced IDs to suppress repeats (in-memory + persistent)
-        new_ids = [str(r.chunk.id) for r in relevant]
-        for mid in new_ids:
-            self._surfaced_ids[mid] = None
-        # Prune if exceeded cap — evict oldest (first-inserted) entries.
-        if len(self._surfaced_ids) > self._surfaced_ids_max:
-            excess = len(self._surfaced_ids) - self._surfaced_ids_max // 2
-            keys = list(self._surfaced_ids)[:excess]
-            for k in keys:
-                del self._surfaced_ids[k]
+        # Persist seen IDs for cross-session dedup (in-memory guard was
+        # claimed above to close the concurrent window).
         if self._feedback_tracker is not None:
             try:
                 self._feedback_tracker.store.mark_surfaced(new_ids)

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -466,6 +466,66 @@ class TestFeedbackBoost:
         adapter.increment_access.assert_not_called()
 
 
+class TestConcurrentSurfacedIdsDedup:
+    """Dedup invariant: each memory surfaced at most once per session, even
+    under concurrency (engine.py:62 / L256 / docstring).
+
+    Before the fix, the in-memory write at ``_surfaced_ids`` happened AFTER
+    the ``scratch_list`` await, opening an interleaving window where two
+    concurrent ``_do_surface`` calls could both build ``relevant`` with the
+    same memory and both return responses containing it."""
+
+    def _make_tracker(self):
+        tracker = MagicMock()
+        tracker.record_feedback = MagicMock(return_value="ok")
+        tracker.store = MagicMock()
+        tracker.store.get_seen_ids = MagicMock(return_value=set())
+        tracker.store.mark_surfaced = MagicMock()
+        tracker.record_surfacing = MagicMock()
+        return tracker
+
+    async def test_concurrent_surface_same_memory_dedups(self):
+        shared_chunk = FakeChunk(id="mem-shared", content="the shared memory content")
+        results = [FakeSearchResult(chunk=shared_chunk, score=0.9)]
+        adapter = _make_mcp_adapter(results)
+
+        async def slow_scratch(**_kwargs):
+            await asyncio.sleep(0.01)
+            return []
+
+        adapter.scratch_list = AsyncMock(side_effect=slow_scratch)
+        adapter.increment_access = AsyncMock()
+
+        tracker = self._make_tracker()
+        engine = SurfacingEngine(
+            config=_make_config(include_session_context=True),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        out_a, out_b = await asyncio.gather(
+            engine.surface(
+                "gh",
+                "read_file",
+                {"path": "src/a.py", "_context_query": "Flask architecture"},
+                LONG_RESPONSE,
+            ),
+            engine.surface(
+                "gh",
+                "search",
+                {"path": "src/b.py", "_context_query": "Django routes"},
+                LONG_RESPONSE,
+            ),
+        )
+
+        appears_in_a = "the shared memory content" in out_a
+        appears_in_b = "the shared memory content" in out_b
+        assert not (appears_in_a and appears_in_b), (
+            "Session dedup violated under concurrency: shared memory surfaced "
+            "in both concurrent responses"
+        )
+
+
 class TestMaybeCleanupExpired:
     """Integration: _maybe_cleanup_expired() scheduling from surface()."""
 


### PR DESCRIPTION
## Summary

- The session-dedup invariant ("each memory surfaced at most once per session") was documented at ``engine.py:62`` and L256 but broken under concurrency: the in-memory ``_surfaced_ids`` write happened AFTER the ``scratch_list`` await, so two concurrent ``surface()`` calls whose searches returned the same memory would both observe an empty guard at L261 and both inject the memory into their responses.
- Move the in-memory write to right after ``relevant`` is built — before any await — so a concurrent ``_do_surface`` sees the claim at its own L261 check and excludes the shared memory.
- ``mark_surfaced`` (persistent store) stays at the end since sqlite is sync and doesn't interleave; only the in-memory guard needs to be claimed early.

## Test plan
- [x] New ``test_concurrent_surface_same_memory_dedups`` runs two ``asyncio.gather``-parallel ``surface()`` calls with overlapping search results and ``include_session_context=True`` (which exposes the interleaving point) — asserts the shared memory appears in at most one response.
- [x] Reproduced the bug on main: test fails with "shared memory surfaced in both concurrent responses".
- [x] Existing ``TestSessionDedup`` (sequential dedup) still passes — fix only claims the guard earlier, no behavior change in the single-call path.
- [x] ``uv run pytest -m "not ollama"`` — 1314 passed.
- [x] ``uv run ruff check src && uv run ruff format --check src``.