### PR TITLE
fix(proxy): drain _background_tasks in a loop until empty

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -270,11 +270,29 @@ class ProxyManager:
         logger.info("Reconnected to '%s' (%s tools)", name, len(conn.tools))
 
     async def stop(self) -> None:
-        # Cancel and drain background tasks (extraction, etc.)
-        for task in self._background_tasks:
-            task.cancel()
-        if self._background_tasks:
-            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        # Cancel and drain background tasks (extraction, etc.). Loop until
+        # the set is empty — a concurrent call_tool may schedule a new
+        # extraction task during our gather await (``call_tool`` adds to
+        # ``_background_tasks`` after ``asyncio.create_task(...)``), and
+        # ``asyncio.gather(*snapshot)`` only awaits the snapshot, leaving
+        # a late task pending. A second iteration catches and cancels it.
+        # Bound the loop so a pathological task that keeps scheduling
+        # replacements can't spin forever.
+        for _ in range(8):
+            if not self._background_tasks:
+                break
+            batch = list(self._background_tasks)
+            for task in batch:
+                task.cancel()
+            await asyncio.gather(*batch, return_exceptions=True)
+            for task in batch:
+                self._background_tasks.discard(task)
+        else:
+            logger.warning(
+                "ProxyManager.stop(): %d background tasks still pending after "
+                "drain loop; leaking them",
+                len(self._background_tasks),
+            )
         self._background_tasks.clear()
         # Close httpx clients
         if self._llm_compressor is not None:

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -377,6 +377,55 @@ class TestReconnectServerCleansUpOnFailure:
         assert mgr._connections["srv"].stack is None
 
 
+# ── Background task race during stop() ──────────────────────────────────
+
+
+class TestBackgroundTasksStopRace:
+    """When ``stop()`` is draining ``_background_tasks``, a task added to the
+    set after ``asyncio.gather(...)`` has snapshotted its arguments must
+    still be cancelled. In production, a request-path coroutine can
+    schedule a background extraction after ``stop()`` began its drain but
+    before it completes, leaving the new task orphaned and potentially
+    accessing ``_extractor`` / ``_index_engine`` after they have been
+    closed."""
+
+    async def test_task_added_during_stop_gather_is_cancelled(self):
+        """Deterministic variant: an existing task, when cancelled by ``stop``,
+        schedules a new background task before re-raising. This mirrors the
+        production race (a ``call_tool`` in flight during shutdown scheduling
+        extraction) without relying on sleep timing."""
+        mgr = _make_manager()
+        added: list[asyncio.Task] = []
+
+        async def self_spawning_on_cancel():
+            try:
+                # Park indefinitely until cancelled.
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                # Simulate ``call_tool`` racing with shutdown — a background
+                # extraction is scheduled and added to ``_background_tasks``
+                # after ``stop()`` has already snapshotted the original set.
+                new = asyncio.create_task(asyncio.sleep(5))
+                mgr._background_tasks.add(new)
+                added.append(new)
+                raise
+
+        existing = asyncio.create_task(self_spawning_on_cancel())
+        mgr._background_tasks.add(existing)
+        # Let the task start and park on the wait() before stop() cancels it,
+        # so cancellation triggers the except block rather than a cancel-
+        # before-start shortcut.
+        await asyncio.sleep(0)
+
+        await mgr.stop()
+
+        assert added, "self_spawning_on_cancel did not schedule follow-up task"
+        assert added[0].done() or added[0].cancelled(), (
+            "Task added to _background_tasks during stop()'s gather was "
+            "neither cancelled nor awaited — it leaks past stop()"
+        )
+
+
 # ── Zero retries configuration ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- ``ProxyManager.stop()`` snapshotted ``_background_tasks`` once, awaited ``asyncio.gather`` over that snapshot, then called ``clear()``. A task added to the set **during** the gather await (common case: ``call_tool`` in flight during shutdown scheduling a background extraction) was not in the gather snapshot. ``clear()`` then removed it from the set without cancelling or awaiting — the task kept running past ``stop()`` and could touch ``_extractor`` / ``_index_engine`` after they were closed.
- Loop until the set is empty: each iteration snapshots, cancels, awaits gather, and ``discard``s those specific tasks (no ``clear()``), so any task added during iteration N is caught by iteration N+1.
- Bound the loop at 8 iterations and log a warning if tasks remain, so a pathological self-scheduling task can't spin shutdown forever.

## Test plan
- [x] New ``test_task_added_during_stop_gather_is_cancelled`` uses an existing task that, on cancel, schedules a follow-up task before re-raising — mirrors the production race deterministically without relying on sleep timing. On main the new task remains pending after ``stop()``; with the fix it is cancelled.
- [x] Reproduced the bug on main (stashed the fix, ran the test, observed failure with pending late task).
- [x] ``uv run pytest -m "not ollama"`` — 1314 passed.
- [x] ``uv run ruff check src && uv run ruff format --check src``.