### PR TITLE
fix(proxy): stop _trace_id mutation from tainting cache.set key

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -788,6 +788,14 @@ class ProxyManager:
         cfg = conn.config
         delay = cfg.reconnect_delay_seconds
 
+        # Snapshot the cache-key args BEFORE injecting ``_trace_id`` below.
+        # The cache lookup at L771 used the original args (no ``_trace_id``);
+        # if cache.set uses the mutated args, every stored entry is keyed on
+        # a per-request random hex and is unreachable by any future lookup
+        # (hit rate structurally 0%). Keep upstream args mutated for trace
+        # propagation, but persist under the original key.
+        cache_args = {**upstream_args}
+
         # Propagate trace context to upstream server for end-to-end correlation.
         if trace_id is not None:
             upstream_args["_trace_id"] = trace_id
@@ -1282,7 +1290,7 @@ class ProxyManager:
                 self._cache.set(
                     server,
                     tool,
-                    upstream_args,
+                    cache_args,
                     compressed,
                     ttl_seconds=cfg_snap.cache.default_ttl_seconds,
                 )

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -649,6 +649,46 @@ class TestCacheWithErrors:
         session.call_tool.assert_not_called()
         assert mgr.tracker.get_summary()["cache_hits"] == 1
 
+    async def test_cache_roundtrip_is_reachable_with_trace_id_propagation(self, tmp_path):
+        """End-to-end cache round-trip: a real ``ProxyCache`` backed by
+        SQLite must observe a hit on a second call with identical args,
+        *even while ``_trace_id`` is being injected into the upstream args
+        for observability*. The bug this regression protects against —
+        ``upstream_args["_trace_id"] = trace_id`` mutating the same dict
+        that later feeds ``cache.set`` — makes every stored entry keyed
+        on a per-request random hex, so no future lookup can ever match
+        (cache hit rate structurally 0%).
+
+        Uses a real ``ProxyCache``, not ``MagicMock``, because mock-backed
+        tests don't enforce key equality between ``get`` and ``set`` and
+        so can't detect the mutation bug."""
+        from memtomem_stm.proxy.cache import ProxyCache
+
+        mgr = _make_manager(tmp_path=tmp_path)
+        session = _get_session(mgr)
+        session.call_tool.side_effect = [_make_result("upstream payload")]
+
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=10)
+        cache.initialize()
+        mgr._cache = cache
+        try:
+            # First call: miss → upstream → set.
+            r1 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert "upstream payload" in r1
+            assert session.call_tool.call_count == 1
+
+            # Second call with the SAME args: must hit cache (no upstream).
+            r2 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert "upstream payload" in r2
+            assert session.call_tool.call_count == 1, (
+                "Cache round-trip broken: second identical call went to "
+                f"upstream ({session.call_tool.call_count} calls). "
+                "cache.set key likely diverged from cache.get key "
+                "(e.g. trace_id injection mutating the shared args dict)."
+            )
+        finally:
+            cache.close()
+
     async def test_cache_set_failure_does_not_break_response(self):
         """A failing ``cache.set`` (SQLite lock timeout, disk full, etc.)
         must not discard a successful upstream response. Cache writes are


### PR DESCRIPTION
## Summary

- ``_call_tool_inner`` looked up the response cache with the agent's original args, then mutated that same dict to inject ``_trace_id`` before the upstream call, and later passed the mutated dict to ``cache.set``. Every stored entry was keyed on a per-request random hex, so no future ``cache.get`` could ever produce a match — **cache hit rate structurally 0%** regardless of repeat traffic. The ``cache_hits`` tracker metric was also misleading (only mock-based tests ever registered a hit).
- Snapshot the cache-key args into ``cache_args`` before the ``_trace_id`` injection; persist under that key. Upstream call is unchanged — the trace id still propagates for end-to-end correlation.

## Why existing tests didn't catch this

- ``test_cache_hit_bypasses_upstream`` seeded ``cache.get.return_value = "cached result"`` unconditionally, so it never checked key equality.
- ``test_proxy_cache.py`` tested ``ProxyCache`` directly without going through the manager, so the trace-id mutation path wasn't exercised.
- Nothing did a round-trip of "set then get under an active ``trace_id``" through the manager.

## Test plan
- [x] New ``test_cache_roundtrip_is_reachable_with_trace_id_propagation`` uses a **real** SQLite-backed ``ProxyCache`` (not ``MagicMock``), calls ``mgr.call_tool`` twice with identical args, and asserts ``session.call_tool.call_count == 1`` on the second call (cache hit).
- [x] Reproduced the bug on main: test fails with ``StopAsyncIteration`` because the second call also goes upstream and exhausts the mocked ``side_effect`` list.
- [x] ``uv run pytest -m "not ollama"`` — 1314 passed.
- [x] ``uv run ruff check src && uv run ruff format --check src``.

## Follow-up

Stampede protection (the original track that led here) is blocked on this and will land as a separate PR on top of this one.