### PR TITLE
fix(surfacing): per-key lock closes cache stampede + poisoning race

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -80,6 +80,15 @@ class SurfacingEngine:
         self._boosted_event_ids: dict[str, None] = {}
         self._boosted_event_ids_max = 10000
         self._background_tasks: set[asyncio.Task] = set()
+        # Per-key stampede guard — identical concurrent ``_do_surface`` calls
+        # serialize on the same lock so a cache miss triggers one LTM search
+        # rather than N and the losing coroutine cannot overwrite the
+        # winning coroutine's populated cache entry with its own (empty due
+        # to session dedup) result. Entries are popped while the lock is
+        # still held so any queued waiter sees the cached result on its
+        # own double-check. Named ``_key_locks`` to match the same pattern
+        # used by ``ProxyManager`` (extractable into a shared helper later).
+        self._key_locks: dict[str, asyncio.Lock] = {}
         # Opportunistic cleanup: run cleanup_expired at most once per hour
         self._cleanup_interval = 3600.0
         self._last_cleanup: float = time.monotonic()
@@ -194,6 +203,29 @@ class SurfacingEngine:
 
         return result
 
+    def _render_cached(
+        self,
+        cached: list[Any],
+        response_text: str,
+        query: str,
+        server: str,
+        tool: str,
+    ) -> str:
+        """Render a cached surfacing result into the response_text, or pass
+        the response through unchanged if the cache entry is an empty list
+        (the deliberate "no results for this query" case)."""
+        if not cached:
+            logger.debug("Surfacing cache hit (empty) for %s/%s", server, tool)
+            return response_text
+        logger.debug("Surfacing cache hit (%d results) for %s/%s", len(cached), server, tool)
+        surfacing_id = uuid.uuid4().hex[:16]
+        return self._formatter.inject(
+            response_text,
+            cached,
+            query,
+            surfacing_id=surfacing_id,
+        )
+
     async def _do_surface(
         self,
         server: str,
@@ -204,22 +236,48 @@ class SurfacingEngine:
         *,
         trace_id: str | None = None,
     ) -> str:
-        # Check surfacing cache (keyed by server+tool+query)
+        # Check surfacing cache (keyed by server+tool+query). The full miss
+        # path lives in ``_do_surface_miss``; this shell handles the
+        # cache-check fast path, per-key stampede lock, and post-lock
+        # double-check so identical concurrent queries share a single LTM
+        # search and the losing coroutine cannot poison the cache with an
+        # empty result (see ``_key_locks`` init docstring).
         cache_key = f"{server}/{tool}/{query}"
         cached = self._cache.get(cache_key)
         if cached is not None:
-            if not cached:
-                logger.debug("Surfacing cache hit (empty) for %s/%s", server, tool)
-                return response_text
-            logger.debug("Surfacing cache hit (%d results) for %s/%s", len(cached), server, tool)
-            surfacing_id = uuid.uuid4().hex[:16]
-            return self._formatter.inject(
-                response_text,
-                cached,
-                query,
-                surfacing_id=surfacing_id,
-            )
+            return self._render_cached(cached, response_text, query, server, tool)
 
+        lock = self._key_locks.setdefault(cache_key, asyncio.Lock())
+        async with lock:
+            try:
+                # Double-check inside the lock: a coroutine that held the
+                # lock ahead of us may have populated the cache already.
+                cached = self._cache.get(cache_key)
+                if cached is not None:
+                    return self._render_cached(cached, response_text, query, server, tool)
+                return await self._do_surface_miss(
+                    server,
+                    tool,
+                    arguments,
+                    response_text,
+                    query,
+                    cache_key,
+                    trace_id=trace_id,
+                )
+            finally:
+                self._key_locks.pop(cache_key, None)
+
+    async def _do_surface_miss(
+        self,
+        server: str,
+        tool: str,
+        arguments: dict[str, Any],
+        response_text: str,
+        query: str,
+        cache_key: str,
+        *,
+        trace_id: str | None = None,
+    ) -> str:
         # Resolve effective config (auto-tuned if enabled)
         tool_cfg = self._config.context_tools.get(tool)
         if self._auto_tuner is not None:

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -261,6 +261,77 @@ class TestSurfacingCache:
         assert adapter.search.call_count == 1  # not called again
 
 
+class TestSurfacingCacheStampede:
+    """Two concurrent ``surface()`` calls for the same ``{server}/{tool}/{query}``
+    cache key should trigger a single LTM search, not one per caller. The
+    cache exists specifically to avoid redundant LTM searches; under the
+    current check-then-await-then-set pattern (engine.py:209 get, L248 await
+    search, L267 set), the ``await`` window lets both coroutines observe a
+    miss before either writes back, so both hit LTM."""
+
+    async def test_concurrent_identical_queries_share_single_search(self):
+        """Three observable symptoms of the stampede, in order of severity:
+
+        1. Duplicate LTM search (wasted upstream load).
+        2. Second caller fails to receive the surfaced memory because the
+           session dedup (``_surfaced_ids``) was claimed by the first caller
+           between the two searches completing.
+        3. Cache poisoning: the second caller's ``cache.set(key, [])``
+           overwrites the first caller's ``cache.set(key, [memory])``, so
+           every subsequent call for the same query inside the TTL window
+           sees an empty-hit and skips surfacing entirely.
+
+        Of these, (3) is the most impactful — a transient race permanently
+        (for the TTL) suppresses surfacing for a query across future
+        requests."""
+        chunk = FakeChunk(id="mem-shared", content="shared result")
+        results = [FakeSearchResult(chunk=chunk, score=0.5)]
+        adapter = AsyncMock()
+
+        async def slow_search(**_kwargs):
+            await asyncio.sleep(0.01)
+            return (results, {})
+
+        adapter.search = AsyncMock(side_effect=slow_search)
+
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+        )
+
+        out_a, out_b = await asyncio.gather(
+            engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE),
+            engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE),
+        )
+
+        # Symptom 1: duplicate LTM search
+        assert adapter.search.call_count == 1, (
+            f"Stampede: {adapter.search.call_count} LTM searches for the "
+            "same {server}/{tool}/{query} cache key (expected 1)"
+        )
+
+        # Symptom 2: both callers should see the memory.
+        assert "shared result" in out_a
+        assert "shared result" in out_b, (
+            "Second concurrent caller did not receive the shared memory — "
+            "the in-flight first caller claimed the _surfaced_ids slot "
+            "before the second caller's filter ran"
+        )
+
+        # Symptom 3: cache entry reflects the populated result, not the
+        # poisoned empty list. A subsequent call for the same query must
+        # still hit the memory, not bypass surfacing on an empty-hit.
+        cache_key = f"gh/read_file/{VALID_ARGS['_context_query']}"
+        cached = engine._cache.get(cache_key)
+        assert cached, (
+            "Cache poisoned with empty list — stampede's losing writer "
+            "overwrote the winning writer's populated cache entry"
+        )
+        assert any(r.chunk.id == "mem-shared" for r in cached), (
+            "Cache entry exists but is missing the shared memory"
+        )
+
+
 class TestSessionContextInjection:
     """Verify include_session_context wires the scratchpad through the MCP adapter."""
 


### PR DESCRIPTION
## Summary

Severity: **HIGH**. Two concurrent ``surface()`` calls for the same ``{server}/{tool}/{query}`` cache key produced three compounding symptoms on main:

1. **Duplicate LTM search** — both coroutines observed a miss at L209 and both awaited the upstream search at L248.
2. **Second caller missed the memory** — between the two search completions, the first caller wrote the hit memory ID to ``_surfaced_ids``, so the second caller's filter at L261 yielded ``relevant=[]`` and returned the response unchanged.
3. **Cache poisoning** — the second caller's ``cache.set(key, [])`` overwrote the first caller's ``cache.set(key, [memory])``. For the rest of the TTL window every subsequent call for that query saw an empty-hit and skipped surfacing entirely, silently suppressing the feature with only a ``Surfacing cache hit (empty)`` debug log as a trace.

(3) is what bumps this from MEDIUM (wasted compute) to HIGH — a transient race becomes a persistent, observably-broken feature for the TTL window, and the failure mode is near-invisible in logs.

## Fix

- Wrap the miss path (extracted to ``_do_surface_miss``) in a per-key ``asyncio.Lock`` + double-check idiom, mirroring the pattern used by ``ProxyManager`` for response-cache stampedes (named ``_key_locks`` on both sides for later helper extraction).
- Fast-path hit check remains lock-free — cache hits pay no synchronisation cost.
- Factor out the cache-hit rendering into ``_render_cached`` so the fast-path check and the post-lock double-check share one implementation.
- ``_key_locks.pop(cache_key)`` happens inside ``async with`` while the lock is still held, so any queued waiter sees the set cache on its own double-check.

## Prior-bug check

``cache_key = f"{server}/{tool}/{query}"`` is an immutable string and is never mutated between ``get`` and ``set`` — no trace-id-style taint like #136. This is a pure await-race fix.

## Test plan
- [x] New ``TestSurfacingCacheStampede::test_concurrent_identical_queries_share_single_search`` asserts all three symptoms are resolved: one LTM search, both responses inject the memory, cache entry holds the populated result.
- [x] Reproduced on main: test fails with ``search.call_count == 2``, ``B has shared result: False``, cache entry ``[]``, and a third sequential call also returns without the memory.
- [x] ``uv run pytest -m "not ollama"`` — 1314 passed.
- [x] ``uv run ruff check src && uv run ruff format --check src``.