### PR TITLE
fix(surfacing): eager rate-limit claim to close RelevanceGate burst race

### DIFF
--- a/src/memtomem_stm/surfacing/relevance.py
+++ b/src/memtomem_stm/surfacing/relevance.py
@@ -29,6 +29,18 @@ class RelevanceGate:
         tool: str,
         query: str | None,
     ) -> bool:
+        """Gate a prospective surfacing. On ``True``, eagerly claim a slot
+        in ``_surfacing_timestamps`` so concurrent callers see the budget
+        consumption immediately — otherwise N coroutines all check the
+        rate limit before any of them reaches ``record_surfacing`` and
+        every one passes, bursting through the ``max_surfacings_per_minute``
+        cap by up to the concurrency level.
+
+        Cooldown claim stays with ``record_surfacing`` (see that method)
+        because cooldown is a "skip if we already returned similar results"
+        heuristic — claiming it for queries that ultimately return nothing
+        would block legitimate retries on empty results.
+        """
         if not self._config.enabled or query is None:
             return False
 
@@ -66,13 +78,27 @@ class RelevanceGate:
             if self._jaccard_similarity(query, prev_query) > _SIMILARITY_THRESHOLD:
                 return False
 
+        # Eagerly claim the rate-limit slot. A concurrent ``should_surface``
+        # for a different query will now observe this timestamp and apply
+        # the cap correctly. A note on failure paths: the slot is kept even
+        # if the surfacing later fails, times out, or returns empty —
+        # ``max_surfacings_per_minute`` counts attempts because an attempt
+        # already consumed LTM/MCP resources and that is what the throttle
+        # is defending against.
+        self._surfacing_timestamps.append(now)
         return True
 
     def record_surfacing(self, query: str) -> None:
-        """Record that a surfacing was actually performed (call after success)."""
+        """Record that a surfacing was actually performed (call after success).
+
+        Updates the cooldown history only — the rate-limit slot was
+        already claimed in ``should_surface`` so this method intentionally
+        does not touch ``_surfacing_timestamps``. Calling it for a
+        cache-hit or empty-result path is not required and would only
+        suppress legitimate similar-query retries.
+        """
         now = time.monotonic()
         self._recent_queries.append((now, query))
-        self._surfacing_timestamps.append(now)
 
     @staticmethod
     def _jaccard_similarity(a: str, b: str) -> float:

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -332,6 +332,53 @@ class TestSurfacingCacheStampede:
         )
 
 
+class TestRelevanceGateConcurrency:
+    """``RelevanceGate.should_surface`` is called at ``surface()`` entry and
+    ``record_surfacing`` is called later inside ``_do_surface_miss`` (after
+    the LTM search ``await``). Concurrent ``surface()`` calls can all pass
+    ``should_surface`` (rate limit + cooldown check) before any of them
+    reaches ``record_surfacing``, so the configured rate limit is bypassed
+    by up to the concurrency level."""
+
+    async def test_concurrent_surface_calls_bypass_rate_limit(self):
+        # Rate-limit config = 1 surfacing per minute. Under the race,
+        # N concurrent calls all observe an empty ``_surfacing_timestamps``
+        # before any writes back, so all N pass the gate.
+        adapter = AsyncMock()
+
+        async def slow_search(**_kwargs):
+            await asyncio.sleep(0.01)
+            return ([FakeSearchResult(chunk=FakeChunk(content="hit"), score=0.5)], {})
+
+        adapter.search = AsyncMock(side_effect=slow_search)
+
+        engine = SurfacingEngine(
+            config=_make_config(max_surfacings_per_minute=1),
+            mcp_adapter=adapter,
+        )
+
+        # 5 distinct cache keys so the cache stampede fix doesn't mask the
+        # race (each query has its own ``_do_surface`` miss path).
+        await asyncio.gather(
+            *(
+                engine.surface(
+                    "gh",
+                    "read_file",
+                    {"path": f"src/f{i}.py", "_context_query": f"query {i}"},
+                    LONG_RESPONSE,
+                )
+                for i in range(5)
+            )
+        )
+
+        assert adapter.search.call_count == 1, (
+            "Rate limit bypassed under concurrency: "
+            f"{adapter.search.call_count} LTM searches fired with "
+            "max_surfacings_per_minute=1 — all should_surface checks "
+            "passed before any record_surfacing wrote back"
+        )
+
+
 class TestSessionContextInjection:
     """Verify include_session_context wires the scratchpad through the MCP adapter."""
 


### PR DESCRIPTION
## Summary

Severity: **MEDIUM**. ``RelevanceGate.should_surface`` at ``engine.py:117`` was paired with ``record_surfacing`` at ``engine.py:275`` — separated by an ``await`` on the LTM search. Under a concurrent burst with distinct queries (different cache keys, so #137's stampede lock does not serialize them), every coroutine ran its rate-limit check while ``_surfacing_timestamps`` was still empty, all passed the gate, and all fired LTM searches. A workload with ``max_surfacings_per_minute=1`` and a burst of N identical-timing calls issued N searches, not 1.

Reproduced on main: 5 ``asyncio.gather``-parallel ``surface()`` calls with distinct queries and ``max_surfacings_per_minute=1`` → 5 LTM searches. With the fix: 1.

## Fix (A-hybrid)

- **Rate limit**: claim the ``_surfacing_timestamps`` slot inside ``should_surface`` right before returning ``True``. A concurrent caller that reaches the rate check after us observes the claim and is throttled. The slot is kept even if the surfacing later fails, times out, or returns empty — the rate limit now counts **attempts**, which is what the throttle is actually defending against (LTM/MCP resources are consumed the moment a search is issued).
- **Cooldown**: still recorded in ``record_surfacing`` after a successful surfacing. Cooldown is a "skip if we just returned similar results" heuristic, and claiming it for empty-result paths would block legitimate retries on different-but-similar queries.

The cooldown race (jaccard > 0.95, within cooldown window) is LOW severity and masked for identical-query cases by #137's cache stampede lock — documenting rather than fixing.

## ⚠️ Semantic change for operators

``max_surfacings_per_minute`` is now an **attempt** cap rather than a **success** cap. Workloads tuned to the prior behaviour may see effective throughput drop if empty results or timeouts were previously uncounted. Rationale: the prior semantic was burst-vulnerable and did not actually protect the resource (LTM) the setting was intended to throttle.

## Test plan
- [x] New ``TestRelevanceGateConcurrency::test_concurrent_surface_calls_bypass_rate_limit`` fires 5 parallel ``surface()`` calls with distinct queries under ``max_surfacings_per_minute=1`` and asserts one LTM search. Fails on main with ``search.call_count == 5``.
- [x] Existing ``TestRelevanceGateRateLimit`` and ``TestRelevanceGateCooldown`` still pass — the rate-limit slot is claimed only on the ``return True`` path (same point in the decision tree as before, just one line earlier in time).
- [x] ``uv run pytest -m "not ollama"`` — 1314 passed.
- [x] ``uv run ruff check src && uv run ruff format --check src``.