### PR TITLE
fix(compression): drain in-flight compress() before LLMCompressor.close()

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -1142,6 +1143,14 @@ class LLMCompressor:
         )
         self._client: httpx.AsyncClient | None = httpx.AsyncClient(timeout=30) if httpx else None
         self.last_fallback: str | None = None
+        # Shutdown gate: close() must wait for in-flight compress() calls to
+        # drain before aclose()ing the httpx client. Otherwise a config swap
+        # or stop() can tear the client down mid-request. Sister pattern to
+        # #125 (extraction), #129 (mcp_client), #130 (proxy conn_stack).
+        self._in_flight: int = 0
+        self._idle: asyncio.Event = asyncio.Event()
+        self._idle.set()
+        self._closed: bool = False
         # Warn about non-standard base_url to flag potential credential exfiltration
         if config.base_url:
             from urllib.parse import urlparse
@@ -1173,6 +1182,16 @@ class LLMCompressor:
         if self._cb.is_open:
             self.last_fallback = "circuit_breaker"
             return TruncateCompressor().compress(text, max_chars=max_chars)
+        if self._closed:
+            self.last_fallback = "closed"
+            return TruncateCompressor().compress(text, max_chars=max_chars)
+        # Register as in-flight so a concurrent close() blocks on ``_idle``
+        # until we finish touching ``_client``. The increment+clear pair is
+        # sync — no ``await`` between the ``_closed`` check above and the
+        # clear, so close() cannot slip in and aclose() the client between
+        # our check and our claim.
+        self._in_flight += 1
+        self._idle.clear()
         try:
             result = await self._call_api(text, max_chars=max_chars)
             self._cb.success()
@@ -1187,6 +1206,10 @@ class LLMCompressor:
             )
             self.last_fallback = "llm_error"
             return TruncateCompressor().compress(text, max_chars=max_chars)
+        finally:
+            self._in_flight -= 1
+            if self._in_flight == 0:
+                self._idle.set()
 
     async def _call_api(self, text: str, *, max_chars: int) -> str:
         if self._client is None:
@@ -1201,6 +1224,11 @@ class LLMCompressor:
                 return await self._ollama(text, system_prompt)
 
     async def close(self) -> None:
+        # Flip the gate first so new compress() calls fall back to truncate
+        # instead of entering ``_in_flight``. Then wait for already-registered
+        # callers to drain before aclose()ing the client.
+        self._closed = True
+        await self._idle.wait()
         if self._client:
             await self._client.aclose()
             self._client = None

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -541,8 +541,12 @@ class ProxyManager:
                             await self._llm_compressor.close()
                         self._llm_compressor = LLMCompressor(llm_cfg)
                         self._llm_compressor_cfg = llm_cfg
-                result = await self._llm_compressor.compress(text, max_chars=max_chars)
-                return result, self._llm_compressor.last_fallback
+                    # Capture the current instance under the lock so a later
+                    # concurrent config swap can't re-bind ``self._llm_compressor``
+                    # before we read ``.last_fallback`` below.
+                    compressor = self._llm_compressor
+                result = await compressor.compress(text, max_chars=max_chars)
+                return result, compressor.last_fallback
             logger.warning(
                 "LLM_SUMMARY requested for %s/%s but no llm config found; falling back to truncate",
                 server,

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -415,3 +415,114 @@ class TestLLMCompressorEmptyResponseGuard:
         result = await comp.compress(text, max_chars=200)
         assert comp.last_fallback == "llm_error"
         assert len(result) < len(text)
+
+
+# ---------------------------------------------------------------------------
+# LLMCompressor — close() vs in-flight compress() race
+# ---------------------------------------------------------------------------
+
+
+class TestLLMCompressorShutdown:
+    """``close()`` must wait for any in-flight ``compress()`` before closing
+    the httpx client. Otherwise the config-swap path in ProxyManager (which
+    calls ``close()`` on the old instance) and the ``stop()`` teardown path
+    can tear down the client while a concurrent caller is still awaiting
+    ``self._client.post(...)``, yielding ``httpx.ClosedError`` or
+    ``RuntimeError("stream has been closed")``.
+
+    Sister pattern to #125 (extraction), #129 (mcp_client), #130 (proxy
+    conn_stack) — the fix here uses an in-flight counter + ``asyncio.Event``
+    gate so ``close()`` drains in-flight callers before ``_client.aclose()``.
+    """
+
+    import asyncio
+
+    @pytest.mark.asyncio
+    async def test_close_waits_for_in_flight_compress(self):
+        """close() must block on in-flight compress() until it completes."""
+        import asyncio
+
+        cfg = LLMCompressorConfig(provider=LLMProvider.OPENAI, api_key="test")
+        comp = LLMCompressor(cfg)
+        compress_started = asyncio.Event()
+        release_compress = asyncio.Event()
+
+        async def slow_call_api(text: str, *, max_chars: int) -> str:
+            compress_started.set()
+            await release_compress.wait()
+            return "summary"
+
+        with patch.object(comp, "_call_api", new=slow_call_api):
+            text = "x" * 500
+            compress_task = asyncio.create_task(comp.compress(text, max_chars=100))
+            await compress_started.wait()
+
+            close_task = asyncio.create_task(comp.close())
+            # Yield several times so close_task has a chance to observe that
+            # a compress is in flight and park on the idle gate.
+            for _ in range(10):
+                await asyncio.sleep(0)
+
+            assert not close_task.done(), (
+                "close() returned before in-flight compress finished — race not fixed"
+            )
+            assert comp._client is not None, (
+                "close() aclose'd the httpx client while compress was mid-call"
+            )
+
+            release_compress.set()
+            result = await compress_task
+            await close_task
+
+            assert result == "summary"
+            assert comp._client is None
+            assert comp.last_fallback is None  # success path
+
+    @pytest.mark.asyncio
+    async def test_compress_after_close_falls_back_to_truncate(self):
+        """Once close() has completed, subsequent compress() calls must
+        degrade to truncate rather than use the aclose'd client."""
+        cfg = LLMCompressorConfig(provider=LLMProvider.OPENAI, api_key="test")
+        comp = LLMCompressor(cfg)
+        await comp.close()
+
+        text = "x" * 500
+        result = await comp.compress(text, max_chars=100)
+        assert len(result) <= len(text)
+        assert comp.last_fallback == "closed"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_compresses_drain_before_close(self):
+        """Multiple concurrent in-flight compresses must all drain before
+        close() proceeds — in-flight counter must track correctly."""
+        import asyncio
+
+        cfg = LLMCompressorConfig(provider=LLMProvider.OPENAI, api_key="test")
+        comp = LLMCompressor(cfg)
+        started = asyncio.Event()
+        release = asyncio.Event()
+        started_count = 0
+
+        async def slow_call_api(text: str, *, max_chars: int) -> str:
+            nonlocal started_count
+            started_count += 1
+            if started_count >= 3:
+                started.set()
+            await release.wait()
+            return "summary"
+
+        with patch.object(comp, "_call_api", new=slow_call_api):
+            tasks = [asyncio.create_task(comp.compress("x" * 500, max_chars=100)) for _ in range(3)]
+            await started.wait()
+
+            close_task = asyncio.create_task(comp.close())
+            for _ in range(10):
+                await asyncio.sleep(0)
+            assert not close_task.done()
+
+            release.set()
+            results = await asyncio.gather(*tasks)
+            await close_task
+
+            assert all(r == "summary" for r in results)
+            assert comp._client is None

--- a/tests/test_proxy_manager_pipeline.py
+++ b/tests/test_proxy_manager_pipeline.py
@@ -269,6 +269,106 @@ class TestLLMCompressorLifecycle:
         instance.close.assert_awaited_once()
         assert mgr._llm_compressor is None
 
+    async def test_config_swap_does_not_tear_down_in_flight_old_instance(self, tmp_path):
+        """Scenario A (regression): a compress() call holding the old
+        LLMCompressor instance must not see its httpx client closed when a
+        concurrent ``_apply_compression`` swaps in a new config.
+
+        The pre-fix code called ``await old.close()`` inline under the lock,
+        which tore the httpx client down while the first call was still
+        awaiting ``self._client.post(...)`` — surfacing as ``ClosedError``
+        / ``RuntimeError('stream has been closed')``.  The fix makes
+        ``close()`` wait on an in-flight gate so the old instance stays
+        usable until its in-flight caller drains.
+        """
+        import asyncio
+
+        from memtomem_stm.proxy.compression import LLMCompressor
+
+        mgr = _make_manager(tmp_path=tmp_path)
+        cfg1 = LLMCompressorConfig(provider=LLMProvider.OPENAI, api_key="k1")
+        cfg2 = LLMCompressorConfig(provider=LLMProvider.OPENAI, api_key="k2")
+
+        release_first = asyncio.Event()
+        first_started = asyncio.Event()
+        first_client_was_alive_at_completion = False
+
+        real_init = LLMCompressor.__init__
+        instances: list[LLMCompressor] = []
+
+        async def slow_first_call(text: str, *, max_chars: int) -> str:
+            first_started.set()
+            await release_first.wait()
+            nonlocal first_client_was_alive_at_completion
+            first_client_was_alive_at_completion = instances[0]._client is not None
+            return "first-summary"
+
+        async def fast_second_call(text: str, *, max_chars: int) -> str:
+            return "second-summary"
+
+        def tracked_init(self: LLMCompressor, config: LLMCompressorConfig) -> None:
+            real_init(self, config)
+            instances.append(self)
+            # Route _call_api based on config identity so the second
+            # instance (created during swap) gets the fast mock even though
+            # it hasn't been returned from any patch() context yet.
+            if config is cfg1:
+                self._call_api = slow_first_call  # type: ignore[method-assign]
+            else:
+                self._call_api = fast_second_call  # type: ignore[method-assign]
+
+        with patch.object(LLMCompressor, "__init__", tracked_init):
+            # Task A: compress with cfg1. Creates instances[0] with a slow
+            # _call_api that parks inside compress().
+            task_a = asyncio.create_task(
+                mgr._apply_compression(
+                    "x" * 500,
+                    CompressionStrategy.LLM_SUMMARY,
+                    max_chars=50,
+                    sel_cfg=None,
+                    llm_cfg=cfg1,
+                    hybrid_cfg=None,
+                    server="srv",
+                    tool="t",
+                )
+            )
+            await first_started.wait()
+
+            # Task B: compress with cfg2. Triggers swap whose close() must
+            # wait for A to drain before aclose()ing the cfg1 client.
+            task_b = asyncio.create_task(
+                mgr._apply_compression(
+                    "x" * 500,
+                    CompressionStrategy.LLM_SUMMARY,
+                    max_chars=50,
+                    sel_cfg=None,
+                    llm_cfg=cfg2,
+                    hybrid_cfg=None,
+                    server="srv",
+                    tool="t",
+                )
+            )
+            for _ in range(20):
+                await asyncio.sleep(0)
+            assert not task_a.done(), "A should still be in flight"
+            assert not task_b.done(), "B's swap-close should be waiting on A"
+            assert instances[0]._client is not None, (
+                "cfg1 client aclose'd before A drained — fix not applied"
+            )
+
+            release_first.set()
+            result_a, fb_a = await task_a
+            result_b, fb_b = await task_b
+
+        assert result_a == "first-summary"
+        assert result_b == "second-summary"
+        assert first_client_was_alive_at_completion, (
+            "cfg1 client was closed while A's compress was still mid-call"
+        )
+        assert instances[0]._client is None, "cfg1 client should have been aclose'd"
+        assert len(instances) == 2
+        assert mgr._llm_compressor is instances[1]
+
 
 # ── _apply_surfacing ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

``LLMCompressor.close()`` could tear down the httpx client while a concurrent ``compress()`` on the same instance was still awaiting ``self._client.post(...)``, producing ``httpx.ClosedError`` / ``RuntimeError(\"stream has been closed\")``.

## Two race scenarios

**A — Config swap during compress:**

```
Coroutine A (manager.py:538-544):          Coroutine B (manager.py:538-544):
  async with _llm_compressor_lock:           (lock held by A, waits)
    # cfg matches, no swap
  # lock released
  await self._llm_compressor.compress(...)   async with _llm_compressor_lock:
    └─ await self._client.post(...)            # cfg mismatch!
       [yield]                                 await self._llm_compressor.close()
                                                 └─ await self._client.aclose()
                                                    # closes A's client mid-post!
```

**B — stop() during compress:**

```
A is mid-compress (httpx POST in flight)    stop() runs:
                                              await self._llm_compressor.close()
                                                └─ aclose() tears down client
                                                   that A is still using
```

## Fix

In-flight counter + ``asyncio.Event`` gate (sister pattern to #125 extraction, #129 mcp_client, #130 proxy conn_stack):

- ``compress()`` checks ``_closed`` then increments ``_in_flight`` / clears ``_idle`` in one sync block (no await between check and claim).
- ``finally`` decrements and ``set()``s ``_idle`` when it reaches zero.
- ``close()`` flips ``_closed = True`` first so new callers fall back to truncate, then ``await _idle.wait()`` drains in-flight before ``aclose()``.

Manager additionally captures ``compressor = self._llm_compressor`` under the lock so a later swap cannot alias ``.last_fallback`` onto a different instance.

## Test plan

Each scenario gets a dedicated regression test; one test alone would leave a gap because the trigger paths differ.

- [x] ``TestLLMCompressorShutdown.test_close_waits_for_in_flight_compress`` — Scenario B.
- [x] ``TestLLMCompressorShutdown.test_compress_after_close_falls_back_to_truncate`` — post-close graceful degradation.
- [x] ``TestLLMCompressorShutdown.test_concurrent_compresses_drain_before_close`` — N concurrent callers drain correctly.
- [x] ``TestLLMCompressorLifecycle.test_config_swap_does_not_tear_down_in_flight_old_instance`` — Scenario A.
- [x] ``uv run pytest -m \"not ollama\" -q`` — 1326 passed (1322 + 4 new).
- [x] ``uv run ruff check src && uv run ruff format --check src`` — clean.
- [x] ``uv run mypy src`` — one pre-existing advisory warning at manager.py:398 (unrelated to this change).

## Follow-ups not in scope

- ``LLMCompressor.last_fallback`` is still a shared instance attribute; two concurrent ``compress()`` calls on the same instance can still race on its value. Preserving existing semantics for now.