### PR TITLE
fix: complete store init-failure cleanup missed by #127

### DIFF
--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -59,16 +59,29 @@ class ProxyCache:
 
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        self._db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
+        db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
         try:
-            self._db_path.chmod(0o600)
-        except OSError:
-            pass
-        tune_connection(self._db)
-        self._db.execute(_CREATE_TABLE)
-        self._db.execute(_CREATE_INDEX)
-        self._db.commit()
-        self.purge_expired()
+            try:
+                self._db_path.chmod(0o600)
+            except OSError:
+                pass
+            tune_connection(db)
+            db.execute(_CREATE_TABLE)
+            db.execute(_CREATE_INDEX)
+            db.commit()
+            # Startup purge of expired rows, running against the local
+            # ``db`` before it is handed off to ``self._db``. Failures fall
+            # through to the outer except so ``self._db`` stays ``None``.
+            db.execute(
+                "DELETE FROM proxy_cache WHERE ttl_seconds IS NOT NULL "
+                "AND created_at + ttl_seconds <= ?",
+                (time.time(),),
+            )
+            db.commit()
+        except Exception:
+            db.close()
+            raise
+        self._db = db
 
     def close(self) -> None:
         if self._db:

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -39,22 +39,28 @@ class MetricsStore:
 
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        self._db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
+        db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
         try:
-            self._db_path.chmod(0o600)
-        except OSError:
-            pass
-        tune_connection(self._db)
-        self._db.execute(_CREATE)
-        self._db.execute(_INDEX)
-        self._db.commit()
-        self._migrate()
+            try:
+                self._db_path.chmod(0o600)
+            except OSError:
+                pass
+            tune_connection(db)
+            db.execute(_CREATE)
+            db.execute(_INDEX)
+            db.commit()
+            # Run migrations against the local ``db`` before it is exposed
+            # as ``self._db`` so a failure here falls through to the outer
+            # except and leaves the store un-initialized.
+            self._migrate(db)
+        except Exception:
+            db.close()
+            raise
+        self._db = db
 
-    def _migrate(self) -> None:
+    def _migrate(self, db: sqlite3.Connection) -> None:
         """Add columns introduced after initial schema (idempotent)."""
-        if self._db is None:
-            return
-        existing = {row[1] for row in self._db.execute("PRAGMA table_info(proxy_metrics)")}
+        existing = {row[1] for row in db.execute("PRAGMA table_info(proxy_metrics)")}
         migrations = {
             "is_error": "ALTER TABLE proxy_metrics ADD COLUMN is_error INTEGER NOT NULL DEFAULT 0",
             "error_category": "ALTER TABLE proxy_metrics ADD COLUMN error_category TEXT DEFAULT NULL",
@@ -72,8 +78,8 @@ class MetricsStore:
         }
         for col, ddl in migrations.items():
             if col not in existing:
-                self._db.execute(ddl)
-        self._db.commit()
+                db.execute(ddl)
+        db.commit()
 
     def close(self) -> None:
         if self._db:

--- a/tests/test_sqlite_init_cleanup.py
+++ b/tests/test_sqlite_init_cleanup.py
@@ -15,7 +15,9 @@ from typing import Any
 
 import pytest
 
+from memtomem_stm.proxy.cache import ProxyCache
 from memtomem_stm.proxy.compression_feedback_store import CompressionFeedbackStore
+from memtomem_stm.proxy.metrics_store import MetricsStore
 from memtomem_stm.proxy.pending_store import SQLitePendingStore
 from memtomem_stm.surfacing.feedback_store import FeedbackStore
 
@@ -28,6 +30,8 @@ _CASES: list[tuple[str, type[Any], str]] = [
         "cfb.db",
     ),
     ("memtomem_stm.proxy.pending_store", SQLitePendingStore, "pending.db"),
+    ("memtomem_stm.proxy.cache", ProxyCache, "cache.db"),
+    ("memtomem_stm.proxy.metrics_store", MetricsStore, "metrics.db"),
 ]
 
 


### PR DESCRIPTION
## Summary

#127 fixed the init-time SQLite connection leak for three stores —
``FeedbackStore``, ``CompressionFeedbackStore``, and
``SQLitePendingStore`` — but two stores using the same pattern were
missed:

- ``src/memtomem_stm/proxy/cache.py`` (``ProxyCache``)
- ``src/memtomem_stm/proxy/metrics_store.py`` (``MetricsStore``)

Both open a connection, assign ``self._db`` immediately, then call
``tune_connection(self._db)`` + ``execute(_CREATE...)`` outside any
guard. If either step raises, the fresh connection is leaked (stale
WAL lock + open FD) because ``close()`` is never reached from the
failed ``initialize``. Retried init — ``FeedbackTracker`` was hardened
in #124 to log-and-continue and may re-init — accumulates FDs and
eventually prevents recovery.

## Fix

Apply the #127 pattern: open connection into a local ``db``, run
setup inside a ``try/except`` that closes the local on failure, assign
``self._db = db`` only on success.

- ``cache.py``: moved the startup ``purge_expired()`` DELETE inline
  inside the setup ``try`` so it runs against the local ``db`` before
  the handoff. A failure here now falls through to the outer except.
- ``metrics_store.py``: refactored ``_migrate()`` to take the
  connection as an argument instead of reading ``self._db``, so it
  can be called against the local ``db`` before handoff.
- ``chmod(0o600)`` stays non-fatal (``OSError`` caught) but is nested
  inside the outer try so any non-``OSError`` exception also triggers
  cleanup.

## Test plan

Extended the parametrized matrix in ``tests/test_sqlite_init_cleanup.py``
(added by #127) with ``ProxyCache`` and ``MetricsStore`` entries. Each
case:

1. Monkeypatch the module's ``tune_connection`` to raise.
2. ``initialize()`` must re-raise and leave ``store._db is None``.
3. Restore ``tune_connection`` and verify ``initialize()`` succeeds on
   retry.

- [x] ``uv run pytest tests/test_sqlite_init_cleanup.py -v`` — all 5
      parametrized cases pass (3 existing from #127 + 2 new).
- [x] ``uv run pytest -m \"not ollama\" -q`` — 1324 passed.
- [x] ``uv run ruff check src && uv run ruff format --check src`` — clean.
- [x] ``uv run mypy src`` — one pre-existing advisory at manager.py:398 (unrelated).

## Merge order

Branched from ``main`` (not from the PR 1 branch). Intended merge
order is PR 1 (LLMCompressor race) first, then this PR. File scopes
do not overlap so conflicts are not expected either way.