### PR TITLE
fix: MCP adapter text=None defense + WAL journal_size_limit

### DIFF
--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -219,7 +219,7 @@ class McpClientSearchAdapter:
 
         try:
             result = await self._session.call_tool("mem_do", {"action": "version"})
-            text_parts = [c.text for c in result.content if c.type == "text"]
+            text_parts = [c.text or "" for c in result.content if c.type == "text"]
             if text_parts:
                 data = json.loads(text_parts[0])
                 formats = data.get("capabilities", {}).get("search_formats", [])
@@ -296,7 +296,7 @@ class McpClientSearchAdapter:
         # Parse text response into results
         # ``result.content or []`` tolerates spec-noncompliant upstreams that
         # return ``None`` instead of an empty list (mirrors PR #114 in proxy).
-        text_parts = [c.text for c in (result.content or []) if c.type == "text"]
+        text_parts = [c.text or "" for c in (result.content or []) if c.type == "text"]
         if not text_parts:
             return [], None
 
@@ -371,7 +371,7 @@ class McpClientSearchAdapter:
 
         # ``result.content or []`` tolerates spec-noncompliant upstreams that
         # return ``None`` instead of an empty list (mirrors PR #114 in proxy).
-        text_parts = [c.text for c in (result.content or []) if c.type == "text"]
+        text_parts = [c.text or "" for c in (result.content or []) if c.type == "text"]
         if not text_parts:
             return []
 

--- a/src/memtomem_stm/utils/sqlite_tuning.py
+++ b/src/memtomem_stm/utils/sqlite_tuning.py
@@ -18,6 +18,9 @@ import sqlite3
 BUSY_TIMEOUT_MS = 3000
 # Negative cache_size values are in KiB per SQLite docs; 64000 KiB = 64 MB.
 CACHE_SIZE_KIB = -64000
+# Cap WAL file growth so long-lived daemons don't accumulate unbounded
+# .db-wal files. 64 MB matches the page cache budget above.
+WAL_JOURNAL_SIZE_LIMIT = 64 * 1024 * 1024  # 64 MB
 
 
 def tune_connection(conn: sqlite3.Connection) -> None:
@@ -30,3 +33,4 @@ def tune_connection(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute(f"PRAGMA cache_size={CACHE_SIZE_KIB}")
     conn.execute("PRAGMA temp_store=MEMORY")
+    conn.execute(f"PRAGMA journal_size_limit={WAL_JOURNAL_SIZE_LIMIT}")

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -340,3 +340,49 @@ class TestStartCleansUpOnFailure:
         assert session_exited.is_set(), "session context must be aclosed on init failure"
         assert adapter._stack is None
         assert adapter._session is None
+
+
+# ── c.text=None tolerance (PR #114 parity) ──────────────────────────────
+
+
+class TestTextNoneTolerance:
+    """MCP spec requires TextContent.text to be str, but a spec-noncompliant
+    server may return None. manager.py:1042 guards with ``c.text or ""``;
+    the surfacing adapter must do the same."""
+
+    @pytest.mark.asyncio
+    async def test_search_tolerates_none_text(self):
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+        mock_session = AsyncMock()
+
+        none_content = MagicMock()
+        none_content.type = "text"
+        none_content.text = None
+
+        good_content = _text_content("[1] 0.90 | [default] note.md\nreal content")
+
+        result_obj = MagicMock()
+        result_obj.content = [none_content, good_content]
+        mock_session.call_tool = AsyncMock(return_value=result_obj)
+        adapter._session = mock_session
+
+        results, _ = await adapter.search("test query")
+        assert len(results) == 1
+        assert "real content" in results[0].chunk.content
+
+    @pytest.mark.asyncio
+    async def test_search_all_none_text_returns_empty(self):
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+        mock_session = AsyncMock()
+
+        none_content = MagicMock()
+        none_content.type = "text"
+        none_content.text = None
+
+        result_obj = MagicMock()
+        result_obj.content = [none_content]
+        mock_session.call_tool = AsyncMock(return_value=result_obj)
+        adapter._session = mock_session
+
+        results, _ = await adapter.search("test query")
+        assert results == []

--- a/tests/test_sqlite_tuning.py
+++ b/tests/test_sqlite_tuning.py
@@ -14,6 +14,7 @@ import pytest
 from memtomem_stm.utils.sqlite_tuning import (
     BUSY_TIMEOUT_MS,
     CACHE_SIZE_KIB,
+    WAL_JOURNAL_SIZE_LIMIT,
     tune_connection,
 )
 
@@ -63,6 +64,11 @@ def test_sets_temp_store_memory(conn):
     assert _pragma(conn, "temp_store") == 2
 
 
+def test_sets_journal_size_limit(conn):
+    tune_connection(conn)
+    assert _pragma(conn, "journal_size_limit") == WAL_JOURNAL_SIZE_LIMIT
+
+
 def test_idempotent(conn):
     """Calling twice leaves PRAGMAs in the same state."""
     tune_connection(conn)
@@ -71,3 +77,4 @@ def test_idempotent(conn):
     assert _pragma(conn, "synchronous") == 1
     assert _pragma(conn, "cache_size") == CACHE_SIZE_KIB
     assert _pragma(conn, "temp_store") == 2
+    assert _pragma(conn, "journal_size_limit") == WAL_JOURNAL_SIZE_LIMIT


### PR DESCRIPTION
## Summary

Two small hardening fixes bundled because they share reviewer context (both are propagating an established pattern to a place it was missed):

- **MCP adapter text=None defense** — `mcp_client.py` had three list comprehensions (``search``, ``_negotiate_format``, ``scratch_list``) that extracted ``c.text`` without the ``or \"\"`` guard that ``manager.py:1042`` added in PR #114. A spec-noncompliant core returning ``TextContent(type=\"text\", text=None)`` would crash surfacing via ``TypeError: sequence item ...: expected str instance, NoneType found`` at the downstream ``\"\\n\".join(...)``. Propagated the same ``c.text or \"\"`` pattern.
- **WAL journal_size_limit** — ``sqlite_tuning.py`` sets WAL mode but omitted ``PRAGMA journal_size_limit``, letting ``.db-wal`` files grow unbounded in long-lived daemons. Added a 64 MB cap matching the existing page cache budget.

## Test plan

- [x] ``test_search_tolerates_none_text`` — mixed None + valid text content parses the valid one
- [x] ``test_search_all_none_text_returns_empty`` — all-None content returns empty results without crash
- [x] ``test_sets_journal_size_limit`` — PRAGMA verified on a fresh connection
- [x] Idempotency test covers the new PRAGMA
- [x] 1331 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)