### PR TITLE
fix: invalidate surfacing cache on negative feedback

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -79,6 +79,15 @@ class SurfacingEngine:
         # 10k matches the sibling _surfaced_ids bound.
         self._boosted_event_ids: dict[str, None] = {}
         self._boosted_event_ids_max = 10000
+        # Cache invalidation set — (server, tool, memory_id) tuples the agent
+        # rated ``not_relevant`` or ``already_known``. ``_render_cached``
+        # filters cache hits through this set so a cached query does not
+        # resurface memories the agent already rejected within the cache TTL
+        # window. Scoped in-memory per session (matching ``SurfacingCache``
+        # lifetime); bounded by the same 10k FIFO cap as sibling sets since
+        # invalidations are a strict subset of surfacings.
+        self._invalidated_ids: dict[tuple[str, str, str], None] = {}
+        self._invalidated_ids_max = 10000
         self._background_tasks: set[asyncio.Task] = set()
         # Per-key stampede guard — identical concurrent ``_do_surface`` calls
         # serialize on the same lock so a cache miss triggers one LTM search
@@ -165,11 +174,20 @@ class SurfacingEngine:
         can rank it higher next time. The boost is guarded with an in-memory
         per-event set so multiple "helpful" ratings for the same surfacing
         event only trigger one increment.
+
+        On a ``not_relevant`` or ``already_known`` rating, adds the
+        ``(server, tool, memory_id)`` tuples to ``_invalidated_ids`` so
+        subsequent cache hits for the same ``server/tool/query`` filter
+        them out. Without this, a repeat query inside the ``SurfacingCache``
+        TTL window would resurface the memory the agent just rejected.
         """
         if self._feedback_tracker is None:
             return "Feedback tracking is not enabled."
 
         result = self._feedback_tracker.record_feedback(surfacing_id, rating, memory_id)
+
+        if rating in ("not_relevant", "already_known"):
+            self._invalidate_cache_for_feedback(surfacing_id, memory_id)
 
         if rating == "helpful" and surfacing_id not in self._boosted_event_ids:
             # Claim the guard optimistically BEFORE the increment_access
@@ -212,6 +230,37 @@ class SurfacingEngine:
 
         return result
 
+    def _invalidate_cache_for_feedback(self, surfacing_id: str, memory_id: str | None) -> None:
+        """Populate ``_invalidated_ids`` from a surfacing event.
+
+        Looks up the event's ``(server, tool, memory_ids)`` and adds one
+        tuple per memory id to the filter set. When ``memory_id`` is given
+        only that id is invalidated; otherwise every memory recorded for
+        the surfacing event is invalidated (i.e. a blanket rejection).
+        """
+        if self._feedback_tracker is None:
+            return
+        try:
+            event = self._feedback_tracker.store.get_surfacing_event(surfacing_id)
+        except Exception:
+            logger.debug(
+                "Failed to look up surfacing event for invalidation of %s",
+                surfacing_id,
+                exc_info=True,
+            )
+            return
+        if event is None:
+            return
+        server = event["server"]
+        tool = event["tool"]
+        target_ids = [memory_id] if memory_id else event["memory_ids"]
+        for mid in target_ids:
+            self._invalidated_ids[(server, tool, mid)] = None
+        if len(self._invalidated_ids) > self._invalidated_ids_max:
+            excess = len(self._invalidated_ids) - self._invalidated_ids_max // 2
+            for k in list(self._invalidated_ids)[:excess]:
+                del self._invalidated_ids[k]
+
     def _render_cached(
         self,
         cached: list[Any],
@@ -228,7 +277,25 @@ class SurfacingEngine:
         can submit ``stm_surfacing_feedback`` for the rendered surfacing_id.
         Without this, cached hits generate orphan IDs that the feedback store
         cannot resolve, silently breaking the feedback learning loop.
+
+        Filters out memory IDs in ``_invalidated_ids`` — memories the agent
+        already rated ``not_relevant`` or ``already_known`` within the cache
+        TTL window. A filtered-empty result pass-throughs like the natural
+        empty case.
         """
+        if cached and self._invalidated_ids:
+            original_count = len(cached)
+            cached = [
+                r for r in cached if (server, tool, str(r.chunk.id)) not in self._invalidated_ids
+            ]
+            if len(cached) < original_count:
+                logger.debug(
+                    "Surfacing cache filter: %s/%s %d→%d (invalidated)",
+                    server,
+                    tool,
+                    original_count,
+                    len(cached),
+                )
         if not cached:
             logger.debug("Surfacing cache hit (empty) for %s/%s", server, tool)
             return response_text

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -133,6 +133,28 @@ class FeedbackStore:
         except (json.JSONDecodeError, TypeError):
             return []
 
+    def get_surfacing_event(self, surfacing_id: str) -> dict | None:
+        """Return ``{server, tool, memory_ids}`` for a surfacing event.
+
+        Used by cache-invalidation on negative feedback — the feedback
+        handler needs (server, tool) along with memory_ids to key the
+        in-memory invalidation set against ``SurfacingCache`` entries.
+        Returns ``None`` if the event does not exist.
+        """
+        if self._db is None:
+            return None
+        row = self._db.execute(
+            "SELECT server, tool, memory_ids FROM surfacing_events WHERE id = ?",
+            (surfacing_id,),
+        ).fetchone()
+        if not row:
+            return None
+        try:
+            memory_ids = json.loads(row[2])
+        except (json.JSONDecodeError, TypeError):
+            memory_ids = []
+        return {"server": row[0], "tool": row[1], "memory_ids": memory_ids}
+
     def get_tool_feedback_summary(self, tool: str | None = None) -> dict:
         """Get feedback summary, optionally filtered by tool."""
         if self._db is None:

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -689,6 +689,246 @@ class TestFeedbackBoost:
         adapter.increment_access.assert_not_called()
 
 
+class TestCacheInvalidationOnNegativeFeedback:
+    """Negative feedback (``not_relevant`` / ``already_known``) must populate
+    ``_invalidated_ids`` so subsequent cache hits for the same
+    ``server/tool/query`` filter out the rejected memory. Without this,
+    repeat queries inside the ``SurfacingCache`` TTL window keep resurfacing
+    memories the agent just rejected (issue #146)."""
+
+    def _make_tracker(
+        self,
+        server: str = "gh",
+        tool: str = "read_file",
+        memory_ids: list[str] | None = None,
+        rating_response: str = "Feedback recorded: not_relevant",
+    ):
+        tracker = MagicMock()
+        tracker.record_feedback = MagicMock(return_value=rating_response)
+        tracker.store = MagicMock()
+        tracker.store.get_seen_ids = MagicMock(return_value=set())
+        tracker.store.get_surfacing_event = MagicMock(
+            return_value={
+                "server": server,
+                "tool": tool,
+                "memory_ids": list(memory_ids or []),
+            }
+        )
+        tracker.store.mark_surfaced = MagicMock()
+        return tracker
+
+    async def test_not_relevant_adds_tuple_to_invalidation_set(self):
+        adapter = _make_mcp_adapter([])
+        tracker = self._make_tracker(memory_ids=["mid-A"])
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        await engine.handle_feedback("sid-1", "not_relevant", memory_id="mid-A")
+
+        assert ("gh", "read_file", "mid-A") in engine._invalidated_ids
+
+    async def test_already_known_adds_tuple_to_invalidation_set(self):
+        adapter = _make_mcp_adapter([])
+        tracker = self._make_tracker(
+            memory_ids=["mid-A"],
+            rating_response="Feedback recorded: already_known",
+        )
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        await engine.handle_feedback("sid-1", "already_known", memory_id="mid-A")
+
+        assert ("gh", "read_file", "mid-A") in engine._invalidated_ids
+
+    async def test_helpful_does_not_add_to_invalidation_set(self):
+        adapter = _make_mcp_adapter([])
+        adapter.increment_access = AsyncMock()
+        tracker = self._make_tracker(
+            memory_ids=["mid-A"],
+            rating_response="Feedback recorded: helpful",
+        )
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        await engine.handle_feedback("sid-1", "helpful", memory_id="mid-A")
+
+        assert engine._invalidated_ids == {}
+
+    async def test_blanket_invalidation_adds_all_event_memory_ids(self):
+        """handle_feedback with no memory_id invalidates every memory in the event."""
+        adapter = _make_mcp_adapter([])
+        tracker = self._make_tracker(memory_ids=["mid-A", "mid-B", "mid-C"])
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        await engine.handle_feedback("sid-1", "not_relevant")
+
+        assert ("gh", "read_file", "mid-A") in engine._invalidated_ids
+        assert ("gh", "read_file", "mid-B") in engine._invalidated_ids
+        assert ("gh", "read_file", "mid-C") in engine._invalidated_ids
+
+    async def test_cache_hit_filters_invalidated_memory_from_output(self):
+        """After rating a memory not_relevant, the next cache hit for the same
+        query returns the cached results minus that memory. Uses a real
+        ``FeedbackTracker`` so the end-to-end event lookup runs."""
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+
+        chunk_a = FakeChunk(id="mid-A", content="apple memory")
+        chunk_b = FakeChunk(id="mid-B", content="banana memory")
+        results = [
+            FakeSearchResult(chunk=chunk_a, score=0.5),
+            FakeSearchResult(chunk=chunk_b, score=0.4),
+        ]
+        adapter = _make_mcp_adapter(results)
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "fb.db"
+            tracker = FeedbackTracker(config=_make_config(), db_path=db_path)
+            engine = SurfacingEngine(
+                config=_make_config(cooldown_seconds=0),
+                mcp_adapter=adapter,
+                feedback_tracker=tracker,
+            )
+
+            # First surface — populates cache with [mid-A, mid-B].
+            out1 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            assert "apple memory" in out1
+            assert "banana memory" in out1
+
+            import re
+
+            match = re.search(r"Surfacing ID: (\w+)", out1)
+            assert match, "surfacing_id not found in first output"
+            first_sid = match.group(1)
+
+            # Rate mid-A as not_relevant.
+            await engine.handle_feedback(first_sid, "not_relevant", memory_id="mid-A")
+
+            # Second surface hits the cache; mid-A must be filtered out.
+            out2 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            assert "apple memory" not in out2
+            assert "banana memory" in out2
+
+            tracker.close()
+
+    async def test_cache_hit_filtered_to_empty_passes_response_through(self):
+        """If every cached memory is invalidated, ``_render_cached`` returns
+        the original response unchanged (no injection, no orphan event)."""
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+
+        chunk_a = FakeChunk(id="mid-A", content="apple memory")
+        results = [FakeSearchResult(chunk=chunk_a, score=0.5)]
+        adapter = _make_mcp_adapter(results)
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "fb.db"
+            tracker = FeedbackTracker(config=_make_config(), db_path=db_path)
+            engine = SurfacingEngine(
+                config=_make_config(cooldown_seconds=0),
+                mcp_adapter=adapter,
+                feedback_tracker=tracker,
+            )
+
+            out1 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            import re
+
+            match = re.search(r"Surfacing ID: (\w+)", out1)
+            assert match
+            first_sid = match.group(1)
+
+            await engine.handle_feedback(first_sid, "not_relevant", memory_id="mid-A")
+
+            out2 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            # Fully filtered — response unchanged (no surfacing block injected).
+            assert out2 == LONG_RESPONSE
+            assert "apple memory" not in out2
+
+            tracker.close()
+
+    async def test_invalidation_keyed_by_server_tool_not_global(self):
+        """Invalidating (srv-A, tool-X, mid) must not affect (srv-B, tool-X, mid)
+        or (srv-A, tool-Y, mid) — the key is the full triple."""
+        adapter = _make_mcp_adapter([])
+        tracker = self._make_tracker(server="srv-A", tool="tool-X", memory_ids=["mid-1"])
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        await engine.handle_feedback("sid-1", "not_relevant", memory_id="mid-1")
+
+        assert ("srv-A", "tool-X", "mid-1") in engine._invalidated_ids
+        assert ("srv-B", "tool-X", "mid-1") not in engine._invalidated_ids
+        assert ("srv-A", "tool-Y", "mid-1") not in engine._invalidated_ids
+
+    async def test_invalidated_ids_fifo_cap_evicts_oldest(self):
+        """When ``_invalidated_ids`` exceeds its cap, oldest entries evict first."""
+        adapter = _make_mcp_adapter([])
+        tracker = self._make_tracker(memory_ids=["mid-X"])
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+        engine._invalidated_ids_max = 10  # shrink for test speed
+
+        for i in range(15):
+            tracker.store.get_surfacing_event = MagicMock(
+                return_value={
+                    "server": "gh",
+                    "tool": "read_file",
+                    "memory_ids": [f"mid-{i}"],
+                }
+            )
+            await engine.handle_feedback(f"sid-{i}", "not_relevant", memory_id=f"mid-{i}")
+
+        # Overflow triggers bulk prune to half the cap.
+        assert len(engine._invalidated_ids) <= 10
+        # Oldest entries evicted; newest retained.
+        assert ("gh", "read_file", "mid-0") not in engine._invalidated_ids
+        assert ("gh", "read_file", "mid-14") in engine._invalidated_ids
+
+    async def test_missing_event_skips_invalidation(self):
+        """If ``get_surfacing_event`` returns None, handle_feedback does not crash
+        and does not pollute ``_invalidated_ids`` with a phantom tuple."""
+        adapter = _make_mcp_adapter([])
+        tracker = MagicMock()
+        tracker.record_feedback = MagicMock(
+            return_value="Error: surfacing event 'sid-ghost' not found"
+        )
+        tracker.store = MagicMock()
+        tracker.store.get_seen_ids = MagicMock(return_value=set())
+        tracker.store.get_surfacing_event = MagicMock(return_value=None)
+        tracker.store.mark_surfaced = MagicMock()
+
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        await engine.handle_feedback("sid-ghost", "not_relevant", memory_id="mid-A")
+
+        assert engine._invalidated_ids == {}
+
+
 class TestConcurrentSurfacedIdsDedup:
     """Dedup invariant: each memory surfaced at most once per session, even
     under concurrency (engine.py:62 / L256 / docstring).


### PR DESCRIPTION
Closes #146.

## Summary

Cache hits previously resurfaced memories the agent had just rated `not_relevant` — feedback was recorded but had no immediate effect on the next cached query result. Adds a per-session invalidation set populated from `handle_feedback` and consulted in `_render_cached` before rendering.

## Design — issue #146 option 2

- **No schema change**, **no `SurfacingCache` internal change**. The cache stays a pure TTL store; the engine filters on read.
- New `FeedbackStore.get_surfacing_event(surfacing_id) -> {server, tool, memory_ids}` — single-query hop from surfacing_id to the fields needed to key the invalidation set.
- New `SurfacingEngine._invalidated_ids: dict[tuple[str, str, str], None]`. Matches sibling sets (`_surfaced_ids`, `_boosted_event_ids`): insertion-ordered `dict[..., None]`, 10k FIFO cap, half-shrink on overflow. Invalidations are a strict subset of surfacings so the shared cap is comfortably above session volume.
- `already_known` invalidates the same way as `not_relevant` — functionally the agent is signalling "I don't need this again now" (issue open question resolved: yes).

## Behavior change

- `_render_cached()` now filters cached results through `_invalidated_ids` before rendering. A cache entry that filters to empty passes the response through unchanged (matches the natural "no results" case).
- `handle_feedback` on `not_relevant`/`already_known` now performs one extra SQLite `SELECT` on `surfacing_events` per call to look up the event fields.

## Test plan

- [x] `test_not_relevant_adds_tuple_to_invalidation_set`
- [x] `test_already_known_adds_tuple_to_invalidation_set`
- [x] `test_helpful_does_not_add_to_invalidation_set`
- [x] `test_blanket_invalidation_adds_all_event_memory_ids` — no memory_id = whole event rejected
- [x] `test_cache_hit_filters_invalidated_memory_from_output` — end-to-end with real `FeedbackTracker` + SQLite
- [x] `test_cache_hit_filtered_to_empty_passes_response_through` — filtered-empty = no injection
- [x] `test_invalidation_keyed_by_server_tool_not_global` — (srv-A, tool-X, mid) does not affect (srv-B, tool-X, mid)
- [x] `test_invalidated_ids_fifo_cap_evicts_oldest` — overflow → half-shrink
- [x] `test_missing_event_skips_invalidation` — `get_surfacing_event` → None does not crash or pollute set
- [x] 1345 tests pass (9 new + 1336 existing), lint clean