### PR TITLE
docs: complete post-v0.1.7 audit — log level, failure guards, cross-links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ uv run mypy src
   - `cli/` — `mms` / `memtomem-stm-proxy` CLI
   - `utils/` — Circuit breaker and shared helpers
 - `tests/` — pytest suite
-- `docs/` — Architecture and operations guides
+- `docs/` — Architecture, operations, and integration guides (incl. `custom-integration.md`)
 
 The LTM core lives in a separate repository: [memtomem/memtomem](https://github.com/memtomem/memtomem). Communication between STM and LTM happens entirely through the MCP protocol — there is no Python-level dependency.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Want to see STM's behavior without wiring it into Claude Code first? The [`noteb
 | [Configuration](https://github.com/memtomem/memtomem-stm/blob/main/docs/configuration.md) | Environment variables and `stm_proxy.json` reference |
 | [CLI](https://github.com/memtomem/memtomem-stm/blob/main/docs/cli.md) | `mms` (= `memtomem-stm-proxy`) commands and the 10 MCP tools |
 | [Operations](https://github.com/memtomem/memtomem-stm/blob/main/docs/operations.md) | Safety, privacy, horizontal scaling, observability, on-disk state |
+| [Custom Integration](https://github.com/memtomem/memtomem-stm/blob/main/docs/custom-integration.md) | FileIndexer protocol, wiring, and known caveats for auto-index / extraction |
 
 ## Development
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -100,3 +100,8 @@ compressed_chars: 8000
 ```
 
 The namespace supports `{server}` and `{tool}` placeholders. Can be toggled per-server via `auto_index: true|false` in `UpstreamServerConfig`.
+
+> **Note:** Auto-indexing requires a `FileIndexer` wired into
+> `ProxyManager`.  The default deployment does not wire one — see
+> [Custom Integration](custom-integration.md) for the protocol,
+> wiring instructions, and known caveats.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,3 +124,14 @@ sequenceDiagram
     Agent->>STM: stm_proxy_stats
     STM-->>Agent: token savings · cache hit ratio · latency p50/p95/p99
 ```
+
+## Logging
+
+Log level is controlled via environment variable (no CLI flag):
+
+```bash
+export MEMTOMEM_STM_LOG_LEVEL=DEBUG   # DEBUG | INFO | WARNING | ERROR | CRITICAL
+```
+
+See [Configuration → General](configuration.md#general) and
+[Operations → Logging](operations.md#logging) for details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,16 @@ For most quick-start scenarios you can ignore the config file entirely and use t
 
 All settings use the `MEMTOMEM_STM_` prefix with `__` for nesting.
 
+### General
+
+```bash
+export MEMTOMEM_STM_LOG_LEVEL=WARNING   # DEBUG | INFO | WARNING | ERROR | CRITICAL
+```
+
+Controls `logging.basicConfig()` level for all `memtomem_stm.*`
+loggers.  Default `WARNING`.  Read once at startup — restart to
+apply changes.  See [Operations → Logging](operations.md#logging).
+
 ### Proxy
 
 ```bash

--- a/docs/custom-integration.md
+++ b/docs/custom-integration.md
@@ -18,6 +18,9 @@ Wire a `FileIndexer` when you want the proxy to:
 If you only need compression, surfacing, and caching, skip this — the
 default deployment covers those without a `FileIndexer`.
 
+For auto-indexing configuration (thresholds, namespace templates,
+file format), see [Caching & Auto-Indexing](caching.md#auto-indexing).
+
 ## Protocol
 
 The proxy expects a structural match against `FileIndexer`
@@ -114,6 +117,11 @@ MEMTOMEM_STM_PROXY__AUTO_INDEX__ENABLED=true
 MEMTOMEM_STM_PROXY__EXTRACTION__ENABLED=true
 ```
 
+For the complete env-var reference, see
+[Configuration](configuration.md).  Both stages run as part of the
+pipeline — see [Pipeline → Stage 4](pipeline.md#stage-4-index-optional)
+for the runtime flow and failure guards.
+
 ## Known caveats
 
 These are documented limitations of the current implementation.  All
@@ -177,3 +185,6 @@ set — it does not log exceptions (unlike the webhook pattern in
 4. **Consider `background=false`** for extraction if you need
    guaranteed delivery — it blocks the response but ensures extraction
    completes or raises visibly.
+5. **Log level**: set `MEMTOMEM_STM_LOG_LEVEL=DEBUG` for full
+   auto-index and extraction tracing.  See
+   [Operations → Logging](operations.md#logging).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -173,6 +173,32 @@ Surfacing: enabled (min_score=0.02)
 
 Metrics are persisted to SQLite (`~/.memtomem/proxy_metrics.db`, max 10K entries) with error category and trace_id columns.
 
+### Logging
+
+STM uses Python's `logging` module.  Format:
+
+```
+LEVEL module_name: message
+```
+
+Set the level via environment variable:
+
+```bash
+export MEMTOMEM_STM_LOG_LEVEL=DEBUG
+```
+
+Default is `WARNING`.  Read once at startup by `server.py:main()`.
+
+| Level | What it shows |
+|-------|---------------|
+| `DEBUG` | Pipeline tracing, strategy selection, cache decisions |
+| `INFO` | Surfacing injections, config reloads, extraction completions |
+| `WARNING` | Failure guards (F1/S1), fallback activations, skips |
+| `ERROR` | Unrecoverable failures (rare — most errors fall back) |
+
+See [Configuration → General](configuration.md#general) for the env
+var reference.
+
 ### Langfuse Tracing (optional)
 
 ```bash

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -101,9 +101,24 @@ Proactively injects relevant memories from a memtomem LTM server. See [Surfacing
 
 Surfacing only activates when the compressed response is at least `min_response_chars` (default 5000). For small responses, surfacing is skipped to avoid negative token savings.
 
+**Failure guard (S1).**  If `record_surfacing` fails (e.g. SQLite
+contention), the engine drops the `surfacing_id` — the memory block
+is still injected but without a feedback ID.  The agent cannot
+submit feedback for that event, but the response is never blocked.
+Logged at WARNING.
+
 ## Stage 4: INDEX (optional)
 
-Automatically indexes large responses to memtomem LTM for future retrieval. See [Caching & Auto-Indexing](caching.md#auto-indexing) for the configuration reference.
+Automatically indexes large responses to memtomem LTM for future
+retrieval.  See [Caching & Auto-Indexing](caching.md#auto-indexing)
+for configuration and
+[Custom Integration](custom-integration.md) for `FileIndexer` wiring.
+
+**Failure guard (F1).**  If `_auto_index_response` raises,
+`ProxyManager` catches at `manager.py:1346`, logs WARNING with
+traceback, and returns the pre-index response unchanged.  The agent
+receives a successful result; the response is just not searchable
+in LTM.
 
 ## Stage 4b: Auto Fact Extraction (optional)
 

--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -167,6 +167,14 @@ sequenceDiagram
     end
 ```
 
+**Failure guard (S1).**  If `record_surfacing` fails (e.g. SQLite
+contention on `stm_feedback.db`), the engine drops the
+`surfacing_id` — the memory block is still injected but without a
+feedback ID.  The agent cannot submit feedback for that particular
+surfacing event, but the response is never blocked or corrupted.
+Logged at WARNING.  See also
+[Pipeline → Stage 3](pipeline.md#stage-3-surface).
+
 ## LTM Connection
 
 STM connects to the LTM exclusively over the MCP protocol. The surfacing engine spawns (or attaches to) a memtomem MCP server using these settings:

--- a/notebooks/03_memory_surfacing.ipynb
+++ b/notebooks/03_memory_surfacing.ipynb
@@ -200,16 +200,7 @@
    "cell_type": "markdown",
    "id": "3bae485f",
    "metadata": {},
-   "source": [
-    "Over time, `\"helpful\"` feedback raises the confidence of the\n",
-    "retrieved memory chunks via STM's auto-tuning loop, and\n",
-    "`\"not_relevant\"` pulls them down. Agents that call the\n",
-    "feedback tool get progressively more relevant surfacing.\n",
-    "See [`docs/surfacing.md`](../docs/surfacing.md) for the\n",
-    "scoring details.\n",
-    "\n",
-    "## 5. Check the surfacing counters"
-   ]
+   "source": "Over time, `\"helpful\"` feedback raises the confidence of the\nretrieved memory chunks via STM's auto-tuning loop, and\n`\"not_relevant\"` pulls them down. Agents that call the\nfeedback tool get progressively more relevant surfacing.\nSee [`docs/surfacing.md`](../docs/surfacing.md) for the\nscoring details.\n\n> **S1 failure guard.** In production, if `record_surfacing`\n> fails (e.g. SQLite contention on `stm_feedback.db`), STM\n> drops the `surfacing_id` — the memory block is still\n> injected but without a feedback ID. When this happens,\n> `stm_surfacing_feedback` cannot be called for that event.\n> The response is never blocked. See\n> [`docs/pipeline.md → Stage 3`](../docs/pipeline.md#stage-3-surface).\n\n## 5. Check the surfacing counters"
   },
   {
    "cell_type": "code",

--- a/notebooks/05_observability_and_langfuse.ipynb
+++ b/notebooks/05_observability_and_langfuse.ipynb
@@ -255,26 +255,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a44394da",
+   "source": "## 9. Log level configuration\n\nSTM uses Python's `logging` module. Control verbosity via\nenvironment variable:\n\n```bash\nexport MEMTOMEM_STM_LOG_LEVEL=WARNING   # default\nexport MEMTOMEM_STM_LOG_LEVEL=DEBUG     # full pipeline tracing\n```\n\n| Level | What it shows |\n|-------|---------------|\n| `DEBUG` | Pipeline tracing, strategy selection, cache decisions |\n| `INFO` | Surfacing injections, config reloads, extraction completions |\n| `WARNING` | Failure guards (F1/S1), fallback activations, skips |\n| `ERROR` | Unrecoverable failures (rare — most errors fall back) |\n\nThe level is read once at startup — restart the server to\napply changes. See\n[`docs/operations.md → Logging`](../docs/operations.md#logging)\nfor format details.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "a26b98f7",
    "metadata": {},
-   "source": [
-    "## Recap\n",
-    "\n",
-    "| Layer | What you get | When to use |\n",
-    "|---|---|---|\n",
-    "| MCP tools | Live snapshot, agent-accessible | Quick checks |\n",
-    "| SQLite | Full history, offline analysis | Debugging, tuning |\n",
-    "| Langfuse | Nested spans, team-shared UI | Production monitoring |\n",
-    "\n",
-    "**Where to next:**\n",
-    "\n",
-    "- [`docs/operations.md`](../docs/operations.md) — full\n",
-    "  observability reference (span table, data storage, safety)\n",
-    "- [`docs/configuration.md`](../docs/configuration.md) — env\n",
-    "  vars for Langfuse and all other settings\n",
-    "- [Langfuse docs](https://langfuse.com/docs) — dashboard\n",
-    "  setup and SDK reference"
-   ]
+   "source": "## Recap\n\n| Layer | What you get | When to use |\n|---|---|---|\n| MCP tools | Live snapshot, agent-accessible | Quick checks |\n| SQLite | Full history, offline analysis | Debugging, tuning |\n| Logging | `MEMTOMEM_STM_LOG_LEVEL` control | Failure diagnosis (F1/S1) |\n| Langfuse | Nested spans, team-shared UI | Production monitoring |\n\n**Where to next:**\n\n- [`docs/operations.md`](../docs/operations.md) — full\n  observability reference (logging, spans, data storage, safety)\n- [`docs/configuration.md`](../docs/configuration.md) — env\n  vars for log level, Langfuse, and all other settings\n- [Langfuse docs](https://langfuse.com/docs) — dashboard\n  setup and SDK reference"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

- Complete the post-v0.1.7 documentation audit across all docs,
  README, CONTRIBUTING, and tutorial notebooks
- Document `MEMTOMEM_STM_LOG_LEVEL` env var in configuration,
  operations, and CLI references
- Add F1/S1 failure guard documentation to pipeline and surfacing
- Wire bidirectional cross-links between `custom-integration.md`
  and existing docs
- Add `custom-integration.md` to README docs table and
  CONTRIBUTING project structure
- Update notebooks 03 (S1 guard note) and 05 (log level section)

## Changes (3 commits, 11 files)

**Core docs (5 files):**
1. `configuration.md` — `### General` section with `MEMTOMEM_STM_LOG_LEVEL`
2. `operations.md` — `### Logging` subsection with level table
3. `pipeline.md` — S1/F1 failure guards in Stage 3/4
4. `caching.md` — cross-ref to `custom-integration.md`
5. `custom-integration.md` — outbound links to 4 other docs

**Additional docs (4 files):**
6. `README.md` — `custom-integration.md` in docs table
7. `surfacing.md` — S1 failure guard + pipeline cross-ref
8. `CONTRIBUTING.md` — `custom-integration.md` in project structure
9. `cli.md` — `## Logging` section

**Notebooks (2 files):**
10. `03_memory_surfacing` — S1 guard callout
11. `05_observability` — section 9 (log level config) + recap table

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1360 passed
- [x] Line length check on all edited docs
- [x] Cross-reference anchor verification
- [ ] Rendered markdown review on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)