### PR TITLE
feat(cli): mms version + --json status + persistence round-trip test

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -75,19 +75,37 @@ def version() -> None:
 
 @cli.command()
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
-def status(config_path: str) -> None:
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
+def status(config_path: str, *, as_json: bool = False) -> None:
     """Show proxy gateway configuration and server list."""
     path = Path(config_path)
     resolved = path.expanduser().resolve()
 
     if not resolved.exists():
-        click.echo(f"Config not found: {resolved}")
-        click.echo("Run `memtomem-stm-proxy add` to create a configuration.")
+        if as_json:
+            click.echo(json.dumps({"error": "config_not_found", "path": str(resolved)}))
+        else:
+            click.echo(f"Config not found: {resolved}")
+            click.echo("Run `memtomem-stm-proxy add` to create a configuration.")
         return
 
     data = _load(path)
     enabled = data.get("enabled", False)
     servers: dict[str, Any] = data.get("upstream_servers", {})
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "config_path": str(resolved),
+                    "enabled": enabled,
+                    "servers": servers,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return
 
     click.echo(f"Config : {resolved}")
     click.echo(f"Enabled: {'yes' if enabled else 'no'}")

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -66,6 +66,14 @@ def cli() -> None:
 
 
 @cli.command()
+def version() -> None:
+    """Show the installed memtomem-stm version."""
+    from importlib.metadata import version as pkg_version
+
+    click.echo(f"memtomem-stm {pkg_version('memtomem-stm')}")
+
+
+@cli.command()
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
 def status(config_path: str) -> None:
     """Show proxy gateway configuration and server list."""

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -88,6 +88,31 @@ class TestStatus:
         assert "Enabled: yes" in result.output
         assert "Servers: 0" in result.output
 
+    def test_json_output(self, runner, config):
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {
+                        "fs": {"prefix": "fs", "command": "uvx", "args": ["mcp-server-fs"]},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["status", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["enabled"] is True
+        assert "fs" in data["servers"]
+        assert str(config) in data["config_path"]
+
+    def test_json_missing_config(self, runner, config):
+        result = runner.invoke(cli, ["status", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["error"] == "config_not_found"
+
     def test_shows_server_details(self, runner, config):
         config.write_text(
             json.dumps(

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -40,6 +40,17 @@ def _cfg_args(config: Path) -> list[str]:
     return ["--config", str(config)]
 
 
+# ── version command ─────────────────────────────────────────────────────
+
+
+class TestVersion:
+    def test_prints_package_version(self, runner):
+        result = runner.invoke(cli, ["version"])
+        assert result.exit_code == 0
+        assert "memtomem-stm" in result.output
+        assert result.output.strip().startswith("memtomem-stm ")
+
+
 # ── _load / config-corruption paths ──────────────────────────────────────
 
 

--- a/tests/test_compression_feedback.py
+++ b/tests/test_compression_feedback.py
@@ -141,6 +141,26 @@ class TestCompressionFeedbackStore:
             compression.close()
             surfacing.close()
 
+    def test_data_survives_store_reopen(self, tmp_path: Path):
+        db_path = tmp_path / "cfb.db"
+        store = CompressionFeedbackStore(db_path)
+        store.initialize()
+        try:
+            store.record("docfix", "get_document", "truncated", "m1", "t1")
+            store.record("docfix", "search", "missing_example", "m2", None)
+        finally:
+            store.close()
+
+        store2 = CompressionFeedbackStore(db_path)
+        store2.initialize()
+        try:
+            stats = store2.get_stats()
+            assert stats["total_feedback"] == 2
+            assert stats["by_kind"] == {"truncated": 1, "missing_example": 1}
+            assert stats["by_tool"] == {"get_document": 1, "search": 1}
+        finally:
+            store2.close()
+
     def test_close_is_idempotent(self, tmp_path: Path):
         store = CompressionFeedbackStore(tmp_path / "cfb.db")
         store.initialize()


### PR DESCRIPTION
## Summary

- Add `mms version` command (closes #26)
- Add `--json` flag to `mms status` for scripting (closes #27)
- Add persistence round-trip test for CompressionFeedbackStore (closes #29)

## Changes

### `mms version` (#26)
New CLI command that prints `memtomem-stm {version}` using
`importlib.metadata`. Test verifies output format.

### `mms status --json` (#27)
When `--json` is passed, outputs config path, enabled state, and
full server config as JSON instead of human-readable text. Missing
config returns `{"error": "config_not_found", "path": "..."}`.

### Persistence round-trip (#29)
New test that creates a `CompressionFeedbackStore`, records 2 rows,
closes it, reopens on the same DB, and verifies all data survived.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1364 passed (+4 new)
- [x] `uv run ruff check src && uv run ruff format --check src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)