### PR TITLE
fix(cli): clarify duplicate prefix warning proceeds anyway

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -219,8 +219,9 @@ def add(
     for srv_name, srv_cfg in servers.items():
         if srv_cfg.get("prefix") == prefix:
             click.echo(
-                f"Warning: prefix '{prefix}' is already used by server '{srv_name}'. "
-                "Tools with the same prefixed name will be shadowed at runtime.",
+                f"Warning: prefix '{prefix}' is already used by server "
+                f"'{srv_name}'. Duplicate-named tools will shadow each "
+                f"other at runtime. Proceeding anyway.",
                 err=True,
             )
             break


### PR DESCRIPTION
## Summary

- Append "Proceeding anyway." to the duplicate prefix warning so users know the `mms add` still succeeded
- No behavior change — warning remains on stderr, exit code stays 0

## Test plan

- [x] `test_warns_on_duplicate_prefix_but_succeeds` passes
- [x] `ruff check` clean