### PR TITLE
feat(cli): add mms health command for upstream connectivity checks

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ Usage: mms [OPTIONS] COMMAND [ARGS]...
 
 Commands:
   add     Add an upstream MCP server to the proxy configuration.
+  health  Check upstream server connectivity.
   list    List configured upstream servers.
   remove  Remove an upstream MCP server from the proxy configuration.
   status  Show proxy gateway configuration and server list.
@@ -89,7 +90,25 @@ mms status
 
 # Remove a server
 mms remove github
+
+# Check upstream connectivity (probes each server)
+mms health
+mms health --json          # machine-readable output
+mms health --timeout 5     # 5s per-server timeout (default: 10)
 ```
+
+### `health`
+
+```
+Usage: mms health [OPTIONS]
+
+Options:
+  --config TEXT          [default: ~/.memtomem/stm_proxy.json]
+  --json                Output as JSON for scripting.
+  --timeout INTEGER     Per-server connection timeout in seconds.  [default: 10]
+```
+
+Connects to each configured upstream server (MCP initialize + list-tools) and reports whether it's reachable and how many tools it exposes. Unlike `stm_proxy_health` (the MCP tool), this command probes servers directly — the proxy does not need to be running.
 
 ## MCP Tools (10 + proxied)
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import shlex
@@ -298,3 +299,107 @@ def remove(name: str, config_path: str, yes: bool) -> None:
     del servers[name]
     _save(path, data)
     click.echo(f"Removed server '{name}'.")
+
+
+# ── health command ──────────────────────────────────────────────────────
+
+
+async def _probe_one(cfg: dict[str, Any], timeout: float) -> dict[str, Any]:
+    """Probe a single upstream server: connect, initialize, list tools."""
+    from mcp import ClientSession
+    from mcp.client.sse import sse_client
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+    from mcp.client.streamable_http import streamablehttp_client
+
+    transport = cfg.get("transport", "stdio")
+    if transport == "stdio":
+        ctx = stdio_client(
+            StdioServerParameters(
+                command=cfg.get("command", ""),
+                args=cfg.get("args", []),
+                env=cfg.get("env"),
+            )
+        )
+    elif transport == "sse":
+        ctx = sse_client(cfg.get("url", ""))
+    else:
+        ctx = streamablehttp_client(cfg.get("url", ""))
+
+    async with ctx as streams:
+        async with ClientSession(streams[0], streams[1]) as session:
+            await asyncio.wait_for(session.initialize(), timeout=timeout)
+            result = await session.list_tools()
+            return {
+                "connected": True,
+                "tools": len(result.tools),
+                "error": None,
+            }
+
+
+async def _probe_servers(servers: dict[str, Any], timeout: float) -> dict[str, dict[str, Any]]:
+    """Probe all servers in parallel, returning per-server results."""
+
+    async def _safe_probe(name: str, cfg: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        try:
+            result = await _probe_one(cfg, timeout)
+        except asyncio.TimeoutError:
+            result = {
+                "connected": False,
+                "tools": 0,
+                "error": f"timeout ({timeout}s)",
+            }
+        except Exception as exc:
+            err = str(exc) or type(exc).__name__
+            result = {"connected": False, "tools": 0, "error": err}
+        return name, result
+
+    tasks = [_safe_probe(n, c) for n, c in servers.items()]
+    pairs = await asyncio.gather(*tasks)
+    return dict(pairs)
+
+
+@cli.command()
+@click.option(
+    "--config",
+    "config_path",
+    default=str(_DEFAULT_CONFIG),
+    show_default=True,
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output as JSON for scripting.",
+)
+@click.option(
+    "--timeout",
+    default=10,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Per-server connection timeout in seconds.",
+)
+def health(config_path: str, *, as_json: bool = False, timeout: int = 10) -> None:
+    """Check upstream server connectivity."""
+    data = _load(Path(config_path))
+    servers: dict[str, Any] = data.get("upstream_servers", {})
+
+    if not servers:
+        if as_json:
+            click.echo(json.dumps({"servers": {}}))
+        else:
+            click.echo("No upstream servers configured.")
+        return
+
+    results = asyncio.run(_probe_servers(servers, timeout))
+
+    if as_json:
+        click.echo(json.dumps({"servers": results}))
+        return
+
+    click.echo("Upstream Server Health")
+    click.echo("=" * 30)
+    for name, info in results.items():
+        if info["connected"]:
+            click.echo(f"  {name}: connected ({info['tools']} tools)")
+        else:
+            click.echo(f"  {name}: DISCONNECTED — {info['error']}")

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -486,3 +486,65 @@ class TestFullFlow:
 
         final_list = runner.invoke(cli, ["list", *_cfg_args(config)])
         assert "No upstream servers configured" in final_list.output
+
+
+# ── health command ──────────────────────────────────────────────────────
+
+
+class TestHealth:
+    def test_health_no_servers(self, runner, config):
+        """Empty config → friendly message, no crash."""
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["health", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "No upstream servers configured" in result.output
+
+    def test_health_json_no_servers(self, runner, config):
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"servers": {}}
+
+    def test_health_unreachable_server(self, runner, config):
+        """A server with a nonexistent command → DISCONNECTED."""
+        config.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "bad": {
+                            "prefix": "bad",
+                            "transport": "stdio",
+                            "command": "__nonexistent_cmd_12345__",
+                            "args": [],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["health", "--timeout", "3", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "DISCONNECTED" in result.output
+
+    def test_health_json_unreachable(self, runner, config):
+        config.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "bad": {
+                            "prefix": "bad",
+                            "transport": "stdio",
+                            "command": "__nonexistent_cmd_12345__",
+                            "args": [],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["health", "--json", "--timeout", "3", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["servers"]["bad"]["connected"] is False
+        assert data["servers"]["bad"]["error"]


### PR DESCRIPTION
## Summary

- New `mms health` command that probes each upstream server via MCP initialize + list_tools
- Parallel probing with `asyncio.gather` for fast results across multiple servers
- `--json` flag for scripting, `--timeout` flag (default 10s per server)
- Works independently — proxy does not need to be running

## Behavior change

New CLI command only. No changes to existing commands or MCP server behavior.

## Test plan

- [x] `test_health_no_servers` — empty config handled
- [x] `test_health_json_no_servers` — JSON output correct
- [x] `test_health_unreachable_server` — nonexistent command reports DISCONNECTED
- [x] `test_health_json_unreachable` — JSON output for failed probe
- [x] 1368 tests pass, ruff clean