### PR TITLE
fix(cli): reject non-dict JSON configs with a clean error

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -38,10 +38,29 @@ def _load(config_path: Path) -> dict[str, Any]:
     if not resolved.exists():
         return {"enabled": True, "upstream_servers": {}}
     try:
-        return json.loads(resolved.read_text(encoding="utf-8"))
+        data = json.loads(resolved.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, ValueError) as exc:
         click.echo(f"Error: Failed to parse {resolved}: {exc}", err=True)
         raise SystemExit(1) from exc
+    # Structural guard: the rest of the CLI assumes top-level dict with a dict
+    # `upstream_servers`. Without this, a valid-but-wrong-shape JSON (e.g. a
+    # list or a string, or `upstream_servers: "oops"`) crashes downstream with
+    # an AttributeError traceback instead of a clean user-facing error.
+    if not isinstance(data, dict):
+        click.echo(
+            f"Error: {resolved} top-level must be a JSON object, got {type(data).__name__}.",
+            err=True,
+        )
+        raise SystemExit(1)
+    servers = data.get("upstream_servers")
+    if servers is not None and not isinstance(servers, dict):
+        click.echo(
+            f"Error: {resolved} 'upstream_servers' must be an object, "
+            f"got {type(servers).__name__}.",
+            err=True,
+        )
+        raise SystemExit(1)
+    return data
 
 
 def _save(config_path: Path, data: dict[str, Any]) -> None:

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -69,6 +69,27 @@ class TestConfigLoad:
         assert result.exit_code == 1
         assert "Failed to parse" in result.output
 
+    @pytest.mark.parametrize(
+        "payload,expected_type",
+        [("[]", "list"), ("null", "NoneType"), ('"oops"', "str"), ("42", "int")],
+    )
+    def test_rejects_non_dict_top_level(self, runner, config, payload, expected_type):
+        """Valid JSON that isn't an object (list/null/string/int) used to crash the
+        CLI with an AttributeError traceback. Guard surfaces a clean error."""
+        config.write_text(payload, encoding="utf-8")
+        result = runner.invoke(cli, ["list", *_cfg_args(config)])
+        assert result.exit_code == 1
+        assert "top-level must be a JSON object" in result.output
+        assert expected_type in result.output
+
+    def test_rejects_non_dict_upstream_servers(self, runner, config):
+        """`upstream_servers` must be a dict — a list/string here would crash
+        downstream iteration with an AttributeError traceback."""
+        config.write_text(json.dumps({"upstream_servers": "oops"}), encoding="utf-8")
+        result = runner.invoke(cli, ["status", *_cfg_args(config)])
+        assert result.exit_code == 1
+        assert "'upstream_servers' must be an object" in result.output
+
     def test_list_empty_config(self, runner, config):
         """No config → ``list`` prints the empty-state message and exits 0."""
         result = runner.invoke(cli, ["list", *_cfg_args(config)])


### PR DESCRIPTION
## Summary
- Valid JSON that wasn't an object (a list, `null`, a string, a number) crashed every `mms` command with an `AttributeError` traceback — `_load` trusted `json.loads` to yield a dict without verifying it.
- Same class of bug hit when `upstream_servers` was present but wasn't a dict.
- Add structural guards that surface the same `Failed to parse`-style user-facing error, so a misconfigured file exits cleanly with an actionable message instead of a stack trace.

## Repro (before this PR)
```bash
$ echo '[]' > /tmp/bad.json && mms list --config /tmp/bad.json
Traceback (most recent call last):
  ...
  File ".../cli/proxy.py", line 137, in list_servers
    servers: dict[str, Any] = data.get("upstream_servers", {})
                              ^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```

## After
```bash
$ mms list --config /tmp/bad.json
Error: /tmp/bad.json top-level must be a JSON object, got list.
```

## Test plan
- [x] `uv run pytest tests/cli/test_proxy_cli.py` — 5 new parametrized + single-case tests over the guard
- [x] `uv run ruff check src && uv run ruff format --check src`
- [x] Manual probe with `[]`, `null`, `"oops"`, `42`, and `{"upstream_servers": "oops"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)