### PR TITLE
feat(cli): first-time setup — mms init + add --validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ memtomem-stm is **independent**: it has no Python-level dependency on memtomem c
 
 ### 1. Add an upstream MCP server
 
+For first-time setup, run the guided wizard — it prompts for name/prefix/command, optionally probes the server, and prints the MCP-client snippet you'll need in step 2:
+
+```bash
+mms init
+```
+
+Or add servers non-interactively:
+
 ```bash
 mms add filesystem \
   --command npx \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,14 @@ Options:
                                   'auto' picks strategy per response by
                                   content type.  [default: auto]
   --max-chars INTEGER             [default: 8000]
+  --validate                      Probe the server (MCP initialize +
+                                  list-tools) before saving; abort on
+                                  failure.
+  --timeout INTEGER               Connection timeout (seconds) when
+                                  --validate is set.  [default: 10]
 ```
+
+Use `--validate` to catch typos and misconfigurations at registration time instead of the next time the proxy starts. Without it `add` only writes the config — bad entries are discovered later via `mms health` or when the proxy fails to spawn.
 
 > **Note**: The CLI's `--compression` flag exposes 5 of the 10 strategies. The remaining five (`extract_fields`, `schema_pruning`, `skeleton`, `progressive`, `llm_summary`) are configured by editing `stm_proxy.json` directly. See [Compression Strategies](compression.md).
 
@@ -81,6 +88,13 @@ mms add docs \
   --transport sse \
   --url https://docs.example.com/mcp \
   --prefix docs
+
+# Validate connectivity at registration time (rejects bad entries up front)
+mms add filesystem \
+  --command npx \
+  --args "-y @modelcontextprotocol/server-filesystem /home/user/projects" \
+  --prefix fs \
+  --validate
 
 # List configured upstreams
 mms list

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,12 +29,35 @@ Usage: mms [OPTIONS] COMMAND [ARGS]...
 Commands:
   add     Add an upstream MCP server to the proxy configuration.
   health  Check upstream server connectivity.
+  init    Guided first-time setup for memtomem-stm.
   list    List configured upstream servers.
   remove  Remove an upstream MCP server from the proxy configuration.
   status  Show proxy gateway configuration and server list.
 ```
 
 All commands accept `--config TEXT` (default `~/.memtomem/stm_proxy.json`).
+
+### `init`
+
+```
+Usage: mms init [OPTIONS]
+
+Options:
+  --config TEXT   [default: ~/.memtomem/stm_proxy.json]
+  --no-validate   Skip the connectivity probe entirely (default: prompt,
+                  probe on yes).
+```
+
+Interactive wizard for the first-time setup. Prompts for a single upstream server (name, prefix, transport, command/URL), optionally probes connectivity, writes the config, then prints an inline summary plus the MCP-client snippet you need to paste into Claude Code / Claude Desktop.
+
+Aborts if the config file already exists — use [`add`](#add) to register additional servers or [`list`](#list) to inspect the current state. This makes `init` safe to run without clobbering existing configuration.
+
+Validation is **advisory**: probe failures are reported as warnings but the config is still written. That way a flaky network or a cold upstream doesn't block setup; re-run `mms health` later once things are up.
+
+```bash
+mms init                # interactive wizard
+mms init --no-validate  # skip the connectivity probe prompt entirely
+```
 
 ### `add`
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -204,6 +204,20 @@ def list_servers(config_path: str) -> None:
 @click.option(
     "--max-chars", "max_result_chars", type=click.IntRange(min=1), default=8000, show_default=True
 )
+@click.option(
+    "--validate",
+    is_flag=True,
+    default=False,
+    help="Probe the server (MCP initialize + list-tools) before saving; abort on failure.",
+)
+@click.option(
+    "--timeout",
+    "validate_timeout",
+    type=click.IntRange(min=1),
+    default=10,
+    show_default=True,
+    help="Connection timeout (seconds) when --validate is set.",
+)
 def add(
     name: str,
     config_path: str,
@@ -215,6 +229,8 @@ def add(
     env_pairs: tuple[str, ...],
     compression: str,
     max_result_chars: int,
+    validate: bool,
+    validate_timeout: int,
 ) -> None:
     """Add an upstream MCP server to the proxy configuration."""
     path = Path(config_path)
@@ -292,6 +308,14 @@ def add(
                 sys.exit(1)
             env_dict[k] = v
         entry["env"] = env_dict
+
+    if validate:
+        click.echo(f"Validating '{name}' (timeout={validate_timeout}s)...")
+        probe = asyncio.run(_probe_servers({name: entry}, validate_timeout))[name]
+        if not probe["connected"]:
+            click.echo(f"Error: validation failed — {probe['error']}", err=True)
+            sys.exit(1)
+        click.echo(f"Validated: {probe['tools']} tool(s) reachable.")
 
     servers[name] = entry
     _save(path, data)

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -322,6 +322,128 @@ def add(
     click.echo(f"Added server '{name}' (prefix={prefix})")
 
 
+# ── init command ────────────────────────────────────────────────────────
+
+
+def _prompt_prefix() -> str:
+    """Prompt for a prefix until it passes the same rules as ``add --prefix``."""
+    while True:
+        value = click.prompt("Tool prefix (letters/digits/underscores, e.g. 'fs')", type=str)
+        if _PREFIX_RE.match(value) and "__" not in value:
+            return value
+        click.echo(
+            "  Invalid: must start with a letter, contain only letters/digits/"
+            "underscores, and not contain '__'. Try again."
+        )
+
+
+@cli.command()
+@click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
+@click.option(
+    "--no-validate",
+    is_flag=True,
+    default=False,
+    help="Skip the connectivity probe entirely (default: prompt, probe on yes).",
+)
+def init(config_path: str, no_validate: bool) -> None:
+    """Guided first-time setup for memtomem-stm.
+
+    Prompts for a single upstream server and writes the config file. Aborts
+    when the config already exists — use ``mms add`` to append more servers.
+    """
+    path = Path(config_path)
+    resolved = path.expanduser().resolve()
+
+    if resolved.exists():
+        click.echo(f"Error: config already exists at {resolved}.", err=True)
+        click.echo("  Use `mms add` to register another server.", err=True)
+        click.echo("  Use `mms list` to see what's already configured.", err=True)
+        sys.exit(1)
+
+    click.echo("Guided setup for memtomem-stm")
+    click.echo("=" * 30)
+    click.echo(f"Config will be written to: {resolved}")
+    click.echo("")
+
+    name = click.prompt("Server name (e.g. 'filesystem', 'github')", type=str).strip()
+    if not name:
+        click.echo("Error: server name must be non-empty.", err=True)
+        sys.exit(1)
+
+    prefix = _prompt_prefix()
+
+    transport = click.prompt(
+        "Transport",
+        type=click.Choice(["stdio", "sse", "streamable_http"]),
+        default="stdio",
+        show_default=True,
+    )
+
+    entry: dict[str, Any] = {
+        "prefix": prefix,
+        "transport": transport,
+        "compression": "auto",
+        "max_result_chars": 8000,
+    }
+
+    if transport == "stdio":
+        command = click.prompt("Command (e.g. 'npx', 'uvx')", type=str).strip()
+        if not command:
+            click.echo("Error: command must be non-empty for stdio transport.", err=True)
+            sys.exit(1)
+        entry["command"] = command
+
+        args_str = click.prompt(
+            "Arguments (space-separated, leave empty for none)",
+            type=str,
+            default="",
+            show_default=False,
+        )
+        if args_str.strip():
+            try:
+                entry["args"] = shlex.split(args_str)
+            except ValueError as exc:
+                click.echo(f"Error: malformed arguments: {exc}", err=True)
+                sys.exit(1)
+    else:
+        url = click.prompt(f"URL for {transport}", type=str).strip()
+        if not url:
+            click.echo(f"Error: URL must be non-empty for {transport} transport.", err=True)
+            sys.exit(1)
+        entry["url"] = url
+
+    if not no_validate and click.confirm("Validate connection now?", default=True):
+        click.echo(f"Validating '{name}' (timeout=10s)...")
+        probe = asyncio.run(_probe_servers({name: entry}, 10))[name]
+        if probe["connected"]:
+            click.echo(f"  Reachable: {probe['tools']} tool(s) discovered.")
+        else:
+            click.echo(f"  Warning: probe failed — {probe['error']}", err=True)
+            click.echo("  Saving config anyway. Run `mms health` later to retry.", err=True)
+
+    data = {"enabled": True, "upstream_servers": {name: entry}}
+    _save(path, data)
+
+    click.echo("")
+    click.echo(f"Saved to: {resolved}")
+    click.echo("")
+    click.echo("Configured upstream servers:")
+    if transport == "stdio":
+        detail = f"{entry['command']} {' '.join(entry.get('args', []))}".strip()
+    else:
+        detail = entry["url"]
+    click.echo(f"  {name:<20} prefix={prefix}  [{transport}] {detail}")
+
+    click.echo("")
+    click.echo("Next: connect your MCP client to memtomem-stm.")
+    click.echo("")
+    click.echo("  Claude Code (CLI):")
+    click.echo("    claude mcp add memtomem-stm -s user -- memtomem-stm")
+    click.echo("")
+    click.echo("  Claude Desktop / JSON MCP config:")
+    click.echo('    { "mcpServers": { "memtomem-stm": { "command": "memtomem-stm" } } }')
+
+
 @cli.command()
 @click.argument("name")
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -556,6 +556,102 @@ class TestAddValidate:
         assert "lazy" in data["upstream_servers"]
 
 
+# ── init command (guided setup) ─────────────────────────────────────────
+
+
+class TestInit:
+    """`mms init` is an interactive one-shot wizard: prompt for the first
+    upstream server, run an optional probe, write config, print paste-targets.
+
+    Prompt order (stdio path): name → prefix → transport → command → args
+    → (optional) validate y/n. ``input=`` feeds one answer per newline."""
+
+    def test_init_happy_path_stdio_no_validate(self, runner, config):
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="filesystem\nfs\nstdio\nnpx\n-y @modelcontextprotocol/server-fs\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Saved to:" in result.output
+        assert "Next:" in result.output
+        assert "claude mcp add memtomem-stm" in result.output
+        assert "mcpServers" in result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        srv = data["upstream_servers"]["filesystem"]
+        assert srv["prefix"] == "fs"
+        assert srv["transport"] == "stdio"
+        assert srv["command"] == "npx"
+        assert srv["args"] == ["-y", "@modelcontextprotocol/server-fs"]
+
+    def test_init_aborts_if_config_exists(self, runner, config):
+        """Init is for first-time setup only; `mms add` handles append."""
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["init", *_cfg_args(config)])
+        assert result.exit_code == 1
+        assert "config already exists" in result.output
+        assert "mms add" in result.output
+        assert "mms list" in result.output
+
+    def test_init_invalid_prefix_reprompts(self, runner, config):
+        """Bad prefix → re-ask instead of aborting; saves on the retry value."""
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="srv\n1bad\nfs\nstdio\ncmd\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Invalid: must start with a letter" in result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert data["upstream_servers"]["srv"]["prefix"] == "fs"
+
+    def test_init_sse_transport_prompts_for_url(self, runner, config):
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="docs\ndocs\nsse\nhttps://docs.example.com/mcp\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        srv = data["upstream_servers"]["docs"]
+        assert srv["transport"] == "sse"
+        assert srv["url"] == "https://docs.example.com/mcp"
+        assert "command" not in srv
+
+    def test_init_validate_failure_still_saves_with_warning(self, config):
+        """Validation is advisory: probe failure warns and continues (a flaky
+        network shouldn't block setup). Uses a real subprocess to dodge
+        CliRunner's stderr-fileno interaction (see TestAddValidate)."""
+        import subprocess
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from memtomem_stm.cli.proxy import cli; cli()",
+                "init",
+                "--config",
+                str(config),
+            ],
+            # server name, prefix, transport, command, args, validate=y
+            input="bad\nbad\nstdio\n__nonexistent_cmd_12345__\n\ny\n",
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        combined = proc.stdout + proc.stderr
+        assert "Warning: probe failed" in combined
+        assert "Saving config anyway" in combined
+        assert "Saved to:" in proc.stdout
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "bad" in data["upstream_servers"]
+
+
 # ── remove command ───────────────────────────────────────────────────────
 
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -16,12 +16,15 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
 from memtomem_stm.cli.proxy import cli
+
+_FAKE_SERVER = Path(__file__).resolve().parents[1] / "_fake_memtomem_server.py"
 
 
 @pytest.fixture
@@ -458,6 +461,99 @@ class TestAddPersistence:
         )
         assert result.exit_code == 1
         assert "malformed --args" in result.output
+
+
+# ── add --validate (probe before save) ──────────────────────────────────
+
+
+class TestAddValidate:
+    """`add --validate` reuses the health probe to reject unreachable servers
+    at config-write time. The contract is: probe fails → exit 1 and *no*
+    entry written; probe succeeds → entry written and tool count reported."""
+
+    def test_validate_unreachable_aborts_and_skips_write(self, runner, config):
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "bad",
+                "--prefix",
+                "bad",
+                "--command",
+                "__nonexistent_cmd_12345__",
+                "--validate",
+                "--timeout",
+                "3",
+                *_cfg_args(config),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "validation failed" in result.output
+
+        # Config file must not carry a partial entry.
+        if config.exists():
+            data = json.loads(config.read_text(encoding="utf-8"))
+            assert "bad" not in data.get("upstream_servers", {})
+
+    def test_validate_success_writes_entry_with_tool_count(self, config):
+        """Probe against the repo's fake MCP server — should report tool count.
+
+        Runs via real subprocess rather than ``CliRunner`` because Click's
+        runner replaces ``sys.stderr`` with a buffer that has no ``fileno()``,
+        and the underlying MCP stdio client passes that stderr to a child
+        ``asyncio.create_subprocess_exec`` call — which requires a real
+        file descriptor. The live ``mms`` binary doesn't hit this."""
+        import subprocess
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from memtomem_stm.cli.proxy import cli; cli()",
+                "add",
+                "fake",
+                "--prefix",
+                "fk",
+                "--command",
+                sys.executable,
+                "--args",
+                str(_FAKE_SERVER),
+                "--validate",
+                "--timeout",
+                "15",
+                "--config",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        assert "Validated:" in proc.stdout
+        assert "tool(s) reachable" in proc.stdout
+        assert "Added server 'fake'" in proc.stdout
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert data["upstream_servers"]["fake"]["command"] == sys.executable
+
+    def test_validate_flag_absent_skips_probe(self, runner, config):
+        """Without --validate, a nonexistent command is accepted (probe opt-in)."""
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "lazy",
+                "--prefix",
+                "lz",
+                "--command",
+                "__nonexistent_cmd_12345__",
+                *_cfg_args(config),
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Validated" not in result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "lazy" in data["upstream_servers"]
 
 
 # ── remove command ───────────────────────────────────────────────────────


### PR DESCRIPTION
> **Depends on #156** (fix: reject non-dict JSON configs). Open as a draft until #156 merges, then rebased onto main so this PR's diff stays scoped to the two features.

## Summary
Two features that together complete the "first-time setup + health check" UX story.

**`mms add --validate`** — opt-in probe at registration time. Reuses the `mms health` pipeline (`_probe_servers`) so a bad command, URL, or missing env var is caught when the user runs `mms add`, not when the proxy next starts. Default behavior unchanged; `--timeout` mirrors `mms health` (10s default).

**`mms init`** — interactive wizard for the very first server. Prompts for name / prefix / transport / command or URL, optionally probes, writes the config, then prints the paste-ready MCP-client snippet (Claude Code CLI + JSON). Aborts if the config already exists (`mms add` is the append path). Probe failure in `init` warns but still saves — a cold upstream or flaky network shouldn't derail setup, and `mms health` retries later.

## Why two commits in one PR
The two features share a UX story (first-time setup + its health check) and the same underlying probe path, so one review grabs the whole mental model. Commits are preserved (not squashed) so the `--validate` foundation is visible under the `init` layer.

## Notes
- The `--validate` success test runs via a real subprocess instead of Click's `CliRunner`. Click's runner swaps `sys.stderr` with a buffer lacking `fileno()`, and the MCP stdio client forwards that stderr into `asyncio.create_subprocess_exec`, which requires a real file descriptor. The live `mms` binary never hits this path — it's purely a test-environment artifact.

## Test plan
- [x] `uv run pytest -m "not ollama"` — 1381 passed
- [x] `uv run ruff check src && uv run ruff format --check src`
- [x] Manual: `mms add --validate` vs fake MCP server → tool count reported; vs nonexistent command → clean abort, no config entry written.
- [x] Manual: `mms init` happy path (stdio + SSE), abort-on-exists, `--no-validate`, probe-fail-warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)