### PR TITLE
feat(metrics): surface INDEX/EXTRACT pipeline outcomes

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -44,7 +44,13 @@ from memtomem_stm.proxy.config import (
     UpstreamServerConfig,
 )
 from memtomem_stm.proxy.extraction import FactExtractor
-from memtomem_stm.proxy.memory_ops import auto_index_response, extract_and_store, format_fact_md
+from memtomem_stm.proxy.memory_ops import (
+    AutoIndexOutcome,
+    ExtractOutcome,
+    auto_index_response,
+    extract_and_store,
+    format_fact_md,
+)
 from memtomem_stm.proxy.tool_metadata import (
     convention_suffix,
     distill_schema,
@@ -637,7 +643,7 @@ class ProxyManager:
         original_chars: int | None = None,
         compressed_chars: int | None = None,
         context_query: str | None = None,
-    ) -> str:
+    ) -> AutoIndexOutcome:
         if self._index_engine is None:
             raise RuntimeError("index_engine not available")
         return await auto_index_response(
@@ -668,10 +674,10 @@ class ProxyManager:
         text: str,
         *,
         context_query: str | None = None,
-    ) -> None:
+    ) -> ExtractOutcome:
         """Extract facts from response and store as individual memory entries."""
         extractor = await self._get_extractor()
-        await extract_and_store(
+        return await extract_and_store(
             index_engine=self._index_engine,
             extractor=extractor,
             ext_cfg=self._config.extraction,
@@ -1321,6 +1327,13 @@ class ProxyManager:
                     _surface_ms = (_time.monotonic() - _t0) * 1000
 
         # ── Stage 4: INDEX (optional) ──
+        # Track outcome for CallMetrics below. ``None`` means "stage did not
+        # run for this call" — either disabled, engine missing, or content
+        # below min_chars. ``False`` means "ran and failed"; dashboards must
+        # distinguish the two.
+        index_ok: bool | None = None
+        index_error: str | None = None
+        chunks_indexed = 0
         ai_cfg = cfg_snap.auto_index
         if (
             tc.auto_index_enabled
@@ -1332,7 +1345,14 @@ class ProxyManager:
                 metadata={"server": server, "tool": tool},
             ):
                 try:
-                    final_result = await self._auto_index_response(
+                    # A1 fix: pre-surfacing ``compressed_chars_for_metrics``
+                    # matches what we record in the metrics row below, so the
+                    # indexed frontmatter and the dashboards agree on what
+                    # "compressed_chars" means for this call. Pre-A1 the
+                    # frontmatter recorded ``len(surfaced)`` (post-surfacing),
+                    # which drifted from the metrics value whenever surfacing
+                    # added content.
+                    outcome = await self._auto_index_response(
                         server,
                         tool,
                         upstream_args,
@@ -1340,10 +1360,18 @@ class ProxyManager:
                         agent_summary=surfaced,
                         compression_strategy=tc.compression.value,
                         original_chars=len(original_text),
-                        compressed_chars=len(surfaced),
+                        compressed_chars=compressed_chars_for_metrics,
                         context_query=context_query,
                     )
-                except Exception:
+                    final_result = outcome.summary
+                    index_ok = outcome.ok
+                    index_error = outcome.error
+                    chunks_indexed = outcome.chunks_indexed
+                except Exception as exc:
+                    # Reaches here only for failures outside the inner
+                    # ``index_file`` try/except in ``auto_index_response``
+                    # (mkdir / atomic write / unexpected errors). The inner
+                    # indexing failure is already captured in the outcome.
                     logger.warning(
                         "Auto-index failed for %s/%s — returning unindexed response",
                         server,
@@ -1351,10 +1379,18 @@ class ProxyManager:
                         exc_info=True,
                     )
                     final_result = surfaced
+                    index_ok = False
+                    index_error = f"{type(exc).__name__}: {exc}"
         else:
             final_result = surfaced
 
         # ── Stage 4b: EXTRACT (optional, background by default) ──
+        # Sync path populates ``extract_ok`` / ``extract_error``; background
+        # path leaves them ``None`` — the outcome arrives after the metrics
+        # row below is committed. Background failures stay visible via
+        # ``memory_ops.extract_and_store``'s WARNING log.
+        extract_ok: bool | None = None
+        extract_error: str | None = None
         ext_cfg = cfg_snap.extraction
         if (
             tc.extraction_enabled
@@ -1374,13 +1410,15 @@ class ProxyManager:
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
             else:
-                await self._extract_and_store(
+                extract_outcome = await self._extract_and_store(
                     server,
                     tool,
                     upstream_args,
                     cleaned,
                     context_query=context_query,
                 )
+                extract_ok = extract_outcome.ok
+                extract_error = extract_outcome.error
 
         # Record metrics (using pre-surfacing compressed size)
         # Approximate token counts: chars / 3.5 (average for mixed en/code/json).
@@ -1407,6 +1445,11 @@ class ProxyManager:
                 scorer_fallback=(
                     getattr(self._relevance_scorer, "fallback_count", 0) > _pre_scorer_fb
                 ),
+                index_ok=index_ok,
+                index_error=index_error,
+                chunks_indexed=chunks_indexed,
+                extract_ok=extract_ok,
+                extract_error=extract_error,
             )
         )
 

--- a/src/memtomem_stm/proxy/memory_ops.py
+++ b/src/memtomem_stm/proxy/memory_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,43 @@ from memtomem_stm.proxy.extraction import ExtractedFact, FactExtractor
 from memtomem_stm.utils.fileio import atomic_write_text
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class AutoIndexOutcome:
+    """Structured result of a single ``auto_index_response`` call.
+
+    ``summary`` is the composed ``[Indexed] … \\n\\n <agent_summary>`` string
+    the caller returns to the agent — identical to the pre-outcome return
+    value, preserved verbatim so existing surfaces don't change.
+
+    The other fields feed ``CallMetrics`` so operators watching
+    ``proxy_metrics.db`` see indexing failures that were previously
+    swallowed: the pre-outcome implementation caught every exception,
+    reported ``0 chunks`` in the summary, and left the metrics row
+    looking healthy even when the LTM pipeline was fully broken.
+    """
+
+    summary: str
+    ok: bool
+    chunks_indexed: int
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractOutcome:
+    """Structured result of a single ``extract_and_store`` call.
+
+    ``ok=True`` means the extraction phase completed without the outer
+    exception path firing. Individual fact-indexing failures inside the
+    loop are logged and counted against ``facts_stored`` (they reduce the
+    count) but do NOT flip ``ok`` — matching the pre-outcome contract
+    where partial failure still returned normally.
+    """
+
+    ok: bool
+    facts_stored: int
+    error: str | None = None
 
 
 async def auto_index_response(
@@ -28,8 +66,16 @@ async def auto_index_response(
     original_chars: int | None = None,
     compressed_chars: int | None = None,
     context_query: str | None = None,
-) -> str:
-    """Write a response to disk and index it via the file indexer."""
+) -> AutoIndexOutcome:
+    """Write a response to disk and index it via the file indexer.
+
+    Returns an ``AutoIndexOutcome`` carrying the summary string plus the
+    indexing status (``ok``, ``chunks_indexed``, ``error``). Callers that
+    only need the summary can read ``outcome.summary``; callers that feed
+    metrics consume the status fields. Failure is still logged via
+    ``logger.warning`` as before — the outcome adds a second observability
+    channel for operators who can't scrape logs.
+    """
     memory_dir = ai_cfg.memory_dir.expanduser().resolve()
     memory_dir.mkdir(parents=True, exist_ok=True)
 
@@ -71,6 +117,8 @@ async def auto_index_response(
 
     ns = ai_cfg.namespace.format(server=server, tool=tool)
 
+    ok = True
+    error: str | None = None
     try:
         stats = await index_engine.index_file(file_path, namespace=ns)
         chunks = stats.indexed_chunks
@@ -83,13 +131,16 @@ async def auto_index_response(
             exc_info=True,
         )
         chunks = 0
+        ok = False
+        error = f"{type(exc).__name__}: {exc}"
 
-    return (
+    summary = (
         f"[Indexed] `{server}/{tool}` ({original_chars or len(text)}"
         f"→{compressed_chars or len(agent_summary)} chars) "
         f"· {chunks} chunks in `{ns}` namespace.\n\n"
         f"{agent_summary}"
     )
+    return AutoIndexOutcome(summary=summary, ok=ok, chunks_indexed=chunks, error=error)
 
 
 async def extract_and_store(
@@ -102,12 +153,19 @@ async def extract_and_store(
     text: str,
     *,
     context_query: str | None = None,
-) -> None:
-    """Extract facts from response and store as individual memory entries."""
+) -> ExtractOutcome:
+    """Extract facts from response and store as individual memory entries.
+
+    Returns an ``ExtractOutcome`` — ``ok=False`` only when the outer
+    extraction phase itself raises (e.g., ``extractor.extract()`` fails).
+    Per-fact indexing failures are logged and counted against
+    ``facts_stored`` but do NOT flip ``ok``.
+    """
+    indexed_count = 0
     try:
         facts = await extractor.extract(text, server=server, tool=tool)
         if not facts:
-            return
+            return ExtractOutcome(ok=True, facts_stored=0)
 
         memory_dir = ext_cfg.memory_dir.expanduser().resolve()
         memory_dir.mkdir(parents=True, exist_ok=True)
@@ -118,7 +176,6 @@ async def extract_and_store(
 
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
         safe_tool = tool.replace("/", "_")
-        indexed_count = 0
 
         for i, fact in enumerate(facts[: ext_cfg.max_facts]):
             if dedup and index_engine is not None:
@@ -156,8 +213,14 @@ async def extract_and_store(
                 tool,
                 ns,
             )
-    except Exception:
+        return ExtractOutcome(ok=True, facts_stored=indexed_count)
+    except Exception as exc:
         logger.warning("Fact extraction failed for %s/%s", server, tool, exc_info=True)
+        return ExtractOutcome(
+            ok=False,
+            facts_stored=indexed_count,
+            error=f"{type(exc).__name__}: {exc}",
+        )
 
 
 def format_fact_md(

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -132,6 +132,29 @@ class CallMetrics:
     ratio_violation: bool = False
     # Scorer fallback: True when EmbeddingScorer fell back to BM25 during this call.
     scorer_fallback: bool = False
+    # Memory-pipeline status — populated by Stage 4 (INDEX) and Stage 4b (EXTRACT).
+    #
+    # Before these fields existed, ``auto_index_response`` and
+    # ``extract_and_store`` swallowed failures internally and returned a
+    # pass-through response. Operators watching ``proxy_metrics.db`` therefore
+    # saw a healthy call rate while the memory pipeline was silently broken
+    # (embedding service down, disk full, LTM connection dropped). Record the
+    # outcome so dashboards can surface the break.
+    #
+    # ``None`` means "stage did not run for this call" — e.g. auto-index
+    # disabled, response below ``min_chars`` threshold, or (for the
+    # surfacing_on_progressive fields) the call did not go down the
+    # progressive path. Readers must distinguish ``None`` from ``False``.
+    index_ok: bool | None = None
+    index_error: str | None = None
+    chunks_indexed: int = 0
+    extract_ok: bool | None = None
+    extract_error: str | None = None
+    # Surfacing on the progressive path — pre-provisioned for PR 2 (F6) so
+    # the schema migration ships once. Stays ``None`` until the progressive
+    # surfacing footer lands.
+    surfacing_on_progressive_ok: bool | None = None
+    surface_error: str | None = None
 
 
 class RPSTracker:

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -28,6 +28,18 @@ CREATE TABLE IF NOT EXISTS proxy_metrics (
 _INDEX = "CREATE INDEX IF NOT EXISTS idx_metrics_created ON proxy_metrics(created_at);"
 
 
+def _tristate(value: bool | None) -> int | None:
+    """Map a tri-state bool to SQLite-friendly ``int | None``.
+
+    ``None`` (stage did not run) is preserved as SQL ``NULL``; ``True`` and
+    ``False`` map to ``1`` and ``0``. Readers must distinguish ``NULL`` from
+    ``0`` — the former is "not observed", the latter is "observed failure".
+    """
+    if value is None:
+        return None
+    return 1 if value else 0
+
+
 class MetricsStore:
     """SQLite-backed persistent metrics for proxy calls."""
 
@@ -59,7 +71,21 @@ class MetricsStore:
         self._db = db
 
     def _migrate(self, db: sqlite3.Connection) -> None:
-        """Add columns introduced after initial schema (idempotent)."""
+        """Add columns introduced after initial schema (idempotent).
+
+        Idempotency is guaranteed per-column via ``PRAGMA table_info`` — a
+        column that already exists is skipped, so restarting against an
+        already-migrated DB runs no ALTER statements. This is stronger than
+        a single ``user_version`` gate because adding a new column below
+        doesn't require bumping a version number; the existence check covers
+        all migration states (fresh, pre-migration, already-migrated).
+
+        Boolean columns use ``INTEGER NOT NULL DEFAULT 0`` so existing rows
+        get a deterministic value. Tri-state columns (``index_ok``,
+        ``extract_ok``, ``surfacing_on_progressive_ok``) are nullable
+        ``INTEGER DEFAULT NULL`` — ``NULL`` means "stage did not run", which
+        readers must distinguish from ``0`` (stage ran and failed).
+        """
         existing = {row[1] for row in db.execute("PRAGMA table_info(proxy_metrics)")}
         migrations = {
             "is_error": "ALTER TABLE proxy_metrics ADD COLUMN is_error INTEGER NOT NULL DEFAULT 0",
@@ -74,6 +100,22 @@ class MetricsStore:
             ),
             "scorer_fallback": (
                 "ALTER TABLE proxy_metrics ADD COLUMN scorer_fallback INTEGER NOT NULL DEFAULT 0"
+            ),
+            "index_ok": "ALTER TABLE proxy_metrics ADD COLUMN index_ok INTEGER DEFAULT NULL",
+            "index_error": "ALTER TABLE proxy_metrics ADD COLUMN index_error TEXT DEFAULT NULL",
+            "chunks_indexed": (
+                "ALTER TABLE proxy_metrics ADD COLUMN chunks_indexed INTEGER NOT NULL DEFAULT 0"
+            ),
+            "extract_ok": "ALTER TABLE proxy_metrics ADD COLUMN extract_ok INTEGER DEFAULT NULL",
+            "extract_error": (
+                "ALTER TABLE proxy_metrics ADD COLUMN extract_error TEXT DEFAULT NULL"
+            ),
+            "surfacing_on_progressive_ok": (
+                "ALTER TABLE proxy_metrics ADD COLUMN surfacing_on_progressive_ok "
+                "INTEGER DEFAULT NULL"
+            ),
+            "surface_error": (
+                "ALTER TABLE proxy_metrics ADD COLUMN surface_error TEXT DEFAULT NULL"
             ),
         }
         for col, ddl in migrations.items():
@@ -95,8 +137,11 @@ class MetricsStore:
                 "INSERT INTO proxy_metrics "
                 "(server, tool, original_chars, compressed_chars, cleaned_chars, "
                 "is_error, error_category, error_code, trace_id, "
-                "compression_strategy, ratio_violation, scorer_fallback, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "compression_strategy, ratio_violation, scorer_fallback, "
+                "index_ok, index_error, chunks_indexed, "
+                "extract_ok, extract_error, "
+                "surfacing_on_progressive_ok, surface_error, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     metrics.server,
                     metrics.tool,
@@ -110,6 +155,13 @@ class MetricsStore:
                     metrics.compression_strategy,
                     int(metrics.ratio_violation),
                     int(metrics.scorer_fallback),
+                    _tristate(metrics.index_ok),
+                    metrics.index_error,
+                    metrics.chunks_indexed,
+                    _tristate(metrics.extract_ok),
+                    metrics.extract_error,
+                    _tristate(metrics.surfacing_on_progressive_ok),
+                    metrics.surface_error,
                     now,
                 ),
             )

--- a/tests/test_memory_ops.py
+++ b/tests/test_memory_ops.py
@@ -19,6 +19,8 @@ import pytest
 from memtomem_stm.proxy.config import AutoIndexConfig, ExtractionConfig
 from memtomem_stm.proxy.extraction import ExtractedFact
 from memtomem_stm.proxy.memory_ops import (
+    AutoIndexOutcome,
+    ExtractOutcome,
     auto_index_response,
     extract_and_store,
     format_fact_md,
@@ -84,7 +86,7 @@ class TestAutoIndexResponse:
 
     async def test_writes_markdown_with_frontmatter(self, config):
         indexer = FakeIndexer()
-        summary = await auto_index_response(
+        outcome = await auto_index_response(
             indexer,
             config,
             server="gh",
@@ -98,6 +100,7 @@ class TestAutoIndexResponse:
             context_query="what does app.py do?",
         )
 
+        assert isinstance(outcome, AutoIndexOutcome)
         # Indexer was called with the file path under memory_dir and the
         # namespace formatted from the template.
         assert len(indexer.indexed_paths) == 1
@@ -118,11 +121,15 @@ class TestAutoIndexResponse:
         assert "> what does app.py do?" in body
         assert "file body contents" in body
 
-        # Return value includes compression headline and wraps the agent summary.
-        assert "[Indexed]" in summary
-        assert "gh/read_file" in summary
-        assert "3 chunks" in summary
-        assert "1 paragraph summary" in summary
+        # Summary includes compression headline and wraps the agent summary.
+        assert "[Indexed]" in outcome.summary
+        assert "gh/read_file" in outcome.summary
+        assert "3 chunks" in outcome.summary
+        assert "1 paragraph summary" in outcome.summary
+        # Status fields record the successful index call.
+        assert outcome.ok is True
+        assert outcome.chunks_indexed == 3
+        assert outcome.error is None
 
     async def test_omits_optional_frontmatter_fields(self, config):
         indexer = FakeIndexer()
@@ -142,11 +149,12 @@ class TestAutoIndexResponse:
 
     async def test_index_failure_returns_zero_chunks(self, config, caplog):
         """Indexer raising must not propagate — log a warning, return
-        summary with 0 chunks. Silent failure would make the CLI emit
-        misleading 'indexed' messages."""
+        summary with 0 chunks, and report ``ok=False`` with a populated
+        ``error`` so the operator metrics dashboard sees the failure
+        (previously swallowed silently)."""
         indexer = FakeIndexer(raise_on_index=True)
         with caplog.at_level("WARNING", logger="memtomem_stm.proxy.memory_ops"):
-            summary = await auto_index_response(
+            outcome = await auto_index_response(
                 indexer,
                 config,
                 server="s",
@@ -155,7 +163,14 @@ class TestAutoIndexResponse:
                 text="body",
                 agent_summary="sum",
             )
-        assert "0 chunks" in summary
+        assert "0 chunks" in outcome.summary
+        assert outcome.ok is False
+        assert outcome.chunks_indexed == 0
+        assert outcome.error is not None
+        # Error string carries the exception class + message so dashboards
+        # can distinguish categories (Timeout vs Permission vs …).
+        assert "RuntimeError" in outcome.error
+        assert "simulated indexing failure" in outcome.error
         assert any("Auto-index failed" in r.message for r in caplog.records)
         rec = next(r for r in caplog.records if "Auto-index failed" in r.message)
         assert rec.exc_info is not None, "exc_info required for traceback diagnosis"
@@ -378,6 +393,94 @@ class TestExtractAndStore:
         assert not config.memory_dir.expanduser().resolve().exists() or not list(
             config.memory_dir.expanduser().resolve().glob("*.md")
         )
+
+
+# ── ExtractOutcome contract ──────────────────────────────────────────────
+
+
+class TestExtractOutcome:
+    """Outcomes exist so operators see extraction status in proxy_metrics.db.
+
+    Without these, a broken LLM or disk full would silently drop facts
+    while the metrics row stayed healthy — the gap F2 is closing.
+    """
+
+    @pytest.fixture
+    def config(self, tmp_path) -> ExtractionConfig:
+        return ExtractionConfig(
+            enabled=True,
+            memory_dir=tmp_path / "facts",
+            namespace="facts-{server}",
+            max_facts=10,
+            dedup_threshold=0.92,
+        )
+
+    def _fact(self, content: str):
+        return ExtractedFact(content=content, category="c", confidence=0.8, tags=[])
+
+    async def test_success_reports_ok_and_count(self, config):
+        facts = [self._fact("a"), self._fact("b")]
+        outcome = await extract_and_store(
+            FakeIndexer(),
+            FakeExtractor(facts),
+            config,
+            server="s",
+            tool="t",
+            arguments={},
+            text="body",
+        )
+        assert isinstance(outcome, ExtractOutcome)
+        assert outcome.ok is True
+        assert outcome.facts_stored == 2
+        assert outcome.error is None
+
+    async def test_extractor_failure_reports_not_ok_with_error(self, config):
+        outcome = await extract_and_store(
+            FakeIndexer(),
+            FakeExtractor(raises=True),
+            config,
+            server="s",
+            tool="t",
+            arguments={},
+            text="body",
+        )
+        assert outcome.ok is False
+        assert outcome.facts_stored == 0
+        assert outcome.error is not None
+        # Error string carries class + message for dashboard categorization.
+        assert "RuntimeError" in outcome.error
+        assert "simulated extraction failure" in outcome.error
+
+    async def test_partial_indexing_failure_stays_ok(self, config):
+        """Per-fact indexing failures reduce ``facts_stored`` but don't
+        flip ``ok`` — the pre-F2 contract was "partial failure returns
+        normally" and we preserve that."""
+        facts = [self._fact("a"), self._fact("b")]
+        outcome = await extract_and_store(
+            FakeIndexer(raise_on_index=True),
+            FakeExtractor(facts),
+            config,
+            server="s",
+            tool="t",
+            arguments={},
+            text="body",
+        )
+        assert outcome.ok is True  # outer phase completed
+        assert outcome.facts_stored == 0  # every index_file call failed
+        assert outcome.error is None
+
+    async def test_empty_facts_reports_ok_zero(self, config):
+        outcome = await extract_and_store(
+            FakeIndexer(),
+            FakeExtractor([]),
+            config,
+            server="s",
+            tool="t",
+            arguments={},
+            text="body",
+        )
+        assert outcome.ok is True
+        assert outcome.facts_stored == 0
 
 
 # ── format_fact_md ───────────────────────────────────────────────────────

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -1,0 +1,230 @@
+"""Tests for ``proxy.metrics_store`` — schema migration idempotency and
+persistence of the observability fields introduced for PR 1 (F2).
+
+Most of the store is exercised indirectly through
+``test_error_metrics.py``; these tests target the migration machinery
+directly because a botched ALTER TABLE can wedge every deployed instance
+on the next restart.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from memtomem_stm.proxy.metrics import CallMetrics
+from memtomem_stm.proxy.metrics_store import MetricsStore
+
+
+NEW_COLUMNS = {
+    "index_ok",
+    "index_error",
+    "chunks_indexed",
+    "extract_ok",
+    "extract_error",
+    "surfacing_on_progressive_ok",
+    "surface_error",
+}
+
+
+def _column_names(db: sqlite3.Connection) -> set[str]:
+    return {row[1] for row in db.execute("PRAGMA table_info(proxy_metrics)")}
+
+
+class TestMigrationIdempotency:
+    """Three DB states must produce the same schema with no errors.
+
+    State (a) fresh empty DB — first-ever install.
+    State (b) pre-F2 DB — has earlier columns but not the new ones.
+    State (c) already-migrated DB — the new columns exist. This is the
+        case on every restart after F2 ships; if ALTER re-runs it will
+        raise ``OperationalError`` and take the proxy down on reboot.
+    """
+
+    def test_fresh_db_gets_all_columns(self, tmp_path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        try:
+            cols = _column_names(store._db)
+            assert NEW_COLUMNS.issubset(cols), f"missing columns on fresh DB: {NEW_COLUMNS - cols}"
+        finally:
+            store.close()
+
+    def test_pre_f2_db_gets_migrated(self, tmp_path):
+        db_path = tmp_path / "metrics.db"
+        # Hand-craft a DB that matches the original _CREATE schema from
+        # before the F2 migration — no new columns, a pre-existing row
+        # that must survive the migration with NULLs in the new fields.
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "CREATE TABLE proxy_metrics ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "server TEXT NOT NULL, tool TEXT NOT NULL, "
+            "original_chars INTEGER NOT NULL, "
+            "compressed_chars INTEGER NOT NULL, "
+            "cleaned_chars INTEGER NOT NULL DEFAULT 0, "
+            "created_at REAL NOT NULL)"
+        )
+        raw.execute(
+            "INSERT INTO proxy_metrics "
+            "(server, tool, original_chars, compressed_chars, cleaned_chars, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("legacy", "tool", 1000, 500, 800, time.time()),
+        )
+        raw.commit()
+        raw.close()
+
+        store = MetricsStore(db_path)
+        store.initialize()
+        try:
+            cols = _column_names(store._db)
+            assert NEW_COLUMNS.issubset(cols)
+            # Legacy row survives with NULL in the new columns — callers
+            # must treat NULL as "not observed", distinct from 0/False.
+            row = store._db.execute(
+                "SELECT server, index_ok, index_error, chunks_indexed, "
+                "extract_ok, surfacing_on_progressive_ok "
+                "FROM proxy_metrics WHERE server = 'legacy'"
+            ).fetchone()
+            assert row is not None
+            server, index_ok, index_error, chunks_indexed, extract_ok, surf_ok = row
+            assert server == "legacy"
+            assert index_ok is None
+            assert index_error is None
+            assert chunks_indexed == 0  # NOT NULL DEFAULT 0
+            assert extract_ok is None
+            assert surf_ok is None
+        finally:
+            store.close()
+
+    def test_already_migrated_db_is_noop(self, tmp_path):
+        """Closing and reopening an already-migrated store must not raise.
+
+        This is the critical invariant: every proxy restart after F2
+        ships re-runs ``_migrate``. If the ALTER statements are not
+        guarded against "column already exists", SQLite raises
+        ``OperationalError: duplicate column name`` and the store fails
+        to initialize — i.e., the proxy cannot start on an existing DB.
+        """
+        db_path = tmp_path / "metrics.db"
+        # First open: creates + migrates.
+        store = MetricsStore(db_path)
+        store.initialize()
+        store.close()
+        # Second open: every migration must be a no-op.
+        store = MetricsStore(db_path)
+        try:
+            store.initialize()  # must not raise
+            cols = _column_names(store._db)
+            assert NEW_COLUMNS.issubset(cols)
+        finally:
+            store.close()
+        # Third open for good measure — migrations run on every init().
+        store = MetricsStore(db_path)
+        try:
+            store.initialize()
+        finally:
+            store.close()
+
+
+class TestRecordPersistsNewFields:
+    """``CallMetrics`` → SQLite round-trip for the F2 observability fields."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        s = MetricsStore(tmp_path / "metrics.db")
+        s.initialize()
+        yield s
+        s.close()
+
+    def test_sync_index_success_row(self, store):
+        store.record(
+            CallMetrics(
+                server="gh",
+                tool="read",
+                original_chars=1000,
+                compressed_chars=400,
+                index_ok=True,
+                chunks_indexed=5,
+                extract_ok=True,
+            )
+        )
+        row = store._db.execute(
+            "SELECT index_ok, index_error, chunks_indexed, extract_ok, extract_error "
+            "FROM proxy_metrics"
+        ).fetchone()
+        assert row == (1, None, 5, 1, None)
+
+    def test_index_failure_row(self, store):
+        store.record(
+            CallMetrics(
+                server="gh",
+                tool="read",
+                original_chars=1000,
+                compressed_chars=400,
+                index_ok=False,
+                index_error="RuntimeError: embedding service down",
+                chunks_indexed=0,
+            )
+        )
+        row = store._db.execute(
+            "SELECT index_ok, index_error, chunks_indexed FROM proxy_metrics"
+        ).fetchone()
+        assert row == (0, "RuntimeError: embedding service down", 0)
+
+    def test_stage_not_run_preserves_null(self, store):
+        """A call that did not run the INDEX stage (auto_index disabled,
+        body below min_chars, …) records ``NULL`` — distinct from
+        ``0``/False. Dashboards filtering on ``index_ok = 0`` must NOT
+        see these rows."""
+        store.record(
+            CallMetrics(
+                server="gh",
+                tool="read",
+                original_chars=100,
+                compressed_chars=100,
+                # index_ok / extract_ok default to None
+            )
+        )
+        row = store._db.execute(
+            "SELECT index_ok, extract_ok, surfacing_on_progressive_ok FROM proxy_metrics"
+        ).fetchone()
+        assert row == (None, None, None)
+
+    def test_count_failures_distinct_from_unobserved(self, store):
+        """Aggregate query on ``index_ok = 0`` returns only observed
+        failures, not rows where the stage didn't run."""
+        # Observed success
+        store.record(
+            CallMetrics(
+                server="s",
+                tool="t",
+                original_chars=1,
+                compressed_chars=1,
+                index_ok=True,
+                chunks_indexed=2,
+            )
+        )
+        # Observed failure
+        store.record(
+            CallMetrics(
+                server="s",
+                tool="t",
+                original_chars=1,
+                compressed_chars=1,
+                index_ok=False,
+                index_error="disk full",
+            )
+        )
+        # Stage did not run
+        store.record(CallMetrics(server="s", tool="t", original_chars=1, compressed_chars=1))
+        failures = store._db.execute(
+            "SELECT COUNT(*) FROM proxy_metrics WHERE index_ok = 0"
+        ).fetchone()[0]
+        unobserved = store._db.execute(
+            "SELECT COUNT(*) FROM proxy_metrics WHERE index_ok IS NULL"
+        ).fetchone()[0]
+        assert failures == 1
+        assert unobserved == 1

--- a/tests/test_proxy_manager_pipeline.py
+++ b/tests/test_proxy_manager_pipeline.py
@@ -556,7 +556,7 @@ class TestAutoIndex:
                 )
             ),
         ):
-            result = await mgr._auto_index_response(
+            outcome = await mgr._auto_index_response(
                 server="srv",
                 tool="t",
                 arguments={"q": "test"},
@@ -567,8 +567,10 @@ class TestAutoIndex:
                 compressed_chars=100,
             )
 
-        assert "[Indexed]" in result
-        assert "3 chunks" in result
+        assert "[Indexed]" in outcome.summary
+        assert "3 chunks" in outcome.summary
+        assert outcome.ok is True
+        assert outcome.chunks_indexed == 3
         mock_indexer.index_file.assert_awaited_once()
 
     async def test_auto_index_failure_returns_surfaced(self, tmp_path, caplog):

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "memtomem-stm"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Adds observability for the Stage 4 (INDEX) and Stage 4b (EXTRACT) memory pipeline, closing a production gap where `auto_index_response` and `extract_and_store` swallowed failures internally while the metrics row stayed healthy. Operators watching `proxy_metrics.db` could see full call success while embedding / LTM / disk failures went unreported — the production-observability scenario in README promises otherwise.

## Why A1 (metric drift) rides with F2

A1 (indexed Markdown frontmatter recording `len(surfaced)` while the metrics row recorded `len(compressed)`) is bundled with F2 because both changes touch the same field semantics — "what do we mean by `compressed_chars` for this call?". Splitting would force reviewers through the metrics mental model twice in the same week. The fix is a one-line argument change (`compressed_chars=compressed_chars_for_metrics`) and lands next to the new metric plumbing.

## What changes

- `CallMetrics` gains `index_ok / index_error / chunks_indexed / extract_ok / extract_error`, plus `surfacing_on_progressive_ok / surface_error` pre-provisioned for PR 2 so the schema migration ships once (see Follow-up PRs below).
- `MetricsStore._migrate` adds seven `ALTER TABLE ADD COLUMN` statements using the existing `PRAGMA table_info` idempotent pattern. No `user_version` gate introduced — the per-column existence check is stronger (covers all migration states without needing version bumps).
- `memory_ops.auto_index_response` returns `AutoIndexOutcome` (summary + ok/chunks_indexed/error); `extract_and_store` returns `ExtractOutcome`. The background extract path leaves `extract_ok=None` — the outcome arrives after the metrics row is committed, and background failures remain visible via the existing `WARNING` log.
- A1 fix: `manager.py` threads `compressed_chars_for_metrics` (pre-surfacing) into the indexed frontmatter so dashboards and indexed files agree on what `compressed_chars` means for the same call.

`NULL` in the tri-state SQLite columns means "stage did not run" (auto_index disabled, body below `min_chars`, surfacing skipped on non-progressive path); `0` means "observed failure". Dashboards must distinguish — callers aggregating with `index_ok = 0` see only real failures, not rows where the stage wasn't even invoked.

## Migration verification

`test_metrics_store.py::TestMigrationIdempotency` covers three DB states:

1. **Fresh DB** — every new column lands via `_migrate`.
2. **Pre-F2 DB** — a hand-crafted fixture matching the original `_CREATE` schema with a surviving legacy row. Migration runs, legacy row survives with `NULL` in the new columns.
3. **Already-migrated DB** — the critical idempotency case: the store is opened, closed, and reopened twice. `_migrate` must re-run without raising `duplicate column name` — otherwise one bad restart wedges every deployed instance.

## Follow-up PRs (depend on fields added here)

- **PR 2 (F6)**: restores surfacing on the progressive-delivery path by injecting a footer on chunk 1. Writes `surfacing_on_progressive_ok` and `surface_error` (both added here) so operators can verify the footer fires without the silent-failure gap this PR is closing re-opening at a new site.
- **PR 3 (F4)**: adds `auto_index.background: bool = False` for latency-sensitive deployments. Independent of PR 2, can ship in parallel.

Adding those two fields here means each follow-up PR touches `CallMetrics` only for its own logic — no second schema migration, no second round of dashboard schema updates.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — passes
- [x] `uv run pytest -m "not ollama"` — 1396 passed
- [x] `test_metrics_store.py` — migration idempotency over three DB states
- [x] `test_memory_ops.py` — `TestExtractOutcome` + outcome fields on existing `auto_index_response` tests
- [ ] CI green before merge