### PR TITLE
feat(proxy): surface on progressive for append/section modes (F6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
-- **Progressive delivery now surfaces memories when `injection_mode` is `append` or `section`** (F6). Previously surfacing was skipped unconditionally on the progressive path to preserve the `stm_proxy_read_more` offset invariant. `prepend` mode still skips (with a one-time WARNING) because it would shift offsets. Default `injection_mode` is `prepend` so existing deployments see no behavior change until they opt in by switching to `append` or `section`. See `docs/pipeline.md` § Stage 3 and `tests/test_progressive.py::TestProgressiveContentIntegrity::test_concat_invariant_under_surfacing` for the empirical safety proof.
-- `CallMetrics.surfacing_on_progressive_ok` / `surface_error` (schema-provisioned in 0.1.x) now populate on the progressive path: `True`/`False` when surfacing ran, `None` when skipped (non-progressive call, no engine, or `prepend` mode).
+- **Progressive delivery surfaces memories for users who opt in via `injection_mode`** (F6). The default `injection_mode` stays `prepend`, which **continues to bypass surfacing on progressive** (upgrading is a no-op for default deployments). Operators who set `injection_mode` to `append` or `section` now get Stage 3 (SURFACE) on progressive responses; `prepend` would shift `stm_proxy_read_more` offsets and stays skipped with a one-time WARNING. See `docs/pipeline.md` § Stage 3 and `tests/test_progressive.py::TestProgressiveContentIntegrity::test_concat_invariant_under_surfacing` for the empirical safety proof.
+- `CallMetrics.surfacing_on_progressive_ok` / `surface_error` (schema-provisioned by v0.1.8) now populate on the progressive path: `True`/`False` when surfacing ran, `None` when skipped (non-progressive call, no engine, or `prepend` mode).
 
 ## [0.1.6] — 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## [Unreleased]
+
+### Changed
+
+- **Progressive delivery now surfaces memories when `injection_mode` is `append` or `section`** (F6). Previously surfacing was skipped unconditionally on the progressive path to preserve the `stm_proxy_read_more` offset invariant. `prepend` mode still skips (with a one-time WARNING) because it would shift offsets. Default `injection_mode` is `prepend` so existing deployments see no behavior change until they opt in by switching to `append` or `section`. See `docs/pipeline.md` § Stage 3 and `tests/test_progressive.py::TestProgressiveContentIntegrity::test_concat_invariant_under_surfacing` for the empirical safety proof.
+- `CallMetrics.surfacing_on_progressive_ok` / `surface_error` (schema-provisioned in 0.1.x) now populate on the progressive path: `True`/`False` when surfacing ran, `None` when skipped (non-progressive call, no engine, or `prepend` mode).
+
 ## [0.1.6] — 2026-04-13
 
 ### Observability

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -101,11 +101,33 @@ Proactively injects relevant memories from a memtomem LTM server. See [Surfacing
 
 Surfacing only activates when the compressed response is at least `min_response_chars` (default 5000). For small responses, surfacing is skipped to avoid negative token savings.
 
+**Progressive delivery + surfacing (F6).**  When Stage 2 produces a
+progressive chunk (either directly or as a ratio-guard fallback), the
+`SurfacingFormatter.injection_mode` determines whether Stage 3 runs:
+
+- `append` / `section` — memory block is placed *after* the chunker
+  footer (`\n---\n`), so the `split("\n---\n")[0]` concat rule agents
+  use to stitch sequential `stm_proxy_read_more` calls still recovers
+  the original content byte-for-byte. Surfacing runs normally and the
+  `surfacing_on_progressive_ok` metric is recorded.
+- `prepend` — memory block would be placed *before* the chunk content
+  and shift downstream byte offsets. Stage 3 is skipped, a one-time
+  WARNING is logged, and `surfacing_on_progressive_ok` stays `None`.
+  Users who want progressive surfacing should switch `injection_mode`
+  to `append` or `section`.
+
 **Failure guard (S1).**  If `record_surfacing` fails (e.g. SQLite
 contention), the engine drops the `surfacing_id` — the memory block
 is still injected but without a feedback ID.  The agent cannot
 submit feedback for that event, but the response is never blocked.
 Logged at WARNING.
+
+**Failure guard (F6).**  If surfacing fails on the progressive path
+(LTM outage, timeout, …), `ProxyManager` catches, logs WARNING, and
+returns the compressed progressive chunk unchanged so
+`stm_proxy_read_more` continues to work. `surfacing_on_progressive_ok`
+is recorded `False` and `surface_error` carries the exception class
+name.
 
 ## Stage 4: INDEX (optional)
 

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -158,6 +158,10 @@ class ProxyManager:
         # Named ``_key_locks`` to match the same pattern used by
         # ``SurfacingEngine`` (extractable into a shared helper later).
         self._key_locks: dict[str, asyncio.Lock] = {}
+        # F6: one WARNING on first progressive call when ``injection_mode`` is
+        # ``"prepend"`` — that mode still skips surfacing on progressive to
+        # preserve the ``stm_proxy_read_more`` offset invariant.
+        self._warned_prepend_on_progressive = False
 
     async def start(self) -> None:
         """Connect to all upstream servers, discover their tools."""
@@ -606,6 +610,61 @@ class ProxyManager:
                 exc_info=True,
             )
             return text
+
+    async def _apply_surfacing_on_progressive(
+        self,
+        server: str,
+        tool: str,
+        arguments: dict[str, Any],
+        text: str,
+        *,
+        trace_id: str | None = None,
+    ) -> tuple[str, bool | None, str | None]:
+        """Surface on a progressive first-chunk when the formatter mode keeps
+        the ``split("\\n---\\n")[0]`` concat invariant intact.
+
+        Returns ``(text, ok, error)``:
+
+        - ``ok=None`` — engine missing, or ``injection_mode == "prepend"``
+          which would shift offsets for ``stm_proxy_read_more``. The call
+          returns the compressed response unchanged.
+        - ``ok=True`` — surfacing injected successfully.
+        - ``ok=False`` — surfacing raised; ``error`` carries the exception
+          class name. The call still returns the compressed response.
+
+        ``"prepend"`` users keep pre-F6 behavior. See
+        ``tests/test_progressive.py::TestProgressiveContentIntegrity::
+        test_concat_invariant_under_surfacing`` for the empirical proof of
+        which modes are safe.
+        """
+        if self._surfacing_engine is None:
+            return text, None, None
+        if self._surfacing_engine.injection_mode == "prepend":
+            if not self._warned_prepend_on_progressive:
+                logger.warning(
+                    "Progressive surfacing skipped: injection_mode='prepend' "
+                    "would shift offsets for stm_proxy_read_more. Set "
+                    "injection_mode to 'append' or 'section' to enable it."
+                )
+                self._warned_prepend_on_progressive = True
+            return text, None, None
+        try:
+            surfaced = await self._surfacing_engine.surface(
+                server=server,
+                tool=tool,
+                arguments=arguments,
+                response_text=text,
+                trace_id=trace_id,
+            )
+            return surfaced, True, None
+        except Exception as exc:
+            logger.warning(
+                "Surfacing failed for %s/%s on progressive path, using compressed response",
+                server,
+                tool,
+                exc_info=True,
+            )
+            return text, False, type(exc).__name__
 
     async def _apply_hybrid(
         self,
@@ -1124,6 +1183,11 @@ class ProxyManager:
         # allows — it feeds into metrics for auditing R4 after the fact.
         effective_compression: CompressionStrategy = tc.compression
         ratio_violation = False
+        # F6: populated only when the call runs the progressive surfacing path.
+        # ``None`` elsewhere (non-progressive path, or ``injection_mode='prepend'``
+        # which skips for offset-invariant reasons).
+        surfacing_on_progressive_ok: bool | None = None
+        surface_error: str | None = None
         _pre_scorer_fb = getattr(self._relevance_scorer, "fallback_count", 0)
         if tc.compression == CompressionStrategy.PROGRESSIVE and tc.progressive:
             pcfg = tc.progressive
@@ -1136,9 +1200,18 @@ class ProxyManager:
                 )
             _compress_ms = 0.0
             compressed_chars_for_metrics = len(cleaned)
-            # Skip surfacing for progressive — injecting memories would shift offsets
-            _surface_ms = 0.0
-            surfaced = compressed
+            # F6: surface on progressive when ``injection_mode`` is append/section.
+            # ``prepend`` stays skipped (offset-shift); helper returns ``ok=None``
+            # in that case and logs a one-time WARNING.
+            _t0 = _time.monotonic()
+            (
+                surfaced,
+                surfacing_on_progressive_ok,
+                surface_error,
+            ) = await self._apply_surfacing_on_progressive(
+                server, tool, upstream_args, compressed, trace_id=trace_id
+            )
+            _surface_ms = (_time.monotonic() - _t0) * 1000
         else:
             # Enforce minimum retention: budget must preserve at least N% of cleaned content.
             # Dynamic scaling: shorter content → higher retention (less to gain from cutting).
@@ -1310,11 +1383,24 @@ class ProxyManager:
             compressed_chars_for_metrics = len(compressed)
 
             # ── Stage 3: SURFACE (proactive memory injection) ──
-            # Skip surfacing when progressive fallback fired — injecting
-            # memories would shift character offsets for stm_proxy_read_more.
+            # F6: progressive_fallback now routes through the same
+            # mode-aware helper the PROGRESSIVE branch uses — append/section
+            # surfaces, prepend still skips to preserve offset arithmetic for
+            # ``stm_proxy_read_more``.
             if progressive_fallback:
-                _surface_ms = 0.0
-                surfaced = compressed
+                with traced(
+                    "proxy_call_surface",
+                    metadata={"server": server, "tool": tool, "path": "progressive_fallback"},
+                ):
+                    _t0 = _time.monotonic()
+                    (
+                        surfaced,
+                        surfacing_on_progressive_ok,
+                        surface_error,
+                    ) = await self._apply_surfacing_on_progressive(
+                        server, tool, upstream_args, compressed, trace_id=trace_id
+                    )
+                    _surface_ms = (_time.monotonic() - _t0) * 1000
             else:
                 with traced(
                     "proxy_call_surface",
@@ -1450,6 +1536,8 @@ class ProxyManager:
                 chunks_indexed=chunks_indexed,
                 extract_ok=extract_ok,
                 extract_error=extract_error,
+                surfacing_on_progressive_ok=surfacing_on_progressive_ok,
+                surface_error=surface_error,
             )
         )
 

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -150,9 +150,11 @@ class CallMetrics:
     chunks_indexed: int = 0
     extract_ok: bool | None = None
     extract_error: str | None = None
-    # Surfacing on the progressive path — pre-provisioned for PR 2 (F6) so
-    # the schema migration ships once. Stays ``None`` until the progressive
-    # surfacing footer lands.
+    # Surfacing on the progressive path (F6). ``None`` when the call did
+    # not go through progressive *or* when ``injection_mode='prepend'``
+    # which still skips surfacing to preserve the
+    # ``stm_proxy_read_more`` offset invariant. ``True``/``False`` once
+    # progressive surfacing ran successfully or failed.
     surfacing_on_progressive_ok: bool | None = None
     surface_error: str | None = None
 

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -102,6 +102,16 @@ class SurfacingEngine:
         self._cleanup_interval = 3600.0
         self._last_cleanup: float = time.monotonic()
 
+    @property
+    def injection_mode(self) -> str:
+        """Formatter injection mode — ``"prepend"``, ``"append"``, or ``"section"``.
+
+        Read by ``ProxyManager`` to decide whether progressive-path surfacing
+        is safe: only ``append``/``section`` keep the ``split("\\n---\\n")[0]``
+        concat invariant that ``stm_proxy_read_more`` depends on.
+        """
+        return self._config.injection_mode
+
     async def surface(
         self,
         server: str,

--- a/src/memtomem_stm/surfacing/formatter.py
+++ b/src/memtomem_stm/surfacing/formatter.py
@@ -21,6 +21,14 @@ class SurfacingFormatter:
         surfacing_id: str | None = None,
         scratch_items: list[dict] | None = None,
     ) -> str:
+        """Inject surfaced memories into ``response_text``.
+
+        When ``response_text`` is a progressive first-chunk, only the
+        ``append`` and ``section`` modes preserve the
+        ``split("\\n---\\n")[0]`` concat invariant relied on by
+        ``stm_proxy_read_more``; ``prepend`` would shift offsets and is
+        therefore skipped by ``ProxyManager`` on the progressive path.
+        """
         if not results and not scratch_items:
             return response_text
 

--- a/tests/test_progressive.py
+++ b/tests/test_progressive.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass, field
+from pathlib import Path
 
+import pytest
 
 from memtomem_stm.proxy.compression import PendingSelection
 from memtomem_stm.proxy.config import (
@@ -16,6 +19,26 @@ from memtomem_stm.proxy.progressive import (
     ProgressiveResponse,
     ProgressiveStoreAdapter,
 )
+from memtomem_stm.surfacing.config import SurfacingConfig
+from memtomem_stm.surfacing.formatter import SurfacingFormatter
+
+
+@dataclass
+class _FakeChunkMeta:
+    source_file: Path = Path("/notes/memory.md")
+    namespace: str = "default"
+
+
+@dataclass
+class _FakeChunk:
+    content: str = "a relevant memory"
+    metadata: _FakeChunkMeta = field(default_factory=_FakeChunkMeta)
+
+
+@dataclass
+class _FakeResult:
+    chunk: _FakeChunk
+    score: float = 0.5
 
 
 # ---------------------------------------------------------------------------
@@ -207,6 +230,50 @@ class TestProgressiveContentIntegrity:
         result = chunker.first_chunk(text, "key1")
         assert "Hello, world!" in result
         assert "has_more=False" in result
+
+    @pytest.mark.parametrize(
+        "mode,expected_pass",
+        [
+            ("append", True),
+            ("section", True),
+            ("prepend", False),
+        ],
+    )
+    def test_concat_invariant_under_surfacing(self, mode, expected_pass):
+        """Per-injection-mode offset invariant when surfacing wraps a progressive
+        first chunk. `append` and `section` inject AFTER the chunker footer
+        (``\\n---\\n``) so ``split("\\n---\\n")[0]`` concat still recovers the
+        original content; `prepend` injects BEFORE and breaks the invariant.
+
+        This pins the per-mode safety so a future reader cannot lift the
+        `prepend` bypass in ``ProxyManager`` without updating this assertion.
+        """
+        text = "".join(f"Line {i}: {'x' * 80}\n" for i in range(200))
+        chunker = ProgressiveChunker(chunk_size=500)
+        formatter = SurfacingFormatter(SurfacingConfig(injection_mode=mode))
+        results = [_FakeResult(_FakeChunk(content="a relevant memory"))]
+
+        first_response = chunker.first_chunk(text, "key1")
+        surfaced_first = formatter.inject(first_response, results, query="q")
+
+        parts: list[str] = [surfaced_first.split("\n---\n")[0]]
+        offset = len(parts[0])
+
+        for _ in range(100):  # safety bound
+            result = chunker.read_chunk(text, offset)
+            if "no more content" in result:
+                break
+            chunk_content = result.split("\n---\n")[0]
+            parts.append(chunk_content)
+            offset += len(chunk_content)
+            if "has_more=False" in result:
+                break
+
+        concat_matches = "".join(parts) == text
+        assert concat_matches is expected_pass, (
+            f"injection_mode={mode!r}: expected concat=={expected_pass}, "
+            f"got concat=={concat_matches}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy_manager_pipeline.py
+++ b/tests/test_proxy_manager_pipeline.py
@@ -409,6 +409,90 @@ class TestApplySurfacing:
         assert "Surfacing failed" in caplog.text
 
 
+# ── _apply_surfacing_on_progressive (F6) ────────────────────────────────
+
+
+def _mock_engine_with_mode(mode: str, *, surface_return: str = "surfaced"):
+    """Return an AsyncMock engine whose ``injection_mode`` property matches *mode*."""
+    eng = AsyncMock()
+    eng.surface.return_value = surface_return
+    # ``injection_mode`` is a sync property on the real engine; set it on the
+    # mock as a plain attribute so attribute access does not return a coroutine.
+    type(eng).injection_mode = property(lambda _self, _m=mode: _m)
+    return eng
+
+
+class TestApplySurfacingOnProgressive:
+    async def test_no_engine_returns_none(self, tmp_path):
+        """Without surfacing engine, returns ``(text, None, None)``."""
+        mgr = _make_manager(tmp_path=tmp_path)
+        mgr._surfacing_engine = None
+        text, ok, err = await mgr._apply_surfacing_on_progressive("srv", "t", {}, "original")
+        assert (text, ok, err) == ("original", None, None)
+
+    async def test_append_mode_surfaces(self, tmp_path):
+        """``append`` mode invokes surface() and returns ``ok=True``."""
+        mgr = _make_manager(tmp_path=tmp_path)
+        mgr._surfacing_engine = _mock_engine_with_mode("append", surface_return="with memories")
+
+        text, ok, err = await mgr._apply_surfacing_on_progressive(
+            "srv", "t", {"q": "x"}, "progressive chunk"
+        )
+
+        assert text == "with memories"
+        assert ok is True
+        assert err is None
+        mgr._surfacing_engine.surface.assert_awaited_once()
+
+    async def test_section_mode_surfaces(self, tmp_path):
+        """``section`` mode invokes surface() and returns ``ok=True``."""
+        mgr = _make_manager(tmp_path=tmp_path)
+        mgr._surfacing_engine = _mock_engine_with_mode("section", surface_return="w/ section")
+
+        text, ok, err = await mgr._apply_surfacing_on_progressive("srv", "t", {}, "chunk")
+
+        assert text == "w/ section"
+        assert ok is True
+        assert err is None
+
+    async def test_prepend_mode_skips_and_warns_once(self, tmp_path, caplog):
+        """``prepend`` mode skips surfacing (offset-invariant guard), logs WARNING
+        once, and subsequent progressive calls do not re-log."""
+        mgr = _make_manager(tmp_path=tmp_path)
+        mgr._surfacing_engine = _mock_engine_with_mode("prepend")
+
+        with caplog.at_level("WARNING"):
+            text_a, ok_a, err_a = await mgr._apply_surfacing_on_progressive(
+                "srv", "t", {}, "first chunk"
+            )
+            text_b, ok_b, err_b = await mgr._apply_surfacing_on_progressive(
+                "srv", "t", {}, "second chunk"
+            )
+
+        assert (text_a, ok_a, err_a) == ("first chunk", None, None)
+        assert (text_b, ok_b, err_b) == ("second chunk", None, None)
+        mgr._surfacing_engine.surface.assert_not_awaited()
+        warnings = [r for r in caplog.records if "injection_mode='prepend'" in r.message]
+        assert len(warnings) == 1, "prepend-on-progressive WARNING must fire exactly once"
+
+    async def test_engine_failure_captured_as_error(self, tmp_path, caplog):
+        """``append`` mode + engine raises → ``ok=False``, ``error`` populated,
+        text falls back to the compressed input (error isolation)."""
+        mgr = _make_manager(tmp_path=tmp_path)
+        engine = _mock_engine_with_mode("append")
+        engine.surface.side_effect = RuntimeError("ltm down")
+        mgr._surfacing_engine = engine
+
+        text, ok, err = await mgr._apply_surfacing_on_progressive(
+            "srv", "t", {}, "progressive chunk"
+        )
+
+        assert text == "progressive chunk"
+        assert ok is False
+        assert err == "RuntimeError"
+        assert "Surfacing failed" in caplog.text
+
+
 # ── select_chunks ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `ProxyManager` no longer skips Stage 3 (SURFACE) unconditionally on the progressive path. Surfacing runs when `SurfacingConfig.injection_mode` is `append` or `section`; `prepend` stays skipped (one-time WARNING) because it would shift `stm_proxy_read_more` offsets.
- Activates `CallMetrics.surfacing_on_progressive_ok` / `surface_error`, schema-provisioned by #159 and now populated on the progressive path (`True`/`False`/`None`).
- Error-isolated: if surfacing throws on progressive, the compressed chunk still ships to the agent and the failure is recorded as `ok=False` + `surface_error`.

## Behavior change

Deployments keeping `SurfacingConfig.injection_mode` at its default (`prepend`) see **no change** — progressive surfacing stays skipped, matching pre-F6 behavior, with a single WARNING logged on first hit. Operators who want memory surfacing on progressive responses must opt in by setting `injection_mode` to `append` or `section`.

## Why the bypass was over-cautious

Before F6, two `ProxyManager` branches (`manager.py:1139-1141` + `1313-1317`) skipped surfacing for *any* progressive call with the comment *"injecting memories would shift character offsets for `stm_proxy_read_more`"*. The preflight test (first commit of this PR) empirically shows that claim holds only for `prepend`:

| `injection_mode` | Memory block placement | `split("\n---\n")[0]` concat recovers original? |
| --- | --- | --- |
| `append`  | After chunker footer | ✅ invariant preserved |
| `section` | After chunker footer | ✅ invariant preserved |
| `prepend` | Before chunk content | ❌ invariant broken — bypass must stay |

The shared helper `_apply_surfacing_on_progressive` encodes this per-mode rule in one place so both progressive branches stay in sync.

## Preflight results (commit `65510a1`)

Run on pre-F6 main (`c476927`):

```text
uv run pytest tests/test_progressive.py::TestProgressiveContentIntegrity -m "not ollama" -v
# 43 passed in 0.05s
```

Parametrized `test_concat_invariant_under_surfacing` covers all three modes with explicit `expected_pass` — the negative case pins the failure shape so a future reader cannot lift the `prepend` bypass without updating the assertion.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1404 passed.
- [x] `uv run ruff check src && uv run ruff format --check src` — All checks passed.
- [x] `uv run mypy src` — 2 pre-existing errors unrelated to F6 (manager.py:410, 772); no new errors introduced.
- [x] Unit test (chunker + formatter) pinning per-mode concat invariant.
- [x] Integration tests at helper boundary (`TestApplySurfacingOnProgressive`): no-engine passthrough, `append`/`section` happy path, `prepend` skip with exactly-once WARNING, engine-failure error isolation.
- [ ] Manual smoke against a live progressive-enabled config (out of scope — covered by existing CI surfacing tests + integration-level error isolation assertions).

## Risks / follow-ups

- The `split("\n---\n")[0]` concat convention itself is fragile when content contains markdown horizontal rules or YAML frontmatter fences — tracked as #160 for a follow-up PR. Kept out of this scope to keep the F6 diff minimal.
- Cached responses go through `_on_cache_hit` which calls `_apply_surfacing` (non-progressive path). Progressive replay via `stm_proxy_read_more` reads from the separate `ProgressiveStoreAdapter` and is unaffected, so cache behavior for progressive stays offset-safe.

## Depends on

Builds on the metrics schema provisioned by #159 (`surfacing_on_progressive_ok`, `surface_error` columns).