### PR TITLE
feat(proxy): opt-in background auto-indexing (F4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Background auto-indexing** (F4) — `auto_index.background` (default `false`). When set `true`, Stage 4 INDEX runs via `asyncio.create_task` off the request path; the agent receives a `[Indexing…] · scheduled` placeholder footer immediately while indexing proceeds in the background. Trade-off: read-your-own-writes consistency is no longer guaranteed until the task completes — opt in only if agents tolerate the gap. Metrics row records `index_ok IS NULL` / `index_error IS NULL` / `chunks_indexed = 0` (tri-state matching background extraction); dashboards filter background rows with `WHERE index_ok IS NULL`. Default `false` preserves the synchronous contract for every existing deployment.
+
 ### Changed
 
 - **Progressive delivery surfaces memories for users who opt in via `injection_mode`** (F6). The default `injection_mode` stays `prepend`, which **continues to bypass surfacing on progressive** (upgrading is a no-op for default deployments). Operators who set `injection_mode` to `append` or `section` now get Stage 3 (SURFACE) on progressive responses; `prepend` would shift `stm_proxy_read_more` offsets and stays skipped with a one-time WARNING. See `docs/pipeline.md` § Stage 3 and `tests/test_progressive.py::TestProgressiveContentIntegrity::test_concat_invariant_under_surfacing` for the empirical safety proof.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -71,6 +71,7 @@ flowchart LR
 {
   "auto_index": {
     "enabled": true,
+    "background": false,
     "min_chars": 2000,
     "memory_dir": "~/.memtomem/proxy_index",
     "namespace": "proxy-{server}"
@@ -100,6 +101,8 @@ compressed_chars: 8000
 ```
 
 The namespace supports `{server}` and `{tool}` placeholders. Can be toggled per-server via `auto_index: true|false` in `UpstreamServerConfig`.
+
+Setting `background: true` (default `false`) schedules the indexing task off the request path: the agent receives a `[Indexing…] · scheduled` placeholder footer immediately, while indexing runs in the background. Trade-off: read-your-own-writes consistency is no longer guaranteed until the task completes — opt in only if agents tolerate the gap. See `pipeline.md` § Stage 4 for the metrics tri-state semantics.
 
 > **Note:** Auto-indexing requires a `FileIndexer` wired into
 > `ProxyManager`.  The default deployment does not wire one — see

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,7 @@ Full example with all options:
   },
   "auto_index": {
     "enabled": false,
+    "background": false,
     "min_chars": 2000,
     "memory_dir": "~/.memtomem/proxy_index",
     "namespace": "proxy-{server}"

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -142,6 +142,18 @@ traceback, and returns the pre-index response unchanged.  The agent
 receives a successful result; the response is just not searchable
 in LTM.
 
+**Background mode (F4).**  Setting `auto_index.background = true`
+schedules the indexing task via `asyncio.create_task` off the request
+path. The agent receives a `[Indexing…] · scheduled` placeholder
+footer synchronously — the namespace is intentionally dropped from
+the placeholder because chunk count and final namespace binding are
+unknown until the task runs. `index_ok` / `index_error` /
+`chunks_indexed` stay `NULL` / `NULL` / `0` in `proxy_metrics.db`,
+matching the tri-state used by background extraction; filter
+background rows with `WHERE index_ok IS NULL`. Trade-off:
+read-your-own-writes consistency is no longer guaranteed until the
+task completes. Default `false` preserves the synchronous contract.
+
 ## Stage 4b: Auto Fact Extraction (optional)
 
 Automatically extracts discrete facts from tool responses using an LLM. Strategies: `llm` (default, Ollama qwen3:4b with no-think mode), `heuristic`, `hybrid`, `none`. Each extracted fact is stored as an individual `.md` file and indexed; deduplication via embedding similarity (threshold 0.92).

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -144,6 +144,7 @@ class SelectiveConfig(BaseModel):
 
 class AutoIndexConfig(BaseModel):
     enabled: bool = False
+    background: bool = False
     min_chars: int = Field(default=2000, ge=0)
     memory_dir: Path = Path("~/.memtomem/proxy_index")
     namespace: str = "proxy-{server}"

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1445,7 +1445,7 @@ class ProxyManager:
                     ns=ns,
                     chunks=None,
                 )
-                task = asyncio.create_task(
+                index_task = asyncio.create_task(
                     self._auto_index_response(
                         server,
                         tool,
@@ -1458,8 +1458,8 @@ class ProxyManager:
                         context_query=context_query,
                     )
                 )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
+                self._background_tasks.add(index_task)
+                index_task.add_done_callback(self._background_tasks.discard)
                 # index_ok / index_error / chunks_indexed stay None / None / 0
                 # — tri-state matches background extraction. Dashboards filter
                 # background rows with WHERE index_ok IS NULL.

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -48,6 +48,7 @@ from memtomem_stm.proxy.memory_ops import (
     AutoIndexOutcome,
     ExtractOutcome,
     auto_index_response,
+    compose_index_footer,
     extract_and_store,
     format_fact_md,
 )
@@ -1426,19 +1427,26 @@ class ProxyManager:
             and self._index_engine is not None
             and len(cleaned) >= ai_cfg.min_chars
         ):
-            with traced(
-                "proxy_call_index",
-                metadata={"server": server, "tool": tool},
-            ):
-                try:
-                    # A1 fix: pre-surfacing ``compressed_chars_for_metrics``
-                    # matches what we record in the metrics row below, so the
-                    # indexed frontmatter and the dashboards agree on what
-                    # "compressed_chars" means for this call. Pre-A1 the
-                    # frontmatter recorded ``len(surfaced)`` (post-surfacing),
-                    # which drifted from the metrics value whenever surfacing
-                    # added content.
-                    outcome = await self._auto_index_response(
+            if ai_cfg.background:
+                # F4: schedule indexing off the request path. The placeholder
+                # footer ([Indexing…] … · scheduled, namespace dropped) ships
+                # to the agent synchronously while the indexing task runs in
+                # the background. Trade-off: response no longer guarantees
+                # read-your-own-writes for the next tool call — opt-in only
+                # (default ai_cfg.background = False preserves sync contract).
+                ns = ai_cfg.namespace.format(server=server, tool=tool)
+                final_result = compose_index_footer(
+                    server=server,
+                    tool=tool,
+                    original_chars=len(original_text),
+                    compressed_chars=compressed_chars_for_metrics,
+                    text=cleaned,
+                    agent_summary=surfaced,
+                    ns=ns,
+                    chunks=None,
+                )
+                task = asyncio.create_task(
+                    self._auto_index_response(
                         server,
                         tool,
                         upstream_args,
@@ -1449,24 +1457,54 @@ class ProxyManager:
                         compressed_chars=compressed_chars_for_metrics,
                         context_query=context_query,
                     )
-                    final_result = outcome.summary
-                    index_ok = outcome.ok
-                    index_error = outcome.error
-                    chunks_indexed = outcome.chunks_indexed
-                except Exception as exc:
-                    # Reaches here only for failures outside the inner
-                    # ``index_file`` try/except in ``auto_index_response``
-                    # (mkdir / atomic write / unexpected errors). The inner
-                    # indexing failure is already captured in the outcome.
-                    logger.warning(
-                        "Auto-index failed for %s/%s — returning unindexed response",
-                        server,
-                        tool,
-                        exc_info=True,
-                    )
-                    final_result = surfaced
-                    index_ok = False
-                    index_error = f"{type(exc).__name__}: {exc}"
+                )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+                # index_ok / index_error / chunks_indexed stay None / None / 0
+                # — tri-state matches background extraction. Dashboards filter
+                # background rows with WHERE index_ok IS NULL.
+            else:
+                with traced(
+                    "proxy_call_index",
+                    metadata={"server": server, "tool": tool},
+                ):
+                    try:
+                        # A1 fix: pre-surfacing ``compressed_chars_for_metrics``
+                        # matches what we record in the metrics row below, so the
+                        # indexed frontmatter and the dashboards agree on what
+                        # "compressed_chars" means for this call. Pre-A1 the
+                        # frontmatter recorded ``len(surfaced)`` (post-surfacing),
+                        # which drifted from the metrics value whenever surfacing
+                        # added content.
+                        outcome = await self._auto_index_response(
+                            server,
+                            tool,
+                            upstream_args,
+                            cleaned,
+                            agent_summary=surfaced,
+                            compression_strategy=tc.compression.value,
+                            original_chars=len(original_text),
+                            compressed_chars=compressed_chars_for_metrics,
+                            context_query=context_query,
+                        )
+                        final_result = outcome.summary
+                        index_ok = outcome.ok
+                        index_error = outcome.error
+                        chunks_indexed = outcome.chunks_indexed
+                    except Exception as exc:
+                        # Reaches here only for failures outside the inner
+                        # ``index_file`` try/except in ``auto_index_response``
+                        # (mkdir / atomic write / unexpected errors). The inner
+                        # indexing failure is already captured in the outcome.
+                        logger.warning(
+                            "Auto-index failed for %s/%s — returning unindexed response",
+                            server,
+                            tool,
+                            exc_info=True,
+                        )
+                        final_result = surfaced
+                        index_ok = False
+                        index_error = f"{type(exc).__name__}: {exc}"
         else:
             final_result = surfaced
 

--- a/src/memtomem_stm/proxy/memory_ops.py
+++ b/src/memtomem_stm/proxy/memory_ops.py
@@ -38,6 +38,33 @@ class AutoIndexOutcome:
     error: str | None = None
 
 
+def compose_index_footer(
+    server: str,
+    tool: str,
+    original_chars: int | None,
+    compressed_chars: int | None,
+    text: str,
+    agent_summary: str,
+    ns: str,
+    chunks: int | None,
+) -> str:
+    """Compose the ``[Indexed]`` / ``[Indexing…]`` summary footer.
+
+    ``chunks=None`` is the background-scheduled placeholder: emits
+    ``[Indexing…] … · scheduled`` with the namespace dropped, since
+    the chunk count and final namespace binding are both unknown until
+    the background indexing task runs.
+    """
+    size_part = f"{original_chars or len(text)}→{compressed_chars or len(agent_summary)} chars"
+    if chunks is None:
+        tag = "Indexing…"
+        tail = "scheduled"
+    else:
+        tag = "Indexed"
+        tail = f"{chunks} chunks in `{ns}` namespace"
+    return f"[{tag}] `{server}/{tool}` ({size_part}) · {tail}.\n\n{agent_summary}"
+
+
 @dataclass(frozen=True, slots=True)
 class ExtractOutcome:
     """Structured result of a single ``extract_and_store`` call.
@@ -134,11 +161,15 @@ async def auto_index_response(
         ok = False
         error = f"{type(exc).__name__}: {exc}"
 
-    summary = (
-        f"[Indexed] `{server}/{tool}` ({original_chars or len(text)}"
-        f"→{compressed_chars or len(agent_summary)} chars) "
-        f"· {chunks} chunks in `{ns}` namespace.\n\n"
-        f"{agent_summary}"
+    summary = compose_index_footer(
+        server=server,
+        tool=tool,
+        original_chars=original_chars,
+        compressed_chars=compressed_chars,
+        text=text,
+        agent_summary=agent_summary,
+        ns=ns,
+        chunks=chunks,
     )
     return AutoIndexOutcome(summary=summary, ok=ok, chunks_indexed=chunks, error=error)
 

--- a/tests/test_auto_index_background.py
+++ b/tests/test_auto_index_background.py
@@ -1,0 +1,219 @@
+"""Background auto-indexing — opt-in via AutoIndexConfig.background=True (F4).
+
+Validates:
+
+- Background flag schedules an asyncio task and returns the
+  ``[Indexing…] · scheduled`` placeholder footer immediately.
+- ``stop()`` cancels in-flight background indexing tasks (re-uses the
+  existing extraction drain loop, no new infrastructure).
+- Metrics row records ``index_ok IS NULL`` / ``chunks_indexed = 0`` —
+  tri-state matches background extraction so dashboards distinguish
+  sync/background with ``index_ok IS NULL``.
+- ``background=False`` (the default) keeps the pre-F4 synchronous
+  contract verbatim — regression guard for the ``compose_index_footer``
+  refactor in commit 3bb800e.
+- Background indexing failure stays captured inside the task; the
+  agent response is unaffected.
+- Latency: with ``index_file`` simulating 500ms LTM latency, the
+  background path returns < 300ms absolute AND < sync/3 relative.
+  Dual assertion guards CI runner jitter (absolute alone is flaky)
+  AND global regression (ratio alone misses proportional slowdown).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from memtomem_stm.proxy.config import (
+    AutoIndexConfig,
+    ProxyConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
+from memtomem_stm.proxy.metrics import TokenTracker
+
+
+def _bg_manager(
+    tmp_path: Path,
+    *,
+    background: bool,
+    sleep_ms: int = 0,
+    raise_on_index: bool = False,
+) -> tuple[ProxyManager, AsyncMock]:
+    """Build a manager with auto_index enabled and a fake indexer.
+
+    ``sleep_ms`` slows ``index_file`` to simulate LTM latency (used by
+    the latency-delta assertion). ``raise_on_index`` makes the indexer
+    raise inside the background task so we can verify error isolation.
+    """
+    indexer = AsyncMock()
+    if raise_on_index:
+        indexer.index_file.side_effect = RuntimeError("simulated index failure")
+    elif sleep_ms:
+
+        async def _slow_index(*_args, **_kwargs):
+            await asyncio.sleep(sleep_ms / 1000)
+            return SimpleNamespace(indexed_chunks=2)
+
+        indexer.index_file.side_effect = _slow_index
+    else:
+        indexer.index_file.return_value = SimpleNamespace(indexed_chunks=2)
+
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={"srv": UpstreamServerConfig(prefix="test")},
+        auto_index=AutoIndexConfig(
+            enabled=True,
+            background=background,
+            min_chars=10,
+            memory_dir=tmp_path / "idx",
+        ),
+    )
+    tracker = TokenTracker()
+    mgr = ProxyManager(proxy_cfg, tracker, index_engine=indexer)
+
+    # Inject a mocked upstream that returns enough text to clear ``min_chars``.
+    session = AsyncMock()
+    session.call_tool.return_value = SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="upstream content " * 100)],
+        isError=False,
+    )
+    mgr._connections["srv"] = UpstreamConnection(
+        name="srv",
+        config=UpstreamServerConfig(prefix="test"),
+        session=session,
+        tools=[],
+    )
+    return mgr, indexer
+
+
+class TestBackgroundAutoIndex:
+    async def test_background_flag_schedules_task(self, tmp_path):
+        """``background=True`` schedules indexing via ``asyncio.create_task``
+        and returns the ``[Indexing…] · scheduled`` placeholder footer
+        immediately — the agent does not block on the indexer."""
+        mgr, indexer = _bg_manager(tmp_path, background=True)
+        try:
+            result = await mgr.call_tool("srv", "some_tool", {})
+
+            assert "[Indexing…]" in result
+            assert "· scheduled." in result
+            # Placeholder intentionally drops the namespace — final ns isn't
+            # known until the background task completes.
+            assert "namespace" not in result
+            assert len(mgr._background_tasks) == 1
+
+            # Drain so the indexer call lands before assertion.
+            await asyncio.gather(*mgr._background_tasks, return_exceptions=True)
+            indexer.index_file.assert_awaited_once()
+        finally:
+            await mgr.stop()
+
+    async def test_background_drains_on_stop(self, tmp_path):
+        """``stop()`` cancels in-flight background indexing tasks via the
+        existing extraction drain loop — no new infrastructure."""
+        mgr, _ = _bg_manager(tmp_path, background=True, sleep_ms=2000)
+        await mgr.call_tool("srv", "some_tool", {})
+        assert len(mgr._background_tasks) == 1
+        task = next(iter(mgr._background_tasks))
+
+        await mgr.stop()
+
+        assert task.done()
+        assert len(mgr._background_tasks) == 0
+
+    async def test_background_metrics_tri_state(self, tmp_path):
+        """Background path leaves ``index_ok=None`` / ``index_error=None`` /
+        ``chunks_indexed=0`` in the recorded metrics row — same tri-state
+        as background extraction. Dashboards distinguish sync vs background
+        with ``WHERE index_ok IS NULL``."""
+        mgr, _ = _bg_manager(tmp_path, background=True)
+        record_spy = MagicMock()
+        mgr.tracker.record = record_spy
+        try:
+            await mgr.call_tool("srv", "some_tool", {})
+            await asyncio.gather(*mgr._background_tasks, return_exceptions=True)
+
+            record_spy.assert_called_once()
+            metrics = record_spy.call_args.args[0]
+            assert metrics.index_ok is None
+            assert metrics.index_error is None
+            assert metrics.chunks_indexed == 0
+        finally:
+            await mgr.stop()
+
+    async def test_sync_default_unchanged(self, tmp_path):
+        """``background=False`` (default) keeps the synchronous contract:
+        ``[Indexed] ... K chunks`` footer + ``index_ok=True`` in metrics.
+        Regression guard for the helper extraction in commit 3bb800e."""
+        mgr, indexer = _bg_manager(tmp_path, background=False)
+        record_spy = MagicMock()
+        mgr.tracker.record = record_spy
+        try:
+            result = await mgr.call_tool("srv", "some_tool", {})
+
+            assert "[Indexed]" in result
+            assert "2 chunks" in result
+            assert "· scheduled" not in result
+            indexer.index_file.assert_awaited_once()
+            assert len(mgr._background_tasks) == 0
+
+            metrics = record_spy.call_args.args[0]
+            assert metrics.index_ok is True
+            assert metrics.chunks_indexed == 2
+        finally:
+            await mgr.stop()
+
+    async def test_background_failure_does_not_break_response(self, tmp_path, caplog):
+        """Background indexing exception stays captured inside the task as
+        ``outcome.ok=False`` (logged WARNING). The agent already received
+        the placeholder footer synchronously — the exception cannot break
+        the in-flight response."""
+        mgr, _ = _bg_manager(tmp_path, background=True, raise_on_index=True)
+        try:
+            with caplog.at_level("WARNING", logger="memtomem_stm.proxy.memory_ops"):
+                result = await mgr.call_tool("srv", "some_tool", {})
+                # Drain so the WARNING is emitted before assertion.
+                await asyncio.gather(*mgr._background_tasks, return_exceptions=True)
+
+            assert "[Indexing…]" in result
+            assert any("Auto-index failed" in r.message for r in caplog.records)
+        finally:
+            await mgr.stop()
+
+
+class TestBackgroundLatency:
+    async def test_background_avoids_indexer_latency(self, tmp_path):
+        """With ``index_file`` simulating 500ms LTM latency:
+
+        - sync (``background=False``) blocks: response latency ≈ 500ms+.
+        - background (``background=True``) returns near-instantly: < 300ms
+          absolute AND < sync/3 relative.
+
+        Both assertions must pass. Absolute alone is flaky on shared CI
+        runners (50–100ms jitter); ratio alone misses a global regression
+        where both paths slow proportionally.
+        """
+        sleep_ms = 500
+        sync_mgr, _ = _bg_manager(tmp_path, background=False, sleep_ms=sleep_ms)
+        bg_mgr, _ = _bg_manager(tmp_path, background=True, sleep_ms=sleep_ms)
+        try:
+            t0 = time.monotonic()
+            await sync_mgr.call_tool("srv", "some_tool", {})
+            sync_ms = (time.monotonic() - t0) * 1000
+
+            t0 = time.monotonic()
+            await bg_mgr.call_tool("srv", "some_tool", {})
+            bg_ms = (time.monotonic() - t0) * 1000
+
+            assert bg_ms < 300, f"background latency {bg_ms:.0f}ms exceeds 300ms cap"
+            assert bg_ms < sync_ms / 3, (
+                f"background latency {bg_ms:.0f}ms not < sync/3 ({sync_ms / 3:.0f}ms)"
+            )
+        finally:
+            await bg_mgr.stop()
+            await sync_mgr.stop()

--- a/tests/test_memory_ops.py
+++ b/tests/test_memory_ops.py
@@ -22,6 +22,7 @@ from memtomem_stm.proxy.memory_ops import (
     AutoIndexOutcome,
     ExtractOutcome,
     auto_index_response,
+    compose_index_footer,
     extract_and_store,
     format_fact_md,
 )
@@ -208,6 +209,65 @@ class TestAutoIndexResponse:
         written_path, _ = indexer.indexed_paths[0]
         assert "/" not in written_path.name
         assert "ns_inner" in written_path.name
+
+
+# ── compose_index_footer ─────────────────────────────────────────────────
+
+
+class TestComposeIndexFooter:
+    """Footer composition shared by sync ``auto_index_response`` and the
+    background INDEX branch in ``ProxyManager``. Sync passes the actual
+    chunk count; background passes ``chunks=None`` so the placeholder
+    renders before the indexing task has even run.
+    """
+
+    def test_sync_renders_indexed_with_chunks_and_namespace(self):
+        out = compose_index_footer(
+            server="gh",
+            tool="read_file",
+            original_chars=12000,
+            compressed_chars=3200,
+            text="ignored when original_chars set",
+            agent_summary="summary body",
+            ns="proxy-gh",
+            chunks=5,
+        )
+        assert out.startswith("[Indexed] `gh/read_file` (12000→3200 chars)")
+        assert "· 5 chunks in `proxy-gh` namespace." in out
+        assert out.endswith("\n\nsummary body")
+
+    def test_background_renders_indexing_scheduled_without_namespace(self):
+        out = compose_index_footer(
+            server="gh",
+            tool="read_file",
+            original_chars=12000,
+            compressed_chars=3200,
+            text="t",
+            agent_summary="summary body",
+            ns="proxy-gh",
+            chunks=None,
+        )
+        assert out.startswith("[Indexing…] `gh/read_file` (12000→3200 chars)")
+        assert "· scheduled." in out
+        # Namespace is intentionally dropped — chunk count and final ns
+        # binding are co-uncertain until the background task completes.
+        assert "namespace" not in out
+        assert "proxy-gh" not in out
+        assert out.endswith("\n\nsummary body")
+
+    def test_falls_back_to_text_and_summary_lengths_when_chars_none(self):
+        out = compose_index_footer(
+            server="s",
+            tool="t",
+            original_chars=None,
+            compressed_chars=None,
+            text="x" * 100,
+            agent_summary="y" * 25,
+            ns="ns",
+            chunks=2,
+        )
+        # 100→25 reflect len(text) / len(agent_summary).
+        assert "(100→25 chars)" in out
 
 
 # ── extract_and_store ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `AutoIndexConfig.background: bool = False` — opt-in flag for asynchronous indexing.
- Stage 4 INDEX gains a background branch: when `true`, the indexing task runs via `asyncio.create_task` off the request path; the agent receives a `[Indexing…] · scheduled` placeholder footer immediately.
- `compose_index_footer` helper extracted from `auto_index_response` so sync (`chunks=N`) and background (`chunks=None`) share one composition path.
- Reuses the existing `_background_tasks` set and `stop()` drain loop — no new lifecycle infrastructure.

## Behavior change

Deployments keeping `auto_index.background` at its default (`false`) see **no change** — Stage 4 INDEX still runs synchronously, returns the existing `[Indexed] ... K chunks in <ns> namespace` footer, and populates `index_ok` / `chunks_indexed` as before. Operators must opt in by setting `background: true`.

When opted in:

- Response footer becomes `` [Indexing…] `server/tool` (N→M chars) · scheduled. `` — the namespace is intentionally dropped (chunk count and final ns binding are unknown until the task runs).
- Read-your-own-writes consistency is no longer guaranteed for the next tool call. An agent that immediately re-queries just-indexed content via `stm_proxy_search` may not find it until the task completes.
- `proxy_metrics.db` records `index_ok IS NULL`, `index_error IS NULL`, `chunks_indexed = 0` for the background row — tri-state matching background extraction. Dashboards distinguish sync/background with `WHERE index_ok IS NULL`.

## Metrics tri-state (builds on #159)

The `CallMetrics.index_ok` / `index_error` / `chunks_indexed` fields provisioned by #159 already used `None` to mean "stage did not run". F4 extends the semantic to "stage scheduled, outcome arrives later":

| Field | Sync (`background=False`) | Background (`background=True`) |
| --- | --- | --- |
| `index_ok` | `True` / `False` | `None` |
| `index_error` | `None` / error str | `None` |
| `chunks_indexed` | actual count | `0` |

Background failures stay visible via `memtomem_stm.proxy.memory_ops`'s WARNING log (same channel as background extraction).

## Why `caching.md` changed

`caching.md` is the conceptual auto-index documentation; the new `background` option is a direct part of the same conceptual surface, so syncing the JSON example and adding one paragraph keeps the docs internally consistent. Same scope as the F4 change, not a separate cleanup.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1413 passed (+9: 6 new in `test_auto_index_background.py`, 3 new in `test_memory_ops.py::TestComposeIndexFooter`).
- [x] `uv run ruff check src && uv run ruff format --check src` — All checks passed.
- [x] `uv run mypy src` — 2 pre-existing errors unrelated to F4 (`manager.py:411`, `:773`); no new errors introduced.
- [x] Background scheduling + placeholder footer + `_background_tasks` registration.
- [x] `stop()` drains the in-flight indexing task (re-uses the existing extraction drain loop).
- [x] Metrics tri-state (`index_ok IS NULL`, `chunks_indexed = 0`).
- [x] Sync default unchanged (regression guard for the helper extraction).
- [x] Background indexer failure stays inside the task; agent response unaffected.
- [x] Latency dual assertion (`< 300ms` absolute AND `< sync/3` relative) with 500ms simulated LTM latency.

## Risks / follow-ups

- **Read-your-own-writes race** — opt-in users only. Default `false` + docs warning mitigate; same trade-off as `extraction.background=true`.
- **Unbounded task accumulation** — under sustained embedding-service slowdown, scheduled tasks can pile up and pressure memory. Same gap exists for background extraction; out of scope here, tracked as a follow-up issue (semaphore / queue-depth cap covering both INDEX and EXTRACT background paths).
- **Ordering** — concurrent background indexing for the same file relies on the LTM's `index_engine.is_duplicate` for dedup; no manager-level serialization (parallel to extraction).
- **Traced span omission** — background INDEX skips the `proxy_call_index` traced span because the task lifetime exceeds the request trace. Failures still surface via the memory_ops WARNING log with traceback. A future enhancement could emit an independent root span from the task; not in this PR.
- **Real-environment verification** — `scripts/verify_real_integration.py` extension to observe `index_ok IS NULL` populating on the background path is intentionally separate; planned as a post-merge follow-up so it runs against production-like traffic rather than the unit fixture.

## Depends on

Builds on metrics fields provisioned by #159 (`index_ok`, `index_error`, `chunks_indexed`).