### PR TITLE
chore(lint): remove unused SelectiveCompressor import

### DIFF
--- a/tests/test_proxy_manager_pipeline.py
+++ b/tests/test_proxy_manager_pipeline.py
@@ -572,8 +572,6 @@ class TestSelectiveHotReload:
     """Selective compressor must be recreated when config changes via hot-reload."""
 
     async def test_selective_recreated_on_config_change(self, tmp_path):
-        from memtomem_stm.proxy.compression import SelectiveCompressor
-
         mgr = _make_manager(
             tmp_path=tmp_path, compression=CompressionStrategy.SELECTIVE
         )


### PR DESCRIPTION
## Summary

Follow-up to #161. `test_selective_recreated_on_config_change` imports `SelectiveCompressor` but never references it in the test body — `mgr._create_selective(sel_cfg_*)` does all the work. `ruff` flags F401 and CI on `main` is red.

Caught while working on an unrelated progressive-split-token change (issue #160); splitting this into its own PR so the lint fix is not buried in a scope-bearing diff.

## Before / after

Before (on `main`):

```
F401 [*] `memtomem_stm.proxy.compression.SelectiveCompressor` imported but unused
   --> tests/test_proxy_manager_pipeline.py:575:52

Found 1 error.
```

After (this PR):

```
All checks passed!
42 files already formatted
```

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — passes
- [x] `uv run pytest tests/test_proxy_manager_pipeline.py::TestSelectiveHotReload -v` — both tests still pass
- [x] Full suite: `uv run pytest -m "not ollama"` — 1418 passed (run locally on the sibling branch before splitting out)