### PR TITLE
fix(metrics_store): add defensive lock to read-path methods

### DIFF
--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -47,6 +47,13 @@ class MetricsStore:
         self._db_path = db_path
         self._max_history = max_history
         self._db: sqlite3.Connection | None = None
+        # Readers and writers share ``self._lock`` defensively. Current
+        # callers are all asyncio single-thread, but the connection uses
+        # ``check_same_thread=False`` so any future move to a thread-pool
+        # executor (or another thread-spawning caller) would race reads
+        # against in-flight ``record()`` writes without this guard. The
+        # uncontended acquire cost is negligible given cold-path call
+        # frequency (tuner drift analysis + feedback correlation lookups).
         self._lock = threading.Lock()
 
     def initialize(self) -> None:
@@ -194,76 +201,78 @@ class MetricsStore:
         if self._db is None:
             return []
         cutoff = time.time() - since_seconds
-        # Main aggregation
-        rows = self._db.execute(
-            """
-            SELECT
-                server,
-                tool,
-                COUNT(*)                                          AS call_count,
-                SUM(ratio_violation)                              AS violation_count,
-                AVG(
-                    CASE WHEN cleaned_chars > 0 AND is_error = 0
-                         THEN CAST(compressed_chars AS REAL) / cleaned_chars
-                    END
-                )                                                 AS avg_ratio,
-                SUM(is_error)                                     AS error_count
-            FROM proxy_metrics
-            WHERE created_at >= ?
-            GROUP BY server, tool
-            """,
-            (cutoff,),
-        ).fetchall()
+        with self._lock:
+            # Main aggregation
+            rows = self._db.execute(
+                """
+                SELECT
+                    server,
+                    tool,
+                    COUNT(*)                                          AS call_count,
+                    SUM(ratio_violation)                              AS violation_count,
+                    AVG(
+                        CASE WHEN cleaned_chars > 0 AND is_error = 0
+                             THEN CAST(compressed_chars AS REAL) / cleaned_chars
+                        END
+                    )                                                 AS avg_ratio,
+                    SUM(is_error)                                     AS error_count
+                FROM proxy_metrics
+                WHERE created_at >= ?
+                GROUP BY server, tool
+                """,
+                (cutoff,),
+            ).fetchall()
 
-        profiles: list[dict] = []
-        for server, tool, call_count, violation_count, avg_ratio, error_count in rows:
-            # p95 approximation: pick the value at rank ceil(0.95 * N)
-            p95_row = self._db.execute(
-                """
-                SELECT original_chars FROM proxy_metrics
-                WHERE server = ? AND tool = ? AND created_at >= ?
-                ORDER BY original_chars ASC
-                LIMIT 1 OFFSET MAX(0, CAST(
-                    (SELECT COUNT(*) FROM proxy_metrics
-                     WHERE server = ? AND tool = ? AND created_at >= ?)
-                    * 0.95 AS INTEGER) - 1)
-                """,
-                (server, tool, cutoff, server, tool, cutoff),
-            ).fetchone()
-            # Dominant strategy
-            strat_row = self._db.execute(
-                """
-                SELECT compression_strategy FROM proxy_metrics
-                WHERE server = ? AND tool = ? AND created_at >= ?
-                    AND compression_strategy IS NOT NULL
-                GROUP BY compression_strategy
-                ORDER BY COUNT(*) DESC
-                LIMIT 1
-                """,
-                (server, tool, cutoff),
-            ).fetchone()
-            profiles.append(
-                {
-                    "server": server,
-                    "tool": tool,
-                    "call_count": call_count,
-                    "violation_count": violation_count or 0,
-                    "avg_ratio": round(avg_ratio, 4) if avg_ratio is not None else None,
-                    "p95_original_chars": p95_row[0] if p95_row else 0,
-                    "dominant_strategy": strat_row[0] if strat_row else None,
-                    "error_count": error_count or 0,
-                }
-            )
+            profiles: list[dict] = []
+            for server, tool, call_count, violation_count, avg_ratio, error_count in rows:
+                # p95 approximation: pick the value at rank ceil(0.95 * N)
+                p95_row = self._db.execute(
+                    """
+                    SELECT original_chars FROM proxy_metrics
+                    WHERE server = ? AND tool = ? AND created_at >= ?
+                    ORDER BY original_chars ASC
+                    LIMIT 1 OFFSET MAX(0, CAST(
+                        (SELECT COUNT(*) FROM proxy_metrics
+                         WHERE server = ? AND tool = ? AND created_at >= ?)
+                        * 0.95 AS INTEGER) - 1)
+                    """,
+                    (server, tool, cutoff, server, tool, cutoff),
+                ).fetchone()
+                # Dominant strategy
+                strat_row = self._db.execute(
+                    """
+                    SELECT compression_strategy FROM proxy_metrics
+                    WHERE server = ? AND tool = ? AND created_at >= ?
+                        AND compression_strategy IS NOT NULL
+                    GROUP BY compression_strategy
+                    ORDER BY COUNT(*) DESC
+                    LIMIT 1
+                    """,
+                    (server, tool, cutoff),
+                ).fetchone()
+                profiles.append(
+                    {
+                        "server": server,
+                        "tool": tool,
+                        "call_count": call_count,
+                        "violation_count": violation_count or 0,
+                        "avg_ratio": round(avg_ratio, 4) if avg_ratio is not None else None,
+                        "p95_original_chars": p95_row[0] if p95_row else 0,
+                        "dominant_strategy": strat_row[0] if strat_row else None,
+                        "error_count": error_count or 0,
+                    }
+                )
         return profiles
 
     def get_history(self, limit: int = 100) -> list[dict]:
         if self._db is None:
             return []
-        rows = self._db.execute(
-            "SELECT server, tool, original_chars, compressed_chars, cleaned_chars, created_at "
-            "FROM proxy_metrics ORDER BY created_at DESC LIMIT ?",
-            (limit,),
-        ).fetchall()
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT server, tool, original_chars, compressed_chars, cleaned_chars, created_at "
+                "FROM proxy_metrics ORDER BY created_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
         return [
             {
                 "server": r[0],
@@ -296,11 +305,12 @@ class MetricsStore:
         if self._db is None:
             return None
         cutoff = time.time() - within_seconds
-        row = self._db.execute(
-            "SELECT trace_id FROM proxy_metrics "
-            "WHERE server = ? AND tool = ? AND created_at >= ? "
-            "AND trace_id IS NOT NULL "
-            "ORDER BY created_at DESC LIMIT 1",
-            (server, tool, cutoff),
-        ).fetchone()
+        with self._lock:
+            row = self._db.execute(
+                "SELECT trace_id FROM proxy_metrics "
+                "WHERE server = ? AND tool = ? AND created_at >= ? "
+                "AND trace_id IS NOT NULL "
+                "ORDER BY created_at DESC LIMIT 1",
+                (server, tool, cutoff),
+            ).fetchone()
         return row[0] if row else None

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sqlite3
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -228,3 +229,84 @@ class TestRecordPersistsNewFields:
         ).fetchone()[0]
         assert failures == 1
         assert unobserved == 1
+
+
+class TestReadPathConcurrency:
+    """Cross-thread reader/writer safety.
+
+    The connection is opened with ``check_same_thread=False``, and
+    ``record()`` / ``_trim()`` serialize via ``self._lock`` against
+    thread-pool writers. Reader paths used to be lockless on the
+    assumption that all callers live on the asyncio single-thread; that
+    assumption is a fragile convention. This test pins the invariant by
+    driving concurrent writers and readers through a thread pool — if a
+    future refactor drops the reader locks and moves a caller to
+    ``run_in_executor``, this test catches it before users do.
+    """
+
+    def test_readers_and_writer_concurrent(self, tmp_path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        total_writes = 200
+        reads_per_worker = 100
+
+        def writer() -> None:
+            for i in range(total_writes):
+                store.record(
+                    CallMetrics(
+                        server="s",
+                        tool=f"t{i % 5}",
+                        original_chars=1000,
+                        compressed_chars=400,
+                        cleaned_chars=800,
+                        trace_id=f"tr-{i}",
+                    )
+                )
+
+        def run_get_tool_profiles() -> None:
+            for _ in range(reads_per_worker):
+                result = store.get_tool_profiles(since_seconds=3600.0)
+                assert isinstance(result, list)
+                for row in result:
+                    # If a torn read ever happened the dict would be
+                    # missing keys or carry mismatched values; asserting
+                    # the contract forces a failure rather than silent
+                    # corruption.
+                    assert row["call_count"] >= 1
+                    assert isinstance(row["server"], str)
+
+        def run_get_history() -> None:
+            for _ in range(reads_per_worker):
+                result = store.get_history(limit=50)
+                assert isinstance(result, list)
+                for row in result:
+                    assert row["original_chars"] == 1000
+                    assert row["compressed_chars"] == 400
+
+        def run_lookup_recent_trace_id() -> None:
+            for _ in range(reads_per_worker):
+                trace = store.lookup_recent_trace_id("s", "t0", within_seconds=3600.0)
+                # trace_id is either a valid match or ``None`` if the
+                # writer hasn't produced a ``t0`` row yet. Never an
+                # empty string or malformed value.
+                assert trace is None or trace.startswith("tr-")
+
+        try:
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                futures = [
+                    pool.submit(writer),
+                    pool.submit(run_get_tool_profiles),
+                    pool.submit(run_get_history),
+                    pool.submit(run_lookup_recent_trace_id),
+                ]
+                # ``f.result()`` re-raises any exception the worker hit,
+                # so a race-induced SQLite error fails the test here.
+                for f in futures:
+                    f.result(timeout=30)
+
+            final_count = store._db.execute(
+                "SELECT COUNT(*) FROM proxy_metrics"
+            ).fetchone()[0]
+            assert final_count == total_writes
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary
- Wrap `MetricsStore.get_tool_profiles`, `get_history`, and `lookup_recent_trace_id` in `self._lock`. The SQLite connection uses `check_same_thread=False` and `record()` already locks against thread-pool writers, but the three readers were relying on an implicit "asyncio single-thread" caller convention.
- Document the convention dependency in `__init__` so a reviewer doesn't strip the locks as dead code on a future pass.
- Add `TestReadPathConcurrency` that drives one writer plus all three readers through a `ThreadPoolExecutor` — any future drop of the reader locks, or a caller move onto `run_in_executor`, is caught in CI before it ships.

## Rationale
Backlog item from the 2026-04-15 concurrency audit. `Lock` is sufficient (not `RLock`): readers don't re-acquire, and `_trim()` (called inside the writer's lock) hits `self._db.execute` directly rather than calling back through a locked method. The three callers (`tuner.get_profiles` — periodic drift analysis; `compression_feedback.record_feedback` — user-initiated; CLI history lookup) are all cold paths, so the uncontended acquire cost is negligible.

Not filing this as a data-loss bug today — the current deployment is asyncio single-thread and the convention holds. It's a defensive pin so that a future optimization PR (\"move this reader onto `run_in_executor` for latency\") can't silently introduce torn reads.

## Test plan
- [x] `uv run pytest tests/test_metrics_store.py -v` — 8 passed (new `TestReadPathConcurrency` included)
- [x] `uv run pytest -m "not ollama" -q` — 1419 passed
- [x] `uv run ruff check src tests && uv run ruff format --check src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)