### PR TITLE
test(bench): scaffold bench_qa harness and S9 smoke scenario

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,8 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 markers = [
     "ollama: requires a running Ollama instance (auto-skipped when unavailable)",
+    "bench_qa: end-to-end compression/surfacing regression gate (fake upstream, deterministic)",
+    "bench_qa_meta: self-test probes for bench_qa — intentional failures, NOT CI-safe",
 ]
 
 [tool.mypy]

--- a/tests/bench/bench_qa/__init__.py
+++ b/tests/bench/bench_qa/__init__.py
@@ -1,0 +1,33 @@
+"""End-to-end bench_qa — drives ProxyManager.call_tool() through fixture
+scenarios and asserts compression efficiency + information loss gates.
+
+See ``/Users/pdstudio/.claude/plans/mcp-snug-river.md`` for the design
+(Context → Goals → Harness → Metrics → Integration).
+"""
+
+from .loader import fixtures_dir, load_fixture
+from .runner import (
+    deterministic_trace_id,
+    latest_metrics_row,
+    make_proxy_manager,
+)
+from .schema import (
+    BenchFixture,
+    BenchReport,
+    QAProbe,
+    ScenarioReport,
+    SurfacingEval,
+)
+
+__all__ = [
+    "BenchFixture",
+    "BenchReport",
+    "QAProbe",
+    "ScenarioReport",
+    "SurfacingEval",
+    "deterministic_trace_id",
+    "fixtures_dir",
+    "latest_metrics_row",
+    "load_fixture",
+    "make_proxy_manager",
+]

--- a/tests/bench/bench_qa/loader.py
+++ b/tests/bench/bench_qa/loader.py
@@ -1,0 +1,31 @@
+"""Fixture loader with strict schema_version enforcement."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .schema import FIXTURE_SCHEMA_VERSION, BenchFixture
+
+
+def fixtures_dir() -> Path:
+    return Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def load_fixture(scenario_id: str) -> BenchFixture:
+    path = fixtures_dir() / f"{scenario_id}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"bench_qa fixture missing: {path}")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    version = raw.get("schema_version")
+    if version != FIXTURE_SCHEMA_VERSION:
+        raise AssertionError(
+            f"fixture {scenario_id} has schema_version={version}; "
+            f"expected {FIXTURE_SCHEMA_VERSION}. Migrate the fixture before running bench_qa."
+        )
+    if raw.get("scenario_id") != scenario_id:
+        raise AssertionError(
+            f"fixture {path} declares scenario_id={raw.get('scenario_id')!r}; "
+            f"file name implies {scenario_id!r}"
+        )
+    return raw  # type: ignore[return-value]

--- a/tests/bench/bench_qa/runner.py
+++ b/tests/bench/bench_qa/runner.py
@@ -1,0 +1,129 @@
+"""ProxyManager runner for bench_qa — fake upstream + per-run config isolation.
+
+Design origin: ``tests/test_compression_ratio_guard.py::_make_manager_with_store``
+already drives ``ProxyManager.call_tool()`` with an AsyncMock session. This
+module generalizes that pattern for the bench_qa suite:
+
+* every run gets its own ``tmp_path`` so ``proxy_metrics.db`` /
+  ``stm_feedback.db`` / progressive store do not cross-talk;
+* ``trace_id`` is derived deterministically from ``scenario_id`` + ``run_seed``
+  so determinism-diff checks are meaningful;
+* later PRs wire a real in-memory LTM adapter for ``surf-*`` scenarios
+  (not needed for P1 smoke).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ProxyConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
+from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.metrics_store import MetricsStore
+
+
+_COMPRESSION_STRATEGY_BY_NAME: dict[str, CompressionStrategy] = {
+    s.value: s for s in CompressionStrategy
+}
+
+
+def deterministic_trace_id(scenario_id: str, run_seed: int = 0) -> str:
+    """Stable trace_id so two bench runs produce identical ``proxy_metrics.trace_id``.
+
+    Using random UUIDs would make report-diff determinism checks always red.
+    The ``"bench-"`` prefix lets operators filter bench rows out of production
+    tuner dashboards.
+    """
+    digest = hashlib.sha256(f"{scenario_id}:{run_seed}".encode()).hexdigest()[:16]
+    return f"bench-{digest}"
+
+
+def _resolve_compression(name: str) -> CompressionStrategy:
+    if name not in _COMPRESSION_STRATEGY_BY_NAME:
+        raise AssertionError(
+            f"expected_compressor={name!r} is not a valid CompressionStrategy; "
+            f"known values: {sorted(_COMPRESSION_STRATEGY_BY_NAME)}"
+        )
+    return _COMPRESSION_STRATEGY_BY_NAME[name]
+
+
+def make_proxy_manager(
+    tmp_path: Path,
+    *,
+    compression: str | CompressionStrategy = CompressionStrategy.AUTO,
+    max_result_chars: int = 50_000,
+    min_retention: float = 0.65,
+    server_name: str = "fake",
+    tool_prefix: str = "fake",
+) -> tuple[ProxyManager, MetricsStore, AsyncMock]:
+    """Build a ``ProxyManager`` wired to a fresh per-run MetricsStore and an
+    AsyncMock upstream session. Returns ``(manager, metrics_store, session)``.
+
+    Callers set ``session.call_tool.return_value`` to the fixture payload
+    (wrap plain strings with ``make_tool_result``).
+    """
+    if isinstance(compression, str):
+        compression = _resolve_compression(compression)
+
+    store = MetricsStore(tmp_path / "proxy_metrics.db")
+    store.initialize()
+    server_cfg = UpstreamServerConfig(
+        prefix=tool_prefix,
+        compression=compression,
+        max_result_chars=max_result_chars,
+        max_retries=0,
+        reconnect_delay_seconds=0.0,
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={server_name: server_cfg},
+        min_result_retention=min_retention,
+    )
+    tracker = TokenTracker(metrics_store=store)
+    mgr = ProxyManager(proxy_cfg, tracker)
+    session = AsyncMock()
+    mgr._connections[server_name] = UpstreamConnection(
+        name=server_name,
+        config=server_cfg,
+        session=session,
+        tools=[],
+    )
+    return mgr, store, session
+
+
+def make_tool_result(text: str) -> SimpleNamespace:
+    """Wrap a string in the MCP CallToolResult shape the proxy expects."""
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=text)], isError=False)
+
+
+def latest_metrics_row(store: MetricsStore) -> dict:
+    """Read the most recent proxy_metrics row as a dict.
+
+    Mirrors ``tests/test_compression_ratio_guard.py::_latest_row`` so both
+    files converge on the same shape if more columns are added.
+    """
+    assert store._db is not None, "MetricsStore must be initialize()d before read"
+    row = store._db.execute(
+        "SELECT server, tool, original_chars, cleaned_chars, compressed_chars, "
+        "compression_strategy, ratio_violation, trace_id "
+        "FROM proxy_metrics ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    if row is None:
+        return {}
+    return {
+        "server": row[0],
+        "tool": row[1],
+        "original_chars": row[2],
+        "cleaned_chars": row[3],
+        "compressed_chars": row[4],
+        "compression_strategy": row[5],
+        "ratio_violation": row[6],
+        "trace_id": row[7],
+    }

--- a/tests/bench/bench_qa/schema.py
+++ b/tests/bench/bench_qa/schema.py
@@ -1,0 +1,123 @@
+"""Frozen fixture + report schemas for bench_qa.
+
+``schema_version`` is bumped whenever on-disk fixture format changes. The
+loader rejects mismatched fixtures immediately so CI fails fast instead of
+silently feeding the runner stale payloads.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+FIXTURE_SCHEMA_VERSION: Literal[1] = 1
+REPORT_SCHEMA_VERSION: Literal[1] = 1
+
+
+class QAProbe(TypedDict):
+    """Single answerability probe.
+
+    Semantics: ``answerable=1`` iff every keyword in ``expected_keywords``
+    appears as a case-insensitive substring of the compressed output.
+    Whole-word matching is not required — numeric answers, code fragments,
+    and ID tokens all work.
+    """
+
+    question: str
+    expected_keywords: list[str]
+
+
+class SurfacingEval(TypedDict):
+    """Ground truth for surfacing_recall@k on ``surf-*`` scenarios.
+
+    ``returned_top_k`` is the first k IDs from ``surfacing_events.memory_ids``.
+    ``recall@k = |returned_top_k ∩ expected_ids| / min(k, len(expected_ids))``.
+    """
+
+    query: str
+    k: int
+    expected_ids: list[str]
+
+
+class BenchFixture(TypedDict, total=False):
+    """On-disk scenario fixture (``tests/bench/fixtures/<scenario_id>.json``).
+
+    Required fields: ``schema_version``, ``scenario_id``, ``payload``,
+    ``expected_compressor``.  All others are optional so simple smoke
+    fixtures stay terse.
+    """
+
+    schema_version: Literal[1]
+    scenario_id: str
+    description: str
+    payload: str
+    content_type: Literal["json", "markdown", "code", "text"]
+    expected_compressor: str
+    max_result_chars: int
+    force_tier: int | None
+    expected_keywords: list[str]
+    qa_probes: list[QAProbe]
+    surfacing_seeds: list[dict]
+    surfacing_eval: SurfacingEval
+
+
+class MetricSummary(TypedDict):
+    """Subset of proxy_metrics row + computed fields recorded per scenario."""
+
+    original_chars: int
+    cleaned_chars: int
+    compressed_chars: int
+    compression_ratio: float
+    compression_strategy: str | None
+    ratio_violation: int
+    surfacing_on_progressive_ok: int | None
+    surface_error: str | None
+    clean_ms: float
+    compress_ms: float
+    surface_ms: float
+
+
+class RuleJudgeResult(TypedDict):
+    """Keyword/heading/JSON score from ``tests.bench.judge.RuleBasedJudge``."""
+
+    score: float
+    missing_keywords: list[str]
+
+
+class QAResult(TypedDict):
+    """Probe-level answerability summary for a single scenario."""
+
+    answerable: int
+    total: int
+    ratio: float
+
+
+class ProgressiveResult(TypedDict):
+    round_trip_equal: bool
+    chunks: int
+    total_chars: int
+
+
+class SurfacingResult(TypedDict):
+    recall_at_k: float
+    returned_ids: list[str]
+    expected_ids: list[str]
+
+
+class ScenarioReport(TypedDict, total=False):
+    scenario_id: str
+    trace_id: str
+    metrics: MetricSummary
+    rule_judge: RuleJudgeResult
+    qa: QAResult
+    progressive: ProgressiveResult
+    surfacing: SurfacingResult
+    tier: str
+    verdict: Literal["pass", "fail", "advisory"]
+
+
+class BenchReport(TypedDict):
+    schema_version: Literal[1]
+    run_seed: int
+    scenarios: list[ScenarioReport]
+    tier_histogram: dict[str, int]
+    totals: dict[str, float]

--- a/tests/bench/fixtures/s09.json
+++ b/tests/bench/fixtures/s09.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s09",
+  "description": "Short text (budget-fit) — compressor should pick 'none' and ratio_violation must stay 0.",
+  "content_type": "text",
+  "expected_compressor": "auto",
+  "force_tier": null,
+  "max_result_chars": 50000,
+  "expected_keywords": [
+    "data-processor",
+    "TLS 1.3",
+    "AES-256",
+    "RPO 1 hour",
+    "RTO 4 hours"
+  ],
+  "qa_probes": [
+    {
+      "question": "What encryption in transit is required?",
+      "expected_keywords": ["TLS 1.3"]
+    },
+    {
+      "question": "What is the RPO requirement?",
+      "expected_keywords": ["RPO", "1 hour"]
+    },
+    {
+      "question": "What is the breach notification window?",
+      "expected_keywords": ["24 hours"]
+    }
+  ],
+  "payload": "DATA PROCESSING ADDENDUM — SUMMARY SHEET (v1.2)\n\n1. Roles\nThe Client acts as data-controller; the Service Provider acts as data-processor for all Personal Data submitted under the Master Services Agreement. Processing is limited to the purposes described in Schedule A and to the Controller's documented instructions.\n\n2. Security Controls\nAll Personal Data is encrypted in transit using TLS 1.3 (minimum) and at rest using AES-256-GCM. Access to production systems requires hardware-backed MFA. Access reviews occur quarterly; key rotation occurs every 90 days.\n\n3. Availability\nThe Service Provider operates to an RPO 1 hour and an RTO 4 hours for Tier-1 services. Backups are replicated to a second region with an encrypted snapshot taken every 15 minutes.\n\n4. Incident Response\nThe Service Provider notifies the Client within 24 hours of confirming a Personal Data Breach. The notification includes (a) the nature of the breach, (b) categories and approximate count of data subjects affected, (c) the likely consequences, and (d) measures taken or proposed.\n\n5. Sub-processors\nThe current sub-processor list is maintained at the URL in Annex B. The Controller receives 30 days' notice before any addition or replacement. All sub-processors are bound by written terms at least as protective as this Addendum.\n\n6. Data Subject Rights\nThe Service Provider assists the Controller in responding to access, rectification, erasure, restriction, objection, and portability requests within 5 business days, to the extent technically feasible.\n\n7. International Transfers\nPersonal Data is transferred only to jurisdictions covered by a European Commission adequacy decision or under the 2021 Standard Contractual Clauses (Module Two: Controller-to-Processor).\n\n8. Return and Deletion\nUpon termination the Service Provider returns Personal Data in a machine-readable format within 30 days and deletes remaining copies within 90 days. A certificate of deletion is provided on request.\n\n9. Audit\nThe Controller may audit compliance once per 12-month period on 30 days' written notice, during business hours, at the Controller's expense. The Service Provider may provide a current SOC 2 Type II or ISO 27001 report in lieu of on-site audit.\n\n10. Liability\nEach party's aggregate liability for breach of this Addendum is capped at the greater of twelve (12) months of fees paid or EUR 500,000. The cap does not apply to indemnification obligations, willful misconduct, or a party's breach of its confidentiality obligations.\n"
+}

--- a/tests/bench/test_bench_qa_scenarios.py
+++ b/tests/bench/test_bench_qa_scenarios.py
@@ -1,0 +1,80 @@
+"""bench_qa — end-to-end scenario gates for ProxyManager.call_tool().
+
+This file hosts the ``@pytest.mark.bench_qa`` suite. Each scenario loads a
+JSON fixture, drives a live ``ProxyManager`` against an AsyncMock upstream,
+and asserts the gates defined in
+``/Users/pdstudio/.claude/plans/mcp-snug-river.md``.
+
+The P1 pass ships only S9 (budget-fit smoke) — S1–S8, S10 arrive in
+subsequent PRs together with fallback-ladder / progressive / surfacing
+assertions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bench.bench_qa import (
+    deterministic_trace_id,
+    latest_metrics_row,
+    load_fixture,
+    make_proxy_manager,
+)
+from bench.bench_qa.runner import make_tool_result
+
+
+def _all_keywords_present(keywords: list[str], text: str) -> bool:
+    lowered = text.lower()
+    return all(kw.lower() in lowered for kw in keywords)
+
+
+def _qa_answerable_ratio(probes: list[dict], text: str) -> tuple[int, int]:
+    if not probes:
+        return 0, 0
+    answerable = sum(1 for p in probes if _all_keywords_present(p["expected_keywords"], text))
+    return answerable, len(probes)
+
+
+@pytest.mark.bench_qa
+@pytest.mark.asyncio
+async def test_s09_budget_fit_short_text(tmp_path):
+    """S9 — payload fits within the budget; compressor should pick a concrete
+    strategy (not ``auto``), ratio_violation must stay 0, all QA probes
+    answerable."""
+    fixture = load_fixture("s09")
+
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+
+    expected_trace_id = deterministic_trace_id(fixture["scenario_id"])
+    result = await mgr.call_tool("fake", "summary", {})
+
+    row = latest_metrics_row(store)
+    try:
+        assert row, "proxy_metrics row was not written"
+        # ProxyManager.call_tool currently assigns its own uuid-based trace_id;
+        # deterministic injection arrives in the report PR (plan back-fill).
+        # P1 only proves the row is written and the column is non-null.
+        assert row["trace_id"], "trace_id column should be populated"
+        assert expected_trace_id.startswith("bench-"), "sanity: hash helper runs"
+        assert row["ratio_violation"] == 0, (
+            f"unexpected ratio_violation=1 for budget-fit payload "
+            f"(cleaned={row['cleaned_chars']}, compressed={row['compressed_chars']})"
+        )
+        assert row["compression_strategy"] is not None, "strategy was not recorded"
+        assert row["compression_strategy"] != "auto", (
+            "strategy must be resolved to a concrete value before recording "
+            f"(got {row['compression_strategy']!r})"
+        )
+        assert row["original_chars"] == len(fixture["payload"]), (
+            f"original_chars={row['original_chars']} expected={len(fixture['payload'])}"
+        )
+        answerable, total = _qa_answerable_ratio(fixture["qa_probes"], result)
+        assert total > 0, "S9 must have at least one qa_probe"
+        assert answerable / total >= 0.75, f"qa_answerable ratio below gate: {answerable}/{total}"
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- Introduces `tests/bench/bench_qa/` (schema + loader + runner) — a fixture-driven wrapper around `ProxyManager.call_tool()` that isolates per-run state via `tmp_path`, so compression/surfacing regressions can be gated from realistic payloads.
- Ships S9 (`tests/bench/fixtures/s09.json`, short DPA summary, budget-fit) as the first end-to-end smoke: asserts AUTO resolves to a concrete strategy, `ratio_violation=0` on a budget-fit payload, and that all expected keywords survive for QA answerability.
- Registers the `bench_qa` and `bench_qa_meta` pytest markers so upcoming scenario and self-test suites have stable selectors.

## Scope
This is P1 of a multi-PR rollout. Follow-ups will add S1–S8 and S10 fixtures, the 3-tier fallback-ladder and progressive round-trip assertions, a frozen `BenchReport` generator, CI wiring, and the `bench_qa_meta` self-test probes.

Deterministic `trace_id` injection is intentionally deferred to the report PR — `ProxyManager.call_tool()` currently assigns its own uuid, so the P1 assertion only proves the `trace_id` column is populated. The runner exposes a `deterministic_trace_id()` helper ready for the injection path (kwarg or `uuid.uuid4` monkeypatch, to be decided in that PR).

## Test plan
- [x] `uv run pytest -m bench_qa --tb=short -q` — 1 passed in 0.36s
- [x] `uv run pytest -m "not ollama"` — 1420 passed (full suite regression)
- [x] `uv run ruff check src tests` — All checks passed
- [x] `uv run ruff format --check tests/bench/bench_qa tests/bench/test_bench_qa_scenarios.py` — clean
- [x] `uv run mypy tests/bench/bench_qa` — no issues