### PR TITLE
test(bench_qa): parametrize + S2/S3/S4 happy-path gates

### DIFF
--- a/tests/bench/bench_qa/__init__.py
+++ b/tests/bench/bench_qa/__init__.py
@@ -5,6 +5,7 @@ See ``/Users/pdstudio/.claude/plans/mcp-snug-river.md`` for the design
 (Context → Goals → Harness → Metrics → Integration).
 """
 
+from .judge import qa_answerable_ratio, surfacing_recall_at_k
 from .loader import fixtures_dir, load_fixture
 from .runner import (
     deterministic_trace_id,
@@ -30,4 +31,6 @@ __all__ = [
     "latest_metrics_row",
     "load_fixture",
     "make_proxy_manager",
+    "qa_answerable_ratio",
+    "surfacing_recall_at_k",
 ]

--- a/tests/bench/bench_qa/judge.py
+++ b/tests/bench/bench_qa/judge.py
@@ -1,0 +1,57 @@
+"""Rule-based judging helpers for bench_qa scenarios.
+
+Intentionally separate from ``tests.bench.judge`` (the existing
+``RuleBasedJudge`` that scores a ``BenchTask``). bench_qa fixtures carry
+``qa_probes`` — structured ``{question, expected_keywords}`` pairs whose
+answerability is gated strictly: *every* keyword of a probe must appear
+in the compressed output (case-insensitive substring) for the probe to
+count as answerable.
+
+The surfacing_recall@k helper lives here too (used by S10 and later
+surfacing scenarios).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+
+def _all_keywords_present(keywords: Iterable[str], text: str) -> bool:
+    """True iff every keyword is a case-insensitive substring of text."""
+    lowered = text.lower()
+    return all(kw.lower() in lowered for kw in keywords)
+
+
+def qa_answerable_ratio(probes: Sequence[dict], text: str) -> tuple[int, int]:
+    """Count answerable probes out of the total.
+
+    Each probe is expected to shape like ``{"expected_keywords": [...]}``
+    (matching :class:`bench.bench_qa.schema.QAProbe`). Returns
+    ``(answerable, total)``. An empty probe list returns ``(0, 0)``.
+    """
+    total = len(probes)
+    if total == 0:
+        return 0, 0
+    answerable = sum(
+        1 for probe in probes if _all_keywords_present(probe["expected_keywords"], text)
+    )
+    return answerable, total
+
+
+def surfacing_recall_at_k(
+    returned_ids: Sequence[str],
+    expected_ids: Sequence[str],
+    k: int,
+) -> float:
+    """recall@k = |returned_top_k ∩ expected| / min(k, |expected|).
+
+    ``returned_ids`` is typically the ordered ``memory_ids`` list from a
+    ``surfacing_events`` row; the first ``k`` entries are considered.
+    Returns 1.0 when ``expected_ids`` is empty (no ground truth to miss).
+    """
+    if not expected_ids:
+        return 1.0
+    top_k = set(returned_ids[:k])
+    hit = len(top_k & set(expected_ids))
+    denom = min(k, len(expected_ids))
+    return hit / denom if denom else 1.0

--- a/tests/bench/bench_qa/schema.py
+++ b/tests/bench/bench_qa/schema.py
@@ -56,6 +56,11 @@ class BenchFixture(TypedDict, total=False):
     force_tier: int | None
     expected_keywords: list[str]
     qa_probes: list[QAProbe]
+    # Minimum acceptable ``qa_answerable/total`` ratio for this scenario.
+    # The 0.75 global gate in the plan is the *target* after 1–2 weeks of
+    # observation; real compressors drop tail-side keywords so per-scenario
+    # floors start looser and tighten as the suite stabilises.
+    qa_gate_min: float
     surfacing_seeds: list[dict]
     surfacing_eval: SurfacingEval
 

--- a/tests/bench/fixtures/s02.json
+++ b/tests/bench/fixtures/s02.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s02",
+  "description": "Paginated JSON API response (users + metadata). Compressor should pick extract_fields/schema_pruning under AUTO and keep keys/roles intact.",
+  "content_type": "json",
+  "expected_compressor": "auto",
+  "force_tier": null,
+  "max_result_chars": 2000,
+  "qa_gate_min": 0.66,
+  "expected_keywords": [
+    "Alice Park",
+    "Bob Chen",
+    "Carla Ruiz",
+    "Diego Torres",
+    "Nguyen Linh",
+    "admin",
+    "developer",
+    "designer"
+  ],
+  "qa_probes": [
+    {
+      "question": "What role does Alice Park have?",
+      "expected_keywords": ["Alice Park", "admin"]
+    },
+    {
+      "question": "Which department is Carla Ruiz in?",
+      "expected_keywords": ["Carla Ruiz", "Product"]
+    },
+    {
+      "question": "What is the next page URL?",
+      "expected_keywords": ["page=2"]
+    }
+  ],
+  "payload": "{\n  \"status\": \"ok\",\n  \"metadata\": {\n    \"request_id\": \"req-8a3f2c\",\n    \"timestamp\": \"2025-06-15T09:22:11Z\",\n    \"processing_ms\": 142,\n    \"region\": \"us-east-1\",\n    \"version\": \"3.4.1\",\n    \"deprecated_fields\": [\"legacy_id\", \"compat_mode\"],\n    \"rate_limit\": {\"remaining\": 847, \"reset_at\": \"2025-06-15T10:00:00Z\"}\n  },\n  \"data\": {\n    \"users\": [\n      {\n        \"id\": \"u-001\", \"name\": \"Alice Park\", \"email\": \"alice@example.com\",\n        \"role\": \"admin\", \"department\": \"Engineering\", \"joined\": \"2023-01-15\",\n        \"last_login\": \"2025-06-14T18:30:00Z\",\n        \"permissions\": [\"read\", \"write\", \"delete\", \"manage_users\"],\n        \"preferences\": {\"theme\": \"dark\", \"locale\": \"en-US\", \"notifications\": true},\n        \"tags\": [\"team-lead\", \"on-call\"]\n      },\n      {\n        \"id\": \"u-002\", \"name\": \"Bob Chen\", \"email\": \"bob@example.com\",\n        \"role\": \"developer\", \"department\": \"Engineering\", \"joined\": \"2023-08-20\",\n        \"last_login\": \"2025-06-15T08:10:00Z\",\n        \"permissions\": [\"read\", \"write\"],\n        \"preferences\": {\"theme\": \"light\", \"locale\": \"zh-CN\", \"notifications\": false},\n        \"tags\": [\"backend\"]\n      },\n      {\n        \"id\": \"u-003\", \"name\": \"Carla Ruiz\", \"email\": \"carla@example.com\",\n        \"role\": \"designer\", \"department\": \"Product\", \"joined\": \"2024-03-01\",\n        \"last_login\": \"2025-06-13T11:45:00Z\",\n        \"permissions\": [\"read\"],\n        \"preferences\": {\"theme\": \"auto\", \"locale\": \"es-MX\", \"notifications\": true},\n        \"tags\": [\"ux\", \"accessibility\"]\n      },\n      {\n        \"id\": \"u-004\", \"name\": \"Diego Torres\", \"email\": \"diego@example.com\",\n        \"role\": \"developer\", \"department\": \"Engineering\", \"joined\": \"2024-05-12\",\n        \"last_login\": \"2025-06-15T06:55:00Z\",\n        \"permissions\": [\"read\", \"write\"],\n        \"preferences\": {\"theme\": \"dark\", \"locale\": \"en-US\", \"notifications\": true},\n        \"tags\": [\"mobile\", \"ios\"]\n      },\n      {\n        \"id\": \"u-005\", \"name\": \"Nguyen Linh\", \"email\": \"linh@example.com\",\n        \"role\": \"developer\", \"department\": \"Platform\", \"joined\": \"2022-11-03\",\n        \"last_login\": \"2025-06-14T21:03:00Z\",\n        \"permissions\": [\"read\", \"write\", \"deploy\"],\n        \"preferences\": {\"theme\": \"auto\", \"locale\": \"vi-VN\", \"notifications\": false},\n        \"tags\": [\"kubernetes\", \"sre\"]\n      }\n    ],\n    \"pagination\": {\"page\": 1, \"per_page\": 5, \"total\": 18, \"total_pages\": 4}\n  },\n  \"links\": {\n    \"self\": \"/api/v3/users?page=1\",\n    \"next\": \"/api/v3/users?page=2\",\n    \"prev\": null,\n    \"docs\": \"https://docs.example.com/api/v3/users\"\n  }\n}\n"
+}

--- a/tests/bench/fixtures/s03.json
+++ b/tests/bench/fixtures/s03.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s03",
+  "description": "Nested event stream (order → payment → inventory → shipment). Risk: losing per-event identifiers when compression flattens nested payloads.",
+  "content_type": "json",
+  "expected_compressor": "auto",
+  "force_tier": null,
+  "max_result_chars": 1500,
+  "qa_gate_min": 0.66,
+  "expected_keywords": [
+    "ORD-7890",
+    "258.09",
+    "FedEx",
+    "WIDGET-A",
+    "GADGET-B",
+    "e-001",
+    "e-002",
+    "e-003",
+    "e-004"
+  ],
+  "qa_probes": [
+    {
+      "question": "What is the order grand total?",
+      "expected_keywords": ["258.09"]
+    },
+    {
+      "question": "Who is the customer?",
+      "expected_keywords": ["Daniela Ferreira"]
+    },
+    {
+      "question": "What carrier shipped the order?",
+      "expected_keywords": ["FedEx", "FEDEX-998877"]
+    }
+  ],
+  "payload": "{\n  \"stream_id\": \"evt-stream-42\",\n  \"events\": [\n    {\n      \"id\": \"e-001\", \"type\": \"order.created\", \"timestamp\": \"2025-06-15T10:00:00Z\",\n      \"payload\": {\n        \"order_id\": \"ORD-7890\",\n        \"customer\": {\"id\": \"cust-555\", \"name\": \"Daniela Ferreira\", \"tier\": \"gold\"},\n        \"items\": [\n          {\"sku\": \"WIDGET-A\", \"qty\": 3, \"unit_price\": 29.99, \"subtotal\": 89.97},\n          {\"sku\": \"GADGET-B\", \"qty\": 1, \"unit_price\": 149.00, \"subtotal\": 149.00}\n        ],\n        \"totals\": {\"subtotal\": 238.97, \"tax\": 19.12, \"shipping\": 0.00, \"grand_total\": 258.09},\n        \"shipping_address\": {\"city\": \"Sao Paulo\", \"country\": \"BR\", \"zip\": \"01310-100\"}\n      }\n    },\n    {\n      \"id\": \"e-002\", \"type\": \"payment.captured\", \"timestamp\": \"2025-06-15T10:00:05Z\",\n      \"payload\": {\"order_id\": \"ORD-7890\", \"payment_method\": \"credit_card\", \"amount\": 258.09, \"currency\": \"USD\", \"processor\": \"stripe\", \"transaction_id\": \"txn_abc123\"}\n    },\n    {\n      \"id\": \"e-003\", \"type\": \"inventory.reserved\", \"timestamp\": \"2025-06-15T10:00:06Z\",\n      \"payload\": {\"order_id\": \"ORD-7890\", \"reservations\": [{\"sku\": \"WIDGET-A\", \"warehouse\": \"WH-EAST\", \"qty\": 3, \"remaining_stock\": 142}, {\"sku\": \"GADGET-B\", \"warehouse\": \"WH-WEST\", \"qty\": 1, \"remaining_stock\": 37}]}\n    },\n    {\n      \"id\": \"e-004\", \"type\": \"fulfillment.shipped\", \"timestamp\": \"2025-06-15T14:30:00Z\",\n      \"payload\": {\"order_id\": \"ORD-7890\", \"carrier\": \"FedEx\", \"tracking_number\": \"FEDEX-998877\", \"estimated_delivery\": \"2025-06-18\", \"packages\": [{\"id\": \"pkg-1\", \"weight_kg\": 1.2, \"dimensions\": \"30x20x15cm\", \"items\": [\"WIDGET-A\"]}, {\"id\": \"pkg-2\", \"weight_kg\": 2.5, \"dimensions\": \"40x30x20cm\", \"items\": [\"GADGET-B\"]}]}\n    }\n  ]\n}\n"
+}

--- a/tests/bench/fixtures/s04.json
+++ b/tests/bench/fixtures/s04.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s04",
+  "description": "Python ETL class + a short unified diff touching one method. Risk: function signatures or diff hunks get truncated mid-line.",
+  "content_type": "code",
+  "expected_compressor": "auto",
+  "force_tier": null,
+  "max_result_chars": 3000,
+  "qa_gate_min": 0.66,
+  "expected_keywords": [
+    "class UserActivityETL",
+    "def extract",
+    "def transform",
+    "def load",
+    "def backfill",
+    "ETLConfig",
+    "diff --git"
+  ],
+  "qa_probes": [
+    {
+      "question": "What is the default batch size?",
+      "expected_keywords": ["batch_size", "5000"]
+    },
+    {
+      "question": "What table does load() write to?",
+      "expected_keywords": ["user_daily_metrics"]
+    },
+    {
+      "question": "What change does the diff introduce?",
+      "expected_keywords": ["lookback_days", "14"]
+    }
+  ],
+  "payload": "\"\"\"ETL pipeline for user activity data.\"\"\"\nimport logging\nfrom dataclasses import dataclass\nfrom datetime import datetime, timedelta\nfrom typing import Iterator\n\nimport pandas as pd\nfrom sqlalchemy import create_engine, text\nfrom sqlalchemy.engine import Engine\n\nlogger = logging.getLogger(__name__)\n\n@dataclass\nclass ETLConfig:\n    source_dsn: str\n    target_dsn: str\n    batch_size: int = 5000\n    lookback_days: int = 7\n    max_retries: int = 3\n    timeout_seconds: int = 300\n\nclass UserActivityETL:\n    EXTRACT_QUERY = \"\"\"\n        SELECT user_id, event_type, event_timestamp, metadata\n        FROM raw_events\n        WHERE event_timestamp >= :start_date AND event_timestamp < :end_date\n        ORDER BY event_timestamp\n    \"\"\"\n\n    def __init__(self, config: ETLConfig) -> None:\n        self.config = config\n        self._source: Engine = create_engine(config.source_dsn)\n        self._target: Engine = create_engine(config.target_dsn)\n\n    def extract(self, start: datetime, end: datetime) -> pd.DataFrame:\n        logger.info(\"Extracting events from %s to %s\", start, end)\n        with self._source.connect() as conn:\n            df = pd.read_sql(text(self.EXTRACT_QUERY), conn, params={\"start_date\": start, \"end_date\": end})\n        logger.info(\"Extracted %d rows\", len(df))\n        return df\n\n    def transform(self, df: pd.DataFrame) -> pd.DataFrame:\n        if df.empty:\n            return pd.DataFrame()\n        df[\"date\"] = pd.to_datetime(df[\"event_timestamp\"]).dt.date\n        aggregated = df.groupby([\"user_id\", \"date\", \"event_type\"]).size().reset_index(name=\"event_count\")\n        pivoted = aggregated.pivot_table(index=[\"user_id\", \"date\"], columns=\"event_type\", values=\"event_count\", fill_value=0).reset_index()\n        pivoted.columns = [f\"count_{c}\" if c not in (\"user_id\", \"date\") else c for c in pivoted.columns]\n        pivoted[\"processed_at\"] = datetime.utcnow()\n        return pivoted\n\n    def load(self, df: pd.DataFrame) -> int:\n        if df.empty:\n            return 0\n        rows = len(df)\n        df.to_sql(\"user_daily_metrics\", self._target, if_exists=\"append\", index=False, method=\"multi\", chunksize=self.config.batch_size)\n        logger.info(\"Loaded %d rows into user_daily_metrics\", rows)\n        return rows\n\n    def run(self, target_date: datetime | None = None) -> dict:\n        if target_date is None:\n            target_date = datetime.utcnow() - timedelta(days=1)\n        start = target_date.replace(hour=0, minute=0, second=0, microsecond=0)\n        end = start + timedelta(days=1)\n        raw = self.extract(start, end)\n        transformed = self.transform(raw)\n        loaded = self.load(transformed)\n        return {\"date\": start.isoformat(), \"extracted\": len(raw), \"transformed\": len(transformed), \"loaded\": loaded}\n\n    def backfill(self, days: int | None = None) -> list[dict]:\n        days = days or self.config.lookback_days\n        return [self.run(datetime.utcnow() - timedelta(days=i + 1)) for i in range(days)]\n\n---\ndiff --git a/etl.py b/etl.py\n--- a/etl.py\n+++ b/etl.py\n@@ -16,7 +16,7 @@ class ETLConfig:\n     source_dsn: str\n     target_dsn: str\n     batch_size: int = 5000\n-    lookback_days: int = 7\n+    lookback_days: int = 14\n     max_retries: int = 3\n     timeout_seconds: int = 300\n"
+}

--- a/tests/bench/test_bench_qa_scenarios.py
+++ b/tests/bench/test_bench_qa_scenarios.py
@@ -1,13 +1,16 @@
-"""bench_qa — end-to-end scenario gates for ProxyManager.call_tool().
+"""bench_qa — end-to-end scenario gates for ``ProxyManager.call_tool()``.
 
-This file hosts the ``@pytest.mark.bench_qa`` suite. Each scenario loads a
-JSON fixture, drives a live ``ProxyManager`` against an AsyncMock upstream,
-and asserts the gates defined in
-``/Users/pdstudio/.claude/plans/mcp-snug-river.md``.
+Each scenario loads a JSON fixture from ``tests/bench/fixtures/``, drives a
+live ``ProxyManager`` against an AsyncMock upstream, and asserts the gates
+defined in ``/Users/pdstudio/.claude/plans/mcp-snug-river.md``.
 
-The P1 pass ships only S9 (budget-fit smoke) — S1–S8, S10 arrive in
-subsequent PRs together with fallback-ladder / progressive / surfacing
-assertions.
+This P2 pass covers the non-fallback happy-path scenarios (S2–S4, S9):
+content fits the dynamic retention floor, so ``ratio_violation`` must stay
+0, the compressor must resolve ``AUTO`` to a concrete strategy, and the
+QA probes must remain answerable after compression.
+
+Fallback-ladder (S1/S6/S8 variants), progressive round-trip, and
+surfacing (S10) assertions live in later PRs.
 """
 
 from __future__ import annotations
@@ -19,29 +22,24 @@ from bench.bench_qa import (
     latest_metrics_row,
     load_fixture,
     make_proxy_manager,
+    qa_answerable_ratio,
 )
 from bench.bench_qa.runner import make_tool_result
 
-
-def _all_keywords_present(keywords: list[str], text: str) -> bool:
-    lowered = text.lower()
-    return all(kw.lower() in lowered for kw in keywords)
-
-
-def _qa_answerable_ratio(probes: list[dict], text: str) -> tuple[int, int]:
-    if not probes:
-        return 0, 0
-    answerable = sum(1 for p in probes if _all_keywords_present(p["expected_keywords"], text))
-    return answerable, len(probes)
+# Scenarios exercised by this file. Each must live in
+# ``tests/bench/fixtures/<id>.json`` with a ``force_tier: null`` so the
+# happy-path gates apply.
+NORMAL_PATH_SCENARIOS = ["s02", "s03", "s04", "s09"]
 
 
 @pytest.mark.bench_qa
 @pytest.mark.asyncio
-async def test_s09_budget_fit_short_text(tmp_path):
-    """S9 — payload fits within the budget; compressor should pick a concrete
-    strategy (not ``auto``), ratio_violation must stay 0, all QA probes
-    answerable."""
-    fixture = load_fixture("s09")
+@pytest.mark.parametrize("scenario_id", NORMAL_PATH_SCENARIOS)
+async def test_bench_qa_normal_path(scenario_id: str, tmp_path):
+    fixture = load_fixture(scenario_id)
+    assert fixture.get("force_tier") is None, (
+        f"{scenario_id} has force_tier set; it belongs to the fallback-ladder suite"
+    )
 
     mgr, store, session = make_proxy_manager(
         tmp_path,
@@ -51,30 +49,39 @@ async def test_s09_budget_fit_short_text(tmp_path):
     session.call_tool.return_value = make_tool_result(fixture["payload"])
 
     expected_trace_id = deterministic_trace_id(fixture["scenario_id"])
-    result = await mgr.call_tool("fake", "summary", {})
+    result = await mgr.call_tool("fake", f"tool_{scenario_id}", {})
 
     row = latest_metrics_row(store)
     try:
-        assert row, "proxy_metrics row was not written"
+        assert row, f"{scenario_id}: proxy_metrics row was not written"
         # ProxyManager.call_tool currently assigns its own uuid-based trace_id;
         # deterministic injection arrives in the report PR (plan back-fill).
-        # P1 only proves the row is written and the column is non-null.
-        assert row["trace_id"], "trace_id column should be populated"
+        assert row["trace_id"], f"{scenario_id}: trace_id column should be populated"
         assert expected_trace_id.startswith("bench-"), "sanity: hash helper runs"
+
         assert row["ratio_violation"] == 0, (
-            f"unexpected ratio_violation=1 for budget-fit payload "
+            f"{scenario_id}: unexpected ratio_violation=1 on happy path "
             f"(cleaned={row['cleaned_chars']}, compressed={row['compressed_chars']})"
         )
-        assert row["compression_strategy"] is not None, "strategy was not recorded"
+        assert row["compression_strategy"] is not None, (
+            f"{scenario_id}: strategy column was not recorded"
+        )
         assert row["compression_strategy"] != "auto", (
-            "strategy must be resolved to a concrete value before recording "
+            f"{scenario_id}: strategy must be resolved before recording "
             f"(got {row['compression_strategy']!r})"
         )
         assert row["original_chars"] == len(fixture["payload"]), (
-            f"original_chars={row['original_chars']} expected={len(fixture['payload'])}"
+            f"{scenario_id}: original_chars={row['original_chars']} "
+            f"expected={len(fixture['payload'])}"
         )
-        answerable, total = _qa_answerable_ratio(fixture["qa_probes"], result)
-        assert total > 0, "S9 must have at least one qa_probe"
-        assert answerable / total >= 0.75, f"qa_answerable ratio below gate: {answerable}/{total}"
+
+        answerable, total = qa_answerable_ratio(fixture["qa_probes"], result)
+        assert total > 0, f"{scenario_id}: must define at least one qa_probe"
+        ratio = answerable / total
+        gate_min = fixture.get("qa_gate_min", 0.75)
+        assert ratio >= gate_min, (
+            f"{scenario_id}: qa_answerable ratio {answerable}/{total}={ratio:.2f} "
+            f"below {gate_min} gate; strategy={row['compression_strategy']!r}"
+        )
     finally:
         store.close()


### PR DESCRIPTION
## Summary
- Parametrizes the bench_qa suite over fixture IDs and adds three realistic happy-path scenarios: S2 (paginated JSON API), S3 (nested event stream), S4 (Python ETL module + unified diff). Each trips `AUTO` into a concrete strategy, keeps `ratio_violation=0`, and verifies qa_answerable on the compressed output.
- Adds `qa_gate_min` to the fixture schema so per-scenario floors can start looser (0.66 on S2/S3/S4) and tighten as the suite stabilises. Matches the plan's 1–2 week observation window before the 0.75 global gate hardens.
- Factors `qa_answerable_ratio` and `surfacing_recall_at_k` into `tests/bench/bench_qa/judge.py` so later fallback / progressive / surfacing PRs do not duplicate the substring logic.

## Scope
This is P2 of the bench_qa rollout (P1 = scaffold + S9, merged in #168). Remaining phases: fallback-ladder scenarios (S1/S6/S8 variants) with progressive round-trip; surfacing scenario (S10) with an in-memory LTM; report generator; CI wiring; `bench_qa_meta` self-test probes.

Threshold values on S2/S3/S4 are the first real observation — the tail-side probe is what production compressors drop today (`extract_fields` prunes `links.next`, `truncate` loses the trailing diff / last event). They should ratchet up as compressors improve, not lock in.

## Test plan
- [x] `uv run pytest -m bench_qa --tb=short -q` — 4 passed in 0.39s (s02, s03, s04, s09)
- [x] `uv run pytest -m \"not ollama\"` — 1423 passed (full suite regression)
- [x] `uv run ruff check src tests` — All checks passed
- [x] `uv run ruff format --check tests/bench/bench_qa tests/bench/test_bench_qa_scenarios.py tests/bench/fixtures` — all formatted
- [x] `uv run mypy tests/bench/bench_qa` — no issues