### PR TITLE
test(bench_qa): fallback-ladder scenarios (S1/S6/S8) + progressive round-trip

### DIFF
--- a/tests/bench/bench_qa/loader.py
+++ b/tests/bench/bench_qa/loader.py
@@ -28,4 +28,9 @@ def load_fixture(scenario_id: str) -> BenchFixture:
             f"fixture {path} declares scenario_id={raw.get('scenario_id')!r}; "
             f"file name implies {scenario_id!r}"
         )
+    multiplier = int(raw.get("payload_multiplier", 1))
+    if multiplier < 1:
+        raise AssertionError(f"fixture {scenario_id}: payload_multiplier={multiplier} must be >= 1")
+    if multiplier > 1:
+        raw["payload"] = raw["payload"] * multiplier
     return raw  # type: ignore[return-value]

--- a/tests/bench/bench_qa/progressive.py
+++ b/tests/bench/bench_qa/progressive.py
@@ -1,0 +1,83 @@
+"""Progressive fallback round-trip helpers for bench_qa.
+
+When ``ProxyManager.call_tool()`` trips the ratio guard into Tier-1
+progressive delivery, the first chunk carries a footer with a
+``stm_proxy_read_more`` pointer. bench_qa reproduces what an agent would
+do — follow that pointer until ``has_more=False`` — and asserts that the
+concatenated content is byte-identical to the cleaned payload
+(PR #160/#165 invariant).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from memtomem_stm.proxy.manager import ProxyManager
+from memtomem_stm.proxy.progressive import PROGRESSIVE_FOOTER_TOKEN
+
+_READ_MORE_POINTER = re.compile(r'stm_proxy_read_more\(key="([^"]+)",\s*offset=(\d+)\)')
+_HAS_MORE_FALSE = "has_more=False"
+_HAS_MORE_TRUE = "has_more=True"
+
+
+@dataclass
+class ReassemblyResult:
+    """Outcome of reading the first chunk + every follow-up ``read_more``."""
+
+    content: str
+    chunks: int
+    has_more_final: bool
+
+
+def split_chunk(text: str) -> tuple[str, str]:
+    """Return ``(content, footer)`` by splitting on ``PROGRESSIVE_FOOTER_TOKEN``.
+
+    The token is the canonical agent-side contract — never split on bare
+    ``\\n---\\n``, which naturally appears in markdown and YAML.
+    """
+    idx = text.find(PROGRESSIVE_FOOTER_TOKEN)
+    if idx == -1:
+        return text, ""
+    return text[:idx], text[idx:]
+
+
+def parse_pointer(footer: str) -> tuple[str, int]:
+    """Extract ``(key, next_offset)`` from a progressive footer.
+
+    Raises ``AssertionError`` if the pointer is missing — that indicates
+    either the fallback did not run or the footer format drifted from
+    ``ProgressiveChunker._build_footer``.
+    """
+    match = _READ_MORE_POINTER.search(footer)
+    assert match, f"progressive footer missing read_more pointer: {footer!r}"
+    return match.group(1), int(match.group(2))
+
+
+def reassemble(mgr: ProxyManager, first_chunk: str, *, max_steps: int = 200) -> ReassemblyResult:
+    """Follow ``stm_proxy_read_more`` calls until ``has_more=False``.
+
+    ``max_steps`` is a hard ceiling — larger values would indicate an
+    offset-arithmetic bug (e.g. zero-width chunks) rather than a legitimate
+    payload, and infinite-looping here would hide the regression.
+    """
+    content, footer = split_chunk(first_chunk)
+    if _HAS_MORE_FALSE in footer:
+        return ReassemblyResult(content=content, chunks=1, has_more_final=False)
+
+    assert _HAS_MORE_TRUE in footer, f"first chunk lacks both has_more markers: {footer!r}"
+    key, offset = parse_pointer(footer)
+
+    parts = [content]
+    for step in range(max_steps):
+        chunk = mgr.read_more(key, offset)
+        piece, footer = split_chunk(chunk)
+        if piece == "(no more content)" or chunk.startswith("(no more content)"):
+            return ReassemblyResult(content="".join(parts), chunks=len(parts), has_more_final=False)
+        parts.append(piece)
+        offset += len(piece)
+        if _HAS_MORE_FALSE in footer:
+            return ReassemblyResult(content="".join(parts), chunks=len(parts), has_more_final=False)
+    raise AssertionError(
+        f"reassembly exceeded {max_steps} chunks — suspected offset-arithmetic bug"
+    )

--- a/tests/bench/bench_qa/schema.py
+++ b/tests/bench/bench_qa/schema.py
@@ -54,6 +54,9 @@ class BenchFixture(TypedDict, total=False):
     expected_compressor: str
     max_result_chars: int
     force_tier: int | None
+    # Repeat ``payload`` N times on load. Keeps fixture files small when a
+    # scenario only needs a large (10–20 KB) payload with repeating structure.
+    payload_multiplier: int
     expected_keywords: list[str]
     qa_probes: list[QAProbe]
     # Minimum acceptable ``qa_answerable/total`` ratio for this scenario.

--- a/tests/bench/fixtures/s01.json
+++ b/tests/bench/fixtures/s01.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s01",
+  "description": "Long markdown guide (multiple headings). Forced into Tier-2 hybrid_fallback by stubbing progressive to raise. Verifies head + TOC is preserved.",
+  "content_type": "markdown",
+  "expected_compressor": "auto",
+  "force_tier": 2,
+  "max_result_chars": 500,
+  "payload_multiplier": 4,
+  "qa_gate_min": 0.66,
+  "expected_keywords": [
+    "HNSW",
+    "IVF",
+    "M parameter",
+    "Pinecone"
+  ],
+  "qa_probes": [
+    {
+      "question": "What indexing algorithm is covered?",
+      "expected_keywords": ["HNSW"]
+    },
+    {
+      "question": "What vector databases are compared?",
+      "expected_keywords": ["Pinecone"]
+    }
+  ],
+  "payload": "# Vector Database Performance Guide\n\n## Overview\n\nThis section covers best practices for deploying vector databases in production with high-throughput requirements. We focus on three engines: Pinecone, Weaviate, and Qdrant.\n\n## Indexing Strategies\n\n### HNSW (Hierarchical Navigable Small World)\n\nHNSW is the default indexing algorithm. Key knobs: M parameter (16-64), ef_construction (200+), ef_search (50-200). Higher M improves recall but increases memory usage by ~8 bytes per link.\n\n### IVF (Inverted File Index)\n\nIVF partitions the vector space into Voronoi cells. Knobs: nlist (sqrt(N) to 4*sqrt(N)), nprobe (5-20% of nlist). IVF uses less memory than HNSW but has lower recall at the same latency.\n\n## Memory Planning\n\nFormula: memory_gb = num_vectors * dimensions * 4 / 1e9 * overhead_factor. HNSW overhead 1.5-2.0x; IVF overhead 1.1-1.3x. Plan for 2x the current vector count.\n\n## Production Checklist\n\n- Set up monitoring for recall degradation\n- Configure automatic index rebuilding thresholds\n- Implement request-level timeout (recommend 100ms)\n- Enable WAL for crash recovery\n- Set memory limits to 80% of available RAM\n\n"
+}

--- a/tests/bench/fixtures/s06.json
+++ b/tests/bench/fixtures/s06.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s06",
+  "description": "Mixed log dump (stack traces + JSON + plain lines) forced into Tier-1 progressive_fallback. Verifies zero-loss round-trip byte-identity across stm_proxy_read_more chunks.",
+  "content_type": "text",
+  "expected_compressor": "auto",
+  "force_tier": 1,
+  "max_result_chars": 500,
+  "payload_multiplier": 12,
+  "qa_gate_min": 0.66,
+  "expected_keywords": [
+    "Traceback",
+    "payment-gateway",
+    "INC-2025-0613",
+    "ACCESS EXCLUSIVE"
+  ],
+  "qa_probes": [
+    {
+      "question": "What incident ID is referenced?",
+      "expected_keywords": ["INC-2025-0613"]
+    },
+    {
+      "question": "Which lock type blocked queries?",
+      "expected_keywords": ["ACCESS EXCLUSIVE"]
+    },
+    {
+      "question": "What service was affected?",
+      "expected_keywords": ["payment-gateway"]
+    }
+  ],
+  "payload": "2025-06-13T03:42:01Z ERROR [payment-gateway] connection pool exhausted — pool=payment-db-primary max=50 active=50 waiting=812\n2025-06-13T03:42:02Z ERROR [payment-gateway] {\"event\":\"db.query.blocked\",\"lock\":\"ACCESS EXCLUSIVE\",\"table\":\"transactions\",\"waiting_queries\":812,\"incident\":\"INC-2025-0613\"}\n2025-06-13T03:42:03Z ERROR [payment-gateway] Traceback (most recent call last):\n  File \"/app/payment_gateway/routes.py\", line 142, in charge\n    conn = await pool.acquire(timeout=5.0)\n  File \"/opt/py/asyncpg/pool.py\", line 218, in acquire\n    raise InterfaceError(\"pool exhausted — INC-2025-0613 lock=ACCESS EXCLUSIVE\")\nasyncpg.exceptions.InterfaceError: pool exhausted — INC-2025-0613 lock=ACCESS EXCLUSIVE\n2025-06-13T03:42:04Z WARN  [order-service] upstream payment-gateway returned 503 — correlation=req-abc-1234\n2025-06-13T03:42:05Z INFO  [checkout-ui] retrying payment for order ORD-7890 (attempt 2/3)\n"
+}

--- a/tests/bench/fixtures/s08.json
+++ b/tests/bench/fixtures/s08.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s08",
+  "description": "Heading-light plain text (incident narrative). Forced into Tier-3 truncate_fallback by stubbing both progressive and hybrid. Guarantees a lossy but non-empty floor.",
+  "content_type": "text",
+  "expected_compressor": "auto",
+  "force_tier": 3,
+  "max_result_chars": 500,
+  "payload_multiplier": 5,
+  "qa_gate_min": 0.5,
+  "expected_keywords": [
+    "connection pool",
+    "payment-db-primary",
+    "schema migration"
+  ],
+  "qa_probes": [
+    {
+      "question": "What kind of change triggered the issue?",
+      "expected_keywords": ["schema migration"]
+    },
+    {
+      "question": "Which pool was exhausted?",
+      "expected_keywords": ["payment-db-primary"]
+    }
+  ],
+  "payload": "The incident began at 03:42 UTC when the payment-gateway started returning 503s for every charge attempt. Within five minutes the on-call engineer observed that the connection pool to payment-db-primary was saturated: every slot was occupied by a query waiting on an ACCESS EXCLUSIVE lock. The lock had been acquired by a schema migration deployed at 03:30 that was in the middle of creating a B-tree index on the transactions table. With the table holding roughly 890M rows the index build was estimated to require over 45 minutes. The rollback attempt was blocked because the long-running lock itself prevented any metadata change. The team escalated to the database lead who decided to terminate the migration process rather than wait. Even after the process was killed the connection pool remained saturated because more than 800 queries had already queued behind the original blocker. A rolling restart of the payment-gateway pods cleared the queue. The incident resolved at 05:17 UTC after 95 minutes and affected approximately 14,200 customers. The post-mortem captured two preventive actions: set a lock_timeout of 5s for every migration connection, and add a CI check that flags any migration statement acquiring ACCESS EXCLUSIVE. A third action, adding a circuit breaker to the connection pool with a maximum queue of 50 and a 5s timeout, was assigned to the platform team. Retrospective scheduled for the following Tuesday.\n\n"
+}

--- a/tests/bench/test_bench_qa_fallback.py
+++ b/tests/bench/test_bench_qa_fallback.py
@@ -1,0 +1,161 @@
+"""bench_qa — fallback-ladder gates (Tier-1 progressive, Tier-2 hybrid, Tier-3 truncate).
+
+Each scenario drives ``ProxyManager.call_tool()`` through a forced ratio
+violation so the Tier-N fallback path activates. Assertions build on
+``tests/test_compression_ratio_guard.py`` — **do not** duplicate those
+unit checks; bench_qa adds the scenario-level story (realistic payload,
+QA probes, round-trip byte-identity on Tier-1).
+
+S6 → Tier-1 progressive_fallback: stub ``_apply_compression`` to overshoot
+so the ratio guard takes over; verify that reading every ``stm_proxy_read_more``
+chunk reproduces the cleaned payload exactly (PR #160/#165 invariant).
+
+S1 → Tier-2 hybrid_fallback: also stub ``_apply_progressive`` to raise, so
+the ladder falls through to hybrid; verify the effective strategy and the
+retention floor.
+
+S8 → Tier-3 truncate_fallback: stub progressive and hybrid so the guaranteed
+floor runs; verify the strategy marker and a non-empty, non-violating
+compressed_chars lower bound.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memtomem_stm.proxy.cleaning import DefaultContentCleaner
+from memtomem_stm.proxy.config import CleaningConfig
+
+from bench.bench_qa import latest_metrics_row, load_fixture, make_proxy_manager
+from bench.bench_qa.progressive import reassemble
+from bench.bench_qa.runner import make_tool_result
+
+
+def _stub_raise(*_args, **_kwargs):
+    raise RuntimeError("forced fallback-ladder failure (bench_qa)")
+
+
+@pytest.mark.bench_qa
+@pytest.mark.asyncio
+async def test_s06_tier1_progressive_round_trip(tmp_path):
+    fixture = load_fixture("s06")
+    assert fixture["force_tier"] == 1
+    payload = fixture["payload"]
+    assert len(payload) >= 10_000, (
+        f"s06 payload is {len(payload)} chars; progressive fallback needs >=10KB "
+        "to exceed the dynamic retention floor"
+    )
+
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(payload)
+    # Force compressor to overshoot the retention floor so the ratio guard
+    # promotes the call to progressive delivery.
+    mgr._apply_compression = AsyncMock(return_value=("x" * 50, None))
+
+    first_chunk = await mgr.call_tool("fake", "tool_s06", {})
+    row = latest_metrics_row(store)
+    try:
+        assert row["ratio_violation"] == 1, "Tier-1 should record a violation"
+        assert "→progressive_fallback" in (row["compression_strategy"] or ""), (
+            f"unexpected strategy: {row['compression_strategy']!r}"
+        )
+        assert "stm_proxy_read_more" in first_chunk
+        assert "has_more=True" in first_chunk
+        assert "ttl=" in first_chunk, "progressive footer should expose TTL"
+
+        # Round-trip: follow read_more until has_more=False and compare bytes.
+        # The invariant is against the *cleaned* payload — the pipeline stores
+        # the cleaner's output, not the raw upstream response.
+        reassembled = reassemble(mgr, first_chunk)
+        assert reassembled.has_more_final is False
+        assert reassembled.chunks >= 2, (
+            f"expected multiple chunks for {len(payload)}-char payload, got {reassembled.chunks}"
+        )
+        cleaned = DefaultContentCleaner(CleaningConfig()).clean(payload)
+        assert reassembled.content == cleaned, (
+            "reassembled content differs from cleaned payload — "
+            f"lens {len(reassembled.content)} vs {len(cleaned)}; "
+            "violates the PR #160/#165 byte-identity invariant"
+        )
+    finally:
+        store.close()
+
+
+@pytest.mark.bench_qa
+@pytest.mark.asyncio
+async def test_s01_tier2_hybrid_fallback(tmp_path):
+    fixture = load_fixture("s01")
+    assert fixture["force_tier"] == 2
+    payload = fixture["payload"]
+    assert payload.count("##") >= 3, (
+        "s01 hybrid_fallback needs at least 3 headings so hybrid has structure to preserve"
+    )
+
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(payload)
+    mgr._apply_compression = AsyncMock(return_value=("x" * 50, None))
+    mgr._apply_progressive = _stub_raise  # type: ignore[method-assign]
+
+    result = await mgr.call_tool("fake", "tool_s01", {})
+    row = latest_metrics_row(store)
+    try:
+        assert row["ratio_violation"] == 1
+        strategy = row["compression_strategy"] or ""
+        assert "→hybrid_fallback" in strategy, f"unexpected strategy: {strategy!r}"
+        # Hybrid_fallback honors the retention floor but only after head +
+        # TOC selection, so the exact floor depends on heading density. The
+        # initial observed value on this fixture is ~850 chars — lock in the
+        # sanity lower bound and ratchet up as the suite stabilises.
+        assert row["compressed_chars"] > 500, (
+            f"hybrid_fallback compressed_chars={row['compressed_chars']} is suspiciously small"
+        )
+        # Realistic payload preserves at least one of the expected anchors.
+        lowered = result.lower()
+        assert any(kw.lower() in lowered for kw in fixture["expected_keywords"]), (
+            f"hybrid_fallback lost every expected_keyword; result[:200]={result[:200]!r}"
+        )
+    finally:
+        store.close()
+
+
+@pytest.mark.bench_qa
+@pytest.mark.asyncio
+async def test_s08_tier3_truncate_fallback(tmp_path):
+    fixture = load_fixture("s08")
+    assert fixture["force_tier"] == 3
+
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+    mgr._apply_compression = AsyncMock(return_value=("x" * 50, None))
+    mgr._apply_progressive = _stub_raise  # type: ignore[method-assign]
+    mgr._apply_hybrid = _stub_raise  # type: ignore[method-assign]
+
+    result = await mgr.call_tool("fake", "tool_s08", {})
+    row = latest_metrics_row(store)
+    try:
+        assert row["ratio_violation"] == 1
+        strategy = row["compression_strategy"] or ""
+        assert "→truncate_fallback" in strategy, f"unexpected strategy: {strategy!r}"
+        # Tier-3 guarantees a floor — result must be non-empty.
+        assert len(result) > 0, "Tier-3 truncate_fallback returned empty result"
+        # Observed compressed_chars on this fixture is ~1_000; lock a
+        # conservative lower bound that still catches empty-truncate bugs.
+        assert row["compressed_chars"] > 500, (
+            f"truncate_fallback compressed_chars={row['compressed_chars']} below expected floor"
+        )
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- Adds three fallback-tier scenarios to the bench_qa suite — S6 → Tier-1 progressive, S1 → Tier-2 hybrid, S8 → Tier-3 truncate — each forcing the ratio guard path the same way `tests/test_compression_ratio_guard.py` does but with realistic payloads and QA probes instead of raw byte patterns.
- Introduces the round-trip byte-identity gate for progressive fallback: the S6 test splits on `PROGRESSIVE_FOOTER_TOKEN`, follows every `stm_proxy_read_more(key, offset)` call until `has_more=False`, and asserts the concatenation equals the cleaned payload — pinning the PR #160/#165 invariant at the scenario level.
- Adds a `payload_multiplier` fixture field so 10–20 KB fallback payloads can live as a small base block × N on load, keeping the JSON readable.
- New helper `bench.bench_qa.progressive.reassemble` is reused by any later progressive-surface (S10-ish) work.

## Scope
This is P3 of the bench_qa rollout (P1 = scaffold + S9, P2 = parametrize + S2/S3/S4). Remaining: surfacing scenario (S10) with an in-memory LTM, report generator, CI wiring, and the `bench_qa_meta` self-test probes.

## Notes on thresholds
Lower bounds for `compressed_chars` on S1/S8 are intentionally loose (>500). Initial observations are 800–1100 chars, so the gate is a non-empty sanity floor only. The plan allows these per-scenario floors to ratchet up after 1–2 weeks of observation, once the real compressor behavior is understood.

## Test plan
- [x] `uv run pytest -m bench_qa --tb=short -q` — 7 passed in 0.43s (s01/s02/s03/s04/s06/s08/s09)
- [x] `uv run pytest -m \"not ollama\"` — 1426 passed (full regression)
- [x] `uv run ruff check src tests` — All checks passed
- [x] `uv run ruff format --check tests/bench/bench_qa tests/bench/test_bench_qa_fallback.py` — formatted
- [x] `uv run mypy tests/bench/bench_qa` — no issues