### PR TITLE
ci(bench_qa): frozen JSON/Markdown report + advisory CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,28 @@ jobs:
             notebooks/02_compression_and_selective.ipynb \
             notebooks/03_memory_surfacing.ipynb \
             --nbmake-timeout=180 --tb=short -q
+
+  bench_qa:
+    # Advisory for the first 1–2 weeks while per-scenario thresholds
+    # settle. Do not promote to a required check until qa_gate_min /
+    # compressed_chars floors have been ratcheted up from observed data.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - run: uv sync --frozen
+      - name: Run bench_qa suite
+        env:
+          BENCH_QA_REPORT_DIR: ${{ github.workspace }}/bench-qa-report
+        run: uv run pytest -m bench_qa --tb=short -q
+      - name: Upload bench_qa report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-qa-report
+          path: bench-qa-report/
+          if-no-files-found: warn
+          retention-days: 14

--- a/tests/bench/bench_qa/report.py
+++ b/tests/bench/bench_qa/report.py
@@ -1,0 +1,177 @@
+"""bench_qa report collector — frozen JSON + readable markdown summary.
+
+Scenario tests call :meth:`BenchReportCollector.record_scenario` after
+their own gate assertions; after the pytest session finishes, the
+conftest writes a single ``report.json`` + ``summary.md`` to the
+configured output dir (default: ``/tmp/stm-qa-<ts>/``).
+
+Determinism: ``report.json`` excludes wall-clock fields that would
+break a two-run diff — latencies, timestamps, and the ``run_timestamp``
+header are canonical strip candidates when diffing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from pathlib import Path
+
+from .schema import (
+    REPORT_SCHEMA_VERSION,
+    BenchReport,
+    MetricSummary,
+    ProgressiveResult,
+    QAResult,
+    RuleJudgeResult,
+    ScenarioReport,
+    SurfacingResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_metrics(row: dict, original_chars: int) -> MetricSummary:
+    cleaned = row.get("cleaned_chars", 0) or 0
+    compressed = row.get("compressed_chars", 0) or 0
+    ratio = compressed / cleaned if cleaned else 0.0
+    return MetricSummary(
+        original_chars=row.get("original_chars", original_chars) or original_chars,
+        cleaned_chars=cleaned,
+        compressed_chars=compressed,
+        compression_ratio=round(ratio, 4),
+        compression_strategy=row.get("compression_strategy"),
+        ratio_violation=int(row.get("ratio_violation") or 0),
+        surfacing_on_progressive_ok=row.get("surfacing_on_progressive_ok"),
+        surface_error=row.get("surface_error"),
+        clean_ms=float(row.get("clean_ms") or 0.0),
+        compress_ms=float(row.get("compress_ms") or 0.0),
+        surface_ms=float(row.get("surface_ms") or 0.0),
+    )
+
+
+class BenchReportCollector:
+    """Accumulates one :class:`ScenarioReport` per bench_qa test.
+
+    Intentionally in-memory and process-local — the conftest session hook
+    flushes to disk exactly once. Thread safety is not required because
+    pytest bench_qa runs are single-process.
+    """
+
+    def __init__(self) -> None:
+        self._rows: list[ScenarioReport] = []
+
+    def has_data(self) -> bool:
+        return bool(self._rows)
+
+    def record_scenario(
+        self,
+        *,
+        scenario_id: str,
+        trace_id: str,
+        row: dict,
+        qa_answerable: int,
+        qa_total: int,
+        original_chars: int,
+        verdict: str = "pass",
+        rule_score: float | None = None,
+        missing_keywords: list[str] | None = None,
+        progressive: ProgressiveResult | None = None,
+        surfacing: SurfacingResult | None = None,
+    ) -> None:
+        metrics = _coerce_metrics(row, original_chars)
+        qa_ratio = qa_answerable / qa_total if qa_total else 1.0
+        qa_result = QAResult(
+            answerable=qa_answerable,
+            total=qa_total,
+            ratio=round(qa_ratio, 4),
+        )
+        rule = RuleJudgeResult(
+            score=round(rule_score, 2) if rule_score is not None else 0.0,
+            missing_keywords=list(missing_keywords or []),
+        )
+        entry: ScenarioReport = {
+            "scenario_id": scenario_id,
+            "trace_id": trace_id,
+            "metrics": metrics,
+            "rule_judge": rule,
+            "qa": qa_result,
+            "tier": metrics["compression_strategy"] or "unknown",
+            "verdict": verdict,  # type: ignore[typeddict-item]
+        }
+        if progressive is not None:
+            entry["progressive"] = progressive
+        if surfacing is not None:
+            entry["surfacing"] = surfacing
+        self._rows.append(entry)
+
+    def build_report(self, *, run_seed: int = 0) -> BenchReport:
+        tier_hist: Counter[str] = Counter(r["tier"] for r in self._rows)
+        totals = {
+            "scenarios": float(len(self._rows)),
+            "passing": float(sum(1 for r in self._rows if r["verdict"] == "pass")),
+            "failing": float(sum(1 for r in self._rows if r["verdict"] == "fail")),
+            "tokens_saved_approx": float(
+                sum(
+                    max(0, r["metrics"]["cleaned_chars"] - r["metrics"]["compressed_chars"])
+                    for r in self._rows
+                )
+                // 4
+            ),
+        }
+        return BenchReport(
+            schema_version=REPORT_SCHEMA_VERSION,
+            run_seed=run_seed,
+            scenarios=sorted(self._rows, key=lambda r: r["scenario_id"]),
+            tier_histogram=dict(tier_hist),
+            totals=totals,
+        )
+
+    def write(self, out_dir: Path, *, run_seed: int = 0) -> Path:
+        """Write ``report.json`` and ``summary.md`` under *out_dir*.
+
+        Creates the directory if missing. Returns the output directory so
+        callers can log it for CI artifact upload.
+        """
+        out_dir.mkdir(parents=True, exist_ok=True)
+        report = self.build_report(run_seed=run_seed)
+        (out_dir / "report.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        (out_dir / "summary.md").write_text(_format_summary_md(report), encoding="utf-8")
+        logger.info("bench_qa report written to %s (%d scenarios)", out_dir, len(self._rows))
+        return out_dir
+
+
+def _format_summary_md(report: BenchReport) -> str:
+    """Human-readable table for CI logs and manual review."""
+    lines = [
+        "# bench_qa summary",
+        "",
+        f"- Scenarios: {int(report['totals']['scenarios'])}",
+        f"- Passing: {int(report['totals']['passing'])}",
+        f"- Failing: {int(report['totals']['failing'])}",
+        f"- Tokens saved (approx): {int(report['totals']['tokens_saved_approx'])}",
+        "",
+        "## Tier histogram",
+        "",
+    ]
+    for tier, count in sorted(report["tier_histogram"].items()):
+        lines.append(f"- `{tier}`: {count}")
+    lines += [
+        "",
+        "## Scenarios",
+        "",
+        "| id | tier | ratio | violation | qa | verdict |",
+        "|----|------|-------|-----------|----|---------|",
+    ]
+    for r in report["scenarios"]:
+        m = r["metrics"]
+        qa = r["qa"]
+        lines.append(
+            f"| {r['scenario_id']} | `{r['tier']}` | {m['compression_ratio']:.2f} | "
+            f"{m['ratio_violation']} | {qa['answerable']}/{qa['total']} | "
+            f"**{r['verdict']}** |"
+        )
+    lines.append("")
+    return "\n".join(lines)

--- a/tests/bench/conftest.py
+++ b/tests/bench/conftest.py
@@ -1,0 +1,50 @@
+"""Session-level plumbing for bench_qa — report collection + final write.
+
+The ``bench_qa_report`` fixture returns a process-wide
+:class:`bench.bench_qa.report.BenchReportCollector`. Scenario tests call
+``record_scenario`` after their own gate assertions; the
+``pytest_sessionfinish`` hook flushes ``report.json`` + ``summary.md``
+to ``$BENCH_QA_REPORT_DIR`` (or ``/tmp/stm-qa-<ts>/`` when the env var
+is unset) provided at least one bench_qa scenario ran.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from bench.bench_qa.report import BenchReportCollector
+
+_COLLECTOR: BenchReportCollector | None = None
+
+
+def _collector() -> BenchReportCollector:
+    global _COLLECTOR
+    if _COLLECTOR is None:
+        _COLLECTOR = BenchReportCollector()
+    return _COLLECTOR
+
+
+@pytest.fixture(scope="session")
+def bench_qa_report() -> BenchReportCollector:
+    return _collector()
+
+
+def _resolve_output_dir() -> Path:
+    env = os.environ.get("BENCH_QA_REPORT_DIR")
+    if env:
+        return Path(env)
+    return Path(f"/tmp/stm-qa-{int(time.time())}")
+
+
+def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001 — pytest hook signature
+    collector = _COLLECTOR
+    if collector is None or not collector.has_data():
+        return
+    out_dir = _resolve_output_dir()
+    path = collector.write(out_dir)
+    # Emit to stdout so CI logs pick it up alongside the test summary.
+    print(f"\nbench_qa report written to: {path}")

--- a/tests/bench/test_bench_qa_fallback.py
+++ b/tests/bench/test_bench_qa_fallback.py
@@ -39,7 +39,7 @@ def _stub_raise(*_args, **_kwargs):
 
 @pytest.mark.bench_qa
 @pytest.mark.asyncio
-async def test_s06_tier1_progressive_round_trip(tmp_path):
+async def test_s06_tier1_progressive_round_trip(tmp_path, bench_qa_report):
     fixture = load_fixture("s06")
     assert fixture["force_tier"] == 1
     payload = fixture["payload"]
@@ -83,13 +83,28 @@ async def test_s06_tier1_progressive_round_trip(tmp_path):
             f"lens {len(reassembled.content)} vs {len(cleaned)}; "
             "violates the PR #160/#165 byte-identity invariant"
         )
+
+        bench_qa_report.record_scenario(
+            scenario_id="s06",
+            trace_id=row["trace_id"],
+            row=row,
+            qa_answerable=0,
+            qa_total=0,
+            original_chars=len(payload),
+            verdict="pass",
+            progressive={
+                "round_trip_equal": True,
+                "chunks": reassembled.chunks,
+                "total_chars": len(reassembled.content),
+            },
+        )
     finally:
         store.close()
 
 
 @pytest.mark.bench_qa
 @pytest.mark.asyncio
-async def test_s01_tier2_hybrid_fallback(tmp_path):
+async def test_s01_tier2_hybrid_fallback(tmp_path, bench_qa_report):
     fixture = load_fixture("s01")
     assert fixture["force_tier"] == 2
     payload = fixture["payload"]
@@ -124,13 +139,23 @@ async def test_s01_tier2_hybrid_fallback(tmp_path):
         assert any(kw.lower() in lowered for kw in fixture["expected_keywords"]), (
             f"hybrid_fallback lost every expected_keyword; result[:200]={result[:200]!r}"
         )
+
+        bench_qa_report.record_scenario(
+            scenario_id="s01",
+            trace_id=row["trace_id"],
+            row=row,
+            qa_answerable=0,
+            qa_total=0,
+            original_chars=len(payload),
+            verdict="pass",
+        )
     finally:
         store.close()
 
 
 @pytest.mark.bench_qa
 @pytest.mark.asyncio
-async def test_s08_tier3_truncate_fallback(tmp_path):
+async def test_s08_tier3_truncate_fallback(tmp_path, bench_qa_report):
     fixture = load_fixture("s08")
     assert fixture["force_tier"] == 3
 
@@ -156,6 +181,16 @@ async def test_s08_tier3_truncate_fallback(tmp_path):
         # conservative lower bound that still catches empty-truncate bugs.
         assert row["compressed_chars"] > 500, (
             f"truncate_fallback compressed_chars={row['compressed_chars']} below expected floor"
+        )
+
+        bench_qa_report.record_scenario(
+            scenario_id="s08",
+            trace_id=row["trace_id"],
+            row=row,
+            qa_answerable=0,
+            qa_total=0,
+            original_chars=len(fixture["payload"]),
+            verdict="pass",
         )
     finally:
         store.close()

--- a/tests/bench/test_bench_qa_scenarios.py
+++ b/tests/bench/test_bench_qa_scenarios.py
@@ -35,7 +35,7 @@ NORMAL_PATH_SCENARIOS = ["s02", "s03", "s04", "s09"]
 @pytest.mark.bench_qa
 @pytest.mark.asyncio
 @pytest.mark.parametrize("scenario_id", NORMAL_PATH_SCENARIOS)
-async def test_bench_qa_normal_path(scenario_id: str, tmp_path):
+async def test_bench_qa_normal_path(scenario_id: str, tmp_path, bench_qa_report):
     fixture = load_fixture(scenario_id)
     assert fixture.get("force_tier") is None, (
         f"{scenario_id} has force_tier set; it belongs to the fallback-ladder suite"
@@ -82,6 +82,16 @@ async def test_bench_qa_normal_path(scenario_id: str, tmp_path):
         assert ratio >= gate_min, (
             f"{scenario_id}: qa_answerable ratio {answerable}/{total}={ratio:.2f} "
             f"below {gate_min} gate; strategy={row['compression_strategy']!r}"
+        )
+
+        bench_qa_report.record_scenario(
+            scenario_id=scenario_id,
+            trace_id=row["trace_id"],
+            row=row,
+            qa_answerable=answerable,
+            qa_total=total,
+            original_chars=len(fixture["payload"]),
+            verdict="pass",
         )
     finally:
         store.close()


### PR DESCRIPTION
## Summary
- Introduces ``BenchReportCollector`` so each bench_qa scenario records its metrics row + qa ratio (and, for S6, the progressive round-trip stats) into a session-level collector. After the pytest session finishes, ``tests/bench/conftest.py`` writes a frozen ``report.json`` plus a human-readable ``summary.md`` under ``\$BENCH_QA_REPORT_DIR`` (default ``/tmp/stm-qa-<ts>/``).
- Wires a new ``bench_qa`` job into ``.github/workflows/ci.yml`` — advisory (``continue-on-error: true``) for the first 1–2 weeks while per-scenario thresholds settle, per plan. The job uploads the report directory as ``bench-qa-report`` (14-day retention) so maintainers can inspect tier distribution without rerunning the suite locally.
- JSON is emitted with ``sort_keys=True`` and excludes live wall-clock summary fields, giving us a clean base for future determinism-diff checks once deterministic ``trace_id`` injection lands.

## Scope
This is P4 of the bench_qa rollout (P1 = scaffold + S9, P2 = S2/S3/S4 + parametrize, P3 = fallback ladder + round-trip). One PR remains: wire the suite into ``scripts/qa-pipeline.sh`` Phase 1.5 and add the ``bench_qa_meta`` self-test probes.

## Why advisory
The ``qa_gate_min`` floors and ``compressed_chars`` lower bounds were set from the very first observation run on each scenario. Promoting this to a required check before real data accrues would either lock in too-tight gates (flaky CI) or require immediate ratchet-up PRs. Advisory gives us two weeks of ``main`` data to tune without blocking merges.

## Report shape (S6 progressive example)
```json
{
  "scenario_id": "s06",
  "tier": "truncate→progressive_fallback",
  "metrics": {"compression_ratio": 0.38, "ratio_violation": 1, ...},
  "progressive": {"round_trip_equal": true, "chunks": 3, "total_chars": 10859},
  "verdict": "pass"
}
```

## Test plan
- [x] ``BENCH_QA_REPORT_DIR=/tmp/stm-qa-p4-test uv run pytest -m bench_qa`` — 7 passed, report.json + summary.md emitted under the configured dir
- [x] ``uv run pytest -m \"not ollama\"`` — 1426 passed (full regression)
- [x] ``uv run ruff check src tests`` — All checks passed
- [x] ``uv run ruff format --check tests/bench/bench_qa tests/bench/conftest.py tests/bench/test_bench_qa_*.py`` — all formatted
- [x] ``uv run mypy tests/bench/bench_qa`` — no issues