### PR TITLE
feat(proxy): optional deterministic trace_id kwarg on call_tool

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -845,7 +845,14 @@ class ProxyManager:
         with traced("proxy_call_cache_hit", metadata={"server": server, "tool": tool}):
             return await self._apply_surfacing(server, tool, arguments, cached, trace_id=trace_id)
 
-    async def call_tool(self, server: str, tool: str, arguments: dict[str, Any]) -> str | list:
+    async def call_tool(
+        self,
+        server: str,
+        tool: str,
+        arguments: dict[str, Any],
+        *,
+        trace_id: str | None = None,
+    ) -> str | list:
         """Forward a tool call to upstream, compress, surface, and return.
 
         Wraps the entire call pipeline in a Langfuse observation span when
@@ -854,10 +861,17 @@ class ProxyManager:
         in ``proxy_metrics.db``. When Langfuse is not configured, ``traced()``
         returns ``nullcontext()`` and the wrapper is a no-op — no perf cost,
         no behavior change for users who don't opt in.
+
+        ``trace_id`` is keyword-only and defaults to a fresh
+        ``uuid.uuid4().hex[:16]``. Callers (e.g. the bench_qa harness) may
+        pass a deterministic value so two runs produce identical
+        ``proxy_metrics``/``surfacing_events`` rows under the same trace,
+        enabling determinism diffs across runs.
         """
         if server not in self._connections:
             raise KeyError(f"Unknown upstream server: '{server}'")
-        trace_id = uuid.uuid4().hex[:16]
+        if trace_id is None:
+            trace_id = uuid.uuid4().hex[:16]
         with traced(
             "proxy_call",
             metadata={"server": server, "tool": tool, "trace_id": trace_id},

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -185,6 +185,25 @@ class TestTraceIdPropagation:
         assert len(trace_ids) == 2
         assert trace_ids[0] != trace_ids[1]
 
+    async def test_caller_supplied_trace_id_is_used_verbatim(self):
+        mgr = _make_manager()
+        mgr._connections["srv"].session.call_tool.return_value = _make_result("ok")
+
+        recorded: list[CallMetrics] = []
+        original_record = mgr.tracker.record
+
+        def capture(m):
+            recorded.append(m)
+            original_record(m)
+
+        mgr.tracker.record = capture
+        # bench_qa uses "bench-<sha256[:16]>" — longer than 16, arbitrary string.
+        fixed = "bench-0123456789abcdef"
+        await mgr.call_tool("srv", "tool", {}, trace_id=fixed)
+        await mgr.call_tool("srv", "tool", {}, trace_id=fixed)
+
+        assert [m.trace_id for m in recorded] == [fixed, fixed]
+
 
 # ── MetricsStore trace_id ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds keyword-only `trace_id: str | None = None` to `ProxyManager.call_tool`. When `None` (production default), the existing `uuid.uuid4().hex[:16]` fallback runs unchanged; when supplied, the value flows verbatim through the span metadata and into `proxy_metrics`/`surfacing_events` rows.
- Enables deterministic `report.json` diffs across bench_qa runs. Previously, the only path to fix the trace id was monkeypatching `memtomem_stm.proxy.manager.uuid.uuid4`, which is brittle and leaks test-mode knowledge into the module's internals.
- No caller currently passes the kwarg, so production behavior is unchanged. Follow-up to the bench_qa P1–P5 rollout (#168–#172); the bench_qa harness is the first planned consumer.

## Test plan

- [x] `uv run pytest tests/test_observability.py::TestTraceIdPropagation -v` — new `test_caller_supplied_trace_id_is_used_verbatim` passes; existing 3 trace_id tests (success path, error path, unique-per-call) unchanged.
- [x] `uv run pytest -m "not ollama and not bench_qa_meta"` — 1427 passed, 3 deselected.
- [x] `uv run pytest -m bench_qa` — 7 passed (existing harness unaffected; does not yet use the kwarg).
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [ ] CI green.