### PR TITLE
test(bench_qa): deterministic trace_id + two-run determinism gate

### DIFF
--- a/tests/bench/bench_qa/__init__.py
+++ b/tests/bench/bench_qa/__init__.py
@@ -7,6 +7,7 @@ See ``/Users/pdstudio/.claude/plans/mcp-snug-river.md`` for the design
 
 from .judge import qa_answerable_ratio, surfacing_recall_at_k
 from .loader import fixtures_dir, load_fixture
+from .report import BenchReportCollector, canonicalize_report
 from .runner import (
     deterministic_trace_id,
     latest_metrics_row,
@@ -23,9 +24,11 @@ from .schema import (
 __all__ = [
     "BenchFixture",
     "BenchReport",
+    "BenchReportCollector",
     "QAProbe",
     "ScenarioReport",
     "SurfacingEval",
+    "canonicalize_report",
     "deterministic_trace_id",
     "fixtures_dir",
     "latest_metrics_row",

--- a/tests/bench/bench_qa/report.py
+++ b/tests/bench/bench_qa/report.py
@@ -7,15 +7,18 @@ configured output dir (default: ``/tmp/stm-qa-<ts>/``).
 
 Determinism: ``report.json`` excludes wall-clock fields that would
 break a two-run diff — latencies, timestamps, and the ``run_timestamp``
-header are canonical strip candidates when diffing.
+header are canonical strip candidates when diffing. Use
+:func:`canonicalize_report` before a deep-equal check.
 """
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from collections import Counter
 from pathlib import Path
+from typing import Any
 
 from .schema import (
     REPORT_SCHEMA_VERSION,
@@ -29,6 +32,41 @@ from .schema import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Fields stripped by ``canonicalize_report`` before a determinism diff.
+# All three carry wall-clock stage timings that are inherently non-reproducible
+# across runs; their values belong in the ``totals`` trend (outside the
+# per-scenario gate surface) but must not enter a deep-equal check.
+_STAGE_TIMING_FIELDS: tuple[str, ...] = ("clean_ms", "compress_ms", "surface_ms")
+
+
+def canonicalize_report(report: BenchReport) -> dict[str, Any]:
+    """Return a copy of *report* with non-reproducible fields stripped.
+
+    Use before ``assert canonicalize(a) == canonicalize(b)`` in a
+    two-run determinism check. The original report is unchanged.
+
+    Stripped:
+
+    * ``scenarios[*].metrics.clean_ms`` / ``compress_ms`` / ``surface_ms``
+      — stage latencies differ run-to-run by definition.
+
+    Preserved:
+
+    * ``trace_id`` — deterministic by construction
+      (``bench-<sha256(scenario_id:run_seed)[:16]>``).
+    * All byte-counted fields (``original_chars``, ``cleaned_chars``,
+      ``compressed_chars``) — identical across runs with fixed payload.
+    * ``tier_histogram`` and ``totals`` aggregates — built from the
+      deterministic counts.
+    """
+    canon: dict[str, Any] = copy.deepcopy(dict(report))
+    for scenario in canon.get("scenarios", []):
+        metrics = scenario.get("metrics", {})
+        for field in _STAGE_TIMING_FIELDS:
+            metrics.pop(field, None)
+    return canon
 
 
 def _coerce_metrics(row: dict, original_chars: int) -> MetricSummary:

--- a/tests/bench/bench_qa/runner.py
+++ b/tests/bench/bench_qa/runner.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from memtomem_stm.proxy.config import (
+    CompressionFeedbackConfig,
     CompressionStrategy,
     ProxyConfig,
     UpstreamServerConfig,
@@ -27,6 +28,23 @@ from memtomem_stm.proxy.config import (
 from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
 from memtomem_stm.proxy.metrics import TokenTracker
 from memtomem_stm.proxy.metrics_store import MetricsStore
+from memtomem_stm.surfacing.config import SurfacingConfig
+
+
+# Drift detector: ``CompressionFeedbackConfig.db_path`` and
+# ``SurfacingConfig.feedback_db_path`` default to the *same* ``stm_feedback.db``
+# in production (plan §Per-run isolation). Bench harness queries assume this —
+# if a future PR bumps one default without the other, the scenario-level
+# ``SELECT ... WHERE trace_id IN (:ids)`` would silently return empty rows.
+# Fail loudly at import time instead.
+_compression_default = CompressionFeedbackConfig().db_path
+_surfacing_default = SurfacingConfig().feedback_db_path
+assert _compression_default == _surfacing_default, (
+    "bench_qa invariant: CompressionFeedbackConfig.db_path "
+    f"({_compression_default}) must match SurfacingConfig.feedback_db_path "
+    f"({_surfacing_default}); both point at the same stm_feedback.db in "
+    "production. Update both defaults together."
+)
 
 
 _COMPRESSION_STRATEGY_BY_NAME: dict[str, CompressionStrategy] = {

--- a/tests/bench/test_bench_qa_determinism.py
+++ b/tests/bench/test_bench_qa_determinism.py
@@ -1,0 +1,131 @@
+"""bench_qa — determinism diff gate.
+
+Two runs of the same scenario under the same ``run_seed`` must produce
+byte-identical ``ScenarioReport`` entries after stripping wall-clock
+timings. This is the load-bearing assumption that makes ``report.json``
+diffs meaningful as a regression signal: without it, every PR's bench
+artifact differs for reasons unrelated to the code under test.
+
+Scope: one scenario (s09, the smallest budget-fit fixture) exercised
+twice in fresh ``tmp_path`` dirs — enough to prove the property per
+scenario without pulling every bench_qa case into a single test. If a
+future change desynchronises a specific compressor, the scenario-local
+determinism check for that scenario can be added alongside the regular
+gate assertions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bench.bench_qa import (
+    BenchReportCollector,
+    canonicalize_report,
+    deterministic_trace_id,
+    latest_metrics_row,
+    load_fixture,
+    make_proxy_manager,
+)
+from bench.bench_qa.runner import make_tool_result
+
+
+async def _run_s09_once(tmp_path) -> dict:
+    """Drive s09 through the full bench pipeline once, return the
+    single-scenario ``BenchReport`` dict."""
+    fixture = load_fixture("s09")
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+    trace_id = deterministic_trace_id("s09")
+
+    try:
+        await mgr.call_tool("fake", "tool_s09", {}, trace_id=trace_id)
+        row = latest_metrics_row(store)
+    finally:
+        store.close()
+
+    collector = BenchReportCollector()
+    collector.record_scenario(
+        scenario_id="s09",
+        trace_id=row["trace_id"],
+        row=row,
+        qa_answerable=0,
+        qa_total=0,
+        original_chars=len(fixture["payload"]),
+        verdict="pass",
+    )
+    return dict(collector.build_report(run_seed=0))
+
+
+@pytest.mark.bench_qa
+@pytest.mark.asyncio
+async def test_two_runs_same_seed_produce_canonically_equal_reports(tmp_path_factory):
+    tmp_a = tmp_path_factory.mktemp("bench_det_a")
+    tmp_b = tmp_path_factory.mktemp("bench_det_b")
+
+    report_a = await _run_s09_once(tmp_a)
+    report_b = await _run_s09_once(tmp_b)
+
+    canon_a = canonicalize_report(report_a)
+    canon_b = canonicalize_report(report_b)
+
+    # trace_id must survive canonicalization — it's deterministic and
+    # differences there indicate an injection bug, not wall-clock noise.
+    scenario_a = canon_a["scenarios"][0]
+    assert scenario_a["trace_id"] == deterministic_trace_id("s09")
+
+    assert canon_a == canon_b, (
+        "bench_qa determinism broken — two runs of s09 at run_seed=0 "
+        "diverged after canonicalization. Inspect: "
+        f"A={canon_a!r} B={canon_b!r}"
+    )
+
+
+@pytest.mark.bench_qa
+def test_canonicalize_strips_only_stage_timings():
+    """Guard against over-eager stripping — byte-counted and categorical
+    fields must survive canonicalization, only wall-clock stage timings
+    are removed."""
+    from bench.bench_qa.report import _STAGE_TIMING_FIELDS
+
+    sample = {
+        "schema_version": 1,
+        "run_seed": 0,
+        "scenarios": [
+            {
+                "scenario_id": "s09",
+                "trace_id": "bench-abc",
+                "metrics": {
+                    "original_chars": 100,
+                    "cleaned_chars": 95,
+                    "compressed_chars": 80,
+                    "compression_ratio": 0.84,
+                    "compression_strategy": "none",
+                    "ratio_violation": 0,
+                    "surfacing_on_progressive_ok": None,
+                    "surface_error": None,
+                    "clean_ms": 1.23,
+                    "compress_ms": 4.56,
+                    "surface_ms": 0.0,
+                },
+                "tier": "none",
+                "verdict": "pass",
+            }
+        ],
+        "tier_histogram": {"none": 1},
+        "totals": {"scenarios": 1.0},
+    }
+    result = canonicalize_report(sample)  # type: ignore[arg-type]
+    metrics = result["scenarios"][0]["metrics"]
+    for field in _STAGE_TIMING_FIELDS:
+        assert field not in metrics, f"{field} should have been stripped"
+    # Byte counts + strategy survive.
+    assert metrics["original_chars"] == 100
+    assert metrics["compressed_chars"] == 80
+    assert metrics["compression_strategy"] == "none"
+    assert result["scenarios"][0]["trace_id"] == "bench-abc"
+    # Original must not be mutated.
+    assert "clean_ms" in sample["scenarios"][0]["metrics"]

--- a/tests/bench/test_bench_qa_fallback.py
+++ b/tests/bench/test_bench_qa_fallback.py
@@ -28,7 +28,12 @@ import pytest
 from memtomem_stm.proxy.cleaning import DefaultContentCleaner
 from memtomem_stm.proxy.config import CleaningConfig
 
-from bench.bench_qa import latest_metrics_row, load_fixture, make_proxy_manager
+from bench.bench_qa import (
+    deterministic_trace_id,
+    latest_metrics_row,
+    load_fixture,
+    make_proxy_manager,
+)
 from bench.bench_qa.progressive import reassemble
 from bench.bench_qa.runner import make_tool_result
 
@@ -58,9 +63,13 @@ async def test_s06_tier1_progressive_round_trip(tmp_path, bench_qa_report):
     # promotes the call to progressive delivery.
     mgr._apply_compression = AsyncMock(return_value=("x" * 50, None))
 
-    first_chunk = await mgr.call_tool("fake", "tool_s06", {})
+    expected_trace_id = deterministic_trace_id("s06")
+    first_chunk = await mgr.call_tool("fake", "tool_s06", {}, trace_id=expected_trace_id)
     row = latest_metrics_row(store)
     try:
+        assert row["trace_id"] == expected_trace_id, (
+            f"s06: trace_id mismatch — got {row['trace_id']!r}, expected {expected_trace_id!r}"
+        )
         assert row["ratio_violation"] == 1, "Tier-1 should record a violation"
         assert "→progressive_fallback" in (row["compression_strategy"] or ""), (
             f"unexpected strategy: {row['compression_strategy']!r}"
@@ -121,9 +130,13 @@ async def test_s01_tier2_hybrid_fallback(tmp_path, bench_qa_report):
     mgr._apply_compression = AsyncMock(return_value=("x" * 50, None))
     mgr._apply_progressive = _stub_raise  # type: ignore[method-assign]
 
-    result = await mgr.call_tool("fake", "tool_s01", {})
+    expected_trace_id = deterministic_trace_id("s01")
+    result = await mgr.call_tool("fake", "tool_s01", {}, trace_id=expected_trace_id)
     row = latest_metrics_row(store)
     try:
+        assert row["trace_id"] == expected_trace_id, (
+            f"s01: trace_id mismatch — got {row['trace_id']!r}, expected {expected_trace_id!r}"
+        )
         assert row["ratio_violation"] == 1
         strategy = row["compression_strategy"] or ""
         assert "→hybrid_fallback" in strategy, f"unexpected strategy: {strategy!r}"
@@ -169,9 +182,13 @@ async def test_s08_tier3_truncate_fallback(tmp_path, bench_qa_report):
     mgr._apply_progressive = _stub_raise  # type: ignore[method-assign]
     mgr._apply_hybrid = _stub_raise  # type: ignore[method-assign]
 
-    result = await mgr.call_tool("fake", "tool_s08", {})
+    expected_trace_id = deterministic_trace_id("s08")
+    result = await mgr.call_tool("fake", "tool_s08", {}, trace_id=expected_trace_id)
     row = latest_metrics_row(store)
     try:
+        assert row["trace_id"] == expected_trace_id, (
+            f"s08: trace_id mismatch — got {row['trace_id']!r}, expected {expected_trace_id!r}"
+        )
         assert row["ratio_violation"] == 1
         strategy = row["compression_strategy"] or ""
         assert "→truncate_fallback" in strategy, f"unexpected strategy: {strategy!r}"

--- a/tests/bench/test_bench_qa_scenarios.py
+++ b/tests/bench/test_bench_qa_scenarios.py
@@ -49,15 +49,15 @@ async def test_bench_qa_normal_path(scenario_id: str, tmp_path, bench_qa_report)
     session.call_tool.return_value = make_tool_result(fixture["payload"])
 
     expected_trace_id = deterministic_trace_id(fixture["scenario_id"])
-    result = await mgr.call_tool("fake", f"tool_{scenario_id}", {})
+    result = await mgr.call_tool("fake", f"tool_{scenario_id}", {}, trace_id=expected_trace_id)
 
     row = latest_metrics_row(store)
     try:
         assert row, f"{scenario_id}: proxy_metrics row was not written"
-        # ProxyManager.call_tool currently assigns its own uuid-based trace_id;
-        # deterministic injection arrives in the report PR (plan back-fill).
-        assert row["trace_id"], f"{scenario_id}: trace_id column should be populated"
-        assert expected_trace_id.startswith("bench-"), "sanity: hash helper runs"
+        assert row["trace_id"] == expected_trace_id, (
+            f"{scenario_id}: trace_id mismatch — "
+            f"got {row['trace_id']!r}, expected {expected_trace_id!r}"
+        )
 
         assert row["ratio_violation"] == 0, (
             f"{scenario_id}: unexpected ratio_violation=1 on happy path "


### PR DESCRIPTION
## Summary

- **Determinism signal restored.** Scenarios (happy path + fallback ladder) now pass `trace_id=deterministic_trace_id(scenario_id)` into `call_tool` (via the kwarg added in #173) and assert exact match on the recorded row. The stale comment in `test_bench_qa_scenarios.py` (`ProxyManager.call_tool currently assigns its own uuid-based trace_id`) is removed.
- **Feedback-DB path drift detector.** `tests/bench/bench_qa/runner.py` asserts at import time that `CompressionFeedbackConfig.db_path` (proxy/config.py:303) and `SurfacingConfig.feedback_db_path` (surfacing/config.py:32) resolve to the same default. Both still point at `~/.memtomem/stm_feedback.db` today — plan §Per-run isolation back-fill: **confirmed shared**. If a future PR moves one default without the other, every bench_qa test fails at collection instead of silently reading empty rows.
- **Canonicalization + single-scenario determinism gate.** New `canonicalize_report(report)` strips `clean_ms` / `compress_ms` / `surface_ms` from a `BenchReport` without touching byte counts, strategies, or trace ids. `test_bench_qa_determinism` runs s09 twice in separate `tmp_path` dirs under `run_seed=0` and deep-equals the canonicalized reports; a companion unit test pins the strip-field set so the canonicalizer can't silently widen.

## Why bundle these three

All share the same code path (`make_proxy_manager` + `latest_metrics_row` + report shape). Splitting leaves intermediate states where, e.g., trace_id is fixed but determinism isn't verified, or the DB-path assumption holds only in intent. One PR, one load-bearing invariant.

## Non-scope

- Full-suite two-run diff (pytest-in-pytest) — deferred. Single-scenario proves the property end-to-end.
- `bench_qa` CI gate promotion from `continue-on-error` — needs 1–2 weeks of observation per plan.

## Test plan

- [x] `uv run pytest -m bench_qa -v` — 9 passed (7 existing + 2 new determinism tests).
- [x] `uv run pytest -m bench_qa_meta -v` — 3 passed (inverse-assert probes still detect broken bench).
- [x] `uv run pytest -m "not ollama and not bench_qa_meta"` — 1429 passed, 3 deselected (was 1427 + 2 new).
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [ ] CI green.