### PR TITLE
test(bench_qa): s10 surfacing recall@k smoke with fixture-driven fake LTM

### DIFF
--- a/tests/_fake_memtomem_server.py
+++ b/tests/_fake_memtomem_server.py
@@ -8,8 +8,8 @@ actions — both returning canned text in **core's real compact format**
 (``[rank] score | source > hierarchy``) so that integration tests validate
 the same parsing path used in production.
 
-**Content must vary per call.** STM's cross-session dedup keys on
-``sha256(content)[:16]`` (see
+**Default mode — content must vary per call.** STM's cross-session dedup
+keys on ``sha256(content)[:16]`` (see
 ``src/memtomem_stm/surfacing/mcp_client.py:34``), so a fixture returning
 identical content across calls gets silently suppressed after the first
 run if the test exercises the ``FeedbackTracker`` path. The current
@@ -19,17 +19,60 @@ future test that *does* hit the dedup path. Assertions here are all
 substring checks (``"JWT authentication"``, ``"current_task"``) so the
 UUID suffixes are invisible to callers.
 
-Run with: `python <path-to-this-file>`
+**bench_qa mode (``--seeds <path>``)** loads a JSON array of search
+results and emits them from ``mem_search`` verbatim — *without* the
+per-call UUID suffix — so ``sha256(content)`` is deterministic and tests
+can assert against pre-computed chunk IDs. The dedup concern does not
+apply here because bench_qa scenarios use an isolated ``tmp_path``
+``stm_feedback.db`` and make a single ``call_tool`` per test.
+
+Run with: ``python <path-to-this-file>`` (default canned hits) or
+``python <path-to-this-file> --seeds <path>`` (fixture-driven).
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import uuid
 
 from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP("fake-memtomem")
+
+# Populated once at startup when ``--seeds`` is passed. Reads like a
+# constant after that — ``mem_search`` branches on ``is not None``.
+_SEEDS: list[dict] | None = None
+
+
+def _load_seeds(path: str) -> list[dict]:
+    """Load bench_qa seed array from *path*.
+
+    Each entry must have ``rank``, ``score``, ``source``, and ``content``
+    keys; extras are ignored. Schema validation is owned by the harness
+    that wrote the file, not by this helper.
+    """
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        raise ValueError(f"--seeds file must contain a JSON array, got {type(data).__name__}")
+    return data
+
+
+def _emit_seeds(seeds: list[dict]) -> str:
+    """Format *seeds* as core's compact ``mem_search`` output.
+
+    Matches the default-mode format (``[rank] score | source > Section``
+    header, content on the next line) but omits the per-call UUID suffix
+    — bench_qa callers require ``sha256(content)`` to be deterministic so
+    pre-computed chunk IDs line up with ``surfacing_events.memory_ids``.
+    """
+    blocks = [f"Found {len(seeds)} results:", ""]
+    for seed in seeds:
+        blocks.append(f"[{seed['rank']}] {seed['score']} | {seed['source']} > Memory")
+        blocks.append(str(seed["content"]))
+        blocks.append("")
+    return "\n".join(blocks).rstrip() + "\n"
 
 
 @mcp.tool()
@@ -39,14 +82,17 @@ async def mem_search(
     namespace: str | list[str] | None = None,
     context_window: int = 0,
 ) -> str:
-    """Return canned search hits in core's compact format.
+    """Return canned search hits, or fixture seeds if ``--seeds`` was given.
 
     Matches the output of ``memtomem.server.formatters._format_compact_result``
-    so integration tests validate the real parsing path.  Each call embeds a
-    fresh UUID in both the source path and the body text so
-    ``sha256(content)`` dedup never collapses repeated calls.
-    See the module docstring for the full rationale.
+    so integration tests validate the real parsing path. In the default
+    (no-seeds) mode each call embeds a fresh UUID in both the source path
+    and the body text so ``sha256(content)`` dedup never collapses repeated
+    calls. See the module docstring for the full rationale.
     """
+    if _SEEDS is not None:
+        return _emit_seeds(_SEEDS)
+
     auth_tag = uuid.uuid4().hex[:8]
     api_tag = uuid.uuid4().hex[:8]
     return (
@@ -88,4 +134,14 @@ async def mem_do(action: str, params: dict | None = None) -> str:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fake memtomem MCP server.")
+    parser.add_argument(
+        "--seeds",
+        metavar="PATH",
+        default=None,
+        help="Optional JSON array of mem_search seeds (bench_qa mode).",
+    )
+    args = parser.parse_args()
+    if args.seeds is not None:
+        _SEEDS = _load_seeds(args.seeds)
     mcp.run()

--- a/tests/bench/bench_qa/runner.py
+++ b/tests/bench/bench_qa/runner.py
@@ -15,6 +15,7 @@ module generalizes that pattern for the bench_qa suite:
 from __future__ import annotations
 
 import hashlib
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -29,6 +30,11 @@ from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
 from memtomem_stm.proxy.metrics import TokenTracker
 from memtomem_stm.proxy.metrics_store import MetricsStore
 from memtomem_stm.surfacing.config import SurfacingConfig
+from memtomem_stm.surfacing.engine import SurfacingEngine
+from memtomem_stm.surfacing.feedback import FeedbackTracker
+from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
+
+_FAKE_LTM_SERVER = Path(__file__).resolve().parents[2] / "_fake_memtomem_server.py"
 
 
 # Drift detector: ``CompressionFeedbackConfig.db_path`` and
@@ -114,6 +120,94 @@ def make_proxy_manager(
         tools=[],
     )
     return mgr, store, session
+
+
+def make_surfacing_proxy_manager(
+    tmp_path: Path,
+    *,
+    seeds_path: Path,
+    compression: str | CompressionStrategy = CompressionStrategy.NONE,
+    max_result_chars: int = 50_000,
+    min_retention: float = 0.65,
+    server_name: str = "fake",
+    tool_prefix: str = "fake",
+) -> tuple[
+    ProxyManager,
+    MetricsStore,
+    AsyncMock,
+    McpClientSearchAdapter,
+    SurfacingEngine,
+    FeedbackTracker,
+]:
+    """Like :func:`make_proxy_manager` but wires a live surfacing pipeline.
+
+    Spawns the stdio fake LTM server (``tests/_fake_memtomem_server.py``)
+    in ``--seeds`` mode so ``mem_search`` emits the JSON array at
+    ``seeds_path`` with deterministic ``sha256(content)`` chunk IDs.
+    ``min_response_chars`` is pinned at 10 so the surfacing gate does not
+    depend on the production default (5000) staying where it is.
+
+    Returns ``(manager, metrics_store, session, adapter, engine, tracker)``.
+    The caller owns the lifecycle of the last three — the helper does
+    **not** call ``adapter.start()`` (stdio connects asynchronously). A
+    typical test body wraps the call in ``try``/``finally``::
+
+        mgr, store, session, adapter, engine, tracker = \
+            make_surfacing_proxy_manager(tmp_path, seeds_path=...)
+        await adapter.start()
+        try:
+            ...                          # mgr.call_tool(...)
+        finally:
+            await adapter.stop()
+            tracker.close()
+            store.close()
+    """
+    if isinstance(compression, str):
+        compression = _resolve_compression(compression)
+
+    store = MetricsStore(tmp_path / "proxy_metrics.db")
+    store.initialize()
+
+    surfacing_cfg = SurfacingConfig(
+        enabled=True,
+        min_response_chars=10,
+        cooldown_seconds=0.0,
+        max_surfacings_per_minute=1000,
+        auto_tune_enabled=False,
+        include_session_context=False,
+        fire_webhook=False,
+        feedback_enabled=True,
+        injection_mode="append",
+        feedback_db_path=tmp_path / "stm_feedback.db",
+        ltm_mcp_command=sys.executable,
+        ltm_mcp_args=[str(_FAKE_LTM_SERVER), "--seeds", str(seeds_path)],
+    )
+    adapter = McpClientSearchAdapter(surfacing_cfg)
+    tracker = FeedbackTracker(surfacing_cfg)
+    engine = SurfacingEngine(surfacing_cfg, mcp_adapter=adapter, feedback_tracker=tracker)
+
+    server_cfg = UpstreamServerConfig(
+        prefix=tool_prefix,
+        compression=compression,
+        max_result_chars=max_result_chars,
+        max_retries=0,
+        reconnect_delay_seconds=0.0,
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={server_name: server_cfg},
+        min_result_retention=min_retention,
+    )
+    token_tracker = TokenTracker(metrics_store=store)
+    mgr = ProxyManager(proxy_cfg, token_tracker, surfacing_engine=engine)
+    session = AsyncMock()
+    mgr._connections[server_name] = UpstreamConnection(
+        name=server_name,
+        config=server_cfg,
+        session=session,
+        tools=[],
+    )
+    return mgr, store, session, adapter, engine, tracker
 
 
 def make_tool_result(text: str) -> SimpleNamespace:

--- a/tests/bench/fixtures/s10.json
+++ b/tests/bench/fixtures/s10.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s10",
+  "description": "Surfacing smoke — fake LTM serves fixture-declared seeds; top-2 memory_ids (sha256 of seed content) recorded in surfacing_events must match the fixture's expected ranks, yielding recall@2 == 1.0.",
+  "content_type": "text",
+  "expected_compressor": "none",
+  "force_tier": null,
+  "max_result_chars": 50000,
+  "qa_gate_min": 0.75,
+  "qa_probes": [
+    {
+      "question": "What is the rotation cadence for JWT signing secrets?",
+      "expected_keywords": ["24", "rotation"]
+    },
+    {
+      "question": "Which signing algorithm is used for internal auth tokens?",
+      "expected_keywords": ["HS256"]
+    }
+  ],
+  "surfacing_seeds": [
+    {
+      "rank": 1,
+      "score": 0.92,
+      "source": "auth-rotation.md",
+      "content": "JWT rotation policy: HS256 signing secrets rotate every 24 hours on a staggered per-region schedule; verifiers retain the previous kid for a 90-minute grace window."
+    },
+    {
+      "rank": 2,
+      "score": 0.85,
+      "source": "session-mgmt.md",
+      "content": "Session invalidation is triggered by JWT rotation events flagged as key-compromise; normal rotations let existing tokens live to their natural exp while compromise rotations invalidate all tokens for the affected kid immediately."
+    },
+    {
+      "rank": 3,
+      "score": 0.60,
+      "source": "rate-limit.md",
+      "content": "Rate limits are advertised through X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset response headers, with per-minute windows aligned to the calendar minute."
+    }
+  ],
+  "surfacing_eval": {
+    "query": "JWT authentication rotation policy",
+    "k": 2,
+    "expected_ids": ["auth-rotation.md", "session-mgmt.md"]
+  },
+  "payload": "JWT AUTHENTICATION — ROTATION POLICY AND OPERATIONAL GUIDE (v3.1)\n\n1. Overview\nThe authentication subsystem uses JSON Web Tokens (JWT) signed with HS256 for all service-to-service and user-to-service authorization paths. This document covers the rotation policy, operational procedures for key compromise scenarios, interaction with the session management layer, and the audit requirements tied to every rotation event.\n\n2. Rotation Policy\nSecrets are rotated every 24 hours on a staggered schedule across regions so that at most one region is in a half-rotation state at any given moment. The rotation window is fixed at 04:00 UTC per region, offset by one hour between adjacent regions to keep error budgets aligned with off-peak traffic patterns. Every rotation produces a new HS256 key identifier (kid) that is embedded in the token header; verifiers track the last two active kid values for a grace period of ninety minutes before the older key is revoked.\n\n3. Key Storage and Distribution\nHS256 secrets live in a hardware security module (HSM) and are never exported in cleartext. Each region's authentication service authenticates to the HSM using a service-account mTLS pair that itself rotates weekly. The distribution path is cached for at most fifteen minutes to bound the blast radius of a compromised cache node; cache invalidation is driven by a signed broadcast from the rotation coordinator.\n\n4. Session Invalidation\nSession invalidation is triggered by any JWT rotation event where a key compromise is declared. In normal rotations, existing tokens remain valid until their natural expiry (default fifteen minutes for user sessions, sixty minutes for service-to-service tokens). In compromise rotations, all tokens signed with the affected kid are immediately invalidated and re-authentication is required. Client libraries handle the 401 response with an automatic refresh token exchange; the refresh path uses a separate key space that is not subject to the standard 24-hour rotation.\n\n5. Rate Limits\nAll authenticated endpoints are protected by rate limits advertised through the X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset response headers. The default limit is 600 requests per minute per principal, with per-endpoint overrides for latency-sensitive paths. Rate limit windows are aligned to calendar minutes to simplify client-side back-off strategies. Repeated 429 responses within a single rotation window are treated as a potential probe and result in a temporary principal-level quarantine.\n\n6. Observability\nEvery token issuance, verification, and refresh emits a structured log line with the rotation kid, the principal identifier, and the outcome. Traces are correlated through the W3C Trace Context header so that downstream service calls can be joined against the originating authentication event. The metrics pipeline exports p50, p95, and p99 verification latency by kid; a latency regression above the 99th percentile for two consecutive minutes opens an alert routed to the on-call authentication engineer.\n\n7. Rotation Audit\nEach rotation is audited through three independent channels: the HSM's append-only audit log, the rotation coordinator's signed event stream, and the canary verifier's rotation acknowledgment timeline. Quarterly reviews correlate these three channels against the incident response record; any unexplained discrepancy triggers a compliance escalation within two business days.\n\n8. Emergency Rotation\nAn emergency rotation can be triggered by the on-call authentication engineer using a dual-operator workflow: one operator issues the rotation command with a reason code, and a second operator approves within ten minutes. The workflow bypasses the staggered schedule and forces all regions into simultaneous rotation, with session invalidation applied globally. The time-to-rotation for an emergency event has a 99.9th percentile target of four minutes.\n\n9. Client Guidance\nClient libraries should cache tokens only until the exp claim minus thirty seconds to avoid last-mile clock skew issues. Libraries should not persist the raw secret under any circumstances; the expected pattern is to hold only the short-lived access token in memory and keep the refresh token in platform-specific secure storage.\n\n10. Interaction with the Data Access Layer\nThe data access layer does not trust the application-layer authentication directly. A separate data-access token is minted for each persisted session; its sub claim maps to the data-access row-level security policy, and its scope claim declares the maximum privilege that can be exercised within that session. Row-level security enforcement is independent of the application-layer JWT and is not affected by an application-layer rotation event.\n\n11. Appendix — Terminology\nJWT — JSON Web Token, RFC 7519. HS256 — HMAC with SHA-256, used as the signing algorithm for all internal auth tokens. kid — key identifier, embedded in the JOSE header to select the verification secret. Refresh token — a long-lived credential used to acquire new access tokens without re-authenticating the user.\n"
+}

--- a/tests/bench/test_bench_qa_scenarios.py
+++ b/tests/bench/test_bench_qa_scenarios.py
@@ -20,6 +20,10 @@ can't share the happy-path parametrize body.
 
 from __future__ import annotations
 
+import hashlib
+import json
+import re
+
 import pytest
 
 from bench.bench_qa import (
@@ -28,8 +32,10 @@ from bench.bench_qa import (
     load_fixture,
     make_proxy_manager,
     qa_answerable_ratio,
+    surfacing_recall_at_k,
 )
-from bench.bench_qa.runner import make_tool_result
+from bench.bench_qa.runner import make_surfacing_proxy_manager, make_tool_result
+from bench.bench_qa.schema import SurfacingResult
 
 # Scenarios exercised by this file. Each must live in
 # ``tests/bench/fixtures/<id>.json`` with a ``force_tier: null`` so the
@@ -173,4 +179,128 @@ async def test_s07_selective_toc_preserves_top_results(tmp_path, bench_qa_report
             verdict="pass",
         )
     finally:
+        store.close()
+
+
+_SURFACING_ID_RE = re.compile(r"Surfacing ID:\s*([a-f0-9]{16})")
+
+
+@pytest.mark.bench_qa
+@pytest.mark.asyncio
+async def test_s10_surfacing_recall_at_k(tmp_path, bench_qa_report):
+    """Fake LTM serves 3 fixture-declared seeds; top-2 match the expected ranks.
+
+    The ``path`` argument (not ``_context_query``) drives ``ContextExtractor``
+    because ``ProxyManager.call_tool`` strips ``_context_query`` from
+    ``upstream_args`` before invoking surfacing (see ``manager.py:973``);
+    ``_context_query`` is today a compression hint, not a surfacing hint.
+    ``path`` tokenizes to ``"src auth jwt rotation py"`` which clears
+    ``min_query_tokens=3``. The fake LTM ignores the query and returns
+    fixture seeds verbatim, so query content does not affect recall —
+    the test exercises the pipeline wiring, not query semantics.
+
+    The fake server's per-call UUID suffix exists only in default mode
+    to defeat ``sha256(content)`` dedup — bench_qa ``--seeds`` mode omits
+    it so ``sha256(content)[:16]`` is deterministic, and the expected
+    chunk IDs below (derived from ``fixture["surfacing_seeds"][i].content``)
+    line up with what ``surfacing_events.memory_ids`` records. Future
+    changes to the fake must preserve both properties.
+    """
+    fixture = load_fixture("s10")
+    assert fixture.get("force_tier") is None, "s10 is a happy-path surfacing scenario"
+    assert fixture["surfacing_seeds"], "s10 fixture must declare surfacing_seeds"
+    assert fixture["surfacing_eval"], "s10 fixture must declare surfacing_eval"
+
+    seeds_path = tmp_path / "s10_seeds.json"
+    seeds_path.write_text(json.dumps(fixture["surfacing_seeds"]), encoding="utf-8")
+
+    source_to_chunk_id = {
+        seed["source"]: hashlib.sha256(seed["content"].encode()).hexdigest()[:16]
+        for seed in fixture["surfacing_seeds"]
+    }
+    expected_chunk_ids = [
+        source_to_chunk_id[src] for src in fixture["surfacing_eval"]["expected_ids"]
+    ]
+
+    mgr, store, session, adapter, engine, tracker = make_surfacing_proxy_manager(
+        tmp_path,
+        seeds_path=seeds_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+    expected_trace_id = deterministic_trace_id(fixture["scenario_id"])
+
+    await adapter.start()
+    try:
+        result = await mgr.call_tool(
+            "fake",
+            "tool_s10",
+            {
+                "path": "src/auth/jwt_rotation.py",
+                "_context_query": fixture["surfacing_eval"]["query"],
+            },
+            trace_id=expected_trace_id,
+        )
+
+        row = latest_metrics_row(store)
+        assert row, "s10: proxy_metrics row was not written"
+        assert row["trace_id"] == expected_trace_id, (
+            f"s10: trace_id mismatch — got {row['trace_id']!r}, expected {expected_trace_id!r}"
+        )
+
+        # Text-level reachability: the surfaced block is present AND at
+        # least one seed's content surfaced through the formatter. DB-only
+        # recall could pass while the formatter silently dropped content;
+        # text-only coverage is fragile to formatter changes. Both guards
+        # together cover each failure class.
+        assert "<surfaced-memories>" in result, (
+            f"s10: <surfaced-memories> block missing: {result[-400:]!r}"
+        )
+        assert any(seed["content"][:40] in result for seed in fixture["surfacing_seeds"]), (
+            f"s10: no seed content surfaced into result: {result[-800:]!r}"
+        )
+
+        # DB-level recall@k via the surfacing_id embedded in the formatter's
+        # output. Keying on surfacing_id (not ``ORDER BY created_at DESC``)
+        # ties the assertion to *this* call's row, so the test survives a
+        # future bench scenario writing additional rows into the same DB.
+        id_match = _SURFACING_ID_RE.search(result)
+        assert id_match, f"s10: surfacing_id not found in result: {result[-400:]!r}"
+        surfacing_id = id_match.group(1)
+        returned_ids = tracker.store.get_memory_ids_for_surfacing(surfacing_id)
+        assert returned_ids, f"s10: no memory_ids recorded for surfacing_id={surfacing_id}"
+
+        k = fixture["surfacing_eval"]["k"]
+        recall = surfacing_recall_at_k(returned_ids, expected_chunk_ids, k)
+        assert recall == 1.0, (
+            f"s10: happy-path recall@{k} must be 1.0 — got {recall} "
+            f"(returned_ids[:{k}]={returned_ids[:k]}, expected={expected_chunk_ids})"
+        )
+
+        answerable, total = qa_answerable_ratio(fixture["qa_probes"], result)
+        assert total > 0, "s10: must define at least one qa_probe"
+        ratio = answerable / total
+        gate_min = fixture.get("qa_gate_min", 0.75)
+        assert ratio >= gate_min, (
+            f"s10: qa_answerable ratio {answerable}/{total}={ratio:.2f} below {gate_min} gate"
+        )
+
+        bench_qa_report.record_scenario(
+            scenario_id="s10",
+            trace_id=row["trace_id"],
+            row=row,
+            qa_answerable=answerable,
+            qa_total=total,
+            original_chars=len(fixture["payload"]),
+            verdict="pass",
+            surfacing=SurfacingResult(
+                recall_at_k=recall,
+                returned_ids=returned_ids[:k],
+                expected_ids=expected_chunk_ids,
+            ),
+        )
+    finally:
+        await adapter.stop()
+        tracker.close()
         store.close()


### PR DESCRIPTION
## Summary

Adds the first bench_qa scenario exercising the SURFACE pipeline stage
(S01-S09 + S07 covered CLEAN/COMPRESS only — a surfacing regression
would ship unnoticed by the gate today).

- `tests/bench/fixtures/s10.json` declares 3 ranked seeds and a
  `surfacing_eval` ground truth (top-2 sources = relevant memories).
- `tests/bench/bench_qa/runner.py::make_surfacing_proxy_manager()`
  wires `SurfacingEngine` + `McpClientSearchAdapter` + `FeedbackTracker`
  into a `ProxyManager` pointed at a `tmp_path` `stm_feedback.db`.
  `min_response_chars` is pinned at 10 so the gate does not depend on
  the production default.
- `test_s10_surfacing_recall_at_k` asserts a **dual invariant**:
  - Text-level: `<surfaced-memories>` block present with at least one
    seed content substring reachable.
  - DB-level: `recall@2 == 1.0` against `surfacing_events.memory_ids`
    keyed by the formatter-injected `Surfacing ID`.
  - DB alone could pass while the formatter silently dropped content;
    text alone would be fragile to formatter changes.

## Behavior change

The fake LTM server (`tests/_fake_memtomem_server.py`) gains an
**additive** `--seeds <path>` CLI flag:

- Flag **absent** → existing canned-hit behaviour preserved. The
  `test_remote_ltm_integration.py` suite is unchanged and still relies
  on the per-call UUID suffix to defeat `sha256(content)` dedup.
- Flag **present** → `mem_search` emits the JSON-array seeds at `path`
  verbatim and the UUID suffix is omitted so `sha256(content)[:16]` is
  deterministic. Scoped to bench_qa; safe because bench tests use an
  isolated `tmp_path` `stm_feedback.db` and make a single `call_tool`
  per test.

No change to production code paths.

## Test plan

- [x] `uv run pytest tests/bench/test_bench_qa_scenarios.py::test_s10_surfacing_recall_at_k -v` (targeted)
- [x] `uv run pytest -m "not ollama"` — full CI filter, 1434 passed
- [x] `uv run ruff check src && uv run ruff format --check src` (CLAUDE.md required)
- [x] `uv run mypy src` — advisory, no new errors from this change
- [x] Bench report inspection: `surfacing` block records `recall_at_k=1.0` with matching `returned_ids`/`expected_ids` (sha256 chunk IDs of seed content)

## Non-goals (deferred to follow-up PRs)

- Meta probe (`bench_qa_meta` failure injection for surfacing) — the
  P5-style negative test.
- Two-run determinism gate inclusion for S10.
- Feedback-rating loop (`stm_surfacing_feedback` → `increment_access`)
  and `scratch_get` session-context coverage.