### PR TITLE
test(bench_qa): LLM-as-judge advisory scoring (opt-in, gpt-4.1-nano default)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           version: "latest"
       - run: uv sync --frozen
-      - run: uv run pytest -m "not ollama and not bench_qa_meta" --tb=short -q
+      - run: uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge" --tb=short -q
 
   notebooks:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ coverage.xml
 .claude/
 scripts/
 CLAUDE.local.md
+
+# bench_qa LLM judge cache (<hash>.json per scenario/model; regenerated on demand)
+tests/bench/.llm_judge_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ markers = [
     "ollama: requires a running Ollama instance (auto-skipped when unavailable)",
     "bench_qa: end-to-end compression/surfacing regression gate (fake upstream, deterministic)",
     "bench_qa_meta: self-test probes for bench_qa — intentional failures, NOT CI-safe",
+    "bench_qa_llm_judge: LLM-as-judge advisory scoring — requires OPENAI_API_KEY or ANTHROPIC_API_KEY, off in default CI",
 ]
 
 [tool.mypy]

--- a/tests/bench/bench_qa/llm_judge_adapter.py
+++ b/tests/bench/bench_qa/llm_judge_adapter.py
@@ -1,0 +1,196 @@
+"""Adapter wiring the LLM-as-judge skeleton into the bench_qa report flow.
+
+The adapter deliberately sits next to ``judge.py`` rather than inside it:
+``judge.py`` is a pure-stdlib synchronous keyword matcher that every bench_qa
+test imports, while the LLM judge is async, httpx-bound and network-dependent.
+Keeping them separate avoids pulling httpx into the keyword path and lets the
+adapter own bench_qa-specific concerns (``QAProbe`` → ``QAPair`` conversion,
+on-disk caching, ``LLMJudgeResultReport`` flattening).
+
+Cache: persistent JSON at ``tests/bench/.llm_judge_cache/<16hex>.json``,
+gitignored. Key is ``sha256(provider:model:scenario_id:content_type:compressed)``
+— including provider and model means switching models invalidates naturally.
+Delete the directory to force a refresh.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path
+
+from ..harness import BenchTask, QAPair
+from ..llm_judge import JudgeDimension, LLMJudge, LLMJudgeResult
+from .schema import LLMJudgeProbeResult, LLMJudgeResultReport, QAProbe
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path(__file__).resolve().parent.parent / ".llm_judge_cache"
+
+_DEFAULT_MODELS = {
+    "anthropic": "claude-haiku-4-5-20251001",
+    "openai": "gpt-4.1-nano",
+}
+
+
+def _resolve_config(provider: str | None, model: str | None) -> tuple[str, str, str]:
+    """Mirror ``LLMJudge.__init__`` resolution so the cache key lines up.
+
+    Returns ``(provider, model, api_key)``. ``api_key`` may be an empty
+    string when no env var is set — the caller decides whether that is a
+    hard skip (local dev) or a soft advisory (production fallback).
+    """
+    resolved_provider = os.environ.get("BENCH_LLM_JUDGE_PROVIDER", provider or "openai")
+    resolved_model = os.environ.get(
+        "BENCH_LLM_JUDGE_MODEL",
+        model or _DEFAULT_MODELS.get(resolved_provider, "gpt-4.1-nano"),
+    )
+    if resolved_provider == "anthropic":
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    elif resolved_provider == "openai":
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+    else:
+        api_key = ""
+    return resolved_provider, resolved_model, api_key
+
+
+def _cache_key(
+    *,
+    provider: str,
+    model: str,
+    scenario_id: str,
+    content_type: str,
+    compressed: str,
+) -> str:
+    payload = f"{provider}:{model}:{scenario_id}:{content_type}:{compressed}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _load_cached(path: Path) -> LLMJudgeResult | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning("llm_judge cache unreadable, discarding: %s", path)
+        return None
+    dims = [JudgeDimension(**d) for d in data.get("dimensions", [])]
+    return LLMJudgeResult(
+        task_id=data.get("task_id", ""),
+        overall=float(data.get("overall", 0.0)),
+        dimensions=dims,
+        qa_results=list(data.get("qa_results", [])),
+        model=data.get("model", ""),
+        prompt_tokens=int(data.get("prompt_tokens", 0)),
+        completion_tokens=int(data.get("completion_tokens", 0)),
+        cached=True,
+        error=data.get("error"),
+    )
+
+
+def _save_cache(path: Path, result: LLMJudgeResult) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = asdict(result)
+    data["cached"] = False
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def score_scenario(
+    *,
+    scenario_id: str,
+    description: str,
+    original: str,
+    compressed: str,
+    probes: Sequence[QAProbe],
+    content_type: str = "text",
+    cache_dir: Path | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+) -> LLMJudgeResult | None:
+    """Score one compressed scenario output with the LLM judge.
+
+    Returns ``None`` when no API key is configured — the caller should
+    ``pytest.skip``.  Returns an ``LLMJudgeResult`` with ``.error`` populated
+    on transport / parse failure rather than raising: the LLM judge is
+    advisory-only today and a single flaky scenario must not fail the run.
+    """
+    effective_cache_dir = cache_dir or DEFAULT_CACHE_DIR
+    resolved_provider, resolved_model, api_key = _resolve_config(provider, model)
+    if not api_key:
+        logger.info(
+            "llm_judge skipping scenario=%s — no API key for provider %s",
+            scenario_id,
+            resolved_provider,
+        )
+        return None
+
+    key = _cache_key(
+        provider=resolved_provider,
+        model=resolved_model,
+        scenario_id=scenario_id,
+        content_type=content_type,
+        compressed=compressed,
+    )
+    path = effective_cache_dir / f"{key}.json"
+    cached = _load_cached(path)
+    if cached is not None:
+        logger.info("llm_judge cache hit: scenario=%s key=%s", scenario_id, key)
+        return cached
+
+    task = BenchTask(
+        task_id=scenario_id,
+        description=description or f"bench_qa scenario {scenario_id}",
+        content=original,
+        content_type=content_type,
+        max_chars=max(len(compressed), 1),
+        qa_pairs=[QAPair(question=p["question"], answer="", source="content") for p in probes],
+    )
+
+    judge = LLMJudge(provider=resolved_provider, model=resolved_model, api_key=api_key)
+    result = asyncio.run(judge.score(task, compressed))
+    _save_cache(path, result)
+    return result
+
+
+def to_report_dict(result: LLMJudgeResult) -> LLMJudgeResultReport:
+    """Flatten an ``LLMJudgeResult`` into the ``ScenarioReport`` shape.
+
+    Raw dimension scores are 0–10 from the model; we divide by 10 so they
+    line up with ``qa.ratio`` and ``rule_judge.score`` (all 0.0–1.0). The
+    ``overall`` score follows the same normalisation.
+    """
+    dim_by_name = {d.name: d.score / 10.0 for d in result.dimensions}
+    per_probe: list[LLMJudgeProbeResult] = []
+    for qa in result.qa_results:
+        probe: LLMJudgeProbeResult = {
+            "question": str(qa.get("question", "")),
+            "answerable": bool(qa.get("answerable", False)),
+            "confidence": float(qa.get("confidence", 0.0)),
+        }
+        reasoning = qa.get("reasoning")
+        if reasoning:
+            probe["reasoning"] = str(reasoning)
+        per_probe.append(probe)
+
+    report: LLMJudgeResultReport = {
+        "model": result.model,
+        "overall": round(result.overall / 10.0, 4),
+        "factual_completeness": round(dim_by_name.get("factual_completeness", 0.0), 4),
+        "structural_coherence": round(dim_by_name.get("structural_coherence", 0.0), 4),
+        "answer_sufficiency": round(dim_by_name.get("answer_sufficiency", 0.0), 4),
+        "per_probe": per_probe,
+        "cached": result.cached,
+        "prompt_tokens": result.prompt_tokens,
+        "completion_tokens": result.completion_tokens,
+    }
+    if result.error:
+        report["error"] = str(result.error)
+    return report

--- a/tests/bench/bench_qa/llm_judge_adapter.py
+++ b/tests/bench/bench_qa/llm_judge_adapter.py
@@ -15,7 +15,6 @@ Delete the directory to force a refresh.
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 import logging
@@ -103,7 +102,7 @@ def _save_cache(path: Path, result: LLMJudgeResult) -> None:
     )
 
 
-def score_scenario(
+async def score_scenario(
     *,
     scenario_id: str,
     description: str,
@@ -116,6 +115,10 @@ def score_scenario(
     model: str | None = None,
 ) -> LLMJudgeResult | None:
     """Score one compressed scenario output with the LLM judge.
+
+    Async because every current caller (the parametrized bench_qa test)
+    already runs under ``@pytest.mark.asyncio`` — wrapping the ``await`` in
+    a nested ``asyncio.run()`` raises ``RuntimeError``.
 
     Returns ``None`` when no API key is configured — the caller should
     ``pytest.skip``.  Returns an ``LLMJudgeResult`` with ``.error`` populated
@@ -155,7 +158,7 @@ def score_scenario(
     )
 
     judge = LLMJudge(provider=resolved_provider, model=resolved_model, api_key=api_key)
-    result = asyncio.run(judge.score(task, compressed))
+    result = await judge.score(task, compressed)
     _save_cache(path, result)
     return result
 

--- a/tests/bench/bench_qa/report.py
+++ b/tests/bench/bench_qa/report.py
@@ -23,6 +23,7 @@ from typing import Any
 from .schema import (
     REPORT_SCHEMA_VERSION,
     BenchReport,
+    LLMJudgeResultReport,
     MetricSummary,
     ProgressiveResult,
     QAResult,
@@ -51,6 +52,12 @@ def canonicalize_report(report: BenchReport) -> dict[str, Any]:
 
     * ``scenarios[*].metrics.clean_ms`` / ``compress_ms`` / ``surface_ms``
       — stage latencies differ run-to-run by definition.
+    * ``scenarios[*].llm_judge`` — the whole block. Even at ``temperature=0``
+      the LLM judge is non-reproducible across provider-side model updates,
+      plus ``cached`` / token counts flip between runs. Stripping the block
+      wholesale keeps the determinism diff silent when the marker is off
+      (key absent on both sides) and when it is on (key absent on both
+      sides after stripping).
 
     Preserved:
 
@@ -66,6 +73,7 @@ def canonicalize_report(report: BenchReport) -> dict[str, Any]:
         metrics = scenario.get("metrics", {})
         for field in _STAGE_TIMING_FIELDS:
             metrics.pop(field, None)
+        scenario.pop("llm_judge", None)
     return canon
 
 
@@ -142,6 +150,33 @@ class BenchReportCollector:
         if surfacing is not None:
             entry["surfacing"] = surfacing
         self._rows.append(entry)
+
+    def record_llm_judge(
+        self,
+        *,
+        scenario_id: str,
+        llm_judge: LLMJudgeResultReport,
+    ) -> None:
+        """Attach an LLM-judge result to a scenario row (no-op if absent).
+
+        Enriches an existing row when the LLM judge test runs in the same
+        session as the main ``bench_qa`` suite (``-m "bench_qa or
+        bench_qa_llm_judge"``). When the judge runs alone (no prior
+        ``record_scenario``), the score is still visible via the test's
+        ``logger.info`` but does not make it into ``report.json`` — the
+        scenario row would be missing ``metrics`` / ``qa`` / ``verdict``
+        that ``build_report`` and the summary formatter read
+        unconditionally, so stubbing a partial row would break both.
+        """
+        for entry in self._rows:
+            if entry.get("scenario_id") == scenario_id:
+                entry["llm_judge"] = llm_judge
+                return
+        logger.warning(
+            "record_llm_judge: no scenario row for %r — run with "
+            "-m 'bench_qa or bench_qa_llm_judge' to capture the score in report.json",
+            scenario_id,
+        )
 
     def build_report(self, *, run_seed: int = 0) -> BenchReport:
         tier_hist: Counter[str] = Counter(r["tier"] for r in self._rows)

--- a/tests/bench/bench_qa/schema.py
+++ b/tests/bench/bench_qa/schema.py
@@ -115,6 +115,37 @@ class SurfacingResult(TypedDict):
     expected_ids: list[str]
 
 
+class LLMJudgeProbeResult(TypedDict, total=False):
+    """Per-QA-probe judgment from the LLM judge."""
+
+    question: str
+    answerable: bool
+    confidence: float
+    reasoning: str
+
+
+class LLMJudgeResultReport(TypedDict, total=False):
+    """LLM-as-judge result for a single scenario.
+
+    Scores are normalised to 0.0–1.0 (raw 0–10 from the model divided by 10)
+    so they line up with ``qa.ratio`` and ``rule_judge.score``. Advisory only
+    today — ``canonicalize_report`` strips this whole block before the
+    two-run determinism diff because provider-side model updates can shift
+    scores even with ``temperature=0``.
+    """
+
+    model: str
+    overall: float
+    factual_completeness: float
+    structural_coherence: float
+    answer_sufficiency: float
+    per_probe: list[LLMJudgeProbeResult]
+    cached: bool
+    prompt_tokens: int
+    completion_tokens: int
+    error: str
+
+
 class ScenarioReport(TypedDict, total=False):
     scenario_id: str
     trace_id: str
@@ -123,6 +154,7 @@ class ScenarioReport(TypedDict, total=False):
     qa: QAResult
     progressive: ProgressiveResult
     surfacing: SurfacingResult
+    llm_judge: LLMJudgeResultReport
     tier: str
     verdict: Literal["pass", "fail", "advisory"]
 

--- a/tests/bench/llm_judge.py
+++ b/tests/bench/llm_judge.py
@@ -1,7 +1,8 @@
 """LLM-as-Judge — semantic quality scoring for benchmark evaluation.
 
-Uses a small/fast LLM (Claude Haiku or GPT-4o-mini) to judge whether
-compressed text preserves the meaning and critical information of the original.
+Uses a small/fast LLM (GPT-4.1-nano by default, Claude Haiku alternate) to
+judge whether compressed text preserves the meaning and critical information
+of the original.
 
 Scoring dimensions:
 1. Factual completeness — are key facts preserved?
@@ -9,14 +10,19 @@ Scoring dimensions:
 3. Answer sufficiency — can QA pairs still be answered?
 
 Usage:
-    judge = LLMJudge(provider="anthropic", model="claude-haiku-4-5-20251001")
+    judge = LLMJudge()  # provider="openai", model="gpt-4.1-nano"
     result = await judge.score(task, compressed_text)
     print(result.overall, result.dimensions)
 
+Determinism: both providers are called with ``temperature=0``; the OpenAI
+path additionally sets ``seed=42``. Scores still drift on provider-side
+model updates, so bench_qa strips the whole ``llm_judge`` block before
+running a two-run deep-equal check.
+
 Cost control:
-    - Use @pytest.mark.llm_judge to isolate cost-bearing tests
+    - Use ``@pytest.mark.bench_qa_llm_judge`` to isolate cost-bearing tests
     - Cache results by content hash to avoid re-scoring identical texts
-    - Default to Haiku/mini for <$0.001 per evaluation
+    - Default to nano/Haiku for <$0.001 per evaluation
 """
 
 from __future__ import annotations
@@ -159,6 +165,7 @@ async def _call_anthropic(
         json={
             "model": model,
             "max_tokens": 512,
+            "temperature": 0,
             "system": system,
             "messages": [{"role": "user", "content": user_msg}],
         },
@@ -188,6 +195,8 @@ async def _call_openai(
         json={
             "model": model,
             "max_tokens": 512,
+            "temperature": 0,
+            "seed": 42,
             "messages": [
                 {"role": "system", "content": system},
                 {"role": "user", "content": user_msg},
@@ -211,24 +220,25 @@ async def _call_openai(
 class LLMJudge:
     """Semantic quality judge using LLM evaluation.
 
-    Providers:
-        - "anthropic": Claude Haiku (default model: claude-haiku-4-5-20251001)
-        - "openai": GPT-4o-mini (default model: gpt-4o-mini)
+    Providers (default: ``openai`` / ``gpt-4.1-nano`` — cheapest cost-per-eval
+    as of early 2026; swap via env):
+        - "openai": default model ``gpt-4.1-nano``
+        - "anthropic": default model ``claude-haiku-4-5-20251001``
 
     Environment variables:
-        - ANTHROPIC_API_KEY or OPENAI_API_KEY
+        - OPENAI_API_KEY or ANTHROPIC_API_KEY
         - BENCH_LLM_JUDGE_PROVIDER (override provider)
         - BENCH_LLM_JUDGE_MODEL (override model)
     """
 
     DEFAULT_MODELS = {
         "anthropic": "claude-haiku-4-5-20251001",
-        "openai": "gpt-4o-mini",
+        "openai": "gpt-4.1-nano",
     }
 
     def __init__(
         self,
-        provider: str = "anthropic",
+        provider: str = "openai",
         model: str | None = None,
         api_key: str | None = None,
         client: httpx.AsyncClient | None = None,
@@ -236,7 +246,7 @@ class LLMJudge:
         self._provider = os.environ.get("BENCH_LLM_JUDGE_PROVIDER", provider)
         self._model = os.environ.get(
             "BENCH_LLM_JUDGE_MODEL",
-            model or self.DEFAULT_MODELS.get(self._provider, "claude-haiku-4-5-20251001"),
+            model or self.DEFAULT_MODELS.get(self._provider, "gpt-4.1-nano"),
         )
         self._api_key = api_key or self._resolve_api_key()
         self._client = client  # externally managed client (for testing)
@@ -261,13 +271,9 @@ class LLMJudge:
         client = self._client or httpx.AsyncClient()
         try:
             if self._provider == "anthropic":
-                return await _call_anthropic(
-                    client, self._model, system, user_msg, self._api_key
-                )
+                return await _call_anthropic(client, self._model, system, user_msg, self._api_key)
             elif self._provider == "openai":
-                return await _call_openai(
-                    client, self._model, system, user_msg, self._api_key
-                )
+                return await _call_openai(client, self._model, system, user_msg, self._api_key)
             else:
                 raise ValueError(f"Unknown provider: {self._provider}")
         finally:
@@ -330,21 +336,25 @@ class LLMJudge:
                             if qa_text.endswith("```"):
                                 qa_text = qa_text[:-3]
                         qa_data = json.loads(qa_text.strip())
-                        qa_results.append({
-                            "question": qa.question,
-                            "answerable": qa_data.get("answerable", False),
-                            "confidence": qa_data.get("confidence", 0.0),
-                            "reasoning": qa_data.get("reasoning", ""),
-                            "source": qa.source,
-                        })
+                        qa_results.append(
+                            {
+                                "question": qa.question,
+                                "answerable": qa_data.get("answerable", False),
+                                "confidence": qa_data.get("confidence", 0.0),
+                                "reasoning": qa_data.get("reasoning", ""),
+                                "source": qa.source,
+                            }
+                        )
                     except (json.JSONDecodeError, KeyError):
-                        qa_results.append({
-                            "question": qa.question,
-                            "answerable": False,
-                            "confidence": 0.0,
-                            "reasoning": f"Parse error: {qa_raw[:100]}",
-                            "source": qa.source,
-                        })
+                        qa_results.append(
+                            {
+                                "question": qa.question,
+                                "answerable": False,
+                                "confidence": 0.0,
+                                "reasoning": f"Parse error: {qa_raw[:100]}",
+                                "source": qa.source,
+                            }
+                        )
 
             result = LLMJudgeResult(
                 task_id=task.task_id,
@@ -367,9 +377,7 @@ class LLMJudge:
                 error=str(exc),
             )
 
-    async def score_batch(
-        self, tasks: list[tuple[BenchTask, str]]
-    ) -> list[LLMJudgeResult]:
+    async def score_batch(self, tasks: list[tuple[BenchTask, str]]) -> list[LLMJudgeResult]:
         """Score multiple (task, compressed_text) pairs sequentially.
 
         Sequential to respect rate limits. For parallel, use asyncio.gather externally.
@@ -398,7 +406,10 @@ def compute_correlation(
     n = len(rule_scores)
     if n != len(llm_scores) or n < 2:
         return CorrelationResult(
-            n=n, pearson_r=0.0, spearman_rho=0.0, mean_abs_diff=0.0,
+            n=n,
+            pearson_r=0.0,
+            spearman_rho=0.0,
+            mean_abs_diff=0.0,
             pairs=list(zip(rule_scores, llm_scores)),
         )
 

--- a/tests/bench/test_bench_qa_llm_judge.py
+++ b/tests/bench/test_bench_qa_llm_judge.py
@@ -28,6 +28,17 @@ import os
 
 import pytest
 
+# Optional: load OPENAI_API_KEY / ANTHROPIC_API_KEY from a repo-root .env so
+# contributors don't have to ``export`` before invoking pytest. ``.env`` is
+# gitignored; ``load_dotenv()`` is a no-op when the file is absent and never
+# overrides variables already set in the process environment.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
 from bench.bench_qa import (
     deterministic_trace_id,
     latest_metrics_row,

--- a/tests/bench/test_bench_qa_llm_judge.py
+++ b/tests/bench/test_bench_qa_llm_judge.py
@@ -85,7 +85,7 @@ async def test_llm_judge_scores_scenario(scenario_id: str, tmp_path, bench_qa_re
         answerable, total = qa_answerable_ratio(probes, compressed)
         keyword_ratio = answerable / total if total else 1.0
 
-        judge_result = score_scenario(
+        judge_result = await score_scenario(
             scenario_id=scenario_id,
             description=fixture.get("description", ""),
             original=fixture["payload"],

--- a/tests/bench/test_bench_qa_llm_judge.py
+++ b/tests/bench/test_bench_qa_llm_judge.py
@@ -1,0 +1,139 @@
+"""bench_qa — LLM-as-judge advisory (opt-in via ``-m bench_qa_llm_judge``).
+
+The marker is intentionally NOT ``bench_qa`` so the default CI job
+(``-m bench_qa``) does not incur API cost. Runs only when
+``OPENAI_API_KEY`` or ``ANTHROPIC_API_KEY`` is set — skipped otherwise.
+
+Scope: happy-path scenarios (no ``force_tier``) where the compression
+pipeline produces a semantic compressed output. Fallback ladder scenarios
+(s01/s06/s08) require additional stubbing that mirrors the fallback
+suite; S10 uses the surfacing harness. Both are follow-up candidates.
+
+Determinism: both providers use ``temperature=0`` (OpenAI also ``seed=42``);
+results cache to ``tests/bench/.llm_judge_cache/`` so re-runs are free.
+``canonicalize_report`` strips the whole ``llm_judge`` block so the
+existing s09 two-run determinism gate is unaffected.
+
+Assertions are advisory: the test fails only if the adapter returns
+``None`` despite an API key being present. Dimension scores and the
+keyword-↔-LLM correlation (Pearson/Spearman) are logged at INFO for
+review but never gate the run. A per-scenario ``llm_gate_min`` ratchet
+belongs to a follow-up PR once scores stabilise over 1–2 weeks.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from bench.bench_qa import (
+    deterministic_trace_id,
+    latest_metrics_row,
+    load_fixture,
+    make_proxy_manager,
+    qa_answerable_ratio,
+)
+from bench.bench_qa.llm_judge_adapter import score_scenario, to_report_dict
+from bench.bench_qa.runner import make_tool_result
+from bench.llm_judge import compute_correlation
+
+logger = logging.getLogger(__name__)
+
+LLM_JUDGE_SCENARIOS = ["s02", "s03", "s04", "s05", "s07", "s09"]
+
+_keyword_vs_llm_pairs: list[tuple[float, float]] = []
+
+
+def _have_api_key() -> bool:
+    return bool(os.environ.get("OPENAI_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _reset_correlation_buffer():
+    _keyword_vs_llm_pairs.clear()
+    yield
+
+
+@pytest.mark.bench_qa_llm_judge
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario_id", LLM_JUDGE_SCENARIOS)
+async def test_llm_judge_scores_scenario(scenario_id: str, tmp_path, bench_qa_report) -> None:
+    if not _have_api_key():
+        pytest.skip("No LLM judge API key (OPENAI_API_KEY / ANTHROPIC_API_KEY)")
+
+    fixture = load_fixture(scenario_id)
+    assert fixture.get("force_tier") is None, (
+        f"{scenario_id}: force_tier set — LLM judge covers happy-path only in this PR"
+    )
+
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+
+    trace_id = deterministic_trace_id(fixture["scenario_id"])
+    compressed = await mgr.call_tool("fake", f"tool_{scenario_id}", {}, trace_id=trace_id)
+    try:
+        row = latest_metrics_row(store)
+        assert row, f"{scenario_id}: proxy_metrics row was not written"
+
+        probes = fixture.get("qa_probes", [])
+        answerable, total = qa_answerable_ratio(probes, compressed)
+        keyword_ratio = answerable / total if total else 1.0
+
+        judge_result = score_scenario(
+            scenario_id=scenario_id,
+            description=fixture.get("description", ""),
+            original=fixture["payload"],
+            compressed=compressed,
+            probes=probes,
+            content_type=fixture.get("content_type", "text"),
+        )
+        assert judge_result is not None, (
+            f"{scenario_id}: score_scenario returned None despite API key present"
+        )
+
+        report = to_report_dict(judge_result)
+        bench_qa_report.record_llm_judge(scenario_id=scenario_id, llm_judge=report)
+
+        logger.info(
+            "llm_judge scenario=%s keyword=%.3f overall=%.3f "
+            "(fc=%.3f sc=%.3f as=%.3f) cached=%s tokens=%d/%d%s",
+            scenario_id,
+            keyword_ratio,
+            report["overall"],
+            report["factual_completeness"],
+            report["structural_coherence"],
+            report["answer_sufficiency"],
+            report["cached"],
+            report["prompt_tokens"],
+            report["completion_tokens"],
+            f" error={report['error']!r}" if report.get("error") else "",
+        )
+        if not report.get("error"):
+            _keyword_vs_llm_pairs.append((keyword_ratio, report["overall"]))
+    finally:
+        store.close()
+
+
+@pytest.mark.bench_qa_llm_judge
+def test_zz_keyword_vs_llm_judge_correlation() -> None:
+    """Log Pearson/Spearman between keyword gate and LLM judge. Advisory."""
+    if not _have_api_key():
+        pytest.skip("No LLM judge API key")
+    if len(_keyword_vs_llm_pairs) < 3:
+        pytest.skip(f"need >=3 scenario results for correlation; have {len(_keyword_vs_llm_pairs)}")
+    keyword_scores = [p[0] for p in _keyword_vs_llm_pairs]
+    llm_scores = [p[1] for p in _keyword_vs_llm_pairs]
+    corr = compute_correlation(keyword_scores, llm_scores)
+    logger.info(
+        "llm_judge correlation vs keyword: n=%d pearson=%.3f spearman=%.3f mad=%.3f",
+        corr.n,
+        corr.pearson_r,
+        corr.spearman_rho,
+        corr.mean_abs_diff,
+    )


### PR DESCRIPTION
## Summary

- Wire the already-present-but-unused `tests/bench/llm_judge.py` skeleton into the bench_qa report flow so paraphrase-style compression (keyword gate false-negatives) can be caught by a second signal.
- Advisory only in this PR: the keyword gate is unchanged and remains the single source of truth for pass/fail. The LLM judge logs per-dimension scores and a Pearson/Spearman correlation against the keyword ratio.
- Opt-in via `@pytest.mark.bench_qa_llm_judge` (off by default in CI; the marker is deliberately not tagged `bench_qa`).

Roadmap position: item 3 of `1-progressive-ttl-merry-seal.md`. Item 9 (multi-model agreement) and the floor ratchet are follow-ups; this PR only produces observation data.

## Behavior change

- New pytest marker `bench_qa_llm_judge` registered in `pyproject.toml`.
- The `test` CI job filter adds `and not bench_qa_llm_judge` (`.github/workflows/ci.yml:41`). The `bench_qa` job already excludes it because the new tests are not tagged `bench_qa`.
- `tests/bench/llm_judge.py` skeleton defaults flipped: provider `anthropic` -> `openai`, model `gpt-4o-mini` -> `gpt-4.1-nano` (cheapest cost-per-eval on the 2026 price list); both provider bodies now send `temperature=0`, OpenAI also `seed=42`. Existing mock tests in `tests/test_bench_pipeline.py` pin `provider=\"anthropic\"` explicitly, so the default change does not cascade.
- `canonicalize_report()` additionally pops `scenarios[*].llm_judge` so the s09 two-run determinism gate stays green — provider-side model updates can shift scores even at temperature=0, and `cached`/token counts flip across runs.
- `.env` auto-load via optional `python-dotenv` (no-op when missing) for local-dev convenience.

## Observation seed (OpenAI gpt-4.1-nano, 2 live runs)

| scenario | keyword ratio | LLM overall | fc | sc | as | tokens in/out | cache hit on re-run |
|----------|---------------|-------------|------|------|------|---------------|---------------------|
| s02 | 0.667 | 0.800 | 0.800 | 0.900 | 0.700 | 3662 / 304 | yes |
| s03 | 0.667 | 0.830 | 0.900 | 0.800 | 0.800 | 3138 / 298 | yes |
| s04 | 0.667 | 0.800 | 0.900 | 0.800 | 0.700 | 3734 / 322 | yes |
| s05 | 0.333 | 0.820 | 0.800 | 0.900 | 0.700 | 3852 / 343 | no (progressive TTL string embedded in compressed output) |
| s07 | 1.000 | 0.700 | 0.700 | 0.800 | 0.600 | 9069 / 500 | no (SELECTIVE TOC ordering drift) |
| s09 | 1.000 | 0.980 | 1.000 | 0.900 | 1.000 | 3153 / 261 | yes |

Correlation (n=6): `pearson=0.113 spearman=-0.063 mad=0.206`.

Cost: ~$0.004 per full 6-scenario run on nano; cache hits bring re-runs down to the two non-deterministic scenarios (~$0.0014).

Two scenarios are interesting as rationale:

- **s05** (`keyword=0.333` but `overall=0.820`): SKELETON produced a paraphrase that dropped the exact keywords but preserved meaning. This is the textbook false-negative case the LLM judge is meant to catch.
- **s07** (`keyword=1.000` but `overall=0.700`): SELECTIVE passes the keyword gate (ranked IDs present) but the LLM flags structural coherence in the compact TOC. Different signal, not necessarily a bug — advisory data.

Low pearson + mildly negative spearman on n=6 means the two signals are measuring genuinely different properties. That is the entire reason for collecting this data before any ratchet.

## Test plan

- [x] `uv run pytest -m \"not ollama and not bench_qa_meta and not bench_qa_llm_judge\" --tb=short -q` — 1433 passed
- [x] `uv run pytest tests/bench/test_bench_qa_determinism.py -v` — 2 passed (s09 two-run deep-equal + canonicalize contract)
- [x] `unset OPENAI_API_KEY ANTHROPIC_API_KEY; uv run pytest tests/bench/test_bench_qa_llm_judge.py -m bench_qa_llm_judge -v` — 7 SKIPPED (no hard fail)
- [x] `uv run pytest tests/bench/test_bench_qa_llm_judge.py -m bench_qa_llm_judge -v --log-cli-level=INFO` with `.env` containing `OPENAI_API_KEY` — all 7 pass, second run shows `cached=True` on 4/6
- [x] `uv run ruff check src && uv run ruff format --check src` — green

## Non-goals (explicit follow-ups)

- CI secret + optional nightly job that exercises the marker
- Per-scenario `llm_gate_min` fixture field; advisory -> soft gate
- `summary.md` column once correlation stabilises over more scenarios
- Multi-model agreement score (roadmap item 9)
- Fallback-ladder (s01 / s06 / s08) and surfacing (s10) coverage — both need harness adjustments
- Root-cause on s05 / s07 non-deterministic compressed output (TTL string, TOC ordering) — low priority since the LLM judge is advisory