### PR TITLE
docs: refresh stale line references in pipeline/custom-integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ uv run pytest -m "not ollama"          # skip Ollama-dependent tests
 uv run pytest                          # full suite (requires running Ollama)
 
 # Lint and format
-uv run ruff check src --fix
+uv run ruff check src
 uv run ruff format src
 
 # Type check

--- a/docs/custom-integration.md
+++ b/docs/custom-integration.md
@@ -134,9 +134,10 @@ If `index_file()` raises, the proxy logs a WARNING with traceback and
 returns the unindexed response.  The caller sees a successful result
 but the response is not searchable in LTM.
 
-- **Manager guard**: `manager.py:1327` catches and returns `surfaced`.
-- **Inner handler**: `memory_ops.py:78` catches, logs, returns
-  `chunks=0`.
+- **Manager guard**: `manager.py:1508` catches and returns `surfaced`.
+- **Inner handler**: `auto_index_response` at `memory_ops.py:152-162`
+  catches, logs, returns `chunks=0` with `ok=False` and
+  `error="<ExcType>: <msg>"`.
 - **Fixed in**: `977da4f` (outer guard), traceback logging confirmed.
 
 ### 2. No file-level dedup on auto-index retries
@@ -164,7 +165,8 @@ remain orphaned until manually re-indexed.
 
 When `extraction.background=true` (default), extraction runs as an
 `asyncio.create_task`.  If the task fails internally, the exception is
-caught and logged at WARNING level (`memory_ops.py:159`), but:
+caught and logged at WARNING level by the `extract_and_store` outer
+handler at `memory_ops.py:248-254`, but:
 
 - The caller (agent/user) is not notified.
 - No retry is attempted.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -151,7 +151,7 @@ for configuration and
 [Custom Integration](custom-integration.md) for `FileIndexer` wiring.
 
 **Failure guard (F1).**  If `_auto_index_response` raises,
-`ProxyManager` catches at `manager.py:1346`, logs WARNING with
+`ProxyManager` catches at `manager.py:1508`, logs WARNING with
 traceback, and returns the pre-index response unchanged.  The agent
 receives a successful result; the response is just not searchable
 in LTM.


### PR DESCRIPTION
## Summary

Four line references in `docs/pipeline.md` and `docs/custom-integration.md` had drifted from the current source after recent `manager.py` / `memory_ops.py` refactoring — one even pointed at the wrong function. Also aligns the `CONTRIBUTING.md` lint snippet with the README/CI invocation.

- `docs/pipeline.md:154` — F1 auto-index outer guard: `manager.py:1346` → **1508**
- `docs/custom-integration.md:137` — F1 manager guard: `manager.py:1327` → **1508**
- `docs/custom-integration.md:138` — F1 inner handler: `memory_ops.py:78` (a dataclass field blank line) → **`auto_index_response` at `memory_ops.py:152-162`** (function name added for grep durability)
- `docs/custom-integration.md:167` — Extraction fire-and-forget: `memory_ops.py:159` was inside `auto_index_response`, not extraction; corrected to **`extract_and_store` outer handler at `memory_ops.py:248-254`**
- `CONTRIBUTING.md:20` — Drop `--fix` from the `ruff check` step so local and CI guidance match

Pure documentation refresh — no behavior change.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — all checks passed
- [x] `grep -rn "manager.py:1327\|manager.py:1346\|memory_ops.py:78\|memory_ops.py:159\|ruff check src --fix"` — 0 hits across the repo
- [x] Spot-check each new reference against `src/memtomem_stm/proxy/{manager.py,memory_ops.py}` at the cited line numbers
- [x] `git diff --stat` — 3 files, +8/−6

🤖 Generated with [Claude Code](https://claude.com/claude-code)