### PR TITLE
fix(notebooks): correct notebook 05 echo fixture refs and notebook 00 count

### DIFF
--- a/notebooks/00_cli_and_mcp_hybrid.ipynb
+++ b/notebooks/00_cli_and_mcp_hybrid.ipynb
@@ -23,7 +23,7 @@
     "This notebook is a prelude to the rest of the series: it\n",
     "walks both interfaces end-to-end against a trivial echo\n",
     "fixture so you can see the relationship explicitly. Every\n",
-    "other notebook (01 through 04) assumes you already have this\n",
+    "other notebook (01 through 05) assumes you already have this\n",
     "mental model.\n",
     "\n",
     "**You will learn:**\n",

--- a/notebooks/05_observability_and_langfuse.ipynb
+++ b/notebooks/05_observability_and_langfuse.ipynb
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fixture_script = str(fixtures_dir() / \"echo_server.py\")\n",
+    "fixture_script = str(fixtures_dir() / \"echo_mcp.py\")\n",
     "subprocess.run(\n",
     "    [\"mms\", \"add\", \"echo\", \"--command\", \"uv\", \"--args\",\n",
     "     f\"run,python,{fixture_script}\", \"--prefix\", \"echo\"],\n",
@@ -108,7 +108,7 @@
     "print(\"Registered echo fixture.\")\n",
     "\n",
     "async with stm_session() as session:\n",
-    "    result = await session.call_tool(\"echo__echo\", {\"text\": \"hello observability\"})\n",
+    "    result = await session.call_tool(\"echo__say\", {\"text\": \"hello observability\"})\n",
     "    print(extract_text(result))"
    ]
   },

--- a/notebooks/_build_notebooks.py
+++ b/notebooks/_build_notebooks.py
@@ -93,7 +93,7 @@ def build_nb00() -> None:
             This notebook is a prelude to the rest of the series: it
             walks both interfaces end-to-end against a trivial echo
             fixture so you can see the relationship explicitly. Every
-            other notebook (01 through 04) assumes you already have this
+            other notebook (01 through 05) assumes you already have this
             mental model.
 
             **You will learn:**
@@ -1196,7 +1196,7 @@ def build_nb05() -> None:
         ),
         _code(
             """
-            fixture_script = str(fixtures_dir() / "echo_server.py")
+            fixture_script = str(fixtures_dir() / "echo_mcp.py")
             subprocess.run(
                 ["mms", "add", "echo", "--command", "uv", "--args",
                  f"run,python,{fixture_script}", "--prefix", "echo"],
@@ -1206,7 +1206,7 @@ def build_nb05() -> None:
             print("Registered echo fixture.")
 
             async with stm_session() as session:
-                result = await session.call_tool("echo__echo", {"text": "hello observability"})
+                result = await session.call_tool("echo__say", {"text": "hello observability"})
                 print(extract_text(result))
             """
         ),


### PR DESCRIPTION
## Summary

Three stale references were found during a post-v0.1.8 audit of the tutorial notebooks. The most serious one made **notebook 05 crash on its second code cell** before any observability content was reached.

| # | Where | Old | New | Impact |
|---|-------|-----|-----|--------|
| 1 | notebook 00 intro | `(01 through 04)` | `(01 through 05)` | Phrasing drift — six notebooks since v0.1.6 added 05 |
| 2 | notebook 05 §2 | `fixtures_dir() / "echo_server.py"` | `"echo_mcp.py"` | **Crash** — file was renamed; current code hits `FileNotFoundError` |
| 3 | notebook 05 §2 | `call_tool("echo__echo", …)` | `call_tool("echo__say", …)` | **Crash** — `echo_mcp.py` exports `say()` (namespaced `echo__say` via `--prefix echo`), not `echo()` |

Notebooks 01–04 were verified drift-free against v0.1.8 (MCP tool list, CLI commands, config keys, compression strategies, Langfuse span names all current).

## Implementation notes

- `_build_notebooks.py` was patched at the matching lines so future regenerations stay consistent with the `.ipynb` files.
- The `.ipynb` edits were applied via **targeted string replacement** rather than a full `uv run python notebooks/_build_notebooks.py` regeneration. Reason: PR #150 added content directly to two `.ipynb` files (notebook 03's S1 failure-guard callout, notebook 05's "Log level configuration" section and Recap row) without routing those edits back through `_build_notebooks.py`. A blind regeneration would clobber that work. Reconciling the builder source with those direct edits is out of scope for this PR and tracked as a follow-up.
- Diff is clean: 3 files, +6/-6 total, one content line per finding.

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` for both edited `.ipynb` files — still valid JSON
- [x] `grep -rn "echo_server\|echo__echo\|01 through 04" notebooks/` — 0 matches
- [x] `git diff --stat notebooks/` shows +6/-6 across 3 files, no id churn
- [ ] Manual smoke of notebook 05's second cell against a running STM — best confirmed by whoever reruns the notebook next