### PR TITLE
fix(notebooks): reconcile builder with direct edits from #150

### DIFF
--- a/notebooks/03_memory_surfacing.ipynb
+++ b/notebooks/03_memory_surfacing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "46fb126e",
+   "id": "ce70ca07",
    "metadata": {},
    "source": [
     "# 03 — Memory surfacing with a fake LTM\n",
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2183f170",
+   "id": "f4839e51",
    "metadata": {},
    "source": [
     "## 1. Isolate state and point surfacing at the fake LTM"
@@ -42,7 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7b680e1",
+   "id": "6665639b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4dce56c8",
+   "id": "e194cf78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1b2a30d",
+   "id": "e7a5c017",
    "metadata": {},
    "source": [
     "> **Note:** In a real setup you would replace the fake LTM\n",
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64ad3441",
+   "id": "d958d90b",
    "metadata": {},
    "source": [
     "## 2. Register a small upstream and talk to it via STM"
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e74995d",
+   "id": "bf997cfd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "326a6ccc",
+   "id": "4e35707e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce773a6a",
+   "id": "58c40e7c",
    "metadata": {},
    "source": [
     "## 3. What just happened\n",
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f4d4214",
+   "id": "8d30ecba",
    "metadata": {},
    "source": [
     "## 4. Send feedback"
@@ -177,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98ce1c9e",
+   "id": "7370febf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,14 +198,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bae485f",
+   "id": "9adb746b",
    "metadata": {},
-   "source": "Over time, `\"helpful\"` feedback raises the confidence of the\nretrieved memory chunks via STM's auto-tuning loop, and\n`\"not_relevant\"` pulls them down. Agents that call the\nfeedback tool get progressively more relevant surfacing.\nSee [`docs/surfacing.md`](../docs/surfacing.md) for the\nscoring details.\n\n> **S1 failure guard.** In production, if `record_surfacing`\n> fails (e.g. SQLite contention on `stm_feedback.db`), STM\n> drops the `surfacing_id` — the memory block is still\n> injected but without a feedback ID. When this happens,\n> `stm_surfacing_feedback` cannot be called for that event.\n> The response is never blocked. See\n> [`docs/pipeline.md → Stage 3`](../docs/pipeline.md#stage-3-surface).\n\n## 5. Check the surfacing counters"
+   "source": [
+    "Over time, `\"helpful\"` feedback raises the confidence of the\n",
+    "retrieved memory chunks via STM's auto-tuning loop, and\n",
+    "`\"not_relevant\"` pulls them down. Agents that call the\n",
+    "feedback tool get progressively more relevant surfacing.\n",
+    "See [`docs/surfacing.md`](../docs/surfacing.md) for the\n",
+    "scoring details.\n",
+    "\n",
+    "> **S1 failure guard.** In production, if `record_surfacing`\n",
+    "> fails (e.g. SQLite contention on `stm_feedback.db`), STM\n",
+    "> drops the `surfacing_id` — the memory block is still\n",
+    "> injected but without a feedback ID. When this happens,\n",
+    "> `stm_surfacing_feedback` cannot be called for that event.\n",
+    "> The response is never blocked. See\n",
+    "> [`docs/pipeline.md → Stage 3`](../docs/pipeline.md#stage-3-surface).\n",
+    "\n",
+    "## 5. Check the surfacing counters"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b54fdb1",
+   "id": "2e9fdafd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbf42770",
+   "id": "c516caf2",
    "metadata": {},
    "source": [
     "## Where to next\n",

--- a/notebooks/05_observability_and_langfuse.ipynb
+++ b/notebooks/05_observability_and_langfuse.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "25f66d7e",
+   "id": "267cc112",
    "metadata": {},
    "source": [
     "# 05 — Observability and Langfuse Tracing\n",
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6da7de8a",
+   "id": "34ee5f5d",
    "metadata": {},
    "source": [
     "## 1. Isolate state and import helpers"
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "729f1de7",
+   "id": "f2d0d9ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19fc7428",
+   "id": "5777b296",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57a47297",
+   "id": "916f6fa2",
    "metadata": {},
    "source": [
     "## 2. Register a fixture server and make a call\n",
@@ -94,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2badd76",
+   "id": "fc802e81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75651044",
+   "id": "81073b50",
    "metadata": {},
    "source": [
     "## 3. Built-in observability: `stm_proxy_stats`\n",
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61bca558",
+   "id": "67f9da3e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23dec035",
+   "id": "cd5a3286",
    "metadata": {},
    "source": [
     "## 4. Built-in observability: `stm_proxy_health`\n",
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93d14ec9",
+   "id": "604aab1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c3ed8521",
+   "id": "73f5949d",
    "metadata": {},
    "source": [
     "## 5. What Langfuse tracing adds\n",
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74a97b90",
+   "id": "1ab72547",
    "metadata": {},
    "source": [
     "## 6. Enabling Langfuse\n",
@@ -204,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b91c8c6",
+   "id": "1f851db8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +221,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1276e875",
+   "id": "c46055fb",
    "metadata": {},
    "source": [
     "## 7. Sampling configuration\n",
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19c04b24",
+   "id": "c031ce2d",
    "metadata": {},
    "source": [
     "## 8. Trace context propagation\n",
@@ -255,15 +255,55 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a44394da",
-   "source": "## 9. Log level configuration\n\nSTM uses Python's `logging` module. Control verbosity via\nenvironment variable:\n\n```bash\nexport MEMTOMEM_STM_LOG_LEVEL=WARNING   # default\nexport MEMTOMEM_STM_LOG_LEVEL=DEBUG     # full pipeline tracing\n```\n\n| Level | What it shows |\n|-------|---------------|\n| `DEBUG` | Pipeline tracing, strategy selection, cache decisions |\n| `INFO` | Surfacing injections, config reloads, extraction completions |\n| `WARNING` | Failure guards (F1/S1), fallback activations, skips |\n| `ERROR` | Unrecoverable failures (rare — most errors fall back) |\n\nThe level is read once at startup — restart the server to\napply changes. See\n[`docs/operations.md → Logging`](../docs/operations.md#logging)\nfor format details.",
-   "metadata": {}
+   "id": "b63b7685",
+   "metadata": {},
+   "source": [
+    "## 9. Log level configuration\n",
+    "\n",
+    "STM uses Python's `logging` module. Control verbosity via\n",
+    "environment variable:\n",
+    "\n",
+    "```bash\n",
+    "export MEMTOMEM_STM_LOG_LEVEL=WARNING   # default\n",
+    "export MEMTOMEM_STM_LOG_LEVEL=DEBUG     # full pipeline tracing\n",
+    "```\n",
+    "\n",
+    "| Level | What it shows |\n",
+    "|-------|---------------|\n",
+    "| `DEBUG` | Pipeline tracing, strategy selection, cache decisions |\n",
+    "| `INFO` | Surfacing injections, config reloads, extraction completions |\n",
+    "| `WARNING` | Failure guards (F1/S1), fallback activations, skips |\n",
+    "| `ERROR` | Unrecoverable failures (rare — most errors fall back) |\n",
+    "\n",
+    "The level is read once at startup — restart the server to\n",
+    "apply changes. See\n",
+    "[`docs/operations.md → Logging`](../docs/operations.md#logging)\n",
+    "for format details."
+   ]
   },
   {
    "cell_type": "markdown",
-   "id": "a26b98f7",
+   "id": "1f0afb84",
    "metadata": {},
-   "source": "## Recap\n\n| Layer | What you get | When to use |\n|---|---|---|\n| MCP tools | Live snapshot, agent-accessible | Quick checks |\n| SQLite | Full history, offline analysis | Debugging, tuning |\n| Logging | `MEMTOMEM_STM_LOG_LEVEL` control | Failure diagnosis (F1/S1) |\n| Langfuse | Nested spans, team-shared UI | Production monitoring |\n\n**Where to next:**\n\n- [`docs/operations.md`](../docs/operations.md) — full\n  observability reference (logging, spans, data storage, safety)\n- [`docs/configuration.md`](../docs/configuration.md) — env\n  vars for log level, Langfuse, and all other settings\n- [Langfuse docs](https://langfuse.com/docs) — dashboard\n  setup and SDK reference"
+   "source": [
+    "## Recap\n",
+    "\n",
+    "| Layer | What you get | When to use |\n",
+    "|---|---|---|\n",
+    "| MCP tools | Live snapshot, agent-accessible | Quick checks |\n",
+    "| SQLite | Full history, offline analysis | Debugging, tuning |\n",
+    "| Logging | `MEMTOMEM_STM_LOG_LEVEL` control | Failure diagnosis (F1/S1) |\n",
+    "| Langfuse | Nested spans, team-shared UI | Production monitoring |\n",
+    "\n",
+    "**Where to next:**\n",
+    "\n",
+    "- [`docs/operations.md`](../docs/operations.md) — full\n",
+    "  observability reference (logging, spans, data storage, safety)\n",
+    "- [`docs/configuration.md`](../docs/configuration.md) — env\n",
+    "  vars for log level, Langfuse, and all other settings\n",
+    "- [Langfuse docs](https://langfuse.com/docs) — dashboard\n",
+    "  setup and SDK reference"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/_build_notebooks.py
+++ b/notebooks/_build_notebooks.py
@@ -843,6 +843,14 @@ def build_nb03() -> None:
             See [`docs/surfacing.md`](../docs/surfacing.md) for the
             scoring details.
 
+            > **S1 failure guard.** In production, if `record_surfacing`
+            > fails (e.g. SQLite contention on `stm_feedback.db`), STM
+            > drops the `surfacing_id` — the memory block is still
+            > injected but without a feedback ID. When this happens,
+            > `stm_surfacing_feedback` cannot be called for that event.
+            > The response is never blocked. See
+            > [`docs/pipeline.md → Stage 3`](../docs/pipeline.md#stage-3-surface).
+
             ## 5. Check the surfacing counters
             """
         ),
@@ -1320,20 +1328,46 @@ def build_nb05() -> None:
         ),
         _md(
             """
+            ## 9. Log level configuration
+
+            STM uses Python's `logging` module. Control verbosity via
+            environment variable:
+
+            ```bash
+            export MEMTOMEM_STM_LOG_LEVEL=WARNING   # default
+            export MEMTOMEM_STM_LOG_LEVEL=DEBUG     # full pipeline tracing
+            ```
+
+            | Level | What it shows |
+            |-------|---------------|
+            | `DEBUG` | Pipeline tracing, strategy selection, cache decisions |
+            | `INFO` | Surfacing injections, config reloads, extraction completions |
+            | `WARNING` | Failure guards (F1/S1), fallback activations, skips |
+            | `ERROR` | Unrecoverable failures (rare — most errors fall back) |
+
+            The level is read once at startup — restart the server to
+            apply changes. See
+            [`docs/operations.md → Logging`](../docs/operations.md#logging)
+            for format details.
+            """
+        ),
+        _md(
+            """
             ## Recap
 
             | Layer | What you get | When to use |
             |---|---|---|
             | MCP tools | Live snapshot, agent-accessible | Quick checks |
             | SQLite | Full history, offline analysis | Debugging, tuning |
+            | Logging | `MEMTOMEM_STM_LOG_LEVEL` control | Failure diagnosis (F1/S1) |
             | Langfuse | Nested spans, team-shared UI | Production monitoring |
 
             **Where to next:**
 
             - [`docs/operations.md`](../docs/operations.md) — full
-              observability reference (span table, data storage, safety)
+              observability reference (logging, spans, data storage, safety)
             - [`docs/configuration.md`](../docs/configuration.md) — env
-              vars for Langfuse and all other settings
+              vars for log level, Langfuse, and all other settings
             - [Langfuse docs](https://langfuse.com/docs) — dashboard
               setup and SDK reference
             """


### PR DESCRIPTION
## Summary

PR #150 added content directly to `notebooks/03_memory_surfacing.ipynb` and `notebooks/05_observability_and_langfuse.ipynb` without routing those edits through `notebooks/_build_notebooks.py`. The builder's own module docstring says:

> edits should flow through here to avoid JSON drift

so the #150 additions were sitting in a state where any future `uv run python notebooks/_build_notebooks.py` would have silently deleted them. This PR ports the three pieces back into the builder and regenerates the two notebooks so source and output are aligned again.

### Ported content

| Location | Content |
|----------|---------|
| nb03 §4 cell | Blockquote explaining the **S1 failure guard** — `record_surfacing` SQLite contention drops the `surfacing_id`; response is never blocked; cross-link to `docs/pipeline.md` Stage 3. |
| nb05 (new) §9 cell | "Log level configuration" — `MEMTOMEM_STM_LOG_LEVEL` env var, DEBUG/INFO/WARNING/ERROR level table, cross-link to `docs/operations.md → Logging`. |
| nb05 Recap | New "Logging" row in the layer table; "Where to next" bullets updated to mention logging alongside Langfuse. |

### Why not regenerate all six notebooks

`_build_notebooks.py` uses `nbformat`'s default random cell IDs, so a full regen would touch all six `.ipynb` files with pure id churn. 00/01/02/04 had zero builder-source changes, so they were reset to HEAD to keep the diff focused on real content.

### Side effect worth noting

The three cells #150 wrote are now serialized as the nbformat-default **list-of-strings** `source` form instead of the **single-string** form #150 produced. Semantically identical (same rendered output), but makes future diffs smaller and matches every other cell in the repo.

## Test plan

- [x] `uv run python notebooks/_build_notebooks.py` — writes all six notebooks without error
- [x] `python3 -c "import json; json.load(open(...))"` for the regenerated `.ipynb` files — valid JSON
- [x] grep verification on regenerated notebooks:
  - `03` contains 1 cell with `"S1 failure guard"`
  - `05` contains 1 cell with `MEMTOMEM_STM_LOG_LEVEL` in §9 plus 1 Recap row `Logging | MEMTOMEM_STM_LOG_LEVEL control`
- [x] `git diff --stat notebooks/` shows exactly 3 files touched (builder + nb03 + nb05)
- [x] No builder-source changes in 00/01/02/04 → reset to HEAD to suppress pure id churn