### PR TITLE
fix: link bench trace prefix in operations.md (follow-up to #180)

### DIFF
--- a/docs/bench_qa.md
+++ b/docs/bench_qa.md
@@ -157,8 +157,9 @@ Two consequences:
    runs, so `SELECT … WHERE trace_id = ?` is a reliable lookup.
 2. The `bench-` prefix lets operators filter bench rows out of
    production dashboards and Langfuse views
-   (`WHERE trace_id LIKE 'bench-%'`). The prefix is code-only today —
-   `docs/operations.md` does not yet cross-link it.
+   (`WHERE trace_id LIKE 'bench-%'`). See
+   [operations.md → Metrics](operations.md#metrics) for the
+   operator-facing cross-link.
 
 `canonicalize_report()` drops wall-clock timings
 (`clean_ms` / `compress_ms` / `surface_ms`), metrics noise that is not

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -169,7 +169,7 @@ Surfacing: enabled (min_score=0.02)
 ```
 
 - **Error classification** — errors are categorized as `transport`, `timeout`, `protocol`, `upstream_error`, `programming`, or `internal_error`. The `internal_error` category covers exceptions raised inside the CLEAN/COMPRESS/SURFACE/INDEX pipeline after the upstream call already returned (rare in practice — most strategies fall back internally — but recording these guarantees no failed call is invisible). Each failed call records the category and code for debugging.
-- **Trace IDs** — every proxy call generates a unique `trace_id` (16-char hex) for correlating logs and metrics.
+- **Trace IDs** — every proxy call generates a unique `trace_id` (16-char hex) for correlating logs and metrics. Bench fixtures instead emit a deterministic `bench-<sha256[:16]>` prefix so operators can exclude them from production aggregates (`WHERE trace_id NOT LIKE 'bench-%'`); see [bench_qa.md → Operator trace filter](bench_qa.md#operator-trace-filter).
 
 Metrics are persisted to SQLite (`~/.memtomem/proxy_metrics.db`, max 10K entries) with error category and trace_id columns.
 


### PR DESCRIPTION
## Summary

PR #180 body called out that `docs/operations.md` would gain a cross-link
to the `bench-<sha256[:16]>` trace_id prefix from the bench_qa subsystem.
This PR closes that follow-up.

- `docs/operations.md` — extend the **Trace IDs** bullet in
  `### Metrics` with the `bench-` prefix, the
  `WHERE trace_id NOT LIKE 'bench-%'` exclusion recipe, and a link into
  `bench_qa.md#operator-trace-filter`.
- `docs/bench_qa.md` — replace the "prefix is code-only today —
  `docs/operations.md` does not yet cross-link it" qualifier with a
  reverse link to `operations.md#metrics`.

No code changes.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — passes
- [x] Manually verified both new anchors resolve: `bench_qa.md` has
      `## Operator trace filter` → `#operator-trace-filter`;
      `operations.md` has `### Metrics` → `#metrics`.
- [x] `uv run pytest -m "not ollama"` unchanged — documentation-only PR.