### PR TITLE
fix(notebooks): correct mms add invocation in notebook 05

### DIFF
--- a/notebooks/05_observability_and_langfuse.ipynb
+++ b/notebooks/05_observability_and_langfuse.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "267cc112",
+   "id": "b74a1b25",
    "metadata": {},
    "source": [
     "# 05 — Observability and Langfuse Tracing\n",
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34ee5f5d",
+   "id": "0b282788",
    "metadata": {},
    "source": [
     "## 1. Isolate state and import helpers"
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2d0d9ab",
+   "id": "43f67417",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5777b296",
+   "id": "c6c33621",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "916f6fa2",
+   "id": "5d3fa517",
    "metadata": {},
    "source": [
     "## 2. Register a fixture server and make a call\n",
@@ -94,14 +94,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc802e81",
+   "id": "4f2af307",
    "metadata": {},
    "outputs": [],
    "source": [
-    "fixture_script = str(fixtures_dir() / \"echo_mcp.py\")\n",
+    "fixture_script = fixtures_dir() / \"echo_mcp.py\"\n",
     "subprocess.run(\n",
-    "    [\"mms\", \"add\", \"echo\", \"--command\", \"uv\", \"--args\",\n",
-    "     f\"run,python,{fixture_script}\", \"--prefix\", \"echo\"],\n",
+    "    [\n",
+    "        \"uv\", \"run\", \"mms\", \"add\", \"echo\",\n",
+    "        \"--config\", str(config_path),\n",
+    "        \"--command\", \"uv\",\n",
+    "        \"--args\", f\"run python {fixture_script}\",\n",
+    "        \"--prefix\", \"echo\",\n",
+    "    ],\n",
     "    check=True,\n",
     "    capture_output=True,\n",
     ")\n",
@@ -114,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81073b50",
+   "id": "aa410a7b",
    "metadata": {},
    "source": [
     "## 3. Built-in observability: `stm_proxy_stats`\n",
@@ -126,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67f9da3e",
+   "id": "4d392130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd5a3286",
+   "id": "640b7cb9",
    "metadata": {},
    "source": [
     "## 4. Built-in observability: `stm_proxy_health`\n",
@@ -148,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "604aab1d",
+   "id": "e3a8f7fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73f5949d",
+   "id": "31525361",
    "metadata": {},
    "source": [
     "## 5. What Langfuse tracing adds\n",
@@ -184,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ab72547",
+   "id": "8a31a9b5",
    "metadata": {},
    "source": [
     "## 6. Enabling Langfuse\n",
@@ -204,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f851db8",
+   "id": "5c20dff8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c46055fb",
+   "id": "1db6a4e1",
    "metadata": {},
    "source": [
     "## 7. Sampling configuration\n",
@@ -238,7 +243,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c031ce2d",
+   "id": "b9ff3657",
    "metadata": {},
    "source": [
     "## 8. Trace context propagation\n",
@@ -255,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b63b7685",
+   "id": "62b1e01b",
    "metadata": {},
    "source": [
     "## 9. Log level configuration\n",
@@ -283,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f0afb84",
+   "id": "3ebe8a62",
    "metadata": {},
    "source": [
     "## Recap\n",

--- a/notebooks/_build_notebooks.py
+++ b/notebooks/_build_notebooks.py
@@ -1204,10 +1204,15 @@ def build_nb05() -> None:
         ),
         _code(
             """
-            fixture_script = str(fixtures_dir() / "echo_mcp.py")
+            fixture_script = fixtures_dir() / "echo_mcp.py"
             subprocess.run(
-                ["mms", "add", "echo", "--command", "uv", "--args",
-                 f"run,python,{fixture_script}", "--prefix", "echo"],
+                [
+                    "uv", "run", "mms", "add", "echo",
+                    "--config", str(config_path),
+                    "--command", "uv",
+                    "--args", f"run python {fixture_script}",
+                    "--prefix", "echo",
+                ],
                 check=True,
                 capture_output=True,
             )


### PR DESCRIPTION
## Summary

Notebook 05 section 2 registered the echo fixture with two bugs that PR #182's builder reconcile did not catch:

- `--args` was comma-separated (`f"run,python,{fixture_script}"`). The CLI parses via `shlex.split` ([`src/memtomem_stm/cli/proxy.py:333`](../blob/main/src/memtomem_stm/cli/proxy.py#L333)), so `uv` received the single literal arg `run,python,/path`, which is not a valid invocation.
- `--config` was omitted. The CLI default is the hardcoded `_DEFAULT_CONFIG` path ([`proxy.py:225`](../blob/main/src/memtomem_stm/cli/proxy.py#L225)); it does not honor `MEMTOMEM_STM_PROXY__CONFIG_PATH`. The notebook was writing the echo entry to the user's real `~/.memtomem/` config instead of the `isolate_stm_state()` tempdir. The helper docstring already instructs callers to pass `--config <path>`.

Rewrote `notebooks/_build_notebooks.py:1205` to mirror the canonical pattern used by notebooks 00/01/02/03/04 and regenerated notebook 05. Notebooks 00-04 were reset to HEAD to avoid committing pure cell-id churn — same workflow PR #182 established.

## Behavior change

Before this PR, running notebook 05 locally from the repo would write an `echo` entry into `~/.memtomem/stm_proxy.json` (the user's real config) and the subsequent `stm_session()` would fail when the proxy tried to spawn `uv run,python,/path...`. After this PR, the CLI call targets the `isolate_stm_state()` tempdir and the echo fixture registers cleanly.

## Test plan

- [x] `uv run pytest --nbmake notebooks/05_observability_and_langfuse.ipynb --nbmake-timeout=180 --tb=short -q` — passes (6.18s)
- [x] `git diff notebooks/` shows only notebook 05 + builder modified (00-04 reset to HEAD)
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [ ] Reviewer confirms notebook 05 content (other than cell ids) is unchanged in structure

Notebook 05 is not in the CI nbmake matrix (`.github/workflows/ci.yml` runs only 00-03), so this was previously unobservable in CI.