### PR TITLE
docs: align README CI pytest filter with workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To check what's happening, ask the agent to call `stm_proxy_stats`.
 
 ```bash
 uv sync                                                    # install dev deps
-uv run pytest -m "not ollama"                              # tests (CI filter)
+uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"   # tests (CI filter)
 uv run ruff check src && uv run ruff format --check src    # lint (required)
 uv run mypy src                                            # typecheck (advisory)
 ```


### PR DESCRIPTION
## Summary

`README.md:140` showed `-m "not ollama"` as the CI-equivalent pytest filter, but [`.github/workflows/ci.yml:41`](../blob/main/.github/workflows/ci.yml#L41) uses `-m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"`. Line 145 claims "CI runs the same commands on every PR", so the literal drift means a contributor copying from README runs a larger suite than CI.

No behavior change to CI — only to what devs get when they copy from README.

## Test plan

- [x] `grep -n 'not ollama' README.md .github/workflows/ci.yml` — literals match
- [ ] Reviewer confirms README section still reads naturally with the longer line