### PR TITLE
docs(readme): add alpha banner above tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![CLA](https://img.shields.io/badge/CLA-required-green)](CLA.md)
 
+> 🚧 **Alpha** — APIs and defaults may change between 0.1.x releases. Feedback and issue reports are especially welcome: [Issues](https://github.com/memtomem/memtomem-stm/issues) · [Discussions](https://github.com/memtomem/memtomem-stm/discussions).
+
 Spend fewer tokens. Remember more. Ship faster.
 
 memtomem-stm is an MCP proxy that typically **cuts token usage by 20–80%** and gives your agent **memory across sessions** — with no changes to your upstream MCP servers.


### PR DESCRIPTION
## Summary
- Add a one-line Alpha banner under the badges, mirroring the parent `memtomem/memtomem` repo.
- Points readers to Issues/Discussions so feedback paths are visible.
- No version bump — the `Development Status :: 3 - Alpha` classifier in `pyproject.toml` is already set, so PyPI metadata will pick up on the next normal release.

## Test plan
- [x] Banner renders as a blockquote on GitHub
- [x] Issues / Discussions links resolve
- [x] No code or version changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)