### PR TITLE
test(contract): cover empty-structured JSON from parent PR #231

### DIFF
--- a/tests/test_core_format_contract.py
+++ b/tests/test_core_format_contract.py
@@ -309,6 +309,39 @@ class TestStructuredFormatSnapshots:
         assert results[1].chunk.id == "def456"
 
 
+# Parent PR #231 (7d184f1, 2026-04-18): mem_search(output_format="structured")
+# now returns JSON on empty results instead of the plain "No results found."
+# text. We pin only ``results == []`` — parent is alpha (Development Status
+# :: 3 - Alpha) and the ``hints`` field is opportunistic, so a future rename
+# or removal upstream must not block STM.
+
+STRUCTURED_NO_RESULTS_PLAIN = '{"results": []}'
+
+STRUCTURED_NO_RESULTS_WITH_HINTS = (
+    '{"results": [], "hints": ['
+    '"No results match your filters (3 results found before filtering). '
+    'Try broader filters or remove source_filter/tag_filter."'
+    ']}'
+)
+
+
+class TestStructuredEmptyResults:
+    """StructuredResultParser tolerates parent PR #231's empty-result JSON
+    in both the bare and hints-augmented shapes."""
+
+    def test_structured_parser_returns_empty_without_hints(self):
+        from memtomem_stm.surfacing.mcp_client import StructuredResultParser
+
+        parser = StructuredResultParser()
+        assert parser.parse(STRUCTURED_NO_RESULTS_PLAIN) == []
+
+    def test_structured_parser_returns_empty_with_hints(self):
+        from memtomem_stm.surfacing.mcp_client import StructuredResultParser
+
+        parser = StructuredResultParser()
+        assert parser.parse(STRUCTURED_NO_RESULTS_WITH_HINTS) == []
+
+
 class TestOutputFormatForwarding:
     """Verify output_format is sent to MCP when using structured parser."""
 


### PR DESCRIPTION
## Summary

- Pin regression coverage for parent memtomem PR #231 (commit `7d184f1`, 2026-04-18), which changed `mem_search(output_format="structured")` to return `{"results": []}` JSON (optionally with a `"hints"` array) on empty results instead of the plain-text `"No results found."`
- `StructuredResultParser` already handles both shapes correctly — this commit just locks that in with two tests so a future drift is caught fast.

## Why the pin is loose

Parent is classified `Development Status :: 3 - Alpha` (`packages/memtomem/pyproject.toml:12`). We pin only `results == []`; the `hints` field is **opportunistic** — present or absent both parse as empty, and a future rename or removal upstream must not block STM.

## What's NOT in this PR

- Fake-server (`_fake_memtomem_server.py`) extension to emit empty-structured JSON end-to-end. That integration-path coverage lands in a later bucket alongside the hints-observability follow-up.
- No production code change. `StructuredResultParser.parse()` already works for both shapes.

## Test plan

- [x] `uv run pytest tests/test_core_format_contract.py -v` → 27 passed (25 existing + 2 new)
- [x] `uv run ruff check src tests` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)