### PR TITLE
feat(surfacing): forward parent LTM hints to operator observability

### DIFF
--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -224,6 +224,12 @@ class TokenTracker:
         # Progressive delivery tracking
         self._progressive_first_chunks = 0
         self._progressive_continuations = 0
+        # LTM hints from parent trust-UX channel (parent PR #231). Count is a
+        # per-surfacing-call event count (not a per-hint count) to keep the
+        # units intuitive for operators reading ``stm_proxy_stats``; the
+        # snapshot is the most recent non-empty hints list.
+        self._total_hint_events = 0
+        self._last_hints: list[str] = []
         # Per-call latencies for percentile computation (bounded rolling window)
         _LATENCY_WINDOW = 10000
         self._clean_latencies: deque[float] = deque(maxlen=_LATENCY_WINDOW)
@@ -279,6 +285,18 @@ class TokenTracker:
 
     def record_progressive_continuation(self) -> None:
         self._progressive_continuations += 1
+
+    def record_hints(self, hints: list[str]) -> None:
+        """Record a non-empty list of LTM hints from a surfacing call.
+
+        Operators read ``stm_proxy_stats`` to see the most recent hints;
+        the event counter answers "did parent send any notices during
+        this run?". Empty lists are no-ops.
+        """
+        if not hints:
+            return
+        self._total_hint_events += 1
+        self._last_hints = list(hints)
 
     def record_error(self, metrics: CallMetrics) -> None:
         """Record a failed tool call for error tracking."""
@@ -357,5 +375,7 @@ class TokenTracker:
             ),
             "progressive_first_chunks": self._progressive_first_chunks,
             "progressive_continuations": self._progressive_continuations,
+            "total_hint_events": self._total_hint_events,
+            "last_hints": list(self._last_hints),
             "by_server": by_server,
         }

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -138,6 +138,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
                         config.surfacing,
                         mcp_adapter=mcp_adapter,
                         feedback_tracker=feedback_tracker,
+                        token_tracker=tracker,
                     )
 
             # Response cache
@@ -303,6 +304,14 @@ async def stm_proxy_stats(
     prog_cont = summary.get("progressive_continuations", 0)
     if prog_first > 0:
         lines.append(f"\nProgressive:     {prog_first} first chunks, {prog_cont} continuations")
+
+    # LTM trust-UX hints (parent PR #231). Quiet when the parent never sent any.
+    hint_events = summary.get("total_hint_events", 0)
+    if hint_events > 0:
+        last_hints = summary.get("last_hints", [])
+        lines.append(f"\nLTM hints:       {hint_events} event(s)")
+        for h in last_hints:
+            lines.append(f"  last: {h}")
 
     if summary["by_server"]:
         lines.append("\nBy server:")

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -38,11 +38,13 @@ class SurfacingEngine:
         mcp_adapter: Any,
         webhook_manager: Any | None = None,
         feedback_tracker: Any | None = None,
+        token_tracker: Any | None = None,
     ) -> None:
         self._config = config
         self._mcp_adapter = mcp_adapter
         self._webhook_manager = webhook_manager
         self._feedback_tracker = feedback_tracker
+        self._token_tracker = token_tracker
         self._auto_tuner = None
         if config.auto_tune_enabled and feedback_tracker is not None:
             from memtomem_stm.surfacing.feedback import AutoTuner
@@ -409,13 +411,27 @@ class SurfacingEngine:
         search_kwargs: dict[str, Any] = {}
         if ctx_win:
             search_kwargs["context_window"] = ctx_win
-        results, _stats = await self._mcp_adapter.search(
+        results, hints = await self._mcp_adapter.search(
             query=query,
             top_k=max_results * 2,
             namespace=namespace,
             trace_id=trace_id,
             **search_kwargs,
         )
+
+        # Parent trust-UX hints (parent PR #231): log at INFO even when results
+        # are empty or get filtered out below, since an operator may want to
+        # see "3 results found before filtering" notices regardless of whether
+        # SURFACE ultimately injects anything. Hints are NOT forwarded to the
+        # downstream agent — that is a prepend-body policy change, out of
+        # scope here. See B3 plan § "forward hints to downstream".
+        if hints:
+            logger.info("LTM hints for %s/%s: %s", server, tool, "; ".join(hints))
+            if self._token_tracker is not None:
+                try:
+                    self._token_tracker.record_hints(hints)
+                except Exception:
+                    logger.debug("token_tracker.record_hints failed", exc_info=True)
 
         # Filter by score, then exclude already-surfaced memories in this session
         scored = [r for r in results if r.score >= min_score]

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -42,9 +42,16 @@ class RemoteSearchResult:
 
 
 class ResultParser:
-    """Strategy interface for parsing mem_search text output."""
+    """Strategy interface for parsing mem_search text output.
 
-    def parse(self, text: str) -> list[RemoteSearchResult]:
+    Returns a ``(results, hints)`` tuple. ``hints`` carries parent-side
+    trust-UX annotations (parent commit ``7d184f1``, PR #231) when the
+    structured format is in use; compact format always returns ``[]``.
+    The hints list is opportunistic — parent is alpha, the field may be
+    renamed or removed, so callers must tolerate an empty list silently.
+    """
+
+    def parse(self, text: str) -> tuple[list[RemoteSearchResult], list[str]]:
         raise NotImplementedError
 
 
@@ -56,12 +63,16 @@ _FIRST_TOKEN_RE = re.compile(r"(\S+)")
 
 
 class CompactResultParser(ResultParser):
-    """Parse core's compact format: ``[rank] score | source > hierarchy``."""
+    """Parse core's compact format: ``[rank] score | source > hierarchy``.
 
-    def parse(self, text: str) -> list[RemoteSearchResult]:
+    The compact format carries no hints channel; the second tuple slot is
+    always an empty list.
+    """
+
+    def parse(self, text: str) -> tuple[list[RemoteSearchResult], list[str]]:
         results: list[RemoteSearchResult] = []
         if not text or not text.strip():
-            return results
+            return results, []
 
         blocks = _BLOCK_SPLIT_RE.split(text)
 
@@ -108,25 +119,34 @@ class CompactResultParser(ResultParser):
                     )
                 )
 
-        return results
+        return results, []
 
 
 class StructuredResultParser(ResultParser):
     """Parse core's structured JSON format: ``{"results": [...]}``.
 
-    Each element contains ``rank``, ``score``, ``source``, ``hierarchy``,
-    ``namespace``, ``chunk_id``, and ``content`` fields.
+    Each ``results`` element contains ``rank``, ``score``, ``source``,
+    ``hierarchy``, ``namespace``, ``chunk_id``, and ``content`` fields.
+    An optional top-level ``hints`` list carries parent-side trust-UX
+    annotations (parent commit ``7d184f1``, PR #231). Hints are read
+    opportunistically via ``data.get("hints", [])`` — the field is not
+    asserted on and its absence degrades silently to an empty list.
     """
 
-    def parse(self, text: str) -> list[RemoteSearchResult]:
+    def parse(self, text: str) -> tuple[list[RemoteSearchResult], list[str]]:
         if not text or not text.strip():
-            return []
+            return [], []
 
         try:
             data = json.loads(text)
         except (json.JSONDecodeError, TypeError):
             logger.warning("StructuredResultParser: invalid JSON, falling back to empty")
-            return []
+            return [], []
+
+        raw_hints = data.get("hints", [])
+        hints: list[str] = (
+            [str(h) for h in raw_hints if isinstance(h, str)] if isinstance(raw_hints, list) else []
+        )
 
         raw_results = data.get("results", [])
         results: list[RemoteSearchResult] = []
@@ -152,7 +172,7 @@ class StructuredResultParser(ResultParser):
                 result.chunk.id = chunk_id
             results.append(result)
 
-        return results
+        return results, hints
 
 
 def get_parser(fmt: str = "compact") -> ResultParser:
@@ -260,10 +280,17 @@ class McpClientSearchAdapter:
         *,
         trace_id: str | None = None,
         **kwargs: Any,
-    ) -> tuple[list[RemoteSearchResult], object]:
-        """Call mem_search on the remote server and parse results."""
+    ) -> tuple[list[RemoteSearchResult], list[str]]:
+        """Call mem_search on the remote server and parse results.
+
+        Returns ``(results, hints)``. ``hints`` carries parent-side
+        trust-UX annotations from the structured format (parent PR #231)
+        and is always ``[]`` for the compact format or when the call
+        fails. Callers that do not care about hints should still accept
+        the tuple to stay compatible with mypy's inferred signature.
+        """
         if self._session is None:
-            return [], None
+            return [], []
 
         args: dict[str, Any] = {"query": query}
         if top_k is not None:
@@ -288,20 +315,20 @@ class McpClientSearchAdapter:
                 result = await self._session.call_tool("mem_search", args)  # type: ignore[union-attr]
             except Exception as retry_exc:
                 logger.debug("MCP mem_search failed after reconnect: %s", retry_exc)
-                return [], None
+                return [], []
         except Exception as exc:
             logger.debug("MCP mem_search failed: %s", exc)
-            return [], None
+            return [], []
 
         # Parse text response into results
         # ``result.content or []`` tolerates spec-noncompliant upstreams that
         # return ``None`` instead of an empty list (mirrors PR #114 in proxy).
         text_parts = [c.text or "" for c in (result.content or []) if c.type == "text"]
         if not text_parts:
-            return [], None
+            return [], []
 
         text = "\n".join(text_parts)
-        return self._parser.parse(text), None
+        return self._parser.parse(text)
 
     async def increment_access(self, chunk_ids: list[str], *, trace_id: str | None = None) -> None:
         """Boost the access_count of the given chunks via mem_do(increment_access).
@@ -455,5 +482,8 @@ class McpClientSearchAdapter:
 
         Delegates to :class:`CompactResultParser`. Kept as a static method
         for backward compatibility with existing tests and callers.
+        Compact parser never emits hints; this helper drops the second
+        tuple slot and returns only the results list.
         """
-        return _compact_parser.parse(text)
+        results, _ = _compact_parser.parse(text)
+        return results

--- a/tests/test_bench_pipeline.py
+++ b/tests/test_bench_pipeline.py
@@ -196,7 +196,7 @@ def _make_surfacing_config(**overrides) -> SurfacingConfig:
 
 def _make_mcp_adapter(results=None):
     adapter = AsyncMock()
-    adapter.search = AsyncMock(return_value=(results or [], {}))
+    adapter.search = AsyncMock(return_value=(results or [], []))
     return adapter
 
 
@@ -271,7 +271,11 @@ class TestBenchHarness:
 
         h = BenchHarness(cleaner=cleaner, compressor=BrokenCompressor(), judge=judge)
         task = BenchTask(
-            task_id="err", description="err", content="some text", content_type="text", max_chars=100
+            task_id="err",
+            description="err",
+            content="some text",
+            content_type="text",
+            max_chars=100,
         )
         result = h.run_stm(task)
         assert result.error is not None
@@ -318,7 +322,11 @@ class TestStageMetrics:
 
     def test_timing_is_positive(self, harness):
         task = BenchTask(
-            task_id="time", description="timing", content=CODE_FILE, content_type="code", max_chars=500
+            task_id="time",
+            description="timing",
+            content=CODE_FILE,
+            content_type="code",
+            max_chars=500,
         )
         result = harness.run_stm(task)
         m = result.stage_metrics
@@ -343,8 +351,13 @@ class TestStageMetrics:
 
     def test_zero_original_safety(self):
         m = StageMetrics(
-            original_chars=0, cleaned_chars=0, compressed_chars=0, surfaced_chars=0,
-            clean_ms=0, compress_ms=0, surface_ms=0,
+            original_chars=0,
+            cleaned_chars=0,
+            compressed_chars=0,
+            surfaced_chars=0,
+            clean_ms=0,
+            compress_ms=0,
+            surface_ms=0,
         )
         assert m.cleaning_ratio == 1.0
         assert m.total_reduction == 1.0
@@ -368,70 +381,109 @@ class TestStageMetrics:
 class TestQualityJudge:
     def test_perfect_score(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="Hello World", content_type="text",
-            max_chars=100, expected_keywords=["Hello", "World"],
+            task_id="t",
+            description="t",
+            content="Hello World",
+            content_type="text",
+            max_chars=100,
+            expected_keywords=["Hello", "World"],
         )
         assert judge.score(task, "Hello World") == 10.0
 
     def test_missing_keyword_deducts(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="text",
-            max_chars=100, expected_keywords=["alpha", "beta", "gamma"],
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="text",
+            max_chars=100,
+            expected_keywords=["alpha", "beta", "gamma"],
         )
         assert judge.score(task, "nothing here") == 4.0
 
     def test_partial_keywords(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="text",
-            max_chars=100, expected_keywords=["alpha", "beta"],
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="text",
+            max_chars=100,
+            expected_keywords=["alpha", "beta"],
         )
         assert judge.score(task, "alpha is present") == 8.0
 
     def test_heading_check(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="markdown",
-            max_chars=100, expect_headings=3,
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="markdown",
+            max_chars=100,
+            expect_headings=3,
         )
         assert judge.score(task, "## H1\n## H2\nno more") == 9.0
 
     def test_code_block_check(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="code",
-            max_chars=100, expect_code_blocks=2,
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="code",
+            max_chars=100,
+            expect_code_blocks=2,
         )
         assert judge.score(task, "```python\ncode\n```\nonly one block") == 9.0
 
     def test_json_validity_bonus(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="json",
-            max_chars=100, expected_keywords=["key"],
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="json",
+            max_chars=100,
+            expected_keywords=["key"],
         )
         assert judge.score(task, '{"key": "value"}') == 10.0
 
     def test_json_invalid_no_bonus(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="json",
-            max_chars=100, expected_keywords=["key"],
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="json",
+            max_chars=100,
+            expected_keywords=["key"],
         )
         assert judge.score(task, "key: value") == 10.0
 
     def test_score_floor_at_zero(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="text",
-            max_chars=100, expected_keywords=["a", "b", "c", "d", "e", "f"],
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="text",
+            max_chars=100,
+            expected_keywords=["a", "b", "c", "d", "e", "f"],
         )
         assert judge.score(task, "nothing") == 0.0
 
     def test_case_insensitive_keywords(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="text",
-            max_chars=100, expected_keywords=["PostgreSQL"],
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="text",
+            max_chars=100,
+            expected_keywords=["PostgreSQL"],
         )
         assert judge.score(task, "we use postgresql for storage") == 10.0
 
     def test_weighted_keywords(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="text",
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="text",
             max_chars=100,
             expected_keywords=["critical", "optional"],
             keyword_weights=[1.0, 0.3],
@@ -441,8 +493,12 @@ class TestQualityJudge:
 
     def test_keyword_report(self, judge):
         task = BenchTask(
-            task_id="t", description="t", content="x", content_type="text",
-            max_chars=100, expected_keywords=["present", "absent"],
+            task_id="t",
+            description="t",
+            content="x",
+            content_type="text",
+            max_chars=100,
+            expected_keywords=["present", "absent"],
         )
         report = judge.keyword_report(task, "present in text")
         assert report["present"] is True
@@ -667,8 +723,12 @@ class TestCompressionStrategies:
 
     def test_hybrid_preserves_head(self, cleaner, hybrid, judge):
         task = BenchTask(
-            task_id="hybrid_head", description="hybrid head test", content=CODE_FILE,
-            content_type="code", max_chars=800, expected_keywords=["JWT", "Overview"],
+            task_id="hybrid_head",
+            description="hybrid head test",
+            content=CODE_FILE,
+            content_type="code",
+            max_chars=800,
+            expected_keywords=["JWT", "Overview"],
         )
         report = self._run_with(cleaner, hybrid, judge, task)
         assert "Authentication Module" in report.stm.text
@@ -692,12 +752,14 @@ class TestSurfacingIntegration:
         pipeline = _make_mcp_adapter(memories)
         engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
 
-        h = BenchHarness(
-            cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
-        )
+        h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
         task = BenchTask(
-            task_id="surf", description="auth token handling", content=CODE_FILE,
-            content_type="code", max_chars=800, expected_keywords=["JWT"],
+            task_id="surf",
+            description="auth token handling",
+            content=CODE_FILE,
+            content_type="code",
+            max_chars=800,
+            expected_keywords=["JWT"],
         )
         result = await h.run_stm_with_surfacing(task)
         assert result.stage_metrics is not None
@@ -715,12 +777,13 @@ class TestSurfacingIntegration:
         pipeline = _make_mcp_adapter(memories)
         engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
 
-        h = BenchHarness(
-            cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
-        )
+        h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
         task = BenchTask(
-            task_id="overhead", description="test overhead", content=MEETING_NOTES,
-            content_type="markdown", max_chars=600,
+            task_id="overhead",
+            description="test overhead",
+            content=MEETING_NOTES,
+            content_type="markdown",
+            max_chars=600,
         )
         result = await h.run_stm_with_surfacing(task)
         m = result.stage_metrics
@@ -732,8 +795,11 @@ class TestSurfacingIntegration:
         """Without surfacing engine, overhead is zero."""
         h = BenchHarness(cleaner=cleaner, compressor=truncate, judge=judge)
         task = BenchTask(
-            task_id="nosrf", description="no surfacing", content=MEETING_NOTES,
-            content_type="markdown", max_chars=500,
+            task_id="nosrf",
+            description="no surfacing",
+            content=MEETING_NOTES,
+            content_type="markdown",
+            max_chars=500,
         )
         result = await h.run_stm_with_surfacing(task)
         m = result.stage_metrics
@@ -872,8 +938,12 @@ class TestReport:
 
     def test_format_single_task(self, harness):
         task = BenchTask(
-            task_id="rpt", description="report test", content=MEETING_NOTES,
-            content_type="markdown", max_chars=500, expected_keywords=["PostgreSQL"],
+            task_id="rpt",
+            description="report test",
+            content=MEETING_NOTES,
+            content_type="markdown",
+            max_chars=500,
+            expected_keywords=["PostgreSQL"],
         )
         report = harness.run_comparison(task)
         text = format_report([report])
@@ -889,12 +959,21 @@ class TestReport:
         assert "Avg quality preservation" in text
 
     def test_warning_on_low_quality(self):
-        direct = BenchResult(task_id="low", mode="direct", text="x", stage_metrics=None, quality_score=10.0)
+        direct = BenchResult(
+            task_id="low", mode="direct", text="x", stage_metrics=None, quality_score=10.0
+        )
         stm = BenchResult(
-            task_id="low", mode="stm", text="y",
+            task_id="low",
+            mode="stm",
+            text="y",
             stage_metrics=StageMetrics(
-                original_chars=100, cleaned_chars=90, compressed_chars=50, surfaced_chars=50,
-                clean_ms=1, compress_ms=1, surface_ms=0,
+                original_chars=100,
+                cleaned_chars=90,
+                compressed_chars=50,
+                surfaced_chars=50,
+                clean_ms=1,
+                compress_ms=1,
+                surface_ms=0,
             ),
             quality_score=6.0,
         )
@@ -943,22 +1022,44 @@ class TestCallMetrics:
 
     def test_timing_fields_set(self):
         m = CallMetrics(
-            server="s", tool="t", original_chars=1000, compressed_chars=500,
-            clean_ms=1.5, compress_ms=3.2, surface_ms=10.0, surfaced_chars=600,
+            server="s",
+            tool="t",
+            original_chars=1000,
+            compressed_chars=500,
+            clean_ms=1.5,
+            compress_ms=3.2,
+            surface_ms=10.0,
+            surfaced_chars=600,
         )
         assert m.clean_ms == 1.5
         assert m.surfaced_chars == 600
 
     def test_tracker_aggregates_timing(self):
         tracker = TokenTracker(metrics_store=None)
-        tracker.record(CallMetrics(
-            server="a", tool="t1", original_chars=1000, compressed_chars=500,
-            clean_ms=2.0, compress_ms=5.0, surface_ms=10.0, surfaced_chars=600,
-        ))
-        tracker.record(CallMetrics(
-            server="a", tool="t2", original_chars=2000, compressed_chars=800,
-            clean_ms=4.0, compress_ms=7.0, surface_ms=20.0, surfaced_chars=900,
-        ))
+        tracker.record(
+            CallMetrics(
+                server="a",
+                tool="t1",
+                original_chars=1000,
+                compressed_chars=500,
+                clean_ms=2.0,
+                compress_ms=5.0,
+                surface_ms=10.0,
+                surfaced_chars=600,
+            )
+        )
+        tracker.record(
+            CallMetrics(
+                server="a",
+                tool="t2",
+                original_chars=2000,
+                compressed_chars=800,
+                clean_ms=4.0,
+                compress_ms=7.0,
+                surface_ms=20.0,
+                surfaced_chars=900,
+            )
+        )
         summary = tracker.get_summary()
         assert summary["total_calls"] == 2
         assert summary["total_surfaced_chars"] == 1500
@@ -1189,7 +1290,9 @@ class TestProxyManagerIntegration:
         )
         # _context_query should NOT be forwarded to upstream
         call_args = mock_session.call_tool.call_args
-        forwarded_args = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("arguments", {})
+        forwarded_args = (
+            call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("arguments", {})
+        )
         assert "_context_query" not in forwarded_args
 
 
@@ -1236,6 +1339,7 @@ class TestStageBreakdown:
     def test_qa_degrades_with_compression(self, harness):
         """Tight compression may reduce answerable QA pairs."""
         from bench.tasks import get_tight_tasks
+
         tasks = get_tight_tasks()
         task = [t for t in tasks if t.task_id == "code_file_large"][0]
         bd = harness.run_stage_breakdown(task)
@@ -1290,8 +1394,11 @@ class TestQAScoring:
 
     def test_qa_score_all_answerable(self, judge):
         task = BenchTask(
-            task_id="qa", description="qa", content="The sky is blue and water is wet.",
-            content_type="text", max_chars=100,
+            task_id="qa",
+            description="qa",
+            content="The sky is blue and water is wet.",
+            content_type="text",
+            max_chars=100,
             qa_pairs=[
                 QAPair("What color is the sky?", "blue", "content"),
                 QAPair("Is water wet?", "wet", "content"),
@@ -1303,7 +1410,11 @@ class TestQAScoring:
 
     def test_qa_score_partial(self, judge):
         task = BenchTask(
-            task_id="qa", description="qa", content="x", content_type="text", max_chars=100,
+            task_id="qa",
+            description="qa",
+            content="x",
+            content_type="text",
+            max_chars=100,
             qa_pairs=[
                 QAPair("Q1?", "alpha", "content"),
                 QAPair("Q2?", "beta", "content"),
@@ -1315,7 +1426,11 @@ class TestQAScoring:
 
     def test_qa_by_source(self, judge):
         task = BenchTask(
-            task_id="qa", description="qa", content="x", content_type="text", max_chars=100,
+            task_id="qa",
+            description="qa",
+            content="x",
+            content_type="text",
+            max_chars=100,
             qa_pairs=[
                 QAPair("From content?", "original_fact", "content"),
                 QAPair("From memory?", "remembered_fact", "memory"),
@@ -1328,7 +1443,11 @@ class TestQAScoring:
 
     def test_qa_no_pairs(self, judge):
         task = BenchTask(
-            task_id="qa", description="qa", content="x", content_type="text", max_chars=100,
+            task_id="qa",
+            description="qa",
+            content="x",
+            content_type="text",
+            max_chars=100,
         )
         result = judge.qa_score(task, "anything")
         assert result["total"] == 0
@@ -1403,7 +1522,9 @@ class TestSurfacingValue:
             config = _make_surfacing_config()
             pipeline = _make_mcp_adapter(memories)
             engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
-            h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
+            h = BenchHarness(
+                cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
+            )
             value = await h.measure_surfacing_value(task)
             # Surfacing should never reduce quality (it only adds content)
             assert value.quality_delta >= 0, f"{task.task_id}: delta={value.quality_delta}"
@@ -1411,9 +1532,15 @@ class TestSurfacingValue:
     def test_format_surfacing_value(self):
         values = [
             SurfacingValue(
-                task_id="test", without_surfacing=6.0, with_surfacing=8.0,
-                qa_without=2, qa_with=5, qa_total=6, memories_injected=3,
-                quality_delta=2.0, qa_delta=3,
+                task_id="test",
+                without_surfacing=6.0,
+                with_surfacing=8.0,
+                qa_without=2,
+                qa_with=5,
+                qa_total=6,
+                memories_injected=3,
+                quality_delta=2.0,
+                qa_delta=3,
             ),
         ]
         text = format_surfacing_value(values)
@@ -1528,9 +1655,7 @@ class TestDistractorRobustness:
         config = _make_surfacing_config()
         pipeline = _make_mcp_adapter(memories)
         engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
-        h = BenchHarness(
-            cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
-        )
+        h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
         value = await h.measure_surfacing_value(task)
         # The relevant memory (HS256) should be surfaced and add a QA answer
         assert value.qa_with >= value.qa_without
@@ -1543,8 +1668,7 @@ class TestDistractorRobustness:
 
         # Clean memories (all relevant)
         clean_mems = [
-            FakeSearchResult(chunk=FakeChunk(content=m), score=0.8)
-            for m in AUTH_MEMORIES
+            FakeSearchResult(chunk=FakeChunk(content=m), score=0.8) for m in AUTH_MEMORIES
         ]
         config = _make_surfacing_config()
         clean_engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(clean_mems))
@@ -1555,6 +1679,7 @@ class TestDistractorRobustness:
 
         # Noisy memories (1 relevant + 3 distractors)
         from bench.tasks import DISTRACTOR_MEMORIES_AUTH
+
         noisy_mems = [
             FakeSearchResult(chunk=FakeChunk(content=m), score=0.5)
             for m in DISTRACTOR_MEMORIES_AUTH
@@ -1606,9 +1731,7 @@ class TestMultihop:
         ]
         config = _make_surfacing_config()
         engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(memories))
-        h = BenchHarness(
-            cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
-        )
+        h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
         value = await h.measure_surfacing_value(task)
         assert value.qa_delta > 0  # Memory QA pairs now answerable
         assert value.qa_with > value.qa_without
@@ -1624,9 +1747,7 @@ class TestMultihop:
         ]
         config = _make_surfacing_config()
         engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(memories))
-        h = BenchHarness(
-            cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
-        )
+        h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
         bd = await h.run_stage_breakdown_with_surfacing(task)
         assert bd.surfacing_qa_gain > 0  # Surfacing added answerable QA pairs
         assert bd.compress_info_loss >= 0  # Compression may or may not lose info
@@ -1659,6 +1780,7 @@ class TestStructuredDatasets:
 
     def test_json_tasks_are_valid_json(self):
         import json
+
         for task in ds_json_tasks():
             json.loads(task.content)  # should not raise
 
@@ -1728,7 +1850,9 @@ class TestStructuredDatasets:
             ]
             config = _make_surfacing_config()
             engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(memories))
-            h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
+            h = BenchHarness(
+                cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
+            )
             value = await h.measure_surfacing_value(task)
             assert value.qa_delta > 0, f"{task.task_id}: surfacing added no QA answers"
 
@@ -1765,16 +1889,24 @@ class TestLLMJudge:
                 # QA prompt → return answerable
                 if "QUESTION:" in user_msg:
                     resp.json.return_value = {
-                        "content": [{"text": '{"answerable": true, "confidence": 0.9, "reasoning": "found in text"}'}],
+                        "content": [
+                            {
+                                "text": '{"answerable": true, "confidence": 0.9, "reasoning": "found in text"}'
+                            }
+                        ],
                         "usage": {"input_tokens": 100, "output_tokens": 50},
                     }
                 else:
                     # Score prompt
                     resp.json.return_value = {
-                        "content": [{"text": '{"factual_completeness": {"score": 8.5, "reasoning": "most facts preserved"}, '
-                                     '"structural_coherence": {"score": 7.0, "reasoning": "some structure lost"}, '
-                                     '"answer_sufficiency": {"score": 9.0, "reasoning": "key answers available"}, '
-                                     '"overall": 8.2}'}],
+                        "content": [
+                            {
+                                "text": '{"factual_completeness": {"score": 8.5, "reasoning": "most facts preserved"}, '
+                                '"structural_coherence": {"score": 7.0, "reasoning": "some structure lost"}, '
+                                '"answer_sufficiency": {"score": 9.0, "reasoning": "key answers available"}, '
+                                '"overall": 8.2}'
+                            }
+                        ],
                         "usage": {"input_tokens": 500, "output_tokens": 100},
                     }
             resp.raise_for_status = MagicMock()
@@ -1824,8 +1956,11 @@ class TestLLMJudge:
         """Second call with same content returns cached result."""
         judge = LLMJudge(provider="anthropic", api_key="test-key", client=mock_anthropic_client)
         task = BenchTask(
-            task_id="test-cache", description="test",
-            content="Same content", content_type="text", max_chars=100,
+            task_id="test-cache",
+            description="test",
+            content="Same content",
+            content_type="text",
+            max_chars=100,
         )
         r1 = await judge.score(task, "compressed text")
         r2 = await judge.score(task, "compressed text")
@@ -1842,8 +1977,11 @@ class TestLLMJudge:
         bad_client.post = raise_error
         judge = LLMJudge(provider="anthropic", api_key="test-key", client=bad_client)
         task = BenchTask(
-            task_id="test-err", description="test",
-            content="Content", content_type="text", max_chars=100,
+            task_id="test-err",
+            description="test",
+            content="Content",
+            content_type="text",
+            max_chars=100,
         )
         result = await judge.score(task, "compressed")
         assert result.error is not None
@@ -1853,9 +1991,16 @@ class TestLLMJudge:
         """score_batch processes multiple tasks."""
         judge = LLMJudge(provider="anthropic", api_key="test-key", client=mock_anthropic_client)
         tasks = [
-            (BenchTask(task_id=f"batch-{i}", description="test",
-                       content=f"Content {i}", content_type="text", max_chars=100),
-             f"Compressed {i}")
+            (
+                BenchTask(
+                    task_id=f"batch-{i}",
+                    description="test",
+                    content=f"Content {i}",
+                    content_type="text",
+                    max_chars=100,
+                ),
+                f"Compressed {i}",
+            )
             for i in range(3)
         ]
         results = await judge.score_batch(tasks)
@@ -1865,9 +2010,11 @@ class TestLLMJudge:
     def test_parse_markdown_fenced_json(self, mock_anthropic_client):
         """Parser handles markdown code fences around JSON."""
         judge = LLMJudge(provider="anthropic", api_key="test-key", client=mock_anthropic_client)
-        raw = '```json\n{"factual_completeness": {"score": 7.0, "reasoning": "ok"}, ' \
-              '"structural_coherence": {"score": 6.0, "reasoning": "ok"}, ' \
-              '"answer_sufficiency": {"score": 8.0, "reasoning": "ok"}, "overall": 7.0}\n```'
+        raw = (
+            '```json\n{"factual_completeness": {"score": 7.0, "reasoning": "ok"}, '
+            '"structural_coherence": {"score": 6.0, "reasoning": "ok"}, '
+            '"answer_sufficiency": {"score": 8.0, "reasoning": "ok"}, "overall": 7.0}\n```'
+        )
         overall, dims = judge._parse_score_response(raw)
         assert overall == 7.0
         assert len(dims) == 3
@@ -2164,9 +2311,7 @@ class TestExpandedDatasets:
         for t in large_doc_tasks():
             result = harness.run_stm(t)
             if result.stage_metrics:
-                assert result.stage_metrics.total_reduction < 1.0, (
-                    f"{t.task_id}: no compression"
-                )
+                assert result.stage_metrics.total_reduction < 1.0, f"{t.task_id}: no compression"
 
     def test_surfacing_expanded_tasks(self, cleaner, truncate, judge):
         """Expanded surfacing tasks have surfacing memories."""
@@ -2183,12 +2328,12 @@ class TestExpandedDatasets:
                 for i, m in enumerate(task.surfacing_memories)
             ]
             config = _make_surfacing_config()
-            engine = SurfacingEngine(
-                config=config, mcp_adapter=_make_mcp_adapter(memories)
-            )
+            engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(memories))
             h = BenchHarness(
-                cleaner=cleaner, compressor=truncate,
-                surfacing_engine=engine, judge=judge,
+                cleaner=cleaner,
+                compressor=truncate,
+                surfacing_engine=engine,
+                judge=judge,
             )
             value = await h.measure_surfacing_value(task)
             assert value.qa_delta > 0, f"{task.task_id}: surfacing added no QA answers"

--- a/tests/test_core_format_contract.py
+++ b/tests/test_core_format_contract.py
@@ -256,20 +256,21 @@ class TestParserStrategy:
             NO_RESULTS,
             ERROR_RESPONSE,
         ]:
-            strategy_results = parser.parse(text)
+            strategy_results, strategy_hints = parser.parse(text)
             static_results = McpClientSearchAdapter._parse_results(text)
             assert len(strategy_results) == len(static_results)
+            assert strategy_hints == []
             for s, st in zip(strategy_results, static_results):
                 assert s.score == st.score
                 assert s.chunk.content == st.chunk.content
 
     def test_structured_parser_returns_empty_for_invalid_json(self):
-        """StructuredResultParser.parse() returns [] for non-JSON input."""
+        """StructuredResultParser.parse() returns ([], []) for non-JSON input."""
         from memtomem_stm.surfacing.mcp_client import StructuredResultParser
 
         parser = StructuredResultParser()
-        assert parser.parse("not json") == []
-        assert parser.parse("") == []
+        assert parser.parse("not json") == ([], [])
+        assert parser.parse("") == ([], [])
 
     def test_adapter_uses_configured_parser(self):
         """McpClientSearchAdapter respects config.result_format."""
@@ -298,8 +299,9 @@ class TestStructuredFormatSnapshots:
         from memtomem_stm.surfacing.mcp_client import StructuredResultParser
 
         parser = StructuredResultParser()
-        results = parser.parse(STRUCTURED_TWO_RESULTS)
+        results, hints = parser.parse(STRUCTURED_TWO_RESULTS)
         assert len(results) == 2
+        assert hints == []
         assert results[0].score == pytest.approx(0.92)
         assert results[1].score == pytest.approx(0.87)
         assert "auth.md" in str(results[0].chunk.metadata.source_file)
@@ -321,25 +323,136 @@ STRUCTURED_NO_RESULTS_WITH_HINTS = (
     '{"results": [], "hints": ['
     '"No results match your filters (3 results found before filtering). '
     'Try broader filters or remove source_filter/tag_filter."'
-    ']}'
+    "]}"
 )
 
 
 class TestStructuredEmptyResults:
     """StructuredResultParser tolerates parent PR #231's empty-result JSON
-    in both the bare and hints-augmented shapes."""
+    in both the bare and hints-augmented shapes, and exposes hints to
+    callers for operator-visible observability (B3)."""
 
     def test_structured_parser_returns_empty_without_hints(self):
         from memtomem_stm.surfacing.mcp_client import StructuredResultParser
 
         parser = StructuredResultParser()
-        assert parser.parse(STRUCTURED_NO_RESULTS_PLAIN) == []
+        results, hints = parser.parse(STRUCTURED_NO_RESULTS_PLAIN)
+        assert results == []
+        assert hints == []
 
     def test_structured_parser_returns_empty_with_hints(self):
         from memtomem_stm.surfacing.mcp_client import StructuredResultParser
 
         parser = StructuredResultParser()
-        assert parser.parse(STRUCTURED_NO_RESULTS_WITH_HINTS) == []
+        results, hints = parser.parse(STRUCTURED_NO_RESULTS_WITH_HINTS)
+        assert results == []
+        assert len(hints) == 1
+        assert "No results match your filters" in hints[0]
+
+    def test_structured_parser_hints_non_list_is_empty(self):
+        """Alpha tolerance: parent may future-rename ``hints``, emit a
+        dict, or drop the field. Non-list values must degrade silently
+        to an empty list."""
+        from memtomem_stm.surfacing.mcp_client import StructuredResultParser
+
+        parser = StructuredResultParser()
+        for payload in (
+            '{"results": [], "hints": "oops not a list"}',
+            '{"results": [], "hints": {"msg": "still wrong"}}',
+            '{"results": [], "hints": null}',
+            '{"results": []}',
+        ):
+            results, hints = parser.parse(payload)
+            assert results == []
+            assert hints == []
+
+    def test_structured_parser_hints_with_results(self):
+        """Hints can accompany non-empty results too (e.g. "3 filtered")."""
+        from memtomem_stm.surfacing.mcp_client import StructuredResultParser
+
+        payload = (
+            '{"results": ['
+            '  {"rank": 1, "score": 0.5, "source": "a.md", "hierarchy": "X",'
+            '   "namespace": "default", "chunk_id": "c1", "content": "hit"}'
+            '], "hints": ["2 additional results hidden by namespace filter"]}'
+        )
+        parser = StructuredResultParser()
+        results, hints = parser.parse(payload)
+        assert len(results) == 1
+        assert hints == ["2 additional results hidden by namespace filter"]
+
+    def test_structured_parser_drops_non_string_hints(self):
+        """Guard against mixed-type hint arrays (defensive, parent is alpha)."""
+        from memtomem_stm.surfacing.mcp_client import StructuredResultParser
+
+        payload = '{"results": [], "hints": ["ok", 42, null, {"x": 1}, "also ok"]}'
+        parser = StructuredResultParser()
+        results, hints = parser.parse(payload)
+        assert results == []
+        assert hints == ["ok", "also ok"]
+
+
+class TestAdapterHintsFlow:
+    """End-to-end through ``McpClientSearchAdapter.search`` — hints arrive
+    at the caller exactly as the parent emits them (B3)."""
+
+    @pytest.mark.asyncio
+    async def test_search_returns_hints_from_structured_payload(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
+
+        adapter = McpClientSearchAdapter(SurfacingConfig(result_format="structured"))
+        mock_session = AsyncMock()
+        mock_content = MagicMock()
+        mock_content.type = "text"
+        mock_content.text = STRUCTURED_NO_RESULTS_WITH_HINTS
+        mock_result = MagicMock()
+        mock_result.content = [mock_content]
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+        adapter._session = mock_session
+
+        results, hints = await adapter.search("q")
+        assert results == []
+        assert len(hints) == 1
+        assert "No results match your filters" in hints[0]
+
+    @pytest.mark.asyncio
+    async def test_search_returns_empty_hints_for_compact_format(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
+
+        adapter = McpClientSearchAdapter(SurfacingConfig(result_format="compact"))
+        mock_session = AsyncMock()
+        mock_content = MagicMock()
+        mock_content.type = "text"
+        mock_content.text = COMPACT_TWO_RESULTS
+        mock_result = MagicMock()
+        mock_result.content = [mock_content]
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+        adapter._session = mock_session
+
+        results, hints = await adapter.search("q")
+        assert len(results) == 2
+        assert hints == []
+
+    @pytest.mark.asyncio
+    async def test_search_returns_empty_hints_on_transport_error(self):
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock
+
+        from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
+
+        adapter = McpClientSearchAdapter(SurfacingConfig(result_format="structured"))
+        mock_session = AsyncMock()
+        mock_session.call_tool.side_effect = ConnectionError("lost")
+        adapter._session = mock_session
+        adapter.start = AsyncMock(side_effect=_asyncio.TimeoutError())  # type: ignore[method-assign]
+
+        results, hints = await adapter.search("q")
+        assert results == []
+        assert hints == []
 
 
 class TestOutputFormatForwarding:
@@ -397,10 +510,12 @@ class TestFormatNegotiation:
         version_result = MagicMock()
         version_content = MagicMock()
         version_content.type = "text"
-        version_content.text = json.dumps({
-            "version": "0.3.0",
-            "capabilities": {"search_formats": ["compact", "structured"]},
-        })
+        version_content.text = json.dumps(
+            {
+                "version": "0.3.0",
+                "capabilities": {"search_formats": ["compact", "structured"]},
+            }
+        )
         version_result.content = [version_content]
         mock_session.call_tool = AsyncMock(return_value=version_result)
         adapter._session = mock_session
@@ -421,10 +536,12 @@ class TestFormatNegotiation:
         version_result = MagicMock()
         version_content = MagicMock()
         version_content.type = "text"
-        version_content.text = json.dumps({
-            "version": "0.2.0",
-            "capabilities": {"search_formats": ["compact"]},
-        })
+        version_content.text = json.dumps(
+            {
+                "version": "0.2.0",
+                "capabilities": {"search_formats": ["compact"]},
+            }
+        )
         version_result.content = [version_content]
         mock_session.call_tool = AsyncMock(return_value=version_result)
         adapter._session = mock_session

--- a/tests/test_cross_session_dedup.py
+++ b/tests/test_cross_session_dedup.py
@@ -65,7 +65,7 @@ def _make_config(**overrides) -> SurfacingConfig:
 
 def _make_mcp_adapter(results=None):
     adapter = AsyncMock()
-    adapter.search = AsyncMock(return_value=(results or [], {}))
+    adapter.search = AsyncMock(return_value=(results or [], []))
     return adapter
 
 
@@ -197,9 +197,7 @@ class TestCrossSessionDedup:
         # Simulate previous session: mark chunk_old as seen
         store.mark_surfaced([chunk_old.id])
 
-        tracker = FeedbackTracker(
-            config=_make_config(), db_path=tmp_path / "feedback.db"
-        )
+        tracker = FeedbackTracker(config=_make_config(), db_path=tmp_path / "feedback.db")
 
         results = [
             FakeSearchResult(chunk=chunk_old, score=0.5),
@@ -225,9 +223,7 @@ class TestCrossSessionDedup:
 
     async def test_engine_persists_new_ids(self, tmp_path):
         """After surfacing, new memory IDs are persisted for future sessions."""
-        tracker = FeedbackTracker(
-            config=_make_config(), db_path=tmp_path / "feedback.db"
-        )
+        tracker = FeedbackTracker(config=_make_config(), db_path=tmp_path / "feedback.db")
 
         chunk = FakeChunk(content="surfaced now")
         results = [FakeSearchResult(chunk=chunk, score=0.5)]

--- a/tests/test_error_metrics.py
+++ b/tests/test_error_metrics.py
@@ -44,8 +44,13 @@ class TestCallMetricsErrorFields:
 
     def test_error_fields(self):
         m = CallMetrics(
-            server="s", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.PROTOCOL, error_code=-32601,
+            server="s",
+            tool="t",
+            original_chars=0,
+            compressed_chars=0,
+            is_error=True,
+            error_category=ErrorCategory.PROTOCOL,
+            error_code=-32601,
         )
         assert m.is_error is True
         assert m.error_category == ErrorCategory.PROTOCOL
@@ -58,50 +63,136 @@ class TestCallMetricsErrorFields:
 class TestTokenTrackerRecordError:
     def test_record_error_increments_total(self):
         tracker = TokenTracker()
-        tracker.record_error(CallMetrics(
-            server="s", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.TRANSPORT,
-        ))
+        tracker.record_error(
+            CallMetrics(
+                server="s",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.TRANSPORT,
+            )
+        )
         assert tracker._total_errors == 1
 
     def test_record_error_by_category(self):
         tracker = TokenTracker()
-        tracker.record_error(CallMetrics(
-            server="s", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.TRANSPORT,
-        ))
-        tracker.record_error(CallMetrics(
-            server="s", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.TRANSPORT,
-        ))
-        tracker.record_error(CallMetrics(
-            server="s", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.PROTOCOL,
-        ))
+        tracker.record_error(
+            CallMetrics(
+                server="s",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.TRANSPORT,
+            )
+        )
+        tracker.record_error(
+            CallMetrics(
+                server="s",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.TRANSPORT,
+            )
+        )
+        tracker.record_error(
+            CallMetrics(
+                server="s",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.PROTOCOL,
+            )
+        )
         assert tracker._errors_by_category["transport"] == 2
         assert tracker._errors_by_category["protocol"] == 1
 
     def test_record_error_by_server(self):
         tracker = TokenTracker()
-        tracker.record_error(CallMetrics(
-            server="srv1", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.TIMEOUT,
-        ))
-        tracker.record_error(CallMetrics(
-            server="srv2", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.TIMEOUT,
-        ))
+        tracker.record_error(
+            CallMetrics(
+                server="srv1",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.TIMEOUT,
+            )
+        )
+        tracker.record_error(
+            CallMetrics(
+                server="srv2",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.TIMEOUT,
+            )
+        )
         assert tracker._errors_by_server["srv1"] == 1
         assert tracker._errors_by_server["srv2"] == 1
 
     def test_record_error_none_category(self):
         tracker = TokenTracker()
-        tracker.record_error(CallMetrics(
-            server="s", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True,
-        ))
+        tracker.record_error(
+            CallMetrics(
+                server="s",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+            )
+        )
         assert tracker._total_errors == 1
         assert len(tracker._errors_by_category) == 0
+
+
+# ── TokenTracker.record_hints (B3 — parent trust-UX forwarding) ──────────
+
+
+class TestTokenTrackerRecordHints:
+    def test_record_hints_increments_events_and_snapshots(self):
+        tracker = TokenTracker()
+        tracker.record_hints(["first notice", "second notice"])
+        assert tracker._total_hint_events == 1
+        assert tracker._last_hints == ["first notice", "second notice"]
+
+    def test_record_hints_empty_is_noop(self):
+        tracker = TokenTracker()
+        tracker.record_hints([])
+        assert tracker._total_hint_events == 0
+        assert tracker._last_hints == []
+
+    def test_record_hints_overwrites_snapshot(self):
+        tracker = TokenTracker()
+        tracker.record_hints(["call 1 hint"])
+        tracker.record_hints(["call 2 hint A", "call 2 hint B"])
+        assert tracker._total_hint_events == 2
+        assert tracker._last_hints == ["call 2 hint A", "call 2 hint B"]
+
+    def test_record_hints_stores_defensive_copy(self):
+        """Caller-owned list mutations must not bleed into the snapshot."""
+        tracker = TokenTracker()
+        hints = ["only hint"]
+        tracker.record_hints(hints)
+        hints.append("mutated after call")
+        assert tracker._last_hints == ["only hint"]
+
+    def test_get_summary_exposes_hints(self):
+        tracker = TokenTracker()
+        tracker.record_hints(["visible"])
+        summary = tracker.get_summary()
+        assert summary["total_hint_events"] == 1
+        assert summary["last_hints"] == ["visible"]
+
+    def test_get_summary_hints_defaults_when_none(self):
+        tracker = TokenTracker()
+        summary = tracker.get_summary()
+        assert summary["total_hint_events"] == 0
+        assert summary["last_hints"] == []
 
 
 # ── get_summary error fields ─────────────────────────────────────────────
@@ -119,12 +210,20 @@ class TestSummaryErrorFields:
         tracker = TokenTracker()
         # 3 successful calls
         for _ in range(3):
-            tracker.record(CallMetrics(server="s", tool="t", original_chars=100, compressed_chars=50))
+            tracker.record(
+                CallMetrics(server="s", tool="t", original_chars=100, compressed_chars=50)
+            )
         # 1 error
-        tracker.record_error(CallMetrics(
-            server="s", tool="t", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.TRANSPORT,
-        ))
+        tracker.record_error(
+            CallMetrics(
+                server="s",
+                tool="t",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.TRANSPORT,
+            )
+        )
         s = tracker.get_summary()
         assert s["total_calls"] == 3
         assert s["total_errors"] == 1
@@ -134,10 +233,16 @@ class TestSummaryErrorFields:
     def test_all_errors(self):
         tracker = TokenTracker()
         for _ in range(5):
-            tracker.record_error(CallMetrics(
-                server="s", tool="t", original_chars=0, compressed_chars=0,
-                is_error=True, error_category=ErrorCategory.TIMEOUT,
-            ))
+            tracker.record_error(
+                CallMetrics(
+                    server="s",
+                    tool="t",
+                    original_chars=0,
+                    compressed_chars=0,
+                    is_error=True,
+                    error_category=ErrorCategory.TIMEOUT,
+                )
+            )
         s = tracker.get_summary()
         assert s["error_rate"] == 100.0
         assert s["errors_by_category"] == {"timeout": 5}
@@ -159,6 +264,7 @@ class TestMetricsStoreMigration:
     def test_existing_db_migrated(self, tmp_path):
         """Pre-existing DB without error columns gets migrated."""
         import sqlite3
+
         db_path = tmp_path / "old.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute(
@@ -180,10 +286,17 @@ class TestMetricsStoreMigration:
     def test_record_with_error_fields(self, tmp_path):
         store = MetricsStore(tmp_path / "test.db")
         store.initialize()
-        store.record(CallMetrics(
-            server="srv", tool="tool", original_chars=0, compressed_chars=0,
-            is_error=True, error_category=ErrorCategory.PROTOCOL, error_code=-32601,
-        ))
+        store.record(
+            CallMetrics(
+                server="srv",
+                tool="tool",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.PROTOCOL,
+                error_code=-32601,
+            )
+        )
         row = store._db.execute(
             "SELECT is_error, error_category, error_code FROM proxy_metrics"
         ).fetchone()
@@ -193,9 +306,14 @@ class TestMetricsStoreMigration:
     def test_record_success_has_defaults(self, tmp_path):
         store = MetricsStore(tmp_path / "test.db")
         store.initialize()
-        store.record(CallMetrics(
-            server="srv", tool="tool", original_chars=100, compressed_chars=50,
-        ))
+        store.record(
+            CallMetrics(
+                server="srv",
+                tool="tool",
+                original_chars=100,
+                compressed_chars=50,
+            )
+        )
         row = store._db.execute(
             "SELECT is_error, error_category, error_code FROM proxy_metrics"
         ).fetchone()
@@ -216,8 +334,10 @@ def _make_result(text: str, is_error: bool = False):
 
 def _make_manager(max_retries: int = 0) -> ProxyManager:
     server_cfg = UpstreamServerConfig(
-        prefix="test", compression=CompressionStrategy.NONE,
-        max_result_chars=50000, max_retries=max_retries,
+        prefix="test",
+        compression=CompressionStrategy.NONE,
+        max_result_chars=50000,
+        max_retries=max_retries,
         reconnect_delay_seconds=0.0,
     )
     proxy_cfg = ProxyConfig(
@@ -227,7 +347,10 @@ def _make_manager(max_retries: int = 0) -> ProxyManager:
     mgr = ProxyManager(proxy_cfg, TokenTracker())
     session = AsyncMock()
     mgr._connections["srv"] = UpstreamConnection(
-        name="srv", config=server_cfg, session=session, tools=[],
+        name="srv",
+        config=server_cfg,
+        session=session,
+        tools=[],
     )
     return mgr
 

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -68,14 +68,14 @@ class TestReconnectRetrySuccess:
         # hits the same mock.
         adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
 
-        results, stats = await adapter.search("anything")
+        results, hints = await adapter.search("anything")
 
         adapter._reconnect.assert_awaited_once()
         assert mock_session.call_tool.await_count == 2
         assert len(results) == 1
         assert "retry worked" in results[0].chunk.content.lower()
         assert results[0].score == 0.95
-        assert stats is None
+        assert hints == []
 
 
 class TestReconnectRetryFailure:
@@ -93,10 +93,10 @@ class TestReconnectRetryFailure:
 
         adapter._reconnect = AsyncMock(side_effect=ConnectionError("reconnect failed"))  # type: ignore[method-assign]
 
-        results, stats = await adapter.search("q")
+        results, hints = await adapter.search("q")
 
         assert results == []
-        assert stats is None
+        assert hints == []
         adapter._reconnect.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -112,10 +112,10 @@ class TestReconnectRetryFailure:
         adapter._session = mock_session
         adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
 
-        results, stats = await adapter.search("q")
+        results, hints = await adapter.search("q")
 
         assert results == []
-        assert stats is None
+        assert hints == []
         assert mock_session.call_tool.await_count == 2
 
 
@@ -133,10 +133,10 @@ class TestNonTransportErrorsDoNotReconnect:
         adapter._session = mock_session
         adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
 
-        results, stats = await adapter.search("q")
+        results, hints = await adapter.search("q")
 
         assert results == []
-        assert stats is None
+        assert hints == []
         adapter._reconnect.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -246,8 +246,9 @@ class TestNegotiationDowngradeAffectsParsing:
 
         # Post: downgraded, and the downgraded parser handles compact text.
         compact = "[1] 0.42 | [default] a/b.md\nHello from compact.\n"
-        results = adapter._parser.parse(compact)
+        results, hints = adapter._parser.parse(compact)
         assert len(results) == 1
+        assert hints == []
         assert results[0].score == 0.42
         assert "Hello from compact" in results[0].chunk.content
 
@@ -271,9 +272,9 @@ class TestNoneContentDefense:
         mock_session.call_tool = AsyncMock(return_value=bad)
         adapter._session = mock_session
 
-        results, stats = await adapter.search("anything")
+        results, hints = await adapter.search("anything")
         assert results == []
-        assert stats is None
+        assert hints == []
 
     @pytest.mark.asyncio
     async def test_scratch_list_returns_empty_when_content_is_none(self):

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -111,6 +111,24 @@ class TestProxyStats:
         result_on = await stm_proxy_stats(ctx=ctx_on)
         assert "Surfacing: enabled" in result_on
 
+    async def test_hints_section_appears_when_events_recorded(self):
+        """B3 — when parent emitted trust-UX hints during the run, the
+        stats output shows an ``LTM hints`` section with the latest
+        snapshot. Quiet when zero events."""
+        tracker = TokenTracker()
+        tracker.record_hints(["2 results filtered by namespace"])
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "LTM hints:" in result
+        assert "1 event(s)" in result
+        assert "2 results filtered by namespace" in result
+
+    async def test_hints_section_omitted_when_no_events(self):
+        tracker = TokenTracker()
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "LTM hints:" not in result
+
 
 # ── stm_proxy_select_chunks ──────────────────────────────────────────────
 

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -386,9 +386,9 @@ class TestMcpClientSearchAdapter:
         from memtomem_stm.surfacing.config import SurfacingConfig
 
         adapter = McpClientSearchAdapter(SurfacingConfig())
-        results, stats = await adapter.search("test query")
+        results, hints = await adapter.search("test query")
         assert results == []
-        assert stats is None
+        assert hints == []
 
     @pytest.mark.asyncio
     async def test_search_calls_mem_search(self) -> None:
@@ -425,9 +425,9 @@ class TestMcpClientSearchAdapter:
         # Prevent reconnect from hitting a real server
         adapter.start = AsyncMock(side_effect=ConnectionError("reconnect failed"))  # type: ignore[method-assign]
 
-        results, stats = await adapter.search("query")
+        results, hints = await adapter.search("query")
         assert results == []
-        assert stats is None
+        assert hints == []
 
     @pytest.mark.asyncio
     async def test_search_timeout_triggers_reconnect(self) -> None:
@@ -442,7 +442,8 @@ class TestMcpClientSearchAdapter:
 
         adapter._reconnect = AsyncMock(side_effect=ConnectionError("reconnect failed"))  # type: ignore[method-assign]
 
-        results, stats = await adapter.search("query")
+        results, hints = await adapter.search("query")
         assert results == []
+        assert hints == []
         # Reconnect was attempted (TimeoutError treated as transport error)
         adapter._reconnect.assert_awaited_once()

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -61,10 +61,14 @@ def _make_config(**overrides) -> SurfacingConfig:
     return SurfacingConfig(**defaults)
 
 
-def _make_mcp_adapter(results: list[FakeSearchResult] | None = None):
+def _make_mcp_adapter(
+    results: list[FakeSearchResult] | None = None,
+    *,
+    hints: list[str] | None = None,
+):
     """Build a mock McpClientSearchAdapter that returns the given results."""
     adapter = AsyncMock()
-    adapter.search = AsyncMock(return_value=(results or [], {}))
+    adapter.search = AsyncMock(return_value=(results or [], hints or []))
     return adapter
 
 
@@ -1254,3 +1258,102 @@ class TestWebhookExceptionPaths:
             "Webhook fire-and-forget task failed" in rec.message for rec in caplog.records
         ), "cancelled tasks must not be logged as failures"
         assert len(engine._background_tasks) == 0
+
+
+class TestLtmHintsObservability:
+    """B3 — parent trust-UX hints are surfaced to operators via INFO log and
+    optional TokenTracker snapshot; they are NOT forwarded to the downstream
+    agent (prepend body is unchanged). See B3 plan § 'forward hints'."""
+
+    async def test_hints_logged_at_info_when_non_empty(self, caplog):
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter(
+                [FakeSearchResult(chunk=FakeChunk(), score=0.5)],
+                hints=["2 results filtered by namespace"],
+            ),
+        )
+        with caplog.at_level("INFO", logger="memtomem_stm.surfacing.engine"):
+            await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        matching = [r for r in caplog.records if "LTM hints for" in r.message]
+        assert len(matching) == 1
+        assert matching[0].levelname == "INFO"
+        assert "2 results filtered" in matching[0].message
+
+    async def test_no_log_when_hints_empty(self, caplog):
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter(
+                [FakeSearchResult(chunk=FakeChunk(), score=0.5)],
+                hints=[],
+            ),
+        )
+        with caplog.at_level("INFO", logger="memtomem_stm.surfacing.engine"):
+            await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert not any("LTM hints for" in r.message for r in caplog.records)
+
+    async def test_hints_logged_even_when_results_empty(self, caplog):
+        """Operator-observability fires independently of result filtering —
+        a "3 filtered before you got here" hint matters even when SURFACE
+        ultimately injects nothing."""
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter(
+                results=[],
+                hints=["All 5 candidates below min_score"],
+            ),
+        )
+        with caplog.at_level("INFO", logger="memtomem_stm.surfacing.engine"):
+            out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        # Prepend body unchanged — hints are not forwarded to downstream.
+        assert out == LONG_RESPONSE
+        assert any(
+            "LTM hints for" in r.message and "below min_score" in r.message for r in caplog.records
+        )
+
+    async def test_hints_forwarded_to_token_tracker_when_provided(self):
+        tracker = MagicMock()
+        tracker.record_hints = MagicMock()
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter(
+                [FakeSearchResult(chunk=FakeChunk(), score=0.5)],
+                hints=["notice A", "notice B"],
+            ),
+            token_tracker=tracker,
+        )
+        await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        tracker.record_hints.assert_called_once_with(["notice A", "notice B"])
+
+    async def test_token_tracker_absent_is_not_fatal(self, caplog):
+        """Engine must log INFO even when no tracker is wired — observability
+        path degrades open, never crashes a proxy response."""
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter(
+                [FakeSearchResult(chunk=FakeChunk(), score=0.5)],
+                hints=["standalone notice"],
+            ),
+            token_tracker=None,
+        )
+        with caplog.at_level("INFO", logger="memtomem_stm.surfacing.engine"):
+            out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        # Response still normal, log still fired.
+        assert "Relevant Memories" in out or out == LONG_RESPONSE
+        assert any("LTM hints for" in r.message for r in caplog.records)
+
+    async def test_token_tracker_failure_is_swallowed(self, caplog):
+        """A misbehaving tracker must not break the proxy response path."""
+        tracker = MagicMock()
+        tracker.record_hints = MagicMock(side_effect=RuntimeError("tracker boom"))
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter(
+                [FakeSearchResult(chunk=FakeChunk(), score=0.5)],
+                hints=["notice"],
+            ),
+            token_tracker=tracker,
+        )
+        # Must not raise
+        out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert out is not None


### PR DESCRIPTION
## Summary

- Forward parent's `mem_search` trust-UX hints (parent PR #231 / commit `7d184f1`) through STM's surfacing pipeline to two operator-visible channels: an `INFO` log in `SurfacingEngine` and a new **LTM hints** section in `stm_proxy_stats`. The downstream agent text is untouched.
- Option A from the B3 plan: `ResultParser.parse()` and `McpClientSearchAdapter.search()` now return `tuple[list, list[str]]` (results, hints) instead of `(list, None | object)`. Caller audit found one production site (`SurfacingEngine._do_surface`, ignored the slot) and a handful of tests asserting `stats is None` — all updated.
- Alpha tolerance preserved: `hints` is read via `data.get("hints", [])`; non-list/non-str entries are dropped. Parent may rename or remove the field without breaking STM.

## Behavior change

- `McpClientSearchAdapter.search()` 2nd tuple element is now `list[str]` (was always `None`). Callers that destructure as `results, _ = ...` or `results, _stats = ...` remain correct; any caller asserting `is None` must switch to `== []`.
- `ResultParser.parse()` (both `CompactResultParser` and `StructuredResultParser`) returns `tuple[list[RemoteSearchResult], list[str]]` instead of `list[RemoteSearchResult]`. Internal API; all current callers in this repo are updated.
- `stm_proxy_stats` gains an **LTM hints** section when the parent emitted any hints during the run. No change when quiet.

The SURFACE prepend body is **deliberately unchanged** — injecting `"no memories surfaced (reason: ...)"` into the agent-facing text on empty LTM responses is a separate policy discussion (see B3 plan § "forward hints to downstream").

## B2 cross-reference

Parent's structured-hints emission was empirically confirmed on real `memtomem-server` v0.1.12 during the B2 smoke — https://github.com/memtomem/memtomem-stm/pull/190#issuecomment-4275877590 (response: `{"results": [], "hints": ["semantic search unavailable: no such table: chunks_vec"]}`).

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1465 passed (up from 1445 pre-PR; 20 new tests cover parser hint extraction, adapter tuple shape, engine INFO log, tracker counter/snapshot, `stm_proxy_stats` output).
- [x] `uv run ruff check src tests && uv run ruff format --check src` — clean.
- [x] `uv run mypy` on the four changed `src` files — 0 errors. (The two pre-existing errors in `src/memtomem_stm/proxy/manager.py` are unrelated to this PR.)
- [ ] Post-merge: verify on real parent v0.1.12 that a populated LTM emits non-empty hints under filter-heavy queries (B2 only probed empty-DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
