### PR TITLE
chore(gitignore): ignore local .env and .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@ __pycache__/
 .venv/
 venv/
 
+# Environment
+.env
+.env.*
+!.env.example
+!.env.*.example
+.mcp.json
+!.mcp.json.example
+
 # Build artifacts
 build/
 dist/


### PR DESCRIPTION
## Summary

- Ignore `.env` / `.env.*` and `.mcp.json` — both are local-only config carrying secrets (API tokens, per-editor MCP stdio wiring) that should never land in the repo.
- Preserve `*.example` variants for onboarding (whitelisted via `!.env.example`, `!.env.*.example`, `!.mcp.json.example`).

## Why now

Contributors may already have tokens in their working copies. A broader `git add .` could accidentally stage them. The rule is defensive — no currently-tracked file becomes orphaned by this (verified via `git ls-files | grep -E '^\.env|\.mcp\.json'` → empty).

## Test plan

- [x] `git check-ignore -v .env` resolves to the new rule.
- [x] `git ls-files` confirms no `.env` / `.mcp.json` is currently tracked, so nothing gets removed from tracking.
- [x] `*.example` still matched out: `git check-ignore .env.example` → no output (not ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)