### PR TITLE
feat(cli): import MCP servers from existing clients in `mms init`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pydantic-settings>=2.7",
     "httpx>=0.28",
     "click>=8.1",
+    "questionary>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -626,6 +626,32 @@ _TUI_CONFIRM = "__confirm__"
 _TUI_CANCEL = "__cancel__"
 
 
+def _tui_style() -> Any:
+    """High-contrast style for the import-selector prompt.
+
+    questionary's built-in palette is conservative and can read as
+    near-default in themed terminals (Ghostty, iTerm2 with custom color
+    schemes, etc.), making the active-row "bar" indistinct. Using
+    ``ansi*`` color names keeps us in the user's own terminal palette —
+    so bright cyan actually IS that terminal's bright cyan, whatever the
+    theme has redefined it to be.
+    """
+    from questionary import Style
+
+    return Style(
+        [
+            ("qmark", "fg:ansibrightblue bold"),
+            ("question", "bold"),
+            ("pointer", "fg:ansibrightcyan bold"),
+            ("highlighted", "fg:ansibrightcyan bold"),
+            ("selected", "fg:ansigreen bold"),
+            ("separator", "fg:ansibrightblack"),
+            ("instruction", "fg:ansibrightblack"),
+            ("answer", "fg:ansigreen bold"),
+        ]
+    )
+
+
 def _pick_imports_tui(candidates: list[dict[str, Any]]) -> list[int]:
     """Enter-to-toggle select loop with explicit Confirm / Cancel.
 
@@ -667,10 +693,19 @@ def _pick_imports_tui(candidates: list[dict[str, Any]]) -> list[int]:
         # but the runtime matches on equality against Choice.value, so our
         # int-or-sentinel cursor works fine. Ignore the type mismatch rather
         # than muddy the cursor's declared type to suit the stub.
+        #
+        # ``use_jk_keys`` + ``use_emacs_keys`` are enabled as backup bindings
+        # in case arrow-key events don't reach the TUI (Ghostty keybindings,
+        # tmux prefix collisions, etc.) — j/k and Ctrl-N/Ctrl-P are the
+        # conventional fallbacks and cost nothing to leave on.
         result = questionary.select(
-            "Select servers to import (Enter toggles; scroll to Confirm):",
+            "Select servers to import (↑↓ or j/k to move, Enter toggles, scroll to Confirm):",
             choices=choices,
             default=cursor,  # type: ignore[arg-type]
+            style=_tui_style(),
+            use_arrow_keys=True,
+            use_jk_keys=True,
+            use_emacs_keys=True,
         ).ask()
 
         if result is None or result == _TUI_CANCEL:

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -619,24 +619,45 @@ def _should_use_tui() -> bool:
     return bool(sys.stdin.isatty())
 
 
+def _patch_questionary_indicators() -> None:
+    """Swap questionary's default checkbox glyphs for clearer ones.
+
+    Defaults are ``●`` (checked) vs ``○`` (unchecked), which blur together on
+    thin fonts — users reported genuine ambiguity. ``[v]`` / ``[ ]`` makes
+    the state unmistakable. We mutate ``questionary.prompts.common`` because
+    that module binds the constants at import time (re-assigning
+    ``questionary.constants`` has no effect on an already-imported consumer).
+    Idempotent — calling more than once just re-asserts the same values.
+    """
+    from questionary.prompts import common as qc_common
+
+    qc_common.INDICATOR_SELECTED = "[v]"
+    qc_common.INDICATOR_UNSELECTED = "[ ]"
+
+
 def _pick_imports(candidates: list[dict[str, Any]]) -> list[int]:
     """Prompt the user to choose which discovered candidates to import.
 
     TTY → ``questionary.checkbox`` (space to toggle, enter to confirm, all
-    pre-checked). Non-TTY → the comma-number prompt from
+    initially unchecked). Non-TTY → the comma-number prompt from
     :func:`_parse_selection`, with a reprompt on parse error so a fat-finger
     entry doesn't silently abort the wizard.
+
+    Defaulting to unchecked matches user feedback: the ~8-candidate lists
+    that come out of a populated Claude Code config usually need 1-2 picks,
+    not 6 unchecks.
     """
     if _should_use_tui():
         import questionary
 
+        _patch_questionary_indicators()
         choices = [
             questionary.Choice(
                 title=(
                     f"{c['name']:<18}  {_format_candidate_detail(c['entry'])}  — from {c['source']}"
                 ),
                 value=i,
-                checked=True,
+                checked=False,
             )
             for i, c in enumerate(candidates)
         ]
@@ -650,17 +671,17 @@ def _pick_imports(candidates: list[dict[str, Any]]) -> list[int]:
 
     while True:
         raw = click.prompt(
-            "Select servers to import (e.g. '1,3', 'all', or 'none' to add manually)",
+            "Select servers to import (e.g. '1,3', 'all', or empty to skip / add manually)",
             type=str,
-            default="all",
-            show_default=True,
+            default="",
+            show_default=False,
         )
         picks = _parse_selection(raw, len(candidates))
         if picks is not None:
             return picks
         click.echo(
             f"  {_warn('Invalid:')} use comma-separated numbers 1..{len(candidates)}, "
-            "'all', or 'none'."
+            "'all', or leave blank."
         )
 
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -635,6 +635,14 @@ def _tui_style() -> Any:
     ``ansi*`` color names keeps us in the user's own terminal palette —
     so bright cyan actually IS that terminal's bright cyan, whatever the
     theme has redefined it to be.
+
+    Deliberately *does not* style ``class:selected``. questionary's
+    ``select()`` applies that class to the choice matching ``default=``
+    (used here to preserve cursor position across re-renders), so
+    colouring it ends up looking like a persistent highlight on the
+    last-toggled row — the exact bug reported. Check-state is already
+    conveyed by the ``[v]``/``[ ]`` marker in the title; we don't need
+    a second visual channel for it.
     """
     from questionary import Style
 
@@ -644,7 +652,6 @@ def _tui_style() -> Any:
             ("question", "bold"),
             ("pointer", "fg:ansibrightcyan bold"),
             ("highlighted", "fg:ansibrightcyan bold"),
-            ("selected", "fg:ansigreen bold"),
             ("separator", "fg:ansibrightblack"),
             ("instruction", "fg:ansibrightblack"),
             ("answer", "fg:ansigreen bold"),

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -376,16 +376,206 @@ def add(
 # ── init command ────────────────────────────────────────────────────────
 
 
-def _prompt_prefix() -> str:
+def _prompt_prefix(default: str | None = None) -> str:
     """Prompt for a prefix until it passes the same rules as ``add --prefix``."""
     while True:
-        value = click.prompt("Tool prefix (letters/digits/underscores, e.g. 'fs')", type=str)
+        value = click.prompt(
+            "Tool prefix (letters/digits/underscores, e.g. 'fs')",
+            type=str,
+            default=default,
+            show_default=default is not None,
+        )
         if _PREFIX_RE.match(value) and "__" not in value:
             return value
         click.echo(
             f"  {_warn('Invalid:')} must start with a letter, contain only letters/digits/"
             "underscores, and not contain '__'. Try again."
         )
+
+
+# ── discovery of already-registered MCP servers ─────────────────────────
+#
+# Reading external-client configs is best-effort: files may not exist, may be
+# malformed, or may have shapes that don't translate (e.g. wrapper types we
+# don't support). Discovery never raises — missing/bad sources just yield
+# zero candidates and fall back to the manual prompt flow.
+
+
+def _desktop_config_path() -> Path:
+    """Claude Desktop's macOS config path; Windows/Linux variants skipped."""
+    return Path("~/Library/Application Support/Claude/claude_desktop_config.json").expanduser()
+
+
+def _read_json_safely(path: Path) -> dict[str, Any] | None:
+    try:
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _normalize_client_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """Map a client-config MCP entry to an STM upstream-server entry.
+
+    Returns ``None`` if the entry's shape isn't one we can import. STM-shape
+    requires a concrete transport and either ``command`` (stdio) or ``url``
+    (sse/streamable_http); ``prefix`` is intentionally left out so the caller
+    can prompt for it.
+    """
+    # Client configs use `type: "http"|"sse"` (Claude Code) or omit it
+    # entirely (stdio). Desktop config is stdio-only in practice.
+    type_hint = (raw.get("type") or "").lower()
+    command = raw.get("command")
+    url = raw.get("url")
+
+    if type_hint == "sse" and isinstance(url, str) and url:
+        transport = "sse"
+    elif type_hint in ("http", "streamable_http") and isinstance(url, str) and url:
+        transport = "streamable_http"
+    elif isinstance(command, str) and command:
+        transport = "stdio"
+    elif isinstance(url, str) and url:
+        # url but no type → best guess; Claude Code sometimes omits `type`.
+        transport = "streamable_http"
+    else:
+        return None
+
+    entry: dict[str, Any] = {
+        "transport": transport,
+        "compression": "auto",
+        "max_result_chars": 8000,
+    }
+    if transport == "stdio":
+        entry["command"] = command
+        args = raw.get("args")
+        if isinstance(args, list) and all(isinstance(a, str) for a in args):
+            entry["args"] = list(args)
+        env = raw.get("env")
+        if isinstance(env, dict):
+            safe_env = {
+                str(k): str(v)
+                for k, v in env.items()
+                if isinstance(k, str) and k.upper() not in _DANGEROUS_ENV_KEYS
+            }
+            if safe_env:
+                entry["env"] = safe_env
+    else:
+        entry["url"] = url
+    return entry
+
+
+def _is_self_reference(entry: dict[str, Any]) -> bool:
+    """Skip entries that would make STM proxy itself, causing recursion."""
+    cmd = (entry.get("command") or "").lower()
+    if not cmd:
+        return False
+    basename = Path(cmd).name
+    return basename in {"mms", "memtomem-stm", "memtomem-stm-proxy"}
+
+
+def _discover_candidates(cwd: Path) -> list[dict[str, Any]]:
+    """Scan known MCP-client configs and return importable candidates.
+
+    Each candidate dict is ``{name, source, entry}`` where ``entry`` is an
+    already-normalized STM upstream-server entry (sans prefix). The first
+    source to claim a name wins; later duplicates are dropped with a
+    ``duplicate_in`` note so the UI can indicate the overlap.
+    """
+    sources: list[tuple[str, dict[str, Any]]] = []
+
+    # 1. Project-scope ``.mcp.json`` in cwd (Claude Code project config).
+    proj = _read_json_safely(cwd / ".mcp.json")
+    if proj and isinstance(proj.get("mcpServers"), dict):
+        sources.append((".mcp.json (project)", proj["mcpServers"]))
+
+    # 2. Claude Code ~/.claude.json user-scope + per-project entries.
+    cc = _read_json_safely(Path("~/.claude.json").expanduser())
+    if cc:
+        if isinstance(cc.get("mcpServers"), dict):
+            sources.append(("Claude Code (user)", cc["mcpServers"]))
+        projects = cc.get("projects")
+        if isinstance(projects, dict):
+            # Match on resolved cwd so we don't duplicate entries across sibling projects.
+            resolved_cwd = str(cwd.resolve())
+            proj_entry = projects.get(resolved_cwd)
+            if isinstance(proj_entry, dict) and isinstance(proj_entry.get("mcpServers"), dict):
+                sources.append(("Claude Code (project)", proj_entry["mcpServers"]))
+
+    # 3. Claude Desktop (macOS path only; non-macOS → file absent → skipped).
+    desktop = _read_json_safely(_desktop_config_path())
+    if desktop and isinstance(desktop.get("mcpServers"), dict):
+        sources.append(("Claude Desktop", desktop["mcpServers"]))
+
+    seen: dict[str, dict[str, Any]] = {}
+    for source_label, servers in sources:
+        if not isinstance(servers, dict):
+            continue
+        for name, raw in servers.items():
+            if not isinstance(name, str) or not isinstance(raw, dict):
+                continue
+            entry = _normalize_client_entry(raw)
+            if entry is None or _is_self_reference(entry):
+                continue
+            if name in seen:
+                seen[name].setdefault("duplicate_in", []).append(source_label)
+                continue
+            seen[name] = {"name": name, "source": source_label, "entry": entry}
+    return list(seen.values())
+
+
+def _format_candidate_detail(entry: dict[str, Any]) -> str:
+    transport = entry.get("transport", "stdio")
+    if transport == "stdio":
+        parts = [entry.get("command", "")]
+        parts.extend(entry.get("args", []))
+        return f"[stdio] {' '.join(p for p in parts if p).strip()}"
+    return f"[{transport}] {entry.get('url', '')}"
+
+
+def _suggest_prefix(name: str, taken: set[str]) -> str:
+    """Derive a valid-ish default prefix from a server name.
+
+    Not authoritative — the user is re-prompted if invalid. Avoids clashing
+    with prefixes already chosen in the current init run.
+    """
+    base = re.sub(r"[^a-zA-Z0-9_]", "_", name).strip("_") or "srv"
+    if not base[0].isalpha():
+        base = "s_" + base
+    base = base.replace("__", "_")
+    candidate = base
+    n = 2
+    while candidate in taken:
+        candidate = f"{base}{n}"
+        n += 1
+    return candidate
+
+
+def _parse_selection(raw: str, count: int) -> list[int] | None:
+    """Parse ``"1,3,5"`` / ``"all"`` / ``""`` / ``"none"`` into 0-based indices.
+
+    Returns ``None`` on parse error so the caller can reprompt. Empty input
+    and ``"none"`` yield ``[]`` (explicit skip).
+    """
+    text = raw.strip().lower()
+    if text in ("", "none", "skip", "n"):
+        return []
+    if text in ("all", "a", "*"):
+        return list(range(count))
+    picks: list[int] = []
+    for tok in text.split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        if not tok.isdigit():
+            return None
+        idx = int(tok) - 1
+        if idx < 0 or idx >= count:
+            return None
+        if idx not in picks:
+            picks.append(idx)
+    return picks
 
 
 @cli.command()
@@ -416,80 +606,125 @@ def init(config_path: str, no_validate: bool) -> None:
     click.echo(f"Config will be written to: {resolved}")
     click.echo("")
 
-    name = click.prompt("Server name (e.g. 'filesystem', 'github')", type=str).strip()
-    if not name:
-        click.echo(f"{_err('Error:')} server name must be non-empty.", err=True)
-        sys.exit(1)
+    candidates = _discover_candidates(Path.cwd())
+    imported: dict[str, dict[str, Any]] = {}
 
-    prefix = _prompt_prefix()
-
-    transport = click.prompt(
-        "Transport",
-        type=click.Choice(["stdio", "sse", "streamable_http"]),
-        default="stdio",
-        show_default=True,
-    )
-
-    entry: dict[str, Any] = {
-        "prefix": prefix,
-        "transport": transport,
-        "compression": "auto",
-        "max_result_chars": 8000,
-    }
-
-    if transport == "stdio":
-        command = click.prompt("Command (e.g. 'npx', 'uvx')", type=str).strip()
-        if not command:
+    if candidates:
+        click.echo(_hdr(f"Found {len(candidates)} MCP server(s) in existing client configs:"))
+        for i, cand in enumerate(candidates, 1):
+            dup = cand.get("duplicate_in")
+            dup_hint = f"  (also in: {', '.join(dup)})" if dup else ""
             click.echo(
-                f"{_err('Error:')} command must be non-empty for stdio transport.",
-                err=True,
+                f"  {i:>2}. {cand['name']:<18} {_format_candidate_detail(cand['entry'])}"
+                f"    — from {cand['source']}{dup_hint}"
             )
-            sys.exit(1)
-        entry["command"] = command
+        click.echo("")
+        while True:
+            raw = click.prompt(
+                "Select servers to import (e.g. '1,3', 'all', or 'none' to add manually)",
+                type=str,
+                default="all",
+                show_default=True,
+            )
+            picks = _parse_selection(raw, len(candidates))
+            if picks is not None:
+                break
+            click.echo(
+                f"  {_warn('Invalid:')} use comma-separated numbers 1..{len(candidates)}, "
+                "'all', or 'none'."
+            )
 
-        args_str = click.prompt(
-            "Arguments (space-separated, leave empty for none)",
-            type=str,
-            default="",
-            show_default=False,
+        if picks:
+            click.echo("")
+            used_prefixes: set[str] = set()
+            for idx in picks:
+                cand = candidates[idx]
+                click.echo(_hdr(f"Configuring '{cand['name']}'"))
+                suggested = _suggest_prefix(cand["name"], used_prefixes)
+                prefix = _prompt_prefix(default=suggested)
+                used_prefixes.add(prefix)
+                entry = {"prefix": prefix, **cand["entry"]}
+                imported[cand["name"]] = entry
+
+    if not imported:
+        if candidates:
+            click.echo("")
+            click.echo("Adding a server manually:")
+        name = click.prompt("Server name (e.g. 'filesystem', 'github')", type=str).strip()
+        if not name:
+            click.echo(f"{_err('Error:')} server name must be non-empty.", err=True)
+            sys.exit(1)
+
+        prefix = _prompt_prefix()
+
+        transport = click.prompt(
+            "Transport",
+            type=click.Choice(["stdio", "sse", "streamable_http"]),
+            default="stdio",
+            show_default=True,
         )
-        if args_str.strip():
-            try:
-                entry["args"] = shlex.split(args_str)
-            except ValueError as exc:
-                click.echo(f"{_err('Error:')} malformed arguments: {exc}", err=True)
+
+        entry = {
+            "prefix": prefix,
+            "transport": transport,
+            "compression": "auto",
+            "max_result_chars": 8000,
+        }
+
+        if transport == "stdio":
+            command = click.prompt("Command (e.g. 'npx', 'uvx')", type=str).strip()
+            if not command:
+                click.echo(
+                    f"{_err('Error:')} command must be non-empty for stdio transport.",
+                    err=True,
+                )
                 sys.exit(1)
-    else:
-        url = click.prompt(f"URL for {transport}", type=str).strip()
-        if not url:
-            click.echo(
-                f"{_err('Error:')} URL must be non-empty for {transport} transport.",
-                err=True,
+            entry["command"] = command
+
+            args_str = click.prompt(
+                "Arguments (space-separated, leave empty for none)",
+                type=str,
+                default="",
+                show_default=False,
             )
-            sys.exit(1)
-        entry["url"] = url
-
-    if not no_validate and click.confirm("Validate connection now?", default=True):
-        click.echo(f"Validating '{name}' (timeout=10s)...")
-        probe = asyncio.run(_probe_servers({name: entry}, 10))[name]
-        if probe["connected"]:
-            click.echo(f"  {_ok('Reachable:')} {probe['tools']} tool(s) discovered.")
+            if args_str.strip():
+                try:
+                    entry["args"] = shlex.split(args_str)
+                except ValueError as exc:
+                    click.echo(f"{_err('Error:')} malformed arguments: {exc}", err=True)
+                    sys.exit(1)
         else:
-            click.echo(f"  {_warn('Warning:')} probe failed — {probe['error']}", err=True)
-            click.echo("  Saving config anyway. Run `mms health` later to retry.", err=True)
+            url = click.prompt(f"URL for {transport}", type=str).strip()
+            if not url:
+                click.echo(
+                    f"{_err('Error:')} URL must be non-empty for {transport} transport.",
+                    err=True,
+                )
+                sys.exit(1)
+            entry["url"] = url
 
-    data = {"enabled": True, "upstream_servers": {name: entry}}
+        imported[name] = entry
+
+    if not no_validate and click.confirm("Validate connection(s) now?", default=True):
+        probe_map = {n: e for n, e in imported.items()}
+        click.echo(f"Validating {len(probe_map)} server(s) (timeout=10s)...")
+        probes = asyncio.run(_probe_servers(probe_map, 10))
+        for n, probe in probes.items():
+            if probe["connected"]:
+                click.echo(f"  {_ok('Reachable:')} {n} — {probe['tools']} tool(s).")
+            else:
+                click.echo(f"  {_warn('Warning:')} {n} — probe failed: {probe['error']}", err=True)
+                click.echo("  Saving config anyway. Run `mms health` later to retry.", err=True)
+
+    data = {"enabled": True, "upstream_servers": imported}
     _save(path, data)
 
     click.echo("")
     click.echo(f"{_ok('Saved to:')} {resolved}")
     click.echo("")
     click.echo(_hdr("Configured upstream servers:"))
-    if transport == "stdio":
-        detail = f"{entry['command']} {' '.join(entry.get('args', []))}".strip()
-    else:
-        detail = entry["url"]
-    click.echo(f"  {name:<20} prefix={prefix}  [{transport}] {detail}")
+    for n, e in imported.items():
+        click.echo(f"  {n:<20} prefix={e['prefix']}  {_format_candidate_detail(e)}")
 
     click.echo("")
     click.echo(f"{_ok('Next:')} connect your MCP client to memtomem-stm.")

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -466,13 +466,39 @@ def _normalize_client_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
     return entry
 
 
+# Names that should never appear as STM upstream servers:
+#
+# * ``mms`` / ``memtomem-stm`` / ``memtomem-stm-proxy`` — STM itself. Importing
+#   would proxy STM through STM, recursing on every tool call.
+# * ``memtomem`` / ``memtomem-server`` — the LTM companion. STM reaches LTM via
+#   a separate mechanism (see CLAUDE.md "pipeline" invariants); adding it as
+#   an upstream double-registers it and surfaces LTM tools twice.
+#
+# Detection looks at both the command basename *and* each argv token (exact
+# match, not substring) because ``uvx --from memtomem memtomem-server`` uses
+# ``uvx`` as the command and carries the blocked name only in args.
+_BLOCKED_IMPORT_NAMES = frozenset(
+    {
+        "mms",
+        "memtomem-stm",
+        "memtomem-stm-proxy",
+        "memtomem",
+        "memtomem-server",
+    }
+)
+
+
 def _is_self_reference(entry: dict[str, Any]) -> bool:
-    """Skip entries that would make STM proxy itself, causing recursion."""
+    """Skip entries that would make STM proxy itself or double-register LTM."""
     cmd = (entry.get("command") or "").lower()
-    if not cmd:
-        return False
-    basename = Path(cmd).name
-    return basename in {"mms", "memtomem-stm", "memtomem-stm-proxy"}
+    if cmd and Path(cmd).name in _BLOCKED_IMPORT_NAMES:
+        return True
+    args = entry.get("args") or []
+    if isinstance(args, list):
+        for tok in args:
+            if isinstance(tok, str) and tok.lower() in _BLOCKED_IMPORT_NAMES:
+                return True
+    return False
 
 
 def _discover_candidates(cwd: Path) -> list[dict[str, Any]]:
@@ -556,7 +582,8 @@ def _parse_selection(raw: str, count: int) -> list[int] | None:
     """Parse ``"1,3,5"`` / ``"all"`` / ``""`` / ``"none"`` into 0-based indices.
 
     Returns ``None`` on parse error so the caller can reprompt. Empty input
-    and ``"none"`` yield ``[]`` (explicit skip).
+    and ``"none"`` yield ``[]`` (explicit skip). Used as the non-TTY fallback
+    for :func:`_pick_imports`; interactive TTY sessions use the checkbox UI.
     """
     text = raw.strip().lower()
     if text in ("", "none", "skip", "n"):
@@ -576,6 +603,65 @@ def _parse_selection(raw: str, count: int) -> list[int] | None:
         if idx not in picks:
             picks.append(idx)
     return picks
+
+
+def _should_use_tui() -> bool:
+    """Gate for the interactive checkbox UI.
+
+    Disabled when:
+    * stdin isn't a TTY (CliRunner tests, shell pipes, CI) — there's no way
+      to read arrow-key escape sequences, so fall back to comma-number input.
+    * ``MMS_NO_TUI`` is set — explicit opt-out for users who pipe answers
+      from scripts or hit terminal-compatibility issues.
+    """
+    if os.environ.get("MMS_NO_TUI"):
+        return False
+    return bool(sys.stdin.isatty())
+
+
+def _pick_imports(candidates: list[dict[str, Any]]) -> list[int]:
+    """Prompt the user to choose which discovered candidates to import.
+
+    TTY → ``questionary.checkbox`` (space to toggle, enter to confirm, all
+    pre-checked). Non-TTY → the comma-number prompt from
+    :func:`_parse_selection`, with a reprompt on parse error so a fat-finger
+    entry doesn't silently abort the wizard.
+    """
+    if _should_use_tui():
+        import questionary
+
+        choices = [
+            questionary.Choice(
+                title=(
+                    f"{c['name']:<18}  {_format_candidate_detail(c['entry'])}  — from {c['source']}"
+                ),
+                value=i,
+                checked=True,
+            )
+            for i, c in enumerate(candidates)
+        ]
+        picks = questionary.checkbox(
+            "Import which servers? (space=toggle, enter=confirm, a=all, i=invert)",
+            choices=choices,
+        ).ask()
+        # questionary returns None on Ctrl-C / aborted session; treat as
+        # "skip import, go manual" rather than crashing mid-wizard.
+        return picks or []
+
+    while True:
+        raw = click.prompt(
+            "Select servers to import (e.g. '1,3', 'all', or 'none' to add manually)",
+            type=str,
+            default="all",
+            show_default=True,
+        )
+        picks = _parse_selection(raw, len(candidates))
+        if picks is not None:
+            return picks
+        click.echo(
+            f"  {_warn('Invalid:')} use comma-separated numbers 1..{len(candidates)}, "
+            "'all', or 'none'."
+        )
 
 
 @cli.command()
@@ -611,6 +697,10 @@ def init(config_path: str, no_validate: bool) -> None:
 
     if candidates:
         click.echo(_hdr(f"Found {len(candidates)} MCP server(s) in existing client configs:"))
+        # TUI path uses questionary's own rendering, so the numbered preview
+        # below is only useful for the fallback mode — but printing it
+        # unconditionally helps TTY users see duplicate-source notes that
+        # don't fit inside a questionary Choice title.
         for i, cand in enumerate(candidates, 1):
             dup = cand.get("duplicate_in")
             dup_hint = f"  (also in: {', '.join(dup)})" if dup else ""
@@ -619,20 +709,7 @@ def init(config_path: str, no_validate: bool) -> None:
                 f"    — from {cand['source']}{dup_hint}"
             )
         click.echo("")
-        while True:
-            raw = click.prompt(
-                "Select servers to import (e.g. '1,3', 'all', or 'none' to add manually)",
-                type=str,
-                default="all",
-                show_default=True,
-            )
-            picks = _parse_selection(raw, len(candidates))
-            if picks is not None:
-                break
-            click.echo(
-                f"  {_warn('Invalid:')} use comma-separated numbers 1..{len(candidates)}, "
-                "'all', or 'none'."
-            )
+        picks = _pick_imports(candidates)
 
         if picks:
             click.echo("")

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -619,59 +619,87 @@ def _should_use_tui() -> bool:
     return bool(sys.stdin.isatty())
 
 
-def _patch_questionary_indicators() -> None:
-    """Swap questionary's default checkbox glyphs for clearer ones.
+# Sentinel values returned by the questionary.select loop in addition to
+# integer indices. Distinct from any valid index so a dict-based toggle set
+# can't collide.
+_TUI_CONFIRM = "__confirm__"
+_TUI_CANCEL = "__cancel__"
 
-    Defaults are ``●`` (checked) vs ``○`` (unchecked), which blur together on
-    thin fonts — users reported genuine ambiguity. ``[v]`` / ``[ ]`` makes
-    the state unmistakable. We mutate ``questionary.prompts.common`` because
-    that module binds the constants at import time (re-assigning
-    ``questionary.constants`` has no effect on an already-imported consumer).
-    Idempotent — calling more than once just re-asserts the same values.
+
+def _pick_imports_tui(candidates: list[dict[str, Any]]) -> list[int]:
+    """Enter-to-toggle select loop with explicit Confirm / Cancel.
+
+    Chose this over ``questionary.checkbox`` after user feedback:
+    checkbox's space-to-toggle + enter-to-confirm is technically standard
+    but non-obvious on first exposure (and the default ``●``/``○`` glyphs
+    are visually ambiguous). The select-loop instead matches the mental
+    model "press enter on what I want, scroll down to Confirm when done,"
+    with explicit ``[v]``/``[ ]`` markers in the choice titles.
+
+    Returns sorted 0-based indices. ``[]`` on Cancel or empty Confirm —
+    the caller treats either as "user declined to import anything,
+    abort the wizard without saving."
     """
-    from questionary.prompts import common as qc_common
+    import questionary
 
-    qc_common.INDICATOR_SELECTED = "[v]"
-    qc_common.INDICATOR_UNSELECTED = "[ ]"
+    picks: set[int] = set()
+    cursor: object = 0
+
+    while True:
+        choices: list[Any] = []
+        for i, c in enumerate(candidates):
+            marker = "[v]" if i in picks else "[ ]"
+            title = (
+                f"{marker}  {c['name']:<18}  "
+                f"{_format_candidate_detail(c['entry'])}  — from {c['source']}"
+            )
+            choices.append(questionary.Choice(title=title, value=i))
+        choices.append(questionary.Separator())
+        choices.append(
+            questionary.Choice(
+                title=f"Confirm — import {len(picks)} server(s)",
+                value=_TUI_CONFIRM,
+            )
+        )
+        choices.append(questionary.Choice(title="Cancel", value=_TUI_CANCEL))
+
+        # questionary's stubs declare ``default: str | Choice | dict | None``
+        # but the runtime matches on equality against Choice.value, so our
+        # int-or-sentinel cursor works fine. Ignore the type mismatch rather
+        # than muddy the cursor's declared type to suit the stub.
+        result = questionary.select(
+            "Select servers to import (Enter toggles; scroll to Confirm):",
+            choices=choices,
+            default=cursor,  # type: ignore[arg-type]
+        ).ask()
+
+        if result is None or result == _TUI_CANCEL:
+            return []
+        if result == _TUI_CONFIRM:
+            return sorted(picks)
+        # Integer index → toggle and keep the cursor in place so the next
+        # render starts on the row the user just acted on (no disorienting
+        # jump to the top).
+        cursor = result
+        if result in picks:
+            picks.remove(result)
+        else:
+            picks.add(result)
 
 
 def _pick_imports(candidates: list[dict[str, Any]]) -> list[int]:
     """Prompt the user to choose which discovered candidates to import.
 
-    TTY → ``questionary.checkbox`` (space to toggle, enter to confirm, all
-    initially unchecked). Non-TTY → the comma-number prompt from
-    :func:`_parse_selection`, with a reprompt on parse error so a fat-finger
-    entry doesn't silently abort the wizard.
-
-    Defaulting to unchecked matches user feedback: the ~8-candidate lists
-    that come out of a populated Claude Code config usually need 1-2 picks,
-    not 6 unchecks.
+    TTY → :func:`_pick_imports_tui` (enter-to-toggle loop). Non-TTY → the
+    comma-number prompt below, with reprompt on parse error so a
+    fat-finger entry doesn't silently abort the wizard.
     """
     if _should_use_tui():
-        import questionary
-
-        _patch_questionary_indicators()
-        choices = [
-            questionary.Choice(
-                title=(
-                    f"{c['name']:<18}  {_format_candidate_detail(c['entry'])}  — from {c['source']}"
-                ),
-                value=i,
-                checked=False,
-            )
-            for i, c in enumerate(candidates)
-        ]
-        picks = questionary.checkbox(
-            "Import which servers? (space=toggle, enter=confirm, a=all, i=invert)",
-            choices=choices,
-        ).ask()
-        # questionary returns None on Ctrl-C / aborted session; treat as
-        # "skip import, go manual" rather than crashing mid-wizard.
-        return picks or []
+        return _pick_imports_tui(candidates)
 
     while True:
         raw = click.prompt(
-            "Select servers to import (e.g. '1,3', 'all', or empty to skip / add manually)",
+            "Select servers to import (e.g. '1,3', 'all', or empty to skip)",
             type=str,
             default="",
             show_default=False,
@@ -718,10 +746,9 @@ def init(config_path: str, no_validate: bool) -> None:
 
     if candidates:
         click.echo(_hdr(f"Found {len(candidates)} MCP server(s) in existing client configs:"))
-        # TUI path uses questionary's own rendering, so the numbered preview
-        # below is only useful for the fallback mode — but printing it
-        # unconditionally helps TTY users see duplicate-source notes that
-        # don't fit inside a questionary Choice title.
+        # TUI renders its own list; this preview exists so duplicate-source
+        # notes ("also in: X") stay visible — those don't fit inside a
+        # questionary Choice title and otherwise would be invisible.
         for i, cand in enumerate(candidates, 1):
             dup = cand.get("duplicate_in")
             dup_hint = f"  (also in: {', '.join(dup)})" if dup else ""
@@ -732,22 +759,32 @@ def init(config_path: str, no_validate: bool) -> None:
         click.echo("")
         picks = _pick_imports(candidates)
 
-        if picks:
+        # Empty selection when candidates exist = intentional "not this
+        # time" (cancel, or Confirm with nothing toggled). We don't
+        # silently drop into the manual-name prompt, which was confusing
+        # when users just wanted to re-think: nothing is saved, the user
+        # can rerun ``mms init`` fresh or use ``mms add`` explicitly.
+        if not picks:
             click.echo("")
-            used_prefixes: set[str] = set()
-            for idx in picks:
-                cand = candidates[idx]
-                click.echo(_hdr(f"Configuring '{cand['name']}'"))
-                suggested = _suggest_prefix(cand["name"], used_prefixes)
-                prefix = _prompt_prefix(default=suggested)
-                used_prefixes.add(prefix)
-                entry = {"prefix": prefix, **cand["entry"]}
-                imported[cand["name"]] = entry
+            click.echo(
+                f"{_ok('No servers selected.')} Config not written — "
+                "rerun `mms init` to re-select, or use `mms add` to configure one by name."
+            )
+            return
 
-    if not imported:
-        if candidates:
-            click.echo("")
-            click.echo("Adding a server manually:")
+        click.echo("")
+        used_prefixes: set[str] = set()
+        for idx in picks:
+            cand = candidates[idx]
+            click.echo(_hdr(f"Configuring '{cand['name']}'"))
+            suggested = _suggest_prefix(cand["name"], used_prefixes)
+            prefix = _prompt_prefix(default=suggested)
+            used_prefixes.add(prefix)
+            entry = {"prefix": prefix, **cand["entry"]}
+            imported[cand["name"]] = entry
+    else:
+        # Zero discovered candidates → true first-time user without any
+        # existing MCP-client config. Full manual prompt flow.
         name = click.prompt("Server name (e.g. 'filesystem', 'github')", type=str).strip()
         if not name:
             click.echo(f"{_err('Error:')} server name must be non-empty.", err=True)

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1133,7 +1133,10 @@ class TestInitImportFlow:
             def ask(self):
                 return self._result
 
-        def fake_select(message, choices, default=None):
+        def fake_select(message, choices, **kwargs):
+            # Accept arbitrary kwargs (style, default, use_arrow_keys,
+            # use_jk_keys, use_emacs_keys) so this stub survives future
+            # param additions without brittle signature drift.
             observed_choice_counts.append(len(choices))
             return _Scripted(next(actions))
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1166,10 +1166,25 @@ class TestInitImportFlow:
         assert result.exit_code == 0, result.output
         data = json.loads(config.read_text(encoding="utf-8"))
         assert set(data["upstream_servers"]) == {"a", "c"}  # index 1 ("b") dropped
-        # All choices start pre-checked so 'enter' on the default
-        # selection imports everything (the common case).
-        assert captured["checked"] == [True, True, True]
+        # All choices start unchecked — populated configs usually have 8+
+        # candidates but users typically only import 1-2, so "check what
+        # you want" beats "uncheck what you don't" in friction terms.
+        assert captured["checked"] == [False, False, False]
         assert "space=toggle" in captured["message"]
+
+    def test_questionary_indicator_glyphs_overridden(self):
+        """Default ``●``/``○`` glyphs are visually ambiguous on thin fonts;
+        we replace them with ``[v]``/``[ ]`` at TUI-entry time. This pins
+        that the override is actually applied so a questionary upgrade
+        doesn't silently revert us to the blurry dots."""
+        from memtomem_stm.cli.proxy import _patch_questionary_indicators
+
+        _patch_questionary_indicators()
+
+        from questionary.prompts import common as qc_common
+
+        assert qc_common.INDICATOR_SELECTED == "[v]"
+        assert qc_common.INDICATOR_UNSELECTED == "[ ]"
 
     def test_tui_ctrl_c_returns_empty_falls_to_manual(self, runner, config, monkeypatch):
         """questionary returns None on Ctrl-C / aborted session; we treat

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1059,10 +1059,14 @@ class TestInitImportFlow:
         data = json.loads(config.read_text(encoding="utf-8"))
         assert set(data["upstream_servers"]) == {"a", "c"}
 
-    def test_none_falls_through_to_manual_flow(self, runner, config, monkeypatch):
-        """``none`` signals 'let me type one in instead'. The legacy manual
-        prompts (name → prefix → transport → command → args) run
-        afterwards, and that's what ends up in the config."""
+    def test_empty_selection_exits_without_saving(self, runner, config, monkeypatch):
+        """When candidates are present but the user picks none (``none`` in
+        fallback / Cancel in TUI / Confirm-with-nothing-toggled), we exit
+        cleanly without writing a config. The previous behavior of
+        auto-dropping into a 'Adding a server manually:' prompt was
+        confusing — users who didn't pick anything almost never intended to
+        type a new server inline. They either wanted to re-think (rerun
+        init) or run ``mms add`` explicitly."""
         self._stub_candidates(
             monkeypatch,
             [
@@ -1076,14 +1080,15 @@ class TestInitImportFlow:
         result = runner.invoke(
             cli,
             ["init", "--no-validate", *_cfg_args(config)],
-            # select=none, then manual: name, prefix, transport, command, args
-            input="none\ncustom\ncu\nstdio\nmy-cmd\n\n",
+            input="none\n",
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(config.read_text(encoding="utf-8"))
-        assert "filesystem" not in data["upstream_servers"]
-        assert "custom" in data["upstream_servers"]
-        assert data["upstream_servers"]["custom"]["command"] == "my-cmd"
+        assert "No servers selected" in result.output
+        # The guidance points users at the two legitimate next steps.
+        assert "rerun `mms init`" in result.output
+        assert "mms add" in result.output
+        # Nothing saved — a subsequent `init` should not see a pre-existing config.
+        assert not config.exists()
 
     def test_invalid_selection_reprompts(self, runner, config, monkeypatch):
         """Out-of-range indices don't save garbage; they reprompt."""
@@ -1107,36 +1112,34 @@ class TestInitImportFlow:
         data = json.loads(config.read_text(encoding="utf-8"))
         assert "one" in data["upstream_servers"]
 
-    def test_tty_delegates_to_questionary_checkbox(self, runner, config, monkeypatch):
-        """When stdin is a TTY we use ``questionary.checkbox`` (space-to-
-        toggle UI). CliRunner can't fake a TTY, so we force
-        ``_should_use_tui`` True and stub ``questionary.checkbox`` to
-        return pre-chosen indices. This pins the contract that the TUI
-        path is actually reached when available."""
+    def test_tty_select_loop_toggles_and_confirms(self, runner, config, monkeypatch):
+        """TUI path uses ``questionary.select`` in a loop: Enter on an
+        item toggles it, Enter on the Confirm sentinel commits. CliRunner
+        can't fake a TTY, so we force ``_should_use_tui`` True and stub
+        ``questionary.select`` to script a fixed sequence of user actions."""
         from memtomem_stm.cli import proxy as proxy_mod
 
         monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
 
-        captured: dict[str, object] = {}
+        # Sequence the fake user will perform: toggle 0, toggle 2, Confirm.
+        # Each questionary.select() call returns the next scripted action.
+        actions = iter([0, 2, proxy_mod._TUI_CONFIRM])
+        observed_choice_counts: list[int] = []
 
-        class _FakePrompt:
-            def __init__(self, picks):
-                self._picks = picks
+        class _Scripted:
+            def __init__(self, result):
+                self._result = result
 
             def ask(self):
-                return self._picks
+                return self._result
 
-        def fake_checkbox(message, choices):
-            # Record what we were passed so we can assert on the UI shape.
-            captured["message"] = message
-            captured["titles"] = [c.title for c in choices]
-            captured["checked"] = [c.checked for c in choices]
-            # Simulate the user unchecking index 1 (keeps 0 + 2).
-            return _FakePrompt([0, 2])
+        def fake_select(message, choices, default=None):
+            observed_choice_counts.append(len(choices))
+            return _Scripted(next(actions))
 
         import questionary
 
-        monkeypatch.setattr(questionary, "checkbox", fake_checkbox)
+        monkeypatch.setattr(questionary, "select", fake_select)
 
         self._stub_candidates(
             monkeypatch,
@@ -1161,45 +1164,32 @@ class TestInitImportFlow:
         result = runner.invoke(
             cli,
             ["init", "--no-validate", *_cfg_args(config)],
-            input="\n\n\n",  # accept default prefix for each selected
+            input="\n\n",  # default prefix for each of the 2 picked servers
         )
         assert result.exit_code == 0, result.output
         data = json.loads(config.read_text(encoding="utf-8"))
-        assert set(data["upstream_servers"]) == {"a", "c"}  # index 1 ("b") dropped
-        # All choices start unchecked — populated configs usually have 8+
-        # candidates but users typically only import 1-2, so "check what
-        # you want" beats "uncheck what you don't" in friction terms.
-        assert captured["checked"] == [False, False, False]
-        assert "space=toggle" in captured["message"]
+        assert set(data["upstream_servers"]) == {"a", "c"}  # index 1 ("b") not toggled
+        # 3 iterations of the select loop: 2 toggles + 1 Confirm.
+        assert len(observed_choice_counts) == 3
+        # Each render shows: 3 candidates + Separator + Confirm + Cancel = 6 items.
+        assert all(n == 6 for n in observed_choice_counts)
 
-    def test_questionary_indicator_glyphs_overridden(self):
-        """Default ``●``/``○`` glyphs are visually ambiguous on thin fonts;
-        we replace them with ``[v]``/``[ ]`` at TUI-entry time. This pins
-        that the override is actually applied so a questionary upgrade
-        doesn't silently revert us to the blurry dots."""
-        from memtomem_stm.cli.proxy import _patch_questionary_indicators
-
-        _patch_questionary_indicators()
-
-        from questionary.prompts import common as qc_common
-
-        assert qc_common.INDICATOR_SELECTED == "[v]"
-        assert qc_common.INDICATOR_UNSELECTED == "[ ]"
-
-    def test_tui_ctrl_c_returns_empty_falls_to_manual(self, runner, config, monkeypatch):
-        """questionary returns None on Ctrl-C / aborted session; we treat
-        that as 'skip import, go manual' rather than crashing the wizard."""
+    def test_tui_cancel_exits_without_saving(self, runner, config, monkeypatch):
+        """Cancel sentinel (or Ctrl-C → None from questionary) exits the
+        wizard cleanly without writing a config. Contrast with the older
+        behavior that silently dropped into a manual name prompt — users
+        found that confusing when they just wanted to bail out."""
         from memtomem_stm.cli import proxy as proxy_mod
 
         monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
 
-        class _Aborted:
+        class _Scripted:
             def ask(self):
-                return None
+                return proxy_mod._TUI_CANCEL
 
         import questionary
 
-        monkeypatch.setattr(questionary, "checkbox", lambda *a, **kw: _Aborted())
+        monkeypatch.setattr(questionary, "select", lambda *a, **kw: _Scripted())
 
         self._stub_candidates(
             monkeypatch,
@@ -1214,13 +1204,47 @@ class TestInitImportFlow:
         result = runner.invoke(
             cli,
             ["init", "--no-validate", *_cfg_args(config)],
-            # manual path: name, prefix, transport, command, args
-            input="only\nonly\nstdio\nc\n\n",
+            input="",  # no prompts should fire after Cancel
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(config.read_text(encoding="utf-8"))
-        assert "x" not in data["upstream_servers"]
-        assert "only" in data["upstream_servers"]
+        assert "No servers selected" in result.output
+        assert not config.exists()
+
+    def test_tui_confirm_with_nothing_toggled_exits_without_saving(
+        self, runner, config, monkeypatch
+    ):
+        """Confirm with an empty selection is semantically 'I'm done and
+        I picked nothing' — same outcome as Cancel, since there's nothing
+        to save."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+
+        class _Scripted:
+            def ask(self):
+                return proxy_mod._TUI_CONFIRM
+
+        import questionary
+
+        monkeypatch.setattr(questionary, "select", lambda *a, **kw: _Scripted())
+
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "x",
+                    "source": "src",
+                    "entry": {"transport": "stdio", "command": "xx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "No servers selected" in result.output
+        assert not config.exists()
 
     def test_import_prompts_prefix_per_pick(self, runner, config, monkeypatch):
         """User-entered prefix overrides the suggested default, and each

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -592,14 +592,29 @@ class TestAddValidate:
 # ── init command (guided setup) ─────────────────────────────────────────
 
 
+@pytest.fixture
+def no_discovery(monkeypatch):
+    """Stub discovery to an empty list so manual-flow tests aren't
+    contaminated by whatever MCP configs happen to exist on the host
+    running the tests (dev machine, CI, etc.)."""
+    from memtomem_stm.cli import proxy as proxy_mod
+
+    monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: [])
+
+
 class TestInit:
-    """`mms init` is an interactive one-shot wizard: prompt for the first
-    upstream server, run an optional probe, write config, print paste-targets.
+    """`mms init` is an interactive wizard. Two entry points:
 
-    Prompt order (stdio path): name → prefix → transport → command → args
-    → (optional) validate y/n. ``input=`` feeds one answer per newline."""
+    * **Import flow:** if discovery finds servers registered in other MCP
+      clients (Claude Code, Claude Desktop, ``.mcp.json``), the user picks
+      from a numbered list and is only prompted for a prefix per pick.
+    * **Manual flow:** discovery empty (or user picks ``none``) → falls
+      back to free-form prompts (name → prefix → transport → command/url).
 
-    def test_init_happy_path_stdio_no_validate(self, runner, config):
+    Tests that only exercise the manual flow use the ``no_discovery``
+    fixture to force an empty candidate list."""
+
+    def test_init_happy_path_stdio_no_validate(self, runner, config, no_discovery):
         result = runner.invoke(
             cli,
             ["init", "--no-validate", *_cfg_args(config)],
@@ -627,7 +642,7 @@ class TestInit:
         assert "mms add" in result.output
         assert "mms list" in result.output
 
-    def test_init_invalid_prefix_reprompts(self, runner, config):
+    def test_init_invalid_prefix_reprompts(self, runner, config, no_discovery):
         """Bad prefix → re-ask instead of aborting; saves on the retry value."""
         result = runner.invoke(
             cli,
@@ -640,7 +655,7 @@ class TestInit:
         data = json.loads(config.read_text(encoding="utf-8"))
         assert data["upstream_servers"]["srv"]["prefix"] == "fs"
 
-    def test_init_sse_transport_prompts_for_url(self, runner, config):
+    def test_init_sse_transport_prompts_for_url(self, runner, config, no_discovery):
         result = runner.invoke(
             cli,
             ["init", "--no-validate", *_cfg_args(config)],
@@ -654,11 +669,20 @@ class TestInit:
         assert srv["url"] == "https://docs.example.com/mcp"
         assert "command" not in srv
 
-    def test_init_validate_failure_still_saves_with_warning(self, config):
+    def test_init_validate_failure_still_saves_with_warning(self, config, tmp_path):
         """Validation is advisory: probe failure warns and continues (a flaky
         network shouldn't block setup). Uses a real subprocess to dodge
-        CliRunner's stderr-fileno interaction (see TestAddValidate)."""
+        CliRunner's stderr-fileno interaction (see TestAddValidate).
+
+        ``HOME``/``cwd`` are redirected to an empty tmp dir so discovery
+        finds no candidates and drops into the manual flow — otherwise the
+        host's real ``~/.claude.json`` would leak in."""
         import subprocess
+
+        isolated_home = tmp_path / "home"
+        isolated_home.mkdir()
+        isolated_cwd = tmp_path / "cwd"
+        isolated_cwd.mkdir()
 
         proc = subprocess.run(
             [
@@ -674,15 +698,420 @@ class TestInit:
             capture_output=True,
             text=True,
             timeout=30,
+            cwd=str(isolated_cwd),
+            env={**os.environ, "HOME": str(isolated_home)},
         )
         assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
         combined = proc.stdout + proc.stderr
-        assert "Warning: probe failed" in combined
+        assert "probe failed" in combined
         assert "Saving config anyway" in combined
         assert "Saved to:" in proc.stdout
 
         data = json.loads(config.read_text(encoding="utf-8"))
         assert "bad" in data["upstream_servers"]
+
+
+# ── init: discovery + import helpers ────────────────────────────────────
+
+
+class TestInitDiscoveryHelpers:
+    """Pure-function tests for discovery building blocks. Keep these fast
+    and source-free (no file I/O) so the import flow can be reasoned about
+    piece by piece."""
+
+    def test_normalize_stdio_entry(self):
+        from memtomem_stm.cli.proxy import _normalize_client_entry
+
+        entry = _normalize_client_entry(
+            {"command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem"]}
+        )
+        assert entry is not None
+        assert entry["transport"] == "stdio"
+        assert entry["command"] == "npx"
+        assert entry["args"] == ["-y", "@modelcontextprotocol/server-filesystem"]
+        # Imported entries get our default compression/max_chars policy.
+        assert entry["compression"] == "auto"
+        assert entry["max_result_chars"] == 8000
+        # Prefix is intentionally absent — the caller prompts per-server.
+        assert "prefix" not in entry
+
+    def test_normalize_http_entry(self):
+        from memtomem_stm.cli.proxy import _normalize_client_entry
+
+        entry = _normalize_client_entry({"type": "http", "url": "https://example.com/mcp"})
+        assert entry is not None
+        assert entry["transport"] == "streamable_http"
+        assert entry["url"] == "https://example.com/mcp"
+
+    def test_normalize_sse_entry(self):
+        from memtomem_stm.cli.proxy import _normalize_client_entry
+
+        entry = _normalize_client_entry({"type": "sse", "url": "https://example.com/sse"})
+        assert entry is not None
+        assert entry["transport"] == "sse"
+
+    def test_normalize_strips_dangerous_env(self):
+        """Same policy as `mms add --env`: never import env keys that could
+        hijack a spawned process."""
+        from memtomem_stm.cli.proxy import _normalize_client_entry
+
+        entry = _normalize_client_entry(
+            {
+                "command": "node",
+                "args": ["srv.js"],
+                "env": {"API_KEY": "ok", "LD_PRELOAD": "/evil.so"},
+            }
+        )
+        assert entry is not None
+        assert entry["env"] == {"API_KEY": "ok"}
+
+    def test_normalize_rejects_unsupported_shape(self):
+        """No command + no url + no recognized type → can't import."""
+        from memtomem_stm.cli.proxy import _normalize_client_entry
+
+        assert _normalize_client_entry({}) is None
+        assert _normalize_client_entry({"type": "http"}) is None  # url missing
+        assert _normalize_client_entry({"command": ""}) is None
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("", []),
+            ("none", []),
+            ("all", [0, 1, 2]),
+            ("ALL", [0, 1, 2]),
+            ("1", [0]),
+            ("1,3", [0, 2]),
+            (" 2 , 1 ", [1, 0]),  # preserves user's ordering
+            ("1,1,2", [0, 1]),  # dedupes
+        ],
+    )
+    def test_parse_selection_valid(self, raw, expected):
+        from memtomem_stm.cli.proxy import _parse_selection
+
+        assert _parse_selection(raw, 3) == expected
+
+    @pytest.mark.parametrize("raw", ["0", "4", "1,4", "abc", "1-3", "1.5"])
+    def test_parse_selection_invalid(self, raw):
+        """Out-of-range, ranges, and non-digit tokens reprompt (None)."""
+        from memtomem_stm.cli.proxy import _parse_selection
+
+        assert _parse_selection(raw, 3) is None
+
+    def test_suggest_prefix_sanitizes_and_dedupes(self):
+        from memtomem_stm.cli.proxy import _suggest_prefix
+
+        assert _suggest_prefix("filesystem", set()) == "filesystem"
+        # dashes / dots → underscores
+        assert _suggest_prefix("my-server.name", set()) == "my_server_name"
+        # leading digit → prefixed so it matches _PREFIX_RE
+        assert _suggest_prefix("123", set()) == "s_123"
+        # collision → numbered suffix
+        assert _suggest_prefix("fs", {"fs"}) == "fs2"
+        assert _suggest_prefix("fs", {"fs", "fs2"}) == "fs3"
+
+    def test_is_self_reference_blocks_recursion(self):
+        """Importing an `mms`/`memtomem-stm` entry from another client would
+        make STM proxy itself → infinite loop on tool calls."""
+        from memtomem_stm.cli.proxy import _is_self_reference
+
+        assert _is_self_reference({"command": "mms"})
+        assert _is_self_reference({"command": "/usr/local/bin/memtomem-stm"})
+        assert _is_self_reference({"command": "memtomem-stm-proxy"})
+        assert not _is_self_reference({"command": "npx"})
+        assert not _is_self_reference({"url": "http://x"})
+
+
+class TestInitDiscoverySources:
+    """`_discover_candidates` reads three source files (project `.mcp.json`,
+    `~/.claude.json`, Claude Desktop config) and dedupes by name in that
+    priority order. Each test sets up a sandbox HOME + cwd to simulate a
+    user with specific configs already present."""
+
+    def _setup_home(self, tmp_path: Path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        # Redirect the macOS-specific Desktop path into our sandbox too.
+        desktop = home / "Library/Application Support/Claude"
+        desktop.mkdir(parents=True)
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(
+            proxy_mod,
+            "_desktop_config_path",
+            lambda: desktop / "claude_desktop_config.json",
+        )
+        return home, cwd, desktop
+
+    def test_discovers_claude_code_user_scope(self, tmp_path, monkeypatch):
+        from memtomem_stm.cli.proxy import _discover_candidates
+
+        home, cwd, _ = self._setup_home(tmp_path, monkeypatch)
+        (home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "filesystem": {"command": "npx", "args": ["-y", "@fs"]},
+                        "docs": {"type": "http", "url": "https://docs.example/mcp"},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cands = _discover_candidates(cwd)
+        names = {c["name"] for c in cands}
+        assert names == {"filesystem", "docs"}
+        fs = next(c for c in cands if c["name"] == "filesystem")
+        assert fs["source"] == "Claude Code (user)"
+        assert fs["entry"]["transport"] == "stdio"
+
+    def test_discovers_desktop_config(self, tmp_path, monkeypatch):
+        from memtomem_stm.cli.proxy import _discover_candidates
+
+        _, cwd, desktop = self._setup_home(tmp_path, monkeypatch)
+        (desktop / "claude_desktop_config.json").write_text(
+            json.dumps({"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}}}),
+            encoding="utf-8",
+        )
+
+        cands = _discover_candidates(cwd)
+        assert len(cands) == 1
+        assert cands[0]["name"] == "fetch"
+        assert cands[0]["source"] == "Claude Desktop"
+
+    def test_discovers_project_mcp_json_in_cwd(self, tmp_path, monkeypatch):
+        from memtomem_stm.cli.proxy import _discover_candidates
+
+        _, cwd, _ = self._setup_home(tmp_path, monkeypatch)
+        (cwd / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"dev-tool": {"command": "node", "args": ["x.js"]}}}),
+            encoding="utf-8",
+        )
+
+        cands = _discover_candidates(cwd)
+        assert len(cands) == 1
+        assert cands[0]["source"] == ".mcp.json (project)"
+
+    def test_dedupes_by_name_priority(self, tmp_path, monkeypatch):
+        """Same name in multiple sources → first-priority wins, others
+        recorded in ``duplicate_in`` so the UI can show the overlap."""
+        from memtomem_stm.cli.proxy import _discover_candidates
+
+        home, cwd, desktop = self._setup_home(tmp_path, monkeypatch)
+        (cwd / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"shared": {"command": "a"}}}),
+            encoding="utf-8",
+        )
+        (home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"shared": {"command": "b"}}}),
+            encoding="utf-8",
+        )
+        (desktop / "claude_desktop_config.json").write_text(
+            json.dumps({"mcpServers": {"shared": {"command": "c"}}}),
+            encoding="utf-8",
+        )
+
+        cands = _discover_candidates(cwd)
+        assert len(cands) == 1
+        assert cands[0]["entry"]["command"] == "a"  # .mcp.json wins
+        assert cands[0]["duplicate_in"] == ["Claude Code (user)", "Claude Desktop"]
+
+    def test_skips_self_reference(self, tmp_path, monkeypatch):
+        """Imports of `mms`/`memtomem-stm` are filtered so users never
+        accidentally configure STM to proxy itself."""
+        from memtomem_stm.cli.proxy import _discover_candidates
+
+        home, cwd, _ = self._setup_home(tmp_path, monkeypatch)
+        (home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "mms-self": {"command": "mms"},
+                        "real": {"command": "npx", "args": ["x"]},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cands = _discover_candidates(cwd)
+        assert [c["name"] for c in cands] == ["real"]
+
+    def test_missing_and_malformed_sources_are_silent(self, tmp_path, monkeypatch):
+        """Discovery is best-effort: a malformed JSON file shouldn't crash
+        ``mms init`` — it just yields nothing from that source."""
+        from memtomem_stm.cli.proxy import _discover_candidates
+
+        home, cwd, _ = self._setup_home(tmp_path, monkeypatch)
+        (home / ".claude.json").write_text("{ not json", encoding="utf-8")
+
+        assert _discover_candidates(cwd) == []
+
+
+class TestInitImportFlow:
+    """End-to-end ``mms init`` when discovery finds candidates. We stub
+    ``_discover_candidates`` directly to focus on the select + prefix UI;
+    source parsing is covered in ``TestInitDiscoverySources``."""
+
+    def _stub_candidates(self, monkeypatch, candidates):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: candidates)
+
+    def test_import_all_imports_every_candidate(self, runner, config, monkeypatch):
+        """Default answer 'all' + accept suggested prefixes → every
+        discovered server is imported with transport/command preserved."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "Claude Code (user)",
+                    "entry": {
+                        "transport": "stdio",
+                        "command": "npx",
+                        "args": ["-y", "@fs"],
+                        "compression": "auto",
+                        "max_result_chars": 8000,
+                    },
+                },
+                {
+                    "name": "docs",
+                    "source": "Claude Desktop",
+                    "entry": {
+                        "transport": "streamable_http",
+                        "url": "https://docs.example/mcp",
+                        "compression": "auto",
+                        "max_result_chars": 8000,
+                    },
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="all\n\n\n",  # pick all, accept default prefix for each
+        )
+        assert result.exit_code == 0, result.output
+        assert "Found 2 MCP server" in result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        servers = data["upstream_servers"]
+        assert set(servers) == {"filesystem", "docs"}
+        assert servers["filesystem"]["command"] == "npx"
+        assert servers["filesystem"]["prefix"] == "filesystem"  # default suggestion
+        assert servers["docs"]["url"] == "https://docs.example/mcp"
+
+    def test_import_subset_by_number(self, runner, config, monkeypatch):
+        """Numeric picks only import the chosen servers — not all of them."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "a",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "ca"},
+                },
+                {
+                    "name": "b",
+                    "source": "Y",
+                    "entry": {"transport": "stdio", "command": "cb"},
+                },
+                {
+                    "name": "c",
+                    "source": "Z",
+                    "entry": {"transport": "stdio", "command": "cc"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="1,3\n\n\n",  # pick a + c, default prefixes
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert set(data["upstream_servers"]) == {"a", "c"}
+
+    def test_none_falls_through_to_manual_flow(self, runner, config, monkeypatch):
+        """``none`` signals 'let me type one in instead'. The legacy manual
+        prompts (name → prefix → transport → command → args) run
+        afterwards, and that's what ends up in the config."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "Claude Code",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            # select=none, then manual: name, prefix, transport, command, args
+            input="none\ncustom\ncu\nstdio\nmy-cmd\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "filesystem" not in data["upstream_servers"]
+        assert "custom" in data["upstream_servers"]
+        assert data["upstream_servers"]["custom"]["command"] == "my-cmd"
+
+    def test_invalid_selection_reprompts(self, runner, config, monkeypatch):
+        """Out-of-range indices don't save garbage; they reprompt."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "one",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "x"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="5\n1\n\n",  # bad → retry with "1" → accept default prefix
+        )
+        assert result.exit_code == 0, result.output
+        assert "Invalid:" in result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "one" in data["upstream_servers"]
+
+    def test_import_prompts_prefix_per_pick(self, runner, config, monkeypatch):
+        """User-entered prefix overrides the suggested default, and each
+        selected server gets its own prompt."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+                {
+                    "name": "github",
+                    "source": "Y",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="all\nfs\ngh\n\n",  # custom prefixes for both
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert data["upstream_servers"]["filesystem"]["prefix"] == "fs"
+        assert data["upstream_servers"]["github"]["prefix"] == "gh"
 
 
 # ── remove command ───────────────────────────────────────────────────────

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -811,15 +811,31 @@ class TestInitDiscoveryHelpers:
         assert _suggest_prefix("fs", {"fs", "fs2"}) == "fs3"
 
     def test_is_self_reference_blocks_recursion(self):
-        """Importing an `mms`/`memtomem-stm` entry from another client would
-        make STM proxy itself → infinite loop on tool calls."""
+        """STM (mms/memtomem-stm) and the LTM companion (memtomem/
+        memtomem-server) must never be imported as upstream servers.
+
+        STM self-proxy → infinite loop on tool calls.
+        LTM as upstream → double-registered, since STM already reaches LTM
+        via a separate mechanism (CLAUDE.md pipeline invariants)."""
         from memtomem_stm.cli.proxy import _is_self_reference
 
+        # STM itself (command basename).
         assert _is_self_reference({"command": "mms"})
         assert _is_self_reference({"command": "/usr/local/bin/memtomem-stm"})
         assert _is_self_reference({"command": "memtomem-stm-proxy"})
+        # LTM companion (command basename).
+        assert _is_self_reference({"command": "memtomem-server"})
+        assert _is_self_reference({"command": "memtomem"})
+        # LTM via uvx wrapper — the blocked name hides in args, not command.
+        # This is the shape Claude Code writes: `uvx --from memtomem memtomem-server`.
+        assert _is_self_reference(
+            {"command": "uvx", "args": ["--from", "memtomem", "memtomem-server"]}
+        )
+        # Legitimate neighbor names must not be over-matched (substring
+        # collisions would flag user-written `memtomem-foo-bar`).
         assert not _is_self_reference({"command": "npx"})
         assert not _is_self_reference({"url": "http://x"})
+        assert not _is_self_reference({"command": "uvx", "args": ["--from", "memtomem-notes"]})
 
 
 class TestInitDiscoverySources:
@@ -921,8 +937,10 @@ class TestInitDiscoverySources:
         assert cands[0]["duplicate_in"] == ["Claude Code (user)", "Claude Desktop"]
 
     def test_skips_self_reference(self, tmp_path, monkeypatch):
-        """Imports of `mms`/`memtomem-stm` are filtered so users never
-        accidentally configure STM to proxy itself."""
+        """Imports of STM (``mms``) or LTM (``memtomem-server``, either as
+        direct command or under ``uvx --from memtomem``) are filtered so
+        users never accidentally configure STM to proxy itself or to
+        double-register the LTM companion."""
         from memtomem_stm.cli.proxy import _discover_candidates
 
         home, cwd, _ = self._setup_home(tmp_path, monkeypatch)
@@ -931,6 +949,10 @@ class TestInitDiscoverySources:
                 {
                     "mcpServers": {
                         "mms-self": {"command": "mms"},
+                        "memtomem": {
+                            "command": "uvx",
+                            "args": ["--from", "memtomem", "memtomem-server"],
+                        },
                         "real": {"command": "npx", "args": ["x"]},
                     }
                 }
@@ -1084,6 +1106,106 @@ class TestInitImportFlow:
         assert "Invalid:" in result.output
         data = json.loads(config.read_text(encoding="utf-8"))
         assert "one" in data["upstream_servers"]
+
+    def test_tty_delegates_to_questionary_checkbox(self, runner, config, monkeypatch):
+        """When stdin is a TTY we use ``questionary.checkbox`` (space-to-
+        toggle UI). CliRunner can't fake a TTY, so we force
+        ``_should_use_tui`` True and stub ``questionary.checkbox`` to
+        return pre-chosen indices. This pins the contract that the TUI
+        path is actually reached when available."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+
+        captured: dict[str, object] = {}
+
+        class _FakePrompt:
+            def __init__(self, picks):
+                self._picks = picks
+
+            def ask(self):
+                return self._picks
+
+        def fake_checkbox(message, choices):
+            # Record what we were passed so we can assert on the UI shape.
+            captured["message"] = message
+            captured["titles"] = [c.title for c in choices]
+            captured["checked"] = [c.checked for c in choices]
+            # Simulate the user unchecking index 1 (keeps 0 + 2).
+            return _FakePrompt([0, 2])
+
+        import questionary
+
+        monkeypatch.setattr(questionary, "checkbox", fake_checkbox)
+
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "a",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "ca"},
+                },
+                {
+                    "name": "b",
+                    "source": "Y",
+                    "entry": {"transport": "stdio", "command": "cb"},
+                },
+                {
+                    "name": "c",
+                    "source": "Z",
+                    "entry": {"transport": "stdio", "command": "cc"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="\n\n\n",  # accept default prefix for each selected
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert set(data["upstream_servers"]) == {"a", "c"}  # index 1 ("b") dropped
+        # All choices start pre-checked so 'enter' on the default
+        # selection imports everything (the common case).
+        assert captured["checked"] == [True, True, True]
+        assert "space=toggle" in captured["message"]
+
+    def test_tui_ctrl_c_returns_empty_falls_to_manual(self, runner, config, monkeypatch):
+        """questionary returns None on Ctrl-C / aborted session; we treat
+        that as 'skip import, go manual' rather than crashing the wizard."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+
+        class _Aborted:
+            def ask(self):
+                return None
+
+        import questionary
+
+        monkeypatch.setattr(questionary, "checkbox", lambda *a, **kw: _Aborted())
+
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "x",
+                    "source": "src",
+                    "entry": {"transport": "stdio", "command": "xx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            # manual path: name, prefix, transport, command, args
+            input="only\nonly\nstdio\nc\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "x" not in data["upstream_servers"]
+        assert "only" in data["upstream_servers"]
 
     def test_import_prompts_prefix_per_pick(self, runner, config, monkeypatch):
         """User-entered prefix overrides the suggested default, and each

--- a/uv.lock
+++ b/uv.lock
@@ -1485,6 +1485,7 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "questionary" },
 ]
 
 [package.optional-dependencies]
@@ -1521,6 +1522,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.7" },
+    { name = "questionary", specifier = ">=2.0" },
 ]
 provides-extras = ["langfuse", "langchain"]
 
@@ -2363,6 +2365,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
     { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
     { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `mms init` now scans existing MCP-client configs (`./.mcp.json`, `~/.claude.json` user+project scope, Claude Desktop macOS config) and offers a multi-select import. Users with servers already registered elsewhere no longer retype them.
- For each selected candidate, only the `prefix` is prompted (sanitized default derived from the name). Transport/command/args/url are imported as-is.
- `none` or empty discovery → falls through to the original free-form manual prompts; the legacy flow is unchanged.
- `init` can now save multiple servers in a single run (previously one-shot).

## Motivation

On this machine `~/.claude.json` + Claude Desktop together list ~5 MCP servers I'd have to re-enter by hand via `init` → `add` loop. The guided flow was strictly worse than editing JSON for anyone with a non-empty existing setup.

## Safety invariants

- **Self-reference filter** — imports whose command basename is `mms` / `memtomem-stm` / `memtomem-stm-proxy` are silently skipped so STM can't accidentally proxy itself (infinite loop on tool calls).
- **Dangerous env scrub** — `LD_PRELOAD`, `NODE_OPTIONS`, `PYTHONSTARTUP`, etc. are stripped from the imported `env` dict, matching the policy `mms add --env` already enforces.
- **Best-effort discovery** — missing / malformed source files yield zero candidates, never an exception.
- **Priority dedupe** — if the same server name appears in multiple sources, first-seen wins (`.mcp.json` > Claude Code user > Claude Code project > Claude Desktop) and the overlap is surfaced as `(also in: ...)` so the user knows.

## UI

```
Found 3 MCP server(s) in existing client configs:
   1. filesystem       [stdio] npx -y @modelcontextprotocol/server-filesystem    — from Claude Code (user)
   2. docs             [streamable_http] https://docs.example/mcp                 — from Claude Code (user)
   3. fetch            [stdio] uvx mcp-server-fetch                              — from Claude Desktop  (also in: Claude Code (user))

Select servers to import (e.g. '1,3', 'all', or 'none' to add manually) [all]: 1,3
Configuring 'filesystem'
Tool prefix (letters/digits/underscores, e.g. 'fs') [filesystem]: fs
Configuring 'fetch'
Tool prefix (letters/digits/underscores, e.g. 'fs') [fetch]:
...
```

## Test plan

- [x] `uv run ruff check src tests/cli` + `ruff format --check` — clean
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean
- [x] `uv run pytest tests/cli/test_proxy_cli.py` — 85 passed (70 pre-existing + 15 new)
- [x] Helper unit tests cover: `_normalize_client_entry` (stdio/http/sse/dangerous-env/unsupported), `_parse_selection` (valid parametrize + invalid parametrize), `_suggest_prefix` (sanitize + dedupe), `_is_self_reference`.
- [x] Source-parsing tests cover: Claude Code user scope, Claude Desktop, `.mcp.json`, priority dedupe with `duplicate_in`, self-reference skip, malformed JSON silence.
- [x] End-to-end flow tests cover: import-all, numeric subset, `none` → manual fallback, invalid-selection reprompt, per-server prefix prompt.
- [x] Existing `init` tests (happy path, invalid prefix reprompt, sse URL, validate failure) still pass via a `no_discovery` fixture that forces empty discovery so host state doesn't contaminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)