### PR TITLE
feat(cli): surface `--config` hints when init uses non-default path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mms init` imports MCP servers from existing clients** (#194) — scans `./.mcp.json`, `~/.claude.json` (user + per-project scope), and Claude Desktop's macOS config, then offers a TUI multi-select (Enter toggles, scroll to Confirm; ↑↓ / j/k / Ctrl+N/P all supported). For each pick the user only confirms a prefix — transport/command/args/url/env are imported as-is. Self-reference filter blocks `mms` / `memtomem-stm` / `memtomem` / `memtomem-server` entries (including `uvx --from memtomem …` shape) so users can't accidentally proxy STM through itself or double-register the LTM companion. Dangerous env keys (`LD_PRELOAD`, `NODE_OPTIONS`, etc.) are stripped during import, matching `mms add --env` policy. Non-TTY / `MMS_NO_TUI=1` / piped stdin fall back to a comma-number prompt so CI and scripted installs still work. Adds `questionary>=2.0` runtime dep.
+- **`mms init` surfaces `--config` management hints on non-default paths** — after saving to a path other than `~/.memtomem/stm_proxy.json`, the output now prints `mms list --config <path>` / `mms health --config <path>` so subsequent management commands don't silently read the empty default config. Reported during dogfooding with throwaway `/tmp/*.json` test paths.
+
 ## [0.1.9] — 2026-04-19
 
 ### Added

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -903,6 +903,16 @@ def init(config_path: str, no_validate: bool) -> None:
     for n, e in imported.items():
         click.echo(f"  {n:<20} prefix={e['prefix']}  {_format_candidate_detail(e)}")
 
+    # Non-default ``--config`` paths: surface the flag in the management
+    # hints so ``mms list`` / ``mms health`` don't silently read the empty
+    # default config and confuse the user (reported after first dogfooding
+    # with a throwaway ``/tmp/*.json`` test path).
+    if resolved != _DEFAULT_CONFIG.expanduser().resolve():
+        click.echo("")
+        click.echo(f"  {_hdr('Manage this config:')}")
+        click.echo(f"    mms list --config {resolved}")
+        click.echo(f"    mms health --config {resolved}")
+
     click.echo("")
     click.echo(f"{_ok('Next:')} connect your MCP client to memtomem-stm.")
     click.echo("")

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1249,6 +1249,65 @@ class TestInitImportFlow:
         assert "No servers selected" in result.output
         assert not config.exists()
 
+    def test_non_default_config_surfaces_management_hint(self, runner, config, monkeypatch):
+        """When `--config` deviates from ``~/.memtomem/stm_proxy.json``
+        the tail of the output must print ``mms list --config <path>``
+        / ``mms health --config <path>`` so the user doesn't get tripped
+        up by ``mms list`` silently reading the empty default config.
+        Caught during dogfooding with a throwaway ``/tmp/*.json`` test
+        path — the gap was confusing."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "only",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "c"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Manage this config:" in result.output
+        # Hints must name the actual resolved path so the user can copy
+        # them verbatim — no ``{path}`` placeholder leakage.
+        assert f"mms list --config {config.resolve()}" in result.output
+        assert f"mms health --config {config.resolve()}" in result.output
+
+    def test_default_config_does_not_show_management_hint(self, runner, tmp_path, monkeypatch):
+        """Inverse of the above: when the user accepts the default
+        config path, the hint is noise and should not print. We stub
+        ``_DEFAULT_CONFIG`` to a tmp path so this test can match the
+        "default" case without actually writing to the user's real
+        ``~/.memtomem/stm_proxy.json``."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        fake_default = tmp_path / "default_stm_proxy.json"
+        monkeypatch.setattr(proxy_mod, "_DEFAULT_CONFIG", fake_default)
+
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "only",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "c"},
+                },
+            ],
+        )
+        # Invoke without --config so the command picks up the (patched) default.
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--config", str(fake_default)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Manage this config:" not in result.output
+
     def test_import_prompts_prefix_per_pick(self, runner, config, monkeypatch):
         """User-entered prefix overrides the suggested default, and each
         selected server gets its own prompt."""


### PR DESCRIPTION
## Summary

- When ``mms init --config <custom-path>`` saves to anywhere other than ``~/.memtomem/stm_proxy.json``, the post-save output now prints a short ``Manage this config:`` block with the exact ``mms list --config <path>`` / ``mms health --config <path>`` commands the user needs to manage what they just wrote.
- Default-path case unchanged — the hint is suppressed so it doesn't become noise for the common install flow.
- [Unreleased] in CHANGELOG.md brought up to date with PR #194 + this entry so the next ``chore: release`` PR only needs to move the section header.

## Why

Reported during dogfooding of #194. Using a throwaway ``/tmp/*.json`` test path to avoid clobbering real ``~/.memtomem/stm_proxy.json``, running ``mms init`` → then naturally ``mms list`` → got ``"No upstream servers configured."`` because list reads the default path. Wizard felt like it silently dropped the work. Closing the loop with explicit commands the user can copy verbatim.

## Test plan

- [x] ``uv run ruff check src tests/cli/test_proxy_cli.py`` + ``ruff format --check`` — clean
- [x] ``uv run mypy src/memtomem_stm/cli/proxy.py`` — clean
- [x] ``uv run pytest tests/cli/test_proxy_cli.py`` — 90 passed (88 pre-existing + 2 new)
- [x] New tests cover: (a) non-default path surfaces the hint with the exact resolved path string, (b) default path suppresses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)