### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.10] — 2026-04-20
+
 ### Added
 
 - **`mms init` imports MCP servers from existing clients** (#194) — scans `./.mcp.json`, `~/.claude.json` (user + per-project scope), and Claude Desktop's macOS config, then offers a TUI multi-select (Enter toggles, scroll to Confirm; ↑↓ / j/k / Ctrl+N/P all supported). For each pick the user only confirms a prefix — transport/command/args/url/env are imported as-is. Self-reference filter blocks `mms` / `memtomem-stm` / `memtomem` / `memtomem-server` entries (including `uvx --from memtomem …` shape) so users can't accidentally proxy STM through itself or double-register the LTM companion. Dangerous env keys (`LD_PRELOAD`, `NODE_OPTIONS`, etc.) are stripped during import, matching `mms add --env` policy. Non-TTY / `MMS_NO_TUI=1` / piped stdin fall back to a comma-number prompt so CI and scripted installs still work. Adds `questionary>=2.0` runtime dep.
-- **`mms init` surfaces `--config` management hints on non-default paths** — after saving to a path other than `~/.memtomem/stm_proxy.json`, the output now prints `mms list --config <path>` / `mms health --config <path>` so subsequent management commands don't silently read the empty default config. Reported during dogfooding with throwaway `/tmp/*.json` test paths.
+- **`mms init` surfaces `--config` management hints on non-default paths** (#195) — after saving to a path other than `~/.memtomem/stm_proxy.json`, the output now prints `mms list --config <path>` / `mms health --config <path>` so subsequent management commands don't silently read the empty default config. Reported during dogfooding with throwaway `/tmp/*.json` test paths.
 
 ## [0.1.9] — 2026-04-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem-stm"
-version = "0.1.9"
+version = "0.1.10"
 description = "Short-term memory proxy gateway with proactive memory surfacing for AI agents"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "memtomem-stm"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bumps version to 0.1.10 and moves [Unreleased] → [0.1.10] — 2026-04-20 in CHANGELOG.md.
- Release covers the `mms init` import-from-existing-clients feature (#194) and the non-default-config management hint follow-up (#195).

## Release flow

1. Squash-merge this PR.
2. Tag ``v0.1.10`` on main → PyPI trusted-publisher workflow builds and waits on the ``pypi`` environment approval (memtomem admin).
3. Approve the pending deployment in Actions.
4. ``gh release create v0.1.10`` with CHANGELOG excerpt as the body (the tag alone doesn't create a GitHub Release).

## Test plan

- [x] ``uv sync`` — lockfile bumped (0.1.9 → 0.1.10).
- [x] Manual dogfood on Ghostty TTY with a throwaway ``/tmp/*.json`` config — TUI toggles work, Confirm/Cancel work, ``memtomem`` LTM filtered from discovery, non-default path hint prints ``mms list --config`` + ``mms health --config``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)