### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.11] — 2026-04-20
+
+### Added
+
+- **`stm_surfacing_stats` MCP tool enriched with parity to `stm_compression_stats`** (#198, closes #197) — output now includes `events_total`, `distinct_tools`, `date_range`, per-tool breakdown (events + average memory count, sorted descending), `rating_distribution`, `total_feedback`, helpfulness percentage, and a DESC-ordered `recent` tail with 80-character query previews. New optional inputs `since` (ISO-8601) and `limit` (default 10) restrict the window. Empty-DB / out-of-range filters return zeros with all collections present, so callers don't branch on shape. Malformed `since` is rejected with a clean error rather than raising. Closes the long-standing observability gap where surfacing analytics required raw SQL against `~/.memtomem/stm_feedback.db` while compression already had an aggregate tool.
+
 ## [0.1.10] — 2026-04-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem-stm"
-version = "0.1.10"
+version = "0.1.11"
 description = "Short-term memory proxy gateway with proactive memory surfacing for AI agents"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "memtomem-stm"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `stm_surfacing_stats` now has parity with `stm_compression_stats` (#198, closes #197) — events_total / distinct_tools / date_range / per-tool breakdown / rating distribution / recent tail with query previews; new `since` (ISO-8601) and `limit` inputs.

## Why now

v0.1.10's `mms init` import flow brought in new adopters whose first observability question is "what has STM been surfacing?" — closing the asymmetry with compression's existing aggregate tool before that question hits the issue tracker.

## Test plan

- [x] `uv run pytest -m "not ollama"` — full suite green at HEAD (pre-release)
- [x] `uv run ruff check src && uv run ruff format --check src`
- [x] PyPI trusted publisher will auto-deploy on `v0.1.11` tag (post-merge)
- [ ] Approve `pypi` environment in web UI to actually publish (memtomem account)
- [ ] `gh release create v0.1.11` after tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)