### PR TITLE
feat(cli): add `mms add --from-clients` / `--import` for bulk re-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mms add --from-clients` (alias `--import`) bulk-imports from MCP clients post-init** — reuses init's discovery + TUI flow so additional servers added to Claude Desktop / Code / project `.mcp.json` after initial setup can be pulled in interactively, without editing JSON by hand or calling `mms add` once per server. Filters candidates two ways before prompting: by name (skips `foo` if a server named `foo` already exists) and by `(transport, command, args)` / `(transport, url)` signature (skips duplicates registered under a different name). When all discovered servers are already registered, exits cleanly with a no-op message instead of an empty selection screen. `--prefix` is suggested from the upstream name and de-duped against prefixes already in the config. Incompatible with `NAME` / `--prefix` / `--command` / `--args` / `--url` / `--env` — those are for the single-server manual path; passing both raises a usage error rather than silently ignoring one. Works with `--validate` and `--timeout` to probe only the selected subset.
+
 ## [0.1.11] — 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ mms add filesystem \
 
 `--prefix` is required: it's the namespace under which the upstream server's tools will appear (e.g. `fs__read_file`). Repeat for each MCP server you want to proxy.
 
+If you've already configured MCP servers in Claude Desktop, Claude Code, or a project `.mcp.json`, `mms add --import` (alias `--from-clients`) reuses the init wizard to bulk-select them — skipping anything already registered.
+
 ```bash
 mms list      # show what you've added
 mms status    # show full config + connectivity

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -221,14 +221,15 @@ def list_servers(config_path: str) -> None:
 
 
 @cli.command()
-@click.argument("name")
+@click.argument("name", required=False)
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
 @click.option("--command", "command", default="", help="Executable command (stdio).")
 @click.option("--args", "args_str", default="", help="Space-separated arguments.")
 @click.option(
     "--prefix",
-    required=True,
-    help="Tool namespace (e.g. 'fs' -> tools appear as fs__read_file).",
+    default="",
+    help="Tool namespace (e.g. 'fs' -> tools appear as fs__read_file). "
+    "Required unless --from-clients is used.",
 )
 @click.option(
     "--transport",
@@ -263,8 +264,19 @@ def list_servers(config_path: str) -> None:
     show_default=True,
     help="Connection timeout (seconds) when --validate is set.",
 )
+@click.option(
+    "--from-clients",
+    "--import",
+    "from_clients",
+    is_flag=True,
+    default=False,
+    help="Import additional servers interactively from existing MCP clients "
+    "(Claude Desktop / Code, project .mcp.json). Reuses init's discovery + "
+    "TUI flow. Skips candidates already registered in this config. "
+    "Incompatible with NAME / --prefix / --command / --args / --url / --env.",
+)
 def add(
-    name: str,
+    name: str | None,
     config_path: str,
     command: str,
     args_str: str,
@@ -276,9 +288,44 @@ def add(
     max_result_chars: int,
     validate: bool,
     validate_timeout: int,
+    from_clients: bool,
 ) -> None:
     """Add an upstream MCP server to the proxy configuration."""
     path = Path(config_path)
+
+    if from_clients:
+        # Guard against mixing interactive-import with single-server manual
+        # flags — silently ignoring them would be surprising. `--validate` /
+        # `--timeout` / `--config` are shared with both paths and don't
+        # conflict.
+        conflicts: list[str] = []
+        if name:
+            conflicts.append("NAME")
+        if prefix:
+            conflicts.append("--prefix")
+        if command:
+            conflicts.append("--command")
+        if args_str:
+            conflicts.append("--args")
+        if url:
+            conflicts.append("--url")
+        if env_pairs:
+            conflicts.append("--env")
+        if conflicts:
+            raise click.UsageError(
+                f"--from-clients cannot be combined with: {', '.join(conflicts)}."
+            )
+        _add_from_clients(path, validate=validate, validate_timeout=validate_timeout)
+        return
+
+    # Manual single-server path — NAME and --prefix were previously click-
+    # required. Relaxed to optional above so --from-clients can omit them;
+    # re-enforce here so the manual path still has the same contract.
+    if not name:
+        raise click.UsageError("Missing argument 'NAME' (or pass --from-clients).")
+    if not prefix:
+        raise click.UsageError("Missing option '--prefix' (or pass --from-clients).")
+
     data = _load(path)
     servers: dict[str, Any] = data.setdefault("upstream_servers", {})
 
@@ -755,6 +802,131 @@ def _pick_imports(candidates: list[dict[str, Any]]) -> list[int]:
         )
 
 
+def _server_signature(cfg: dict[str, Any]) -> tuple[str, ...] | None:
+    """Best-effort content signature for dedup between discovered + registered.
+
+    Same ``(transport, command, *args)`` or ``(transport, url)`` → assume
+    the user already imported this server under a different name. Returns
+    ``None`` when the entry is missing the identifying field (caller falls
+    back to name-based match only).
+    """
+    transport = cfg.get("transport", "stdio")
+    if transport == "stdio":
+        cmd = cfg.get("command", "") or ""
+        if not cmd:
+            return None
+        args = cfg.get("args") or []
+        if not isinstance(args, list):
+            args = []
+        return ("stdio", cmd, *(str(a) for a in args))
+    url = cfg.get("url", "") or ""
+    if not url:
+        return None
+    return (transport, url)
+
+
+def _add_from_clients(
+    config_path: Path,
+    *,
+    validate: bool,
+    validate_timeout: int,
+) -> None:
+    """Interactive bulk-import path for ``mms add --from-clients``.
+
+    Reuses init's discovery + selection + prefix-prompt helpers. Difference
+    from init: merges into an existing config (rather than creating one) and
+    filters out candidates that match servers already registered, so the TUI
+    only shows *new* options.
+    """
+    data = _load(config_path)
+    servers: dict[str, Any] = data.setdefault("upstream_servers", {})
+
+    all_candidates = _discover_candidates(Path.cwd())
+    if not all_candidates:
+        click.echo("No MCP servers found in Claude Desktop / Code / .mcp.json.")
+        click.echo("Use `mms add <NAME> --prefix ... --command ...` to register one manually.")
+        return
+
+    existing_names = set(servers.keys())
+    existing_signatures = {
+        sig for srv_cfg in servers.values() if (sig := _server_signature(srv_cfg)) is not None
+    }
+
+    new_candidates: list[dict[str, Any]] = []
+    for cand in all_candidates:
+        cand_name = cand["name"]
+        entry = cand["entry"]
+        if cand_name in existing_names:
+            click.echo(
+                f"  {_warn('Skipping:')} '{cand_name}' — already registered.",
+                err=True,
+            )
+            continue
+        sig = _server_signature(entry)
+        if sig is not None and sig in existing_signatures:
+            click.echo(
+                f"  {_warn('Skipping:')} '{cand_name}' — matches an existing server "
+                "by command/url.",
+                err=True,
+            )
+            continue
+        new_candidates.append(cand)
+
+    if not new_candidates:
+        click.echo("All discovered servers are already registered.")
+        return
+
+    resolved = config_path.expanduser().resolve()
+    click.echo(_hdr(f"Found {len(new_candidates)} new MCP server(s) to import:"))
+    for i, cand in enumerate(new_candidates, 1):
+        dup = cand.get("duplicate_in")
+        dup_hint = f"  (also in: {', '.join(dup)})" if dup else ""
+        click.echo(
+            f"  {i:>2}. {cand['name']:<18} {_format_candidate_detail(cand['entry'])}"
+            f"    — from {cand['source']}{dup_hint}"
+        )
+    click.echo("")
+    picks = _pick_imports(new_candidates)
+
+    if not picks:
+        click.echo("")
+        click.echo(f"{_ok('No servers selected.')} Config unchanged.")
+        return
+
+    # Seed the "taken prefixes" set with what's already in the config so
+    # suggestions don't collide with prior registrations.
+    used_prefixes: set[str] = {p for srv_cfg in servers.values() if (p := srv_cfg.get("prefix"))}
+    imported: dict[str, dict[str, Any]] = {}
+    click.echo("")
+    for idx in picks:
+        cand = new_candidates[idx]
+        click.echo(_hdr(f"Configuring '{cand['name']}'"))
+        suggested = _suggest_prefix(cand["name"], used_prefixes)
+        prefix = _prompt_prefix(default=suggested)
+        used_prefixes.add(prefix)
+        entry = {"prefix": prefix, **cand["entry"]}
+        imported[cand["name"]] = entry
+
+    if validate:
+        click.echo("")
+        click.echo(f"Validating {len(imported)} server(s) (timeout={validate_timeout}s)...")
+        probes = asyncio.run(_probe_servers(imported, validate_timeout))
+        for n, probe in probes.items():
+            if probe["connected"]:
+                click.echo(f"  {_ok('Reachable:')} {n} — {probe['tools']} tool(s).")
+            else:
+                click.echo(f"  {_warn('Warning:')} {n} — probe failed: {probe['error']}", err=True)
+                click.echo("  Saving anyway. Run `mms health` later to retry.", err=True)
+
+    servers.update(imported)
+    _save(config_path, data)
+
+    click.echo("")
+    click.echo(f"{_ok('Added')} {len(imported)} server(s) to {resolved}:")
+    for n, e in imported.items():
+        click.echo(f"  {n:<20} prefix={e['prefix']}  {_format_candidate_detail(e)}")
+
+
 @cli.command()
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
 @click.option(
@@ -775,6 +947,10 @@ def init(config_path: str, no_validate: bool) -> None:
     if resolved.exists():
         click.echo(f"{_err('Error:')} config already exists at {resolved}.", err=True)
         click.echo("  Use `mms add` to register another server.", err=True)
+        click.echo(
+            "  Use `mms add --import` to bulk-import more from MCP clients.",
+            err=True,
+        )
         click.echo("  Use `mms list` to see what's already configured.", err=True)
         sys.exit(1)
 
@@ -912,6 +1088,7 @@ def init(config_path: str, no_validate: bool) -> None:
         click.echo(f"  {_hdr('Manage this config:')}")
         click.echo(f"    mms list --config {resolved}")
         click.echo(f"    mms health --config {resolved}")
+        click.echo(f"    mms add --import --config {resolved}")
 
     click.echo("")
     click.echo(f"{_ok('Next:')} connect your MCP client to memtomem-stm.")

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1337,6 +1337,278 @@ class TestInitImportFlow:
         assert data["upstream_servers"]["github"]["prefix"] == "gh"
 
 
+# ── add --from-clients (bulk import) ────────────────────────────────────
+
+
+class TestAddFromClients:
+    """`mms add --from-clients` (alias `--import`) reuses init's discovery +
+    TUI to bulk-import additional servers. Difference from init: merges into
+    an existing config and filters out servers already registered, so the
+    user only sees *new* candidates."""
+
+    def _stub_candidates(self, monkeypatch, candidates):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: candidates)
+
+    def _seed_config(self, config: Path, servers: dict) -> None:
+        config.write_text(
+            json.dumps({"enabled": True, "upstream_servers": servers}, indent=2),
+            encoding="utf-8",
+        )
+
+    def test_from_clients_happy_path_imports_new_server(self, runner, config, monkeypatch):
+        """Fresh candidate + existing server in config → imports candidate,
+        preserves existing entry, and shows the discovery header."""
+        self._seed_config(
+            config, {"existing": {"prefix": "ex", "command": "old", "transport": "stdio"}}
+        )
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "Claude Code (user)",
+                    "entry": {
+                        "transport": "stdio",
+                        "command": "npx",
+                        "args": ["-y", "@fs"],
+                        "compression": "auto",
+                        "max_result_chars": 8000,
+                    },
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+            input="all\n\n",  # pick all + accept suggested prefix
+        )
+        assert result.exit_code == 0, result.output
+        assert "Found 1 new MCP server" in result.output
+        assert "Added 1 server" in result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert set(data["upstream_servers"]) == {"existing", "filesystem"}
+        fs = data["upstream_servers"]["filesystem"]
+        assert fs["command"] == "npx"
+        assert fs["prefix"] == "filesystem"  # default suggestion
+
+    def test_from_clients_import_alias(self, runner, config, monkeypatch):
+        """`--import` is a flag synonym for `--from-clients`; must hit the
+        same code path without any other difference."""
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "npx", "args": []},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--import", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "filesystem" in data["upstream_servers"]
+
+    def test_filters_already_registered_by_name(self, runner, config, monkeypatch):
+        """Discovered candidate whose name matches an existing server is
+        dropped with a skip notice — the user isn't forced to re-review or
+        re-pick a prefix for something they've already configured."""
+        self._seed_config(
+            config,
+            {
+                "filesystem": {
+                    "prefix": "fs",
+                    "transport": "stdio",
+                    "command": "different",
+                },
+            },
+        )
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+                {
+                    "name": "github",
+                    "source": "Y",
+                    "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@gh"]},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Skipping: 'filesystem'" in result.output
+        assert "already registered" in result.output
+        assert "Found 1 new MCP server" in result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        # Existing filesystem entry preserved (different command proves it wasn't overwritten).
+        assert data["upstream_servers"]["filesystem"]["command"] == "different"
+        assert "github" in data["upstream_servers"]
+
+    def test_filters_already_registered_by_signature(self, runner, config, monkeypatch):
+        """Same (command, args) under a different name → still dedup'd so
+        users don't end up with two registrations of the same underlying
+        server (would double-surface tools)."""
+        self._seed_config(
+            config,
+            {
+                "my-fs": {
+                    "prefix": "fs",
+                    "transport": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "@fs"],
+                },
+            },
+        )
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",  # different name...
+                    "source": "X",
+                    "entry": {
+                        "transport": "stdio",
+                        "command": "npx",
+                        "args": ["-y", "@fs"],  # ...same command+args
+                    },
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+            input="",  # no prompts expected — exits early
+        )
+        assert result.exit_code == 0, result.output
+        assert "Skipping: 'filesystem'" in result.output
+        assert "matches an existing server" in result.output
+        assert "All discovered servers are already registered." in result.output
+
+        # Nothing was appended.
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert set(data["upstream_servers"]) == {"my-fs"}
+
+    def test_all_registered_exits_cleanly(self, runner, config, monkeypatch):
+        """When every discovered candidate is already registered, we exit
+        with a no-op message instead of prompting for an empty selection."""
+        self._seed_config(
+            config,
+            {"filesystem": {"prefix": "fs", "transport": "stdio", "command": "npx"}},
+        )
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "x"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "All discovered servers are already registered." in result.output
+
+    def test_no_candidates_discovered_exits_cleanly(self, runner, config, monkeypatch):
+        """No MCP-client configs on the machine → no-op with a pointer to
+        the manual `mms add NAME ...` path."""
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, [])
+
+        result = runner.invoke(cli, ["add", "--from-clients", *_cfg_args(config)])
+        assert result.exit_code == 0, result.output
+        assert "No MCP servers found" in result.output
+        assert "mms add <NAME>" in result.output
+
+    def test_rejects_conflicting_name_and_prefix(self, runner, config, monkeypatch):
+        """Passing NAME or --prefix alongside --from-clients is a usage
+        error — silently ignoring them would be surprising."""
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, [])
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "mysrv",
+                "--from-clients",
+                "--prefix",
+                "fs",
+                "--command",
+                "x",
+                *_cfg_args(config),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--from-clients cannot be combined with" in result.output
+        # Lists the conflicting flags by name so the user knows what to drop.
+        assert "NAME" in result.output
+        assert "--prefix" in result.output
+        assert "--command" in result.output
+
+    def test_validate_flag_probes_only_picked_servers(self, runner, config, monkeypatch):
+        """With --validate, the selected subset gets probed; unpicked
+        candidates must not reach _probe_servers (would be surprising
+        perf cost for servers the user declined)."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "a",
+                    "source": "X",
+                    "entry": {"transport": "stdio", "command": "ca"},
+                },
+                {
+                    "name": "b",
+                    "source": "Y",
+                    "entry": {"transport": "stdio", "command": "cb"},
+                },
+            ],
+        )
+
+        probe_calls: list[dict] = []
+
+        async def fake_probe_servers(servers, timeout):
+            probe_calls.append(dict(servers))
+            return {n: {"connected": True, "tools": 3, "error": None} for n in servers}
+
+        monkeypatch.setattr(proxy_mod, "_probe_servers", fake_probe_servers)
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--validate", *_cfg_args(config)],
+            input="1\n\n",  # pick only index 1 (server "a")
+        )
+        assert result.exit_code == 0, result.output
+        assert "Reachable:" in result.output
+        assert "Validating 1 server" in result.output
+
+        assert len(probe_calls) == 1
+        assert set(probe_calls[0].keys()) == {"a"}  # "b" not probed
+
+
 # ── remove command ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Extends `mms add` with `--from-clients` (alias `--import`) so additional MCP servers added to Claude Desktop / Code / project `.mcp.json` after initial setup can be bulk-imported through init's discovery + TUI flow, without editing JSON or running `mms add` once per server.
- Filters discovered candidates by name and by `(transport, command, args)` / `(transport, url)` signature before prompting, so the TUI only surfaces *new* options and users aren't pushed through a prefix prompt for servers they've already configured (possibly under a different name).
- `mms init` stays first-time-only (the abort test at `tests/cli/test_proxy_cli.py:636` is intentional, not a gap — PR #195's management hints sit on top of that invariant). The abort message and PR #195's non-default-`--config` hints now point at `mms add --import`.

## Behavior change

`mms add` before this change: `NAME` and `--prefix` were click-required. After: both are optional when `--from-clients` is set; passing them together raises a usage error (`--from-clients cannot be combined with: NAME, --prefix, ...`) instead of silently resolving one way.

## Why extend `mms add` instead of re-entering `mms init`?

Re-entering init was the first idea considered. The concerns that pushed against it:

- **Silent data loss** — init prompts for a small subset of the config schema (upstream servers + basic transport/command/prefix). ~20 top-level fields + per-server `llm` / `selective` / `hybrid` / `retention_floor` / `tool_overrides` are never prompted. "Re-run init, preserve what I've edited manually" is ambiguous at the schema level.
- **Duplicated role with `mms add`** — single-server append is already `mms add`'s job. The gap is specifically *bulk import from MCP clients*, which is init's discovery + TUI flow. Lifting that one capability keeps each command doing one thing.
- **Intentional abort invariant** — `test_init_aborts_if_config_exists` is explicitly scoped ("Init is for first-time setup only; `mms add` handles append"). Re-running init would either invalidate that test or require a mode flag, neither of which earns its weight for this pain point.

## Design notes

- All discovery / TUI / prefix-prompt helpers already existed from PR #194; no refactor needed to share them between init and add.
- `_server_signature()` is a new helper: `(transport, command, *args)` for stdio, `(transport, url)` otherwise. Returns `None` when the identifying field is missing so the caller falls back to name-only dedup.
- `--validate` with `--from-clients` probes only the selected subset (not every discovered candidate) — test locks this in so a future refactor can't accidentally probe un-picked servers.
- Mutual-exclusion check reports the conflicting flags by name so the user knows exactly what to drop.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — lint green
- [x] `uv run pytest -m "not ollama"` — all 1516 tests pass (8 new in `TestAddFromClients`)
- [x] Existing `test_init_aborts_if_config_exists` unchanged and still green (abort behavior preserved)
- [x] E2E against real Claude Desktop / Code config (7 discovered candidates):
  - `mms init` with config → saves one server, management hint now lists `mms add --import --config <path>`
  - `mms add --import` re-run → previously-imported server skipped with `Skipping: '<name>' — already registered.`, remaining 6 offered
  - `mms init` again → abort message now points at `mms add --import` alongside existing `mms add` / `mms list` hints
  - `mms add --import --prefix fs mysrv` → clean usage error listing the conflicting flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)