### PR TITLE
fix(cli): warn about dual registration after mms add --import

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -607,6 +607,57 @@ def _format_candidate_detail(entry: dict[str, Any]) -> str:
     return f"[{transport}] {entry.get('url', '')}"
 
 
+def _source_removal_hint(name: str, source: str) -> str:
+    """One informational shell-line telling the user how to remove a server
+    from the client that originated it.
+
+    STM never edits source client configs itself — the hint is copy-paste
+    only. Scope-label mapping matches the ``claude mcp remove -s`` flag:
+    ``Claude Code (project)`` is the per-project entry in ``~/.claude.json``,
+    which the Claude Code CLI calls ``local``.
+    """
+    if source == "Claude Code (user)":
+        return f"claude mcp remove {name} -s user"
+    if source == "Claude Code (project)":
+        return f"claude mcp remove {name} -s local"
+    if source == ".mcp.json (project)":
+        return f"claude mcp remove {name} -s project"
+    if source == "Claude Desktop":
+        return f"# Edit {_desktop_config_path()} and remove '{name}' under mcpServers."
+    return f"# Remove '{name}' from {source}."
+
+
+def _print_source_removal_hints(imported_candidates: list[dict[str, Any]]) -> None:
+    """Print the post-import dual-registration warning, deduped across sources.
+
+    A single server can be discovered in more than one client (e.g. Claude
+    Code and Claude Desktop both list ``playwright``), so each candidate's
+    primary ``source`` plus any ``duplicate_in`` entries all get a line.
+    """
+    if not imported_candidates:
+        return
+    lines: list[str] = []
+    seen: set[str] = set()
+    for cand in imported_candidates:
+        for src in [cand["source"], *(cand.get("duplicate_in") or [])]:
+            line = _source_removal_hint(cand["name"], src)
+            if line in seen:
+                continue
+            seen.add(line)
+            lines.append(line)
+    if not lines:
+        return
+    click.echo("")
+    click.echo(
+        f"{_warn('Note:')} the server(s) above are still registered in their source MCP client(s)."
+    )
+    click.echo("      Until removed there, tools are advertised on two paths (direct + via STM)")
+    click.echo("      and direct calls bypass STM's compression, caching, and LTM surfacing.")
+    click.echo("      To route through STM only, remove the direct registrations:")
+    for line in lines:
+        click.echo(f"        {line}")
+
+
 def _suggest_prefix(name: str, taken: set[str]) -> str:
     """Derive a valid-ish default prefix from a server name.
 
@@ -925,6 +976,13 @@ def _add_from_clients(
     click.echo(f"{_ok('Added')} {len(imported)} server(s) to {resolved}:")
     for n, e in imported.items():
         click.echo(f"  {n:<20} prefix={e['prefix']}  {_format_candidate_detail(e)}")
+
+    # Imported servers stay registered in their source MCP clients: discovery
+    # is read-only, so removal is the user's call. Until they remove the
+    # direct registrations, tools are surfaced on two paths (client → upstream
+    # and client → STM → upstream) and the direct path bypasses compression,
+    # caching, and LTM surfacing entirely.
+    _print_source_removal_hints([new_candidates[i] for i in picks])
 
 
 @cli.command()

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1608,6 +1608,78 @@ class TestAddFromClients:
         assert len(probe_calls) == 1
         assert set(probe_calls[0].keys()) == {"a"}  # "b" not probed
 
+    def test_prints_source_removal_hint_per_client(self, runner, config, monkeypatch):
+        """After a successful import, the user sees a per-source hint for
+        removing the direct registration from the originating MCP client.
+        Without it, tools are advertised on two paths (direct + STM) and the
+        direct path bypasses compression/caching/LTM surfacing — see #202."""
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "from-user",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@u"]},
+                },
+                {
+                    "name": "from-local",
+                    "source": "Claude Code (project)",
+                    "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@l"]},
+                },
+                {
+                    "name": "from-proj",
+                    "source": ".mcp.json (project)",
+                    "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@p"]},
+                },
+                {
+                    "name": "from-desktop",
+                    "source": "Claude Desktop",
+                    "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@d"]},
+                    "duplicate_in": ["Claude Code (user)"],
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+            input="all\n\n\n\n\n",  # pick all + accept suggested prefix for each
+        )
+        assert result.exit_code == 0, result.output
+
+        # Per-source remediation, matching `claude mcp remove -s <scope>` flags.
+        assert "claude mcp remove from-user -s user" in result.output
+        assert "claude mcp remove from-local -s local" in result.output
+        assert "claude mcp remove from-proj -s project" in result.output
+        # Claude Desktop has no CLI analog — print a file-edit hint instead.
+        assert "claude_desktop_config.json" in result.output
+        assert "from-desktop" in result.output
+        # `duplicate_in` yields a second hint line for the same server.
+        assert "claude mcp remove from-desktop -s user" in result.output
+
+    def test_no_removal_hint_when_nothing_imported(self, runner, config, monkeypatch):
+        """Empty selection → no "Added" block, no removal hint either. The
+        warning is scoped to actually-imported servers."""
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "skipme",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+            input="\n",  # empty selection = decline
+        )
+        assert result.exit_code == 0, result.output
+        assert "No servers selected" in result.output
+        assert "claude mcp remove" not in result.output
+
 
 # ── remove command ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #202.

## Summary

After a successful `mms add --import`, the upstream MCP server stays registered in its originating client (Claude Code user/local/project scope, or Claude Desktop). The same tools are then advertised on two paths — direct from the client and via STM — and the direct calls bypass compression, caching, and LTM surfacing entirely.

This PR adds a post-import warning with the exact remediation command per source:

```
Note: the server(s) above are still registered in their source MCP client(s).
      Until removed there, tools are advertised on two paths (direct + via STM)
      and direct calls bypass STM's compression, caching, and LTM surfacing.
      To route through STM only, remove the direct registrations:
        claude mcp remove from-user -s user
        claude mcp remove from-local -s local
        claude mcp remove from-proj -s project
        # Edit ~/Library/Application Support/Claude/claude_desktop_config.json and remove 'from-desktop' under mcpServers.
```

Implementation notes:

- Scope-label → `claude mcp remove -s <scope>` mapping matches the CLI's scope names exactly (`local` is the `~/.claude.json` per-project entry, not `.mcp.json`).
- `duplicate_in` sources get their own lines so every direct registration is covered.
- STM never edits source client configs itself — discovery stays read-only and the write-path one-directional. This avoids scope mismatch with e.g. Claude Desktop's runtime-loaded config.

This is variant **(A)** from issue #202. Variants (B) opt-in prompt and (C) `--prune-source` flag would require STM to write to source client configs; deferred until warning-alone proves insufficient.

## Behavior change

- `mms add --import`: after the "Added N server(s)" block, a new "Note:" block is emitted listing remediation commands. No config write-path change. No effect on exit code, selection flow, or validation.
- Empty-selection path unchanged — no hint when nothing was imported.

## Out of scope

- `mms init` has the same dual-path potential but is bootstrap-only; the dual-path only materializes once the user wires STM into a client that still has the direct registration. Left for a follow-up audit.
- `mms add <name>` single-server registration takes the name directly from the user, so dual-registration is an explicit user choice, not an accidental UX gap.

## Test plan

- [x] `uv run pytest tests/cli/` — 100 passed (2 new: per-client hint mapping, no-hint on empty selection)
- [x] `uv run ruff check src && uv run ruff format --check src`
- [x] Manual: ran `mms add --import` against live Claude Code + Claude Desktop configs (throwaway `--config`). Verified three source shapes:
  - `Claude Code (user)` only (`shadcn`) → `claude mcp remove shadcn -s user`
  - `Claude Desktop` only (`filesystem`) → `# Edit .../claude_desktop_config.json and remove 'filesystem' under mcpServers.`
  - `duplicate_in` cross-source (`playwright` in Claude Code user + Claude Desktop) → both hint lines emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
