### PR TITLE
feat(proxy): thread trace_id through progressive delivery path

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -810,17 +810,38 @@ class ProxyManager:
         return chunker.first_chunk(text, key, ttl_seconds=cfg.ttl_seconds)
 
     def read_more(self, key: str, offset: int, limit: int | None = None) -> str:
-        """Return next chunk from a progressive delivery response."""
+        """Return next chunk from a progressive delivery response.
+
+        Wrapped in a ``proxy_call_read_more`` span (when Langfuse is
+        configured) so that the revisit is filterable in the Langfuse UI
+        as a cohort with the original ``proxy_call``. Correlation is
+        metadata-tag based (both spans carry the same ``trace_id``
+        attribute), not trace-tree merging — the two MCP turns run in
+        separate OTel contexts, so this span is always a root. Other
+        ``stm_proxy_*`` tools lack spans because they are local reads;
+        ``read_more`` is the exception because it is a revisit of a prior
+        upstream call and otherwise loses its link to the originating
+        trace_id.
+        """
         store = self._get_progressive_store()
         resp = store.get(key)
         if resp is None:
             return f"Progressive delivery key '{key}' not found or expired."
-        store.touch(key)
-        chunk_size = limit or 4000
-        chunker = ProgressiveChunker(chunk_size=chunk_size, include_hint=True)
-        return chunker.read_chunk(
-            resp.content, offset, limit, key=key, ttl_seconds=resp.ttl_seconds
-        )
+        with traced(
+            "proxy_call_read_more",
+            metadata={
+                "server": resp.server,
+                "tool": resp.tool,
+                "trace_id": resp.trace_id,
+                "key": key,
+            },
+        ):
+            store.touch(key)
+            chunk_size = limit or 4000
+            chunker = ProgressiveChunker(chunk_size=chunk_size, include_hint=True)
+            return chunker.read_chunk(
+                resp.content, offset, limit, key=key, ttl_seconds=resp.ttl_seconds
+            )
 
     def get_upstream_health(self) -> dict[str, dict]:
         """Return per-server health: connection status, tool count."""

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -782,6 +782,8 @@ class ProxyManager:
         server: str,
         tool: str,
         sel_cfg: SelectiveConfig | None = None,
+        *,
+        trace_id: str | None = None,
     ) -> str:
         store = self._get_progressive_store(sel_cfg)
         store.evict(cfg.ttl_seconds, cfg.max_stored)
@@ -795,6 +797,9 @@ class ProxyManager:
             structure_hint=ProgressiveChunker.structure_hint(text),
             created_at=_time.monotonic(),
             ttl_seconds=cfg.ttl_seconds,
+            server=server,
+            tool=tool,
+            trace_id=trace_id,
         )
         store.put(key, resp)
 
@@ -1211,7 +1216,7 @@ class ProxyManager:
                 compressed = cleaned
             else:
                 compressed = self._apply_progressive(
-                    cleaned, pcfg, server, tool, sel_cfg=tc.selective
+                    cleaned, pcfg, server, tool, sel_cfg=tc.selective, trace_id=trace_id
                 )
             _compress_ms = 0.0
             compressed_chars_for_metrics = len(cleaned)
@@ -1317,7 +1322,12 @@ class ProxyManager:
                         if cleaned_len > pcfg.chunk_size:
                             try:
                                 compressed = self._apply_progressive(
-                                    cleaned, pcfg, server, tool, sel_cfg=tc.selective
+                                    cleaned,
+                                    pcfg,
+                                    server,
+                                    tool,
+                                    sel_cfg=tc.selective,
+                                    trace_id=trace_id,
                                 )
                                 metrics_strategy = f"{original_strategy}→progressive_fallback"
                                 progressive_fallback = True

--- a/src/memtomem_stm/proxy/progressive.py
+++ b/src/memtomem_stm/proxy/progressive.py
@@ -38,6 +38,11 @@ class ProgressiveResponse:
     created_at: float
     ttl_seconds: float = 1800.0
     access_count: int = 0
+    server: str = ""
+    tool: str = ""
+    # ``None`` only for legacy rows deserialized without the key; the live
+    # ``call_tool`` path always populates ``trace_id`` via auto-gen UUID.
+    trace_id: str | None = None
 
 
 class ProgressiveStoreAdapter:
@@ -58,6 +63,9 @@ class ProgressiveStoreAdapter:
                 "structure_hint": resp.structure_hint,
                 "access_count": resp.access_count,
                 "ttl_seconds": resp.ttl_seconds,
+                "server": resp.server,
+                "tool": resp.tool,
+                "trace_id": resp.trace_id,
             },
             ensure_ascii=False,
         )
@@ -93,6 +101,9 @@ class ProgressiveStoreAdapter:
             created_at=sel.created_at,
             ttl_seconds=meta.get("ttl_seconds", 1800.0),
             access_count=meta.get("access_count", 0),
+            server=meta.get("server", ""),
+            tool=meta.get("tool", ""),
+            trace_id=meta.get("trace_id"),
         )
 
     def touch(self, key: str) -> None:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
+import json
+import re
 import time
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from memtomem_stm.proxy.config import CompressionStrategy, ProxyConfig, UpstreamServerConfig
+from memtomem_stm.proxy.compression import PendingSelection
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ProgressiveConfig,
+    ProxyConfig,
+    UpstreamServerConfig,
+)
 from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
 from memtomem_stm.proxy.metrics import CallMetrics, RPSTracker, TokenTracker
 from memtomem_stm.proxy.metrics_store import MetricsStore
+from memtomem_stm.proxy.progressive import ProgressiveChunker
 
 
 # ── RPSTracker ───────────────────────────────────────────────────────────
@@ -203,6 +213,142 @@ class TestTraceIdPropagation:
         await mgr.call_tool("srv", "tool", {}, trace_id=fixed)
 
         assert [m.trace_id for m in recorded] == [fixed, fixed]
+
+
+# ── Progressive delivery trace_id propagation ────────────────────────────
+
+
+_KEY_RE = re.compile(r'key="(?P<key>[^"]+)"')
+
+
+def _extract_key(footer_text: str) -> str:
+    m = _KEY_RE.search(footer_text)
+    assert m is not None, f"no key in footer: {footer_text!r}"
+    return m.group("key")
+
+
+class TestProgressiveTraceIdPropagation:
+    def test_trace_id_reaches_progressive_response(self):
+        mgr = _make_manager()
+        pcfg = ProgressiveConfig(chunk_size=100)
+        text = "x" * 5000
+
+        rendered = mgr._apply_progressive(text, pcfg, "srv", "my-tool", trace_id="tid-deadbeef")
+        key = _extract_key(rendered)
+
+        resp = mgr._get_progressive_store().get(key)
+        assert resp is not None
+        assert resp.trace_id == "tid-deadbeef"
+        assert resp.server == "srv"
+        assert resp.tool == "my-tool"
+
+    def test_read_more_span_uses_original_trace_id(self):
+        mgr = _make_manager()
+        pcfg = ProgressiveConfig(chunk_size=100)
+        text = "x" * 5000
+
+        rendered = mgr._apply_progressive(text, pcfg, "srv", "my-tool", trace_id="tid-deadbeef")
+        key = _extract_key(rendered)
+
+        recorded: list[tuple[str, dict]] = []
+
+        def recording_traced(name, **kwargs):
+            recorded.append((name, kwargs.get("metadata", {})))
+            return nullcontext()
+
+        with patch("memtomem_stm.proxy.manager.traced", recording_traced):
+            mgr.read_more(key, 0)
+
+        assert len(recorded) == 1
+        name, metadata = recorded[0]
+        assert name == "proxy_call_read_more"
+        assert metadata == {
+            "server": "srv",
+            "tool": "my-tool",
+            "trace_id": "tid-deadbeef",
+            "key": key,
+        }
+
+    def test_read_more_backwards_compat_old_row(self):
+        mgr = _make_manager()
+        store = mgr._get_progressive_store()
+
+        # Simulate a row written by a pre-PR version: no server/tool/trace_id
+        # in __meta__. ProgressiveStoreAdapter.get must deserialize this
+        # cleanly via dict.get(..., default), not raise KeyError.
+        legacy_meta = json.dumps(
+            {
+                "total_lines": 1,
+                "content_type": "text",
+                "structure_hint": "",
+                "access_count": 0,
+                "ttl_seconds": 1800.0,
+            }
+        )
+        content = "legacy-" * 100
+        legacy_key = "legacy-key-12345"
+        store._store.put(
+            legacy_key,
+            PendingSelection(
+                chunks={"__content__": content, "__meta__": legacy_meta},
+                format="progressive",
+                created_at=time.monotonic(),
+                total_chars=len(content),
+            ),
+        )
+
+        resp = store.get(legacy_key)
+        assert resp is not None
+        assert resp.server == ""
+        assert resp.tool == ""
+        assert resp.trace_id is None
+
+        # read_more on a legacy row returns a chunk (not the not-found error)
+        # and emits a span with the empty/None defaults rather than crashing.
+        out = mgr.read_more(legacy_key, 0, 100)
+        assert "not found or expired" not in out
+        assert out.startswith("legacy-")
+
+    def test_both_apply_progressive_call_sites_pass_trace_id_kwarg(self):
+        # manager.py has two _apply_progressive call sites: the normal
+        # PROGRESSIVE branch and the hybrid-fallback branch. Both must pass
+        # trace_id=trace_id. This test source-inspects _call_tool_inner,
+        # pins the count of call sites at 2, and asserts each call contains
+        # the trace_id= kwarg — cheap regression insurance against a future
+        # refactor that drops the kwarg at one site (functionally tight:
+        # both sites are currently shape-identical, so a unit-level spy
+        # cannot distinguish them).
+        import inspect
+
+        from memtomem_stm.proxy import manager as manager_module
+
+        src = inspect.getsource(manager_module.ProxyManager._call_tool_inner)
+        calls = re.findall(r"self\._apply_progressive\(\s*.*?\)", src, re.DOTALL)
+        assert len(calls) == 2, f"expected 2 _apply_progressive call sites, found {len(calls)}"
+        for call in calls:
+            assert "trace_id=" in call, f"call site missing trace_id kwarg: {call}"
+
+    def test_read_more_behavior_byte_identical_on_success(self):
+        # Pin the chunker construction params (chunk_size=<limit or 4000>,
+        # include_hint=True) that read_more uses. If a future edit inside
+        # read_more silently flips include_hint to False or swaps the
+        # chunker impl, this test fires. If ProgressiveChunker internals
+        # legitimately evolve, both sides move together — no fixture churn.
+        mgr = _make_manager()
+        pcfg = ProgressiveConfig(chunk_size=100)
+        text = "abcdefghij" * 600  # 6000 chars, plenty for multiple chunks
+
+        rendered = mgr._apply_progressive(text, pcfg, "srv", "tool", trace_id="tid-snapshot")
+        key = _extract_key(rendered)
+        resp = mgr._get_progressive_store().get(key)
+        assert resp is not None
+
+        actual = mgr.read_more(key, 100, 100)
+
+        expected = ProgressiveChunker(chunk_size=100, include_hint=True).read_chunk(
+            resp.content, 100, 100, key=key, ttl_seconds=resp.ttl_seconds
+        )
+        assert actual == expected
 
 
 # ── MetricsStore trace_id ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #204. Completes the `trace_id` threading PR #173 started — the
progressive delivery path (`_apply_progressive` → `ProgressiveResponse` →
`read_more`) now carries `server / tool / trace_id` end to end, and
`stm_proxy_read_more` emits a new `proxy_call_read_more` span.

Pure data-flow change: no SQLite schema change, no new tables, no
agent-visible behavior change on success.

## Behavior change

- `ProgressiveResponse` gains three fields: `server`, `tool`, `trace_id`.
  Serialized into the existing `__meta__` JSON of the progressive store
  row (same pattern as `access_count` / `ttl_seconds`). Legacy rows
  deserialize cleanly with safe defaults (`""`, `""`, `None`) — no
  migration needed; TTL expiry (1800s default) ages them out.
- New span `proxy_call_read_more` emitted from `manager.read_more` when
  Langfuse is configured. Metadata: `{server, tool, trace_id, key}`.
  `nullcontext()` no-op when Langfuse off.
- `store.touch(key)` now runs inside the span (previously outside). Touch
  latency (SQLite UPDATE) is trivial; acceptable tradeoff for a
  self-contained span boundary.

## Langfuse correlation mechanics

`proxy_call` (turn N) and `proxy_call_read_more` (turn N+1) appear as
**two separate Langfuse traces**. Both carry the same `metadata.trace_id`
value, so they are joinable as a **filterable cohort** in the Langfuse UI
(`metadata.trace_id = "..."`). This is enough for the stated driver —
stratified analysis of progressive follow-up rate by tool / strategy /
size. It is NOT trace-tree merging; if that is ever wanted, a follow-up
can pass `trace_id=trace_id` as a top-level kwarg to
`start_as_current_observation` (Langfuse SDK ≥ 4.x). Out of scope here.

## Deviation from issue spec

The issue body says "include `tool` and `trace_id` in the not-found /
expired error message." When `store.get(key)` returns `None`, there is
no recovered `tool` / `trace_id` — nothing to include. This PR keeps the
not-found error byte-identical (`"Progressive delivery key '{key}' not
found or expired."`) and adds the span only on the success path, which
is where `tool` / `trace_id` actually exist. Trivial to change if
reviewer disagrees.

## Follow-up (separate PR, not this one)

`progressive_reads` table in `~/.memtomem/stm_feedback.db` +
`stm_progressive_stats` MCP tool for parity with `stm_compression_stats`
/ `stm_surfacing_stats`. Will be filed as `Refs #204` (not `Closes`).

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run pytest tests/test_observability.py -v` — 36 passed
- [x] `uv run pytest -m "not ollama"` — 1529 passed
- [x] `uv run mypy src` — advisory; two pre-existing errors at
  manager.py:411 and 773, unrelated to this PR
- New tests under `TestProgressiveTraceIdPropagation`:
  - `test_trace_id_reaches_progressive_response` — trace_id survives round-trip
  - `test_read_more_span_uses_original_trace_id` — no fresh UUID on re-entry
  - `test_read_more_backwards_compat_old_row` — legacy `__meta__` loads
  - `test_both_apply_progressive_call_sites_pass_trace_id_kwarg` —
    source-inspection regression guard on both call sites
  - `test_read_more_behavior_byte_identical_on_success` — hybrid snapshot
    against a directly-constructed `ProgressiveChunker`; pins construction
    params `read_more` uses

## Commit structure

Three commits — each is independently green because defaults absorb the
incremental change:

1. `feat(progressive): persist server/tool/trace_id in ProgressiveResponse`
   — dataclass fields + adapter put/get serialization
2. `feat(proxy): thread trace_id into _apply_progressive call sites`
   — helper signature + both call sites in `_call_tool_inner`
3. `feat(proxy): emit proxy_call_read_more span with original trace_id`
   — `read_more` rewrite + 5 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)