### PR TITLE
feat(server): exception barrier around mcp.run() (#209 Part A)

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -750,7 +750,16 @@ def main() -> None:
         level=getattr(logging, level, logging.WARNING),
         format="%(levelname)s %(name)s: %(message)s",
     )
-    mcp.run()
+    # Exception barrier (#209): without this, an unhandled exception from
+    # ``mcp.run()`` (e.g. a background task crashing the event loop) ends the
+    # process with only stderr output — operators get no ERROR-level log, and
+    # clients see stdio EOF without any signal about WHY STM died. Re-raise
+    # after logging so the process still terminates; we only add observability.
+    try:
+        mcp.run()
+    except Exception:
+        logger.exception("STM MCP server terminated with an unhandled exception")
+        raise
 
 
 if __name__ == "__main__":

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -629,3 +629,59 @@ class TestAdvertiseObservabilityFlagEndToEnd:
         assert callable(stm_proxy_stats)
         assert callable(stm_surfacing_stats)
         assert callable(stm_tuning_recommendations)
+
+
+# ── main() exception barrier (#209) ──────────────────────────────────────
+
+
+class TestMainExceptionBarrier:
+    """#209 Part A: unhandled exceptions from ``mcp.run()`` must be logged at
+    ERROR level before the process terminates, so operators have a visible
+    signal instead of only stderr tail output."""
+
+    def test_unhandled_exception_is_logged_then_reraised(self, caplog):
+        import logging
+
+        from memtomem_stm import server
+
+        class _ServerBoom(RuntimeError):
+            pass
+
+        caplog.clear()
+        with (
+            caplog.at_level(logging.ERROR, logger="memtomem_stm.server"),
+            patch.object(server.mcp, "run", side_effect=_ServerBoom("event loop crashed")),
+        ):
+            try:
+                server.main()
+            except _ServerBoom:
+                pass
+            else:
+                import pytest as _pytest
+
+                _pytest.fail("main() must re-raise the underlying exception")
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "expected at least one ERROR-level log from the barrier"
+        # The logger.exception call must attach the traceback so operators
+        # can diagnose WHY the server died — not just that it did.
+        assert any(r.exc_info is not None for r in error_records)
+        assert any("unhandled exception" in r.getMessage() for r in error_records)
+
+    def test_clean_exit_does_not_log_error(self, caplog):
+        import logging
+
+        from memtomem_stm import server
+
+        caplog.clear()
+        with (
+            caplog.at_level(logging.ERROR, logger="memtomem_stm.server"),
+            patch.object(server.mcp, "run", return_value=None),
+        ):
+            server.main()
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not error_records, (
+            f"clean exit should not emit ERROR logs; got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )


### PR DESCRIPTION
## Summary

Part A of #209: wrap `mcp.run()` in `main()` with `try/except Exception` + `logger.exception` so unhandled server-lifetime exceptions produce a visible ERROR log (with traceback) instead of only stderr output.

Part B (periodic upstream ping) is explicitly marked optional in the issue body; deferred until signal shows it's useful (per wait-for-signal policy on optional features).

Closes #209 for Part A. Part B tracked separately — reopen or file new if signal develops.

## Why this matters

`src/memtomem_stm/server.py:main()` today is:

```python
def main() -> None:
    level = os.environ.get(\"MEMTOMEM_STM_LOG_LEVEL\", \"WARNING\").upper()
    logging.basicConfig(...)
    mcp.run()
```

If anything inside `mcp.run()` raises (a crashed background task, an unhandled asyncio error, a misconfigured transport), Python's default `sys.excepthook` dumps a traceback to stderr and the process exits. The MCP client sees stdio EOF. Combined with #206 now bounding the client-side wait, the failure mode is \"call times out eventually and client reconnects\" — but the operator has no idea WHY STM died. Debugging requires finding the stderr tail.

Adding this barrier:
- Uses `logger.exception` which attaches the full traceback to a structured ERROR log record.
- Re-raises so the process still terminates (we're adding observability, not swallowing).
- Costs ~5 lines, no runtime overhead on the happy path.

## Relationship to #206 / #207 (#210) / #208 (#211)

This PR addresses a different failure mode from the request-path timeouts:

| PR | Scope | Fires when |
|---|---|---|
| #206 (merged) | upstream call_tool hang | upstream MCP server stops responding mid-call |
| #210 (#207) | LLM compression hang | LLM API stops responding mid-compression |
| #211 (#208) | internal lock hang | coroutine deadlocked holding a state lock |
| **this (#209)** | STM process death | unhandled exception escapes `mcp.run()` lifetime loop |

File-disjoint with #210 and #211 — off main, no rebase coordination needed.

## Why only Part A

Issue body explicitly says Part B (periodic upstream ping) \"can land alone; Part B is a separate decision and may be deferred until signal shows it's useful\". Following that — defer Part B until:

- An incident shows STM losing upstream liveness detection.
- `reconnects` metric shows a pattern of stale-connection issues.
- An operator requests it.

Cost-of-implementation (new background task + per-connection state + config field) is non-trivial for a feature with no concrete demand yet.

## Test plan

- [x] `TestMainExceptionBarrier::test_unhandled_exception_is_logged_then_reraised` — patched `mcp.run` raises `RuntimeError`; verify (1) ERROR-level record logged under `memtomem_stm.server`, (2) `exc_info` attached (traceback present), (3) exception re-raised.
- [x] `TestMainExceptionBarrier::test_clean_exit_does_not_log_error` — patched `mcp.run` returns normally; no ERROR record emitted.
- [x] Regression: full non-ollama suite 1536 passed.
- [x] `ruff check src && ruff format --check src` clean.

Refs #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)