### PR TITLE
feat(proxy): progressive_reads telemetry + stm_progressive_stats

### DIFF
--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -336,6 +336,23 @@ class CompressionFeedbackConfig(BaseModel):
     db_path: Path = Path("~/.memtomem/stm_feedback.db")
 
 
+class ProgressiveReadsConfig(BaseModel):
+    """Configuration for progressive-delivery read telemetry.
+
+    Records one row per initial progressive response plus one row per
+    ``stm_proxy_read_more`` follow-up into ``progressive_reads``.
+    Aggregates surface via ``stm_progressive_stats`` and enable
+    stratified analysis of follow-up rate by tool / compression
+    strategy / response size. Shares the user-wide
+    ``~/.memtomem/stm_feedback.db`` file with surfacing and
+    compression feedback (disjoint tables; WAL mode makes concurrent
+    access safe).
+    """
+
+    enabled: bool = True
+    db_path: Path = Path("~/.memtomem/stm_feedback.db")
+
+
 # Static context window sizes (tokens) for known model families.
 # Used by ProxyConfig.effective_max_result_chars() to scale compression budget.
 # Prefix-matched: "claude-sonnet-4-20250514" matches "claude-sonnet-4".
@@ -459,6 +476,7 @@ class ProxyConfig(BaseModel):
     compression_feedback: CompressionFeedbackConfig = Field(
         default_factory=CompressionFeedbackConfig
     )
+    progressive_reads: ProgressiveReadsConfig = Field(default_factory=ProgressiveReadsConfig)
 
     def effective_max_result_chars(self) -> int:
         """Compute max_result_chars scaled by consumer model's context window.

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -58,10 +58,12 @@ from memtomem_stm.proxy.tool_metadata import (
     truncate_description,
 )
 from memtomem_stm.proxy.progressive import (
+    PROGRESSIVE_FOOTER_TOKEN,
     ProgressiveChunker,
     ProgressiveResponse,
     ProgressiveStoreAdapter,
 )
+from memtomem_stm.proxy.progressive_reads import ProgressiveReadsTracker
 from memtomem_stm.proxy._locks import LockTimeoutError, bounded_lock
 from memtomem_stm.proxy.metrics import CallMetrics, ErrorCategory, TokenTracker
 from memtomem_stm.observability.tracing import traced
@@ -130,6 +132,7 @@ class ProxyManager:
         surfacing_engine: SurfacingEngine | None = None,
         cache: ProxyCache | None = None,
         env_overrides: dict[str, Any] | None = None,
+        progressive_reads_tracker: ProgressiveReadsTracker | None = None,
     ) -> None:
         self._config_loader = ProxyConfigLoader(config.config_path, env_overrides=env_overrides)
         self._config_loader.seed(config)
@@ -137,6 +140,7 @@ class ProxyManager:
         self._index_engine = index_engine
         self._surfacing_engine = surfacing_engine
         self._cache = cache
+        self._progressive_reads_tracker = progressive_reads_tracker
         self._connections: dict[str, UpstreamConnection] = {}
         self._stack: AsyncExitStack | None = None
         self._selective_compressor: SelectiveCompressor | None = None
@@ -824,7 +828,22 @@ class ProxyManager:
             chunk_size=cfg.chunk_size,
             include_hint=cfg.include_structure_hint,
         )
-        return chunker.first_chunk(text, key, ttl_seconds=cfg.ttl_seconds)
+        first = chunker.first_chunk(text, key, ttl_seconds=cfg.ttl_seconds)
+        if self._progressive_reads_tracker is not None:
+            # The first_chunk return concatenates ``chunk + footer`` where
+            # the footer starts with PROGRESSIVE_FOOTER_TOKEN; splitting
+            # once on that sentinel recovers the exact chunk length
+            # without duplicating ``_find_boundary``.
+            initial_chars = len(first.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
+            self._progressive_reads_tracker.record_initial(
+                key=key,
+                trace_id=trace_id,
+                server=server,
+                tool=tool,
+                initial_chars=initial_chars,
+                total_chars=len(text),
+            )
+        return first
 
     def read_more(self, key: str, offset: int, limit: int | None = None) -> str:
         """Return next chunk from a progressive delivery response.
@@ -856,9 +875,28 @@ class ProxyManager:
             store.touch(key)
             chunk_size = limit or 4000
             chunker = ProgressiveChunker(chunk_size=chunk_size, include_hint=True)
-            return chunker.read_chunk(
+            output = chunker.read_chunk(
                 resp.content, offset, limit, key=key, ttl_seconds=resp.ttl_seconds
             )
+            if self._progressive_reads_tracker is not None:
+                # ``chunker.read_chunk`` emits ``(no more content)`` without
+                # the footer when offset >= len(content); split-on-sentinel
+                # still returns the full string in that case, so we log it
+                # as chars=len(output) which correctly records zero-useful-
+                # bytes as the emitted length. Callers using offset past
+                # end is rare and this preserves the invariant that every
+                # read_more invocation produces exactly one row.
+                chunk_chars = len(output.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
+                self._progressive_reads_tracker.record_follow_up(
+                    key=key,
+                    trace_id=resp.trace_id,
+                    server=resp.server,
+                    tool=resp.tool,
+                    offset=offset,
+                    chars=chunk_chars,
+                    total_chars=resp.total_chars,
+                )
+            return output
 
     def get_upstream_health(self) -> dict[str, dict]:
         """Return per-server health: connection status, tool count."""

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -878,14 +878,13 @@ class ProxyManager:
             output = chunker.read_chunk(
                 resp.content, offset, limit, key=key, ttl_seconds=resp.ttl_seconds
             )
-            if self._progressive_reads_tracker is not None:
-                # ``chunker.read_chunk`` emits ``(no more content)`` without
-                # the footer when offset >= len(content); split-on-sentinel
-                # still returns the full string in that case, so we log it
-                # as chars=len(output) which correctly records zero-useful-
-                # bytes as the emitted length. Callers using offset past
-                # end is rare and this preserves the invariant that every
-                # read_more invocation produces exactly one row.
+            # Skip telemetry when ``read_chunk`` short-circuits with the
+            # ``(no more content)`` sentinel (offset >= len(content)) —
+            # that response carries no footer and no payload, so logging
+            # it would inflate ``follow_up_rate`` with calls that served
+            # zero new bytes and push ``avg_chars_served`` above
+            # ``total_chars``.
+            if self._progressive_reads_tracker is not None and PROGRESSIVE_FOOTER_TOKEN in output:
                 chunk_chars = len(output.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
                 self._progressive_reads_tracker.record_follow_up(
                     key=key,

--- a/src/memtomem_stm/proxy/progressive_reads.py
+++ b/src/memtomem_stm/proxy/progressive_reads.py
@@ -1,0 +1,92 @@
+"""Thin tracker orchestrating ``ProgressiveReadsStore`` writes.
+
+The tracker is called from the proxy hot path (``_apply_progressive``
+and ``read_more``) for every progressive-delivery read event. Writes
+are opportunistic: any exception is logged at DEBUG and swallowed so a
+telemetry failure never degrades the response served to the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from memtomem_stm.proxy.progressive_reads_store import ProgressiveReadsStore
+
+logger = logging.getLogger(__name__)
+
+
+class ProgressiveReadsTracker:
+    """Records progressive-delivery read events to SQLite.
+
+    Unlike ``CompressionFeedbackTracker`` this does not consult the
+    metrics store for ``trace_id`` correlation — the caller always
+    supplies ``trace_id`` (from the ``trace_id`` parameter threaded
+    through ``_apply_progressive`` by PR #205, or from the cached
+    ``ProgressiveResponse.trace_id`` attribute in ``read_more``).
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._store = ProgressiveReadsStore(db_path.expanduser())
+        self._store.initialize()
+
+    @property
+    def store(self) -> ProgressiveReadsStore:
+        return self._store
+
+    def close(self) -> None:
+        self._store.close()
+
+    def record_initial(
+        self,
+        *,
+        key: str,
+        trace_id: str | None,
+        server: str,
+        tool: str,
+        initial_chars: int,
+        total_chars: int,
+    ) -> None:
+        """Record the first-chunk event (``offset=0``)."""
+        try:
+            self._store.record(
+                key=key,
+                trace_id=trace_id,
+                server=server,
+                tool=tool,
+                offset=0,
+                chars=initial_chars,
+                served_to=initial_chars,
+                total_chars=total_chars,
+            )
+        except Exception:
+            logger.debug("progressive_reads record_initial failed", exc_info=True)
+
+    def record_follow_up(
+        self,
+        *,
+        key: str,
+        trace_id: str | None,
+        server: str,
+        tool: str,
+        offset: int,
+        chars: int,
+        total_chars: int,
+    ) -> None:
+        """Record a follow-up ``read_more`` event."""
+        try:
+            self._store.record(
+                key=key,
+                trace_id=trace_id,
+                server=server,
+                tool=tool,
+                offset=offset,
+                chars=chars,
+                served_to=offset + chars,
+                total_chars=total_chars,
+            )
+        except Exception:
+            logger.debug("progressive_reads record_follow_up failed", exc_info=True)
+
+    def get_stats(self, tool: str | None = None) -> dict:
+        return self._store.get_stats(tool)

--- a/src/memtomem_stm/proxy/progressive_reads_store.py
+++ b/src/memtomem_stm/proxy/progressive_reads_store.py
@@ -1,0 +1,212 @@
+"""SQLite persistence for progressive-delivery read events.
+
+Every progressive response generates one row at creation (``offset=0``,
+``chars=<initial chunk>``) plus one additional row per follow-up
+``stm_proxy_read_more`` call. The table is append-only and purely
+observational — writes feed ``stm_progressive_stats`` and future
+analysis of nudge-strength vs. follow-up rate; they never affect the
+response served to the caller.
+
+The store shares its SQLite file with surfacing feedback and compression
+feedback (``~/.memtomem/stm_feedback.db`` by default). SQLite WAL
+journaling makes concurrent connections to the same file safe, and the
+table namespaces are disjoint so the three subsystems don't conflict.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+from memtomem_stm.utils.sqlite_tuning import tune_connection
+
+logger = logging.getLogger(__name__)
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS progressive_reads (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    key         TEXT    NOT NULL,
+    trace_id    TEXT,
+    server      TEXT    NOT NULL,
+    tool        TEXT    NOT NULL,
+    offset      INTEGER NOT NULL,
+    chars       INTEGER NOT NULL,
+    served_to   INTEGER NOT NULL,
+    total_chars INTEGER NOT NULL,
+    created_at  REAL    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_pr_key     ON progressive_reads(key);
+CREATE INDEX IF NOT EXISTS idx_pr_trace   ON progressive_reads(trace_id);
+CREATE INDEX IF NOT EXISTS idx_pr_tool    ON progressive_reads(tool);
+CREATE INDEX IF NOT EXISTS idx_pr_created ON progressive_reads(created_at);
+"""
+
+
+class ProgressiveReadsStore:
+    """SQLite store for per-event progressive-delivery reads.
+
+    Opens its own connection to ``db_path`` — safe to share the file
+    with other stores (e.g. surfacing ``FeedbackStore`` and
+    ``CompressionFeedbackStore``) because SQLite WAL journaling permits
+    multiple concurrent connections and the tables are disjoint.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        self._db: sqlite3.Connection | None = None
+        self._lock = threading.Lock()
+
+    def initialize(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        db = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        try:
+            tune_connection(db)
+            db.executescript(_SCHEMA)
+            db.commit()
+        except Exception:
+            db.close()
+            raise
+        self._db = db
+
+    def close(self) -> None:
+        if self._db:
+            self._db.close()
+            self._db = None
+
+    def record(
+        self,
+        key: str,
+        trace_id: str | None,
+        server: str,
+        tool: str,
+        offset: int,
+        chars: int,
+        served_to: int,
+        total_chars: int,
+    ) -> None:
+        """Persist one read event.
+
+        No-op when the store is closed; callers are expected to
+        construct the tracker via ``app_lifespan`` and rely on the
+        finally-block close, so hitting a closed store from the hot
+        path would be a shutdown-race and losing a row is preferable
+        to raising into the response path.
+        """
+        if self._db is None:
+            return
+        with self._lock:
+            self._db.execute(
+                "INSERT INTO progressive_reads "
+                "(key, trace_id, server, tool, offset, chars, served_to, "
+                "total_chars, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    key,
+                    trace_id,
+                    server,
+                    tool,
+                    offset,
+                    chars,
+                    served_to,
+                    total_chars,
+                    time.time(),
+                ),
+            )
+            self._db.commit()
+
+    def get_stats(self, tool: str | None = None) -> dict:
+        """Return aggregate stats for ``stm_progressive_stats``.
+
+        Shape::
+
+            {
+                "total_reads": int,          # row count
+                "total_responses": int,      # DISTINCT keys
+                "follow_up_rate": float,     # keys w/ >1 row / total_responses
+                "avg_chars_served": float,   # avg MAX(served_to) per key
+                "avg_total_chars": float,    # avg total_chars per key
+                "avg_coverage": float,       # avg MAX(served_to)/total_chars per key
+                "by_tool": {tool: {"responses": int, "follow_up_rate": float}},
+            }
+
+        When ``tool`` is provided, ``by_tool`` is returned as an empty
+        dict so callers can rely on the key always being present
+        (parity with ``CompressionFeedbackStore.get_stats``). Averages
+        are computed per-key so a 5-follow-up response is weighted the
+        same as a 0-follow-up response.
+        """
+        empty = {
+            "total_reads": 0,
+            "total_responses": 0,
+            "follow_up_rate": 0.0,
+            "avg_chars_served": 0.0,
+            "avg_total_chars": 0.0,
+            "avg_coverage": 0.0,
+            "by_tool": {},
+        }
+        if self._db is None:
+            return empty
+
+        where = ""
+        params: tuple = ()
+        if tool is not None:
+            where = "WHERE tool = ?"
+            params = (tool,)
+
+        total_reads = self._db.execute(
+            f"SELECT COUNT(*) FROM progressive_reads {where}", params
+        ).fetchone()[0]
+        if total_reads == 0:
+            return empty
+
+        # Per-key aggregate: last served_to (= cumulative coverage),
+        # total_chars, tool, and row count per key.
+        per_key_rows = self._db.execute(
+            "SELECT key, MAX(served_to), MAX(total_chars), tool, COUNT(*) "
+            f"FROM progressive_reads {where} GROUP BY key",
+            params,
+        ).fetchall()
+        total_responses = len(per_key_rows)
+        if total_responses == 0:
+            return empty
+
+        followed_up = sum(1 for _, _, _, _, n in per_key_rows if n > 1)
+        follow_up_rate = followed_up / total_responses
+        avg_chars_served = sum(r[1] for r in per_key_rows) / total_responses
+        avg_total_chars = sum(r[2] for r in per_key_rows) / total_responses
+        # Coverage is bounded to 1.0 per key: rare edge case where a
+        # misbehaving upstream revises total_chars downward between
+        # rows would otherwise push the ratio above 1.0 and skew the
+        # average.
+        avg_coverage = (
+            sum(min(1.0, r[1] / r[2]) if r[2] > 0 else 0.0 for r in per_key_rows) / total_responses
+        )
+
+        by_tool: dict[str, dict] = {}
+        if tool is None:
+            # Re-group per-key rows by tool for the breakdown.
+            tool_buckets: dict[str, list[int]] = {}
+            for _, _, _, tool_name, n in per_key_rows:
+                tool_buckets.setdefault(tool_name, []).append(n)
+            for tool_name, counts in tool_buckets.items():
+                responses = len(counts)
+                followed = sum(1 for n in counts if n > 1)
+                by_tool[tool_name] = {
+                    "responses": responses,
+                    "follow_up_rate": followed / responses if responses else 0.0,
+                }
+
+        return {
+            "total_reads": total_reads,
+            "total_responses": total_responses,
+            "follow_up_rate": follow_up_rate,
+            "avg_chars_served": avg_chars_served,
+            "avg_total_chars": avg_total_chars,
+            "avg_coverage": avg_coverage,
+            "by_tool": by_tool,
+        }

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -17,6 +17,7 @@ from memtomem_stm.proxy.compression_feedback import CompressionFeedbackTracker
 from memtomem_stm.proxy.config import ProxyConfig, collect_proxy_env_overrides
 from memtomem_stm.proxy.manager import ProxyManager
 from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.progressive_reads import ProgressiveReadsTracker
 from memtomem_stm.surfacing.engine import SurfacingEngine
 from memtomem_stm.observability.tracing import traced
 from memtomem_stm.surfacing.feedback import FeedbackTracker
@@ -34,6 +35,7 @@ class STMContext:
     surfacing_engine: SurfacingEngine | None
     feedback_tracker: FeedbackTracker | None
     compression_feedback_tracker: CompressionFeedbackTracker | None
+    progressive_reads_tracker: ProgressiveReadsTracker | None
 
 
 CtxType = Context[ServerSession, STMContext]
@@ -67,6 +69,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
     mcp_adapter = None
     feedback_tracker: FeedbackTracker | None = None
     compression_feedback_tracker: CompressionFeedbackTracker | None = None
+    progressive_reads_tracker: ProgressiveReadsTracker | None = None
     langfuse_client = None
     tracker = TokenTracker()
     proxy_manager: ProxyManager | None = None
@@ -102,6 +105,22 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
                         exc_info=True,
                     )
                     compression_feedback_tracker = None
+
+            # Progressive reads telemetry — records one row per
+            # ``_apply_progressive`` initial chunk plus one per
+            # ``stm_proxy_read_more`` follow-up into ``progressive_reads``.
+            # Surfaces via ``stm_progressive_stats``.
+            if config.proxy.progressive_reads.enabled:
+                try:
+                    progressive_reads_tracker = ProgressiveReadsTracker(
+                        config.proxy.progressive_reads.db_path,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Progressive reads tracker init failed — tool will be disabled",
+                        exc_info=True,
+                    )
+                    progressive_reads_tracker = None
 
             # Surfacing engine — LTM access is always remote-only via the
             # MCP client adapter. The adapter spawns (or connects to) a
@@ -169,6 +188,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             surfacing_engine=surfacing_engine,
             cache=proxy_cache,
             env_overrides=proxy_env_overrides,
+            progressive_reads_tracker=progressive_reads_tracker,
         )
 
         if config.proxy.enabled:
@@ -197,6 +217,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             surfacing_engine=surfacing_engine,
             feedback_tracker=feedback_tracker,
             compression_feedback_tracker=compression_feedback_tracker,
+            progressive_reads_tracker=progressive_reads_tracker,
         )
         yield ctx
     finally:
@@ -220,6 +241,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             (metrics_store, "metrics_store"),
             (feedback_tracker, "feedback_tracker"),
             (compression_feedback_tracker, "compression_feedback_tracker"),
+            (progressive_reads_tracker, "progressive_reads_tracker"),
         ]:
             if resource is not None:
                 try:
@@ -687,6 +709,61 @@ async def stm_compression_stats(
             stats["by_tool"].items(), key=lambda kv: kv[1], reverse=True
         ):
             lines.append(f"  {tool_name}: {count}")
+
+    if tool:
+        lines.append(f"\n(filtered by tool: {tool})")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tool: stm_progressive_stats
+# ---------------------------------------------------------------------------
+
+
+@_obs_tool
+async def stm_progressive_stats(
+    tool: str | None = None,
+    ctx: CtxType = None,  # type: ignore[assignment]
+) -> str:
+    """Show progressive-delivery read statistics.
+
+    Reports per-response follow-up rate and coverage across all
+    progressive-compressed calls. Each initial chunk and each
+    follow-up ``stm_proxy_read_more`` appears as a row in
+    ``progressive_reads``; aggregates here collapse to one entry
+    per cache key so a response with five follow-ups is weighted
+    the same as one with none.
+
+    Args:
+        tool: Optional filter by upstream tool name.
+    """
+    app = _get_ctx(ctx)
+    if app.progressive_reads_tracker is None:
+        return "Progressive reads tracking is not enabled."
+
+    stats = app.progressive_reads_tracker.get_stats(tool)
+
+    lines = [
+        "Progressive Reads Stats",
+        "=======================",
+        f"Total reads: {stats['total_reads']}",
+        f"Total responses: {stats['total_responses']}",
+        f"Follow-up rate: {stats['follow_up_rate'] * 100:.1f}%",
+        f"Avg chars served: {stats['avg_chars_served']:.0f}",
+        f"Avg total chars: {stats['avg_total_chars']:.0f}",
+        f"Avg coverage: {stats['avg_coverage'] * 100:.1f}%",
+    ]
+
+    if not tool and stats["by_tool"]:
+        lines.append("\nBy tool:")
+        for tool_name, per_tool in sorted(
+            stats["by_tool"].items(), key=lambda kv: kv[1]["responses"], reverse=True
+        ):
+            lines.append(
+                f"  {tool_name}: responses={per_tool['responses']}, "
+                f"follow_up_rate={per_tool['follow_up_rate'] * 100:.1f}%"
+            )
 
     if tool:
         lines.append(f"\n(filtered by tool: {tool})")

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -531,6 +531,7 @@ class TestSurfacingToolSpans:
             surfacing_engine=mock_engine,
             feedback_tracker=None,
             compression_feedback_tracker=None,
+            progressive_reads_tracker=None,
         )
         ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
 
@@ -572,6 +573,7 @@ class TestSurfacingToolSpans:
             surfacing_engine=None,
             feedback_tracker=mock_tracker,
             compression_feedback_tracker=None,
+            progressive_reads_tracker=None,
         )
         ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
 

--- a/tests/test_progressive.py
+++ b/tests/test_progressive.py
@@ -731,3 +731,31 @@ class TestProgressiveReadsTelemetry:
             text, ProgressiveConfig(chunk_size=4000), server="s", tool="t", trace_id="tx"
         )
         assert PROGRESSIVE_FOOTER_TOKEN in first
+
+    def test_read_more_past_end_does_not_record_row(self, tmp_path: Path):
+        """``(no more content)`` sentinel must not inflate follow_up_rate."""
+        mgr, tracker = self._build_manager(tmp_path)
+        try:
+            text = "u" * 5000
+            cfg = ProgressiveConfig(chunk_size=4000)
+            mgr._apply_progressive(
+                text, cfg, server="srv", tool="tool_c", trace_id="t3"
+            )
+
+            store = mgr._get_progressive_store()
+            key = next(iter(store._store._data))  # type: ignore[attr-defined]
+
+            # Read past end — chunker returns "(no more content)" without
+            # the progressive footer.
+            output = mgr.read_more(key, offset=len(text) + 1000, limit=4000)
+            assert "no more content" in output
+            assert PROGRESSIVE_FOOTER_TOKEN not in output
+
+            stats = tracker.get_stats()
+            # Only the initial row; the past-end read must not produce
+            # a second row.
+            assert stats["total_reads"] == 1
+            assert stats["total_responses"] == 1
+            assert stats["follow_up_rate"] == 0.0
+        finally:
+            tracker.close()

--- a/tests/test_progressive.py
+++ b/tests/test_progressive.py
@@ -625,3 +625,109 @@ class TestRemainingHeadings:
 
     def test_empty_when_no_headings(self):
         assert ProgressiveChunker._remaining_headings("plain text only", 0) == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration: ProxyManager hot-path writes into ProgressiveReadsTracker
+# ---------------------------------------------------------------------------
+
+
+class TestProgressiveReadsTelemetry:
+    """_apply_progressive + read_more should persist rows via the tracker."""
+
+    def _build_manager(self, tmp_path: Path):
+        from memtomem_stm.proxy.config import ProxyConfig
+        from memtomem_stm.proxy.manager import ProxyManager
+        from memtomem_stm.proxy.metrics import TokenTracker
+        from memtomem_stm.proxy.progressive_reads import ProgressiveReadsTracker
+
+        tracker = ProgressiveReadsTracker(tmp_path / "stm_feedback.db")
+        mgr = ProxyManager(
+            ProxyConfig(enabled=True),
+            TokenTracker(),
+            progressive_reads_tracker=tracker,
+        )
+        return mgr, tracker
+
+    def test_apply_progressive_records_initial_row(self, tmp_path: Path):
+        mgr, tracker = self._build_manager(tmp_path)
+        try:
+            text = "x" * 10000
+            cfg = ProgressiveConfig(chunk_size=4000)
+            first = mgr._apply_progressive(
+                text, cfg, server="srv", tool="tool_a", trace_id="t1"
+            )
+            assert PROGRESSIVE_FOOTER_TOKEN in first
+
+            stats = tracker.get_stats()
+            assert stats["total_reads"] == 1
+            assert stats["total_responses"] == 1
+            assert stats["follow_up_rate"] == 0.0
+            assert stats["avg_total_chars"] == 10000.0
+        finally:
+            tracker.close()
+
+    def test_read_more_records_follow_up_row(self, tmp_path: Path):
+        mgr, tracker = self._build_manager(tmp_path)
+        try:
+            text = "y" * 12000
+            cfg = ProgressiveConfig(chunk_size=4000)
+            first = mgr._apply_progressive(
+                text, cfg, server="srv", tool="tool_b", trace_id="t2"
+            )
+
+            # Recover the key from the in-memory progressive store
+            store = mgr._get_progressive_store()
+            store_rows = list(store._store._data.keys())  # type: ignore[attr-defined]
+            assert len(store_rows) == 1
+            key = store_rows[0]
+
+            # Follow-up read starting where the initial chunk ended
+            initial_chars = len(first.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
+            second = mgr.read_more(key, offset=initial_chars, limit=4000)
+            assert PROGRESSIVE_FOOTER_TOKEN in second
+
+            stats = tracker.get_stats()
+            assert stats["total_reads"] == 2
+            assert stats["total_responses"] == 1
+            assert stats["follow_up_rate"] == 1.0
+            # Rows share the same trace_id
+            rows = tracker.store._db.execute(  # type: ignore[union-attr]
+                "SELECT key, trace_id, offset, chars, total_chars "
+                "FROM progressive_reads ORDER BY id"
+            ).fetchall()
+            assert len(rows) == 2
+            assert rows[0][0] == rows[1][0] == key
+            assert rows[0][1] == rows[1][1] == "t2"
+            assert rows[0][2] == 0
+            assert rows[1][2] == initial_chars
+            assert rows[0][4] == rows[1][4] == 12000
+        finally:
+            tracker.close()
+
+    def test_no_tracker_does_not_break_hot_path(self, tmp_path: Path):
+        """progressive_reads_tracker=None → normal chunk, no exception."""
+        from memtomem_stm.proxy.config import ProxyConfig
+        from memtomem_stm.proxy.manager import ProxyManager
+        from memtomem_stm.proxy.metrics import TokenTracker
+
+        mgr = ProxyManager(
+            ProxyConfig(enabled=True),
+            TokenTracker(),
+            progressive_reads_tracker=None,
+        )
+        text = "z" * 8000
+        first = mgr._apply_progressive(
+            text, ProgressiveConfig(chunk_size=4000), server="s", tool="t", trace_id=None
+        )
+        assert PROGRESSIVE_FOOTER_TOKEN in first
+
+    def test_closed_tracker_does_not_break_hot_path(self, tmp_path: Path):
+        """Tracker closed mid-session — writes are swallowed."""
+        mgr, tracker = self._build_manager(tmp_path)
+        tracker.close()  # simulate shutdown race
+        text = "q" * 6000
+        first = mgr._apply_progressive(
+            text, ProgressiveConfig(chunk_size=4000), server="s", tool="t", trace_id="tx"
+        )
+        assert PROGRESSIVE_FOOTER_TOKEN in first

--- a/tests/test_progressive_reads.py
+++ b/tests/test_progressive_reads.py
@@ -1,0 +1,246 @@
+"""Tests for ``ProgressiveReadsStore`` and ``ProgressiveReadsTracker``.
+
+Exercises schema/aggregation invariants without touching the proxy
+manager — manager-level hot-path integration lives in
+``test_progressive.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.proxy.progressive_reads import ProgressiveReadsTracker
+from memtomem_stm.proxy.progressive_reads_store import ProgressiveReadsStore
+
+
+# ---------------------------------------------------------------------------
+# ProgressiveReadsStore
+# ---------------------------------------------------------------------------
+
+
+class TestProgressiveReadsStore:
+    def test_empty_stats(self, tmp_path: Path):
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        try:
+            stats = store.get_stats()
+            assert stats == {
+                "total_reads": 0,
+                "total_responses": 0,
+                "follow_up_rate": 0.0,
+                "avg_chars_served": 0.0,
+                "avg_total_chars": 0.0,
+                "avg_coverage": 0.0,
+                "by_tool": {},
+            }
+        finally:
+            store.close()
+
+    def test_single_initial_row(self, tmp_path: Path):
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        try:
+            store.record(
+                key="k1",
+                trace_id="t1",
+                server="docfix",
+                tool="get_document",
+                offset=0,
+                chars=4000,
+                served_to=4000,
+                total_chars=10000,
+            )
+            stats = store.get_stats()
+            assert stats["total_reads"] == 1
+            assert stats["total_responses"] == 1
+            assert stats["follow_up_rate"] == 0.0
+            assert stats["avg_chars_served"] == 4000.0
+            assert stats["avg_total_chars"] == 10000.0
+            assert stats["avg_coverage"] == pytest.approx(0.4)
+            assert stats["by_tool"] == {"get_document": {"responses": 1, "follow_up_rate": 0.0}}
+        finally:
+            store.close()
+
+    def test_full_follow_up_rate(self, tmp_path: Path):
+        """Initial + 2 follow-ups on the same key → follow_up_rate 1.0."""
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        try:
+            store.record("k1", "t1", "docfix", "tool_a", 0, 4000, 4000, 10000)
+            store.record("k1", "t1", "docfix", "tool_a", 4000, 4000, 8000, 10000)
+            store.record("k1", "t1", "docfix", "tool_a", 8000, 2000, 10000, 10000)
+            stats = store.get_stats()
+            assert stats["total_reads"] == 3
+            assert stats["total_responses"] == 1
+            assert stats["follow_up_rate"] == 1.0
+            assert stats["avg_chars_served"] == 10000.0
+            assert stats["avg_coverage"] == pytest.approx(1.0)
+        finally:
+            store.close()
+
+    def test_mixed_follow_up_rate(self, tmp_path: Path):
+        """Two responses: one multi-read, one single-read → rate 0.5."""
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        try:
+            # k1: full coverage across 2 reads
+            store.record("k1", "t1", "s", "tool_a", 0, 4000, 4000, 8000)
+            store.record("k1", "t1", "s", "tool_a", 4000, 4000, 8000, 8000)
+            # k2: initial only, no follow-up
+            store.record("k2", "t2", "s", "tool_b", 0, 4000, 4000, 12000)
+
+            stats = store.get_stats()
+            assert stats["total_reads"] == 3
+            assert stats["total_responses"] == 2
+            assert stats["follow_up_rate"] == pytest.approx(0.5)
+            # avg of (8000, 4000) = 6000
+            assert stats["avg_chars_served"] == pytest.approx(6000.0)
+            assert stats["avg_total_chars"] == pytest.approx(10000.0)
+            # avg of (1.0, 4000/12000) = (1.0 + 1/3) / 2
+            assert stats["avg_coverage"] == pytest.approx((1.0 + 1 / 3) / 2)
+            assert stats["by_tool"] == {
+                "tool_a": {"responses": 1, "follow_up_rate": 1.0},
+                "tool_b": {"responses": 1, "follow_up_rate": 0.0},
+            }
+        finally:
+            store.close()
+
+    def test_tool_filter_empties_by_tool(self, tmp_path: Path):
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        try:
+            store.record("k1", None, "s", "tool_a", 0, 1000, 1000, 5000)
+            store.record("k2", None, "s", "tool_b", 0, 1000, 1000, 5000)
+            stats = store.get_stats(tool="tool_a")
+            assert stats["total_reads"] == 1
+            assert stats["total_responses"] == 1
+            assert stats["by_tool"] == {}
+        finally:
+            store.close()
+
+    def test_coverage_capped_at_one(self, tmp_path: Path):
+        """Defensive: served_to > total_chars should cap coverage at 1.0."""
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        try:
+            store.record("k1", None, "s", "t", 0, 10000, 10000, 8000)
+            stats = store.get_stats()
+            assert stats["avg_coverage"] == pytest.approx(1.0)
+        finally:
+            store.close()
+
+    def test_record_after_close_is_noop(self, tmp_path: Path):
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        store.close()
+        # No exception — telemetry must never raise into the hot path
+        store.record("k1", None, "s", "t", 0, 10, 10, 10)
+
+    def test_get_stats_on_closed_store_returns_empty(self, tmp_path: Path):
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        store.close()
+        stats = store.get_stats()
+        assert stats["total_reads"] == 0
+        assert stats["by_tool"] == {}
+
+    def test_close_is_idempotent(self, tmp_path: Path):
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        store.close()
+        store.close()  # second close must not raise
+
+    def test_trace_id_nullable(self, tmp_path: Path):
+        store = ProgressiveReadsStore(tmp_path / "pr.db")
+        store.initialize()
+        try:
+            store.record("k1", None, "s", "t", 0, 100, 100, 500)
+            stats = store.get_stats()
+            assert stats["total_reads"] == 1
+        finally:
+            store.close()
+
+
+# ---------------------------------------------------------------------------
+# ProgressiveReadsTracker
+# ---------------------------------------------------------------------------
+
+
+class TestProgressiveReadsTracker:
+    def test_record_initial_stores_offset_zero(self, tmp_path: Path):
+        tracker = ProgressiveReadsTracker(tmp_path / "pr.db")
+        try:
+            tracker.record_initial(
+                key="k1",
+                trace_id="t1",
+                server="docfix",
+                tool="search",
+                initial_chars=2500,
+                total_chars=8000,
+            )
+            stats = tracker.get_stats()
+            assert stats["total_reads"] == 1
+            assert stats["avg_chars_served"] == 2500.0
+            assert stats["avg_total_chars"] == 8000.0
+        finally:
+            tracker.close()
+
+    def test_record_follow_up_computes_served_to(self, tmp_path: Path):
+        tracker = ProgressiveReadsTracker(tmp_path / "pr.db")
+        try:
+            tracker.record_initial(
+                key="k1",
+                trace_id="t1",
+                server="s",
+                tool="t",
+                initial_chars=4000,
+                total_chars=10000,
+            )
+            tracker.record_follow_up(
+                key="k1",
+                trace_id="t1",
+                server="s",
+                tool="t",
+                offset=4000,
+                chars=4000,
+                total_chars=10000,
+            )
+            stats = tracker.get_stats()
+            # Last served_to on key k1 = 4000 + 4000 = 8000
+            assert stats["avg_chars_served"] == 8000.0
+            assert stats["follow_up_rate"] == 1.0
+        finally:
+            tracker.close()
+
+    def test_record_after_close_is_swallowed(self, tmp_path: Path):
+        tracker = ProgressiveReadsTracker(tmp_path / "pr.db")
+        tracker.close()
+        # Must not raise — telemetry failure cannot break the hot path
+        tracker.record_initial(
+            key="k1",
+            trace_id=None,
+            server="s",
+            tool="t",
+            initial_chars=100,
+            total_chars=500,
+        )
+        tracker.record_follow_up(
+            key="k1",
+            trace_id=None,
+            server="s",
+            tool="t",
+            offset=100,
+            chars=100,
+            total_chars=500,
+        )
+
+    def test_path_expansion(self, tmp_path: Path, monkeypatch):
+        """``~`` in db_path should be expanded to ``$HOME``."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        tracker = ProgressiveReadsTracker(Path("~/pr_expand.db"))
+        try:
+            assert (tmp_path / "pr_expand.db").exists()
+        finally:
+            tracker.close()

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -13,6 +13,7 @@ from memtomem_stm.server import (
     _should_advertise_obs_tools,
     stm_compression_feedback,
     stm_compression_stats,
+    stm_progressive_stats,
     stm_proxy_cache_clear,
     stm_proxy_health,
     stm_proxy_read_more,
@@ -38,6 +39,7 @@ def _make_ctx(
     surfacing_engine: object | None = None,
     feedback_tracker: object | None = None,
     compression_feedback_tracker: object | None = None,
+    progressive_reads_tracker: object | None = None,
 ) -> SimpleNamespace:
     """Build a fake CtxType that _get_ctx() can unwrap.
 
@@ -57,6 +59,7 @@ def _make_ctx(
         surfacing_engine=surfacing_engine,
         feedback_tracker=feedback_tracker,
         compression_feedback_tracker=compression_feedback_tracker,
+        progressive_reads_tracker=progressive_reads_tracker,
     )
     return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
 
@@ -384,6 +387,62 @@ class TestCompressionStats:
         assert "By tool:" in result
 
 
+# ── stm_progressive_stats ────────────────────────────────────────────────
+
+
+class TestProgressiveStats:
+    async def test_no_tracker(self):
+        """Without tracker, returns 'not enabled'."""
+        ctx = _make_ctx(progressive_reads_tracker=None)
+        result = await stm_progressive_stats(ctx=ctx)
+        assert "not enabled" in result.lower()
+
+    async def test_with_data(self):
+        """Returns formatted stats with per-tool breakdown."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "total_reads": 12,
+            "total_responses": 5,
+            "follow_up_rate": 0.4,
+            "avg_chars_served": 7200.0,
+            "avg_total_chars": 9500.0,
+            "avg_coverage": 0.76,
+            "by_tool": {
+                "docfix:get_doc": {"responses": 3, "follow_up_rate": 0.667},
+                "next:search": {"responses": 2, "follow_up_rate": 0.0},
+            },
+        }
+        ctx = _make_ctx(progressive_reads_tracker=mock_tracker)
+        result = await stm_progressive_stats(ctx=ctx)
+
+        assert "Progressive Reads Stats" in result
+        assert "Total reads: 12" in result
+        assert "Total responses: 5" in result
+        assert "Follow-up rate: 40.0%" in result
+        assert "Avg coverage: 76.0%" in result
+        assert "By tool:" in result
+        assert "docfix:get_doc" in result
+        assert "responses=3" in result
+
+    async def test_tool_filter_omits_by_tool(self):
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "total_reads": 2,
+            "total_responses": 1,
+            "follow_up_rate": 1.0,
+            "avg_chars_served": 9000.0,
+            "avg_total_chars": 9000.0,
+            "avg_coverage": 1.0,
+            "by_tool": {},
+        }
+        ctx = _make_ctx(progressive_reads_tracker=mock_tracker)
+        result = await stm_progressive_stats(tool="docfix:get_doc", ctx=ctx)
+
+        assert "By tool:" not in result
+        assert "filtered by tool: docfix:get_doc" in result
+        mock_tracker.get_stats.assert_called_once_with("docfix:get_doc")
+
+
 # ── stm_tuning_recommendations ────────────────────────────────────────────
 
 
@@ -468,6 +527,7 @@ class TestLifespan:
             mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
             mock_cfg.proxy.metrics.enabled = False
             mock_cfg.proxy.compression_feedback.enabled = False
+            mock_cfg.proxy.progressive_reads.enabled = False
             mock_cfg.proxy.cache.enabled = False
             mock_cfg.surfacing = MagicMock()
             mock_cfg.surfacing.enabled = True
@@ -517,6 +577,7 @@ class TestLifespan:
             mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
             mock_cfg.proxy.metrics.enabled = False
             mock_cfg.proxy.compression_feedback.enabled = False
+            mock_cfg.proxy.progressive_reads.enabled = False
             mock_cfg.proxy.cache.enabled = False
             mock_cfg.surfacing = MagicMock()
             mock_cfg.surfacing.enabled = True
@@ -556,6 +617,7 @@ _OBSERVABILITY_TOOLS = {
     "stm_proxy_cache_clear",
     "stm_surfacing_stats",
     "stm_compression_stats",
+    "stm_progressive_stats",
     "stm_tuning_recommendations",
 }
 
@@ -611,10 +673,10 @@ class TestAdvertiseObservabilityFlagEndToEnd:
         )
         return json.loads(result.stdout.strip().splitlines()[-1])
 
-    def test_default_advertises_all_ten(self):
+    def test_default_advertises_all_eleven(self):
         names = set(self._list_registered(env_override=None))
         assert names == _MODEL_FACING_TOOLS | _OBSERVABILITY_TOOLS
-        assert len(names) == 10
+        assert len(names) == 11
 
     def test_flag_false_keeps_only_model_facing(self):
         names = set(self._list_registered(env_override="false"))


### PR DESCRIPTION
## Summary

Second and final part of issue #204 — lands the telemetry layer on top of the `trace_id` propagation merged in #205.

- New `progressive_reads` table in `~/.memtomem/stm_feedback.db` (shared file, disjoint namespace — same pattern as `compression_feedback`). One row per initial progressive response plus one row per `stm_proxy_read_more` follow-up.
- New `stm_progressive_stats` MCP tool (parity with `stm_compression_stats` / `stm_surfacing_stats`) reporting total reads, distinct responses, follow-up rate, avg chars served, avg total chars, avg coverage, and a per-tool breakdown.
- Tracker injection on `ProxyManager` mirrors the existing `cache=` / `surfacing_engine=` pattern. Writes are guarded at two layers (non-null check + tracker-side try/except) so a telemetry outage cannot affect the response served to the caller.

Refs #204.

## Behavior change

- `ProxyManager` now performs one SQLite insert per progressive initial-chunk and one per `stm_proxy_read_more` follow-up. Writes go to `~/.memtomem/stm_feedback.db` (table: `progressive_reads`), shared with surfacing and compression feedback via WAL + disjoint tables.
- Default configuration is `proxy.progressive_reads.enabled=true`; setting it to `false` disables initialization and leaves the tool returning `"not enabled"`.
- No new DB file, no new retention policy — unbounded growth for now, monitored via `stm_progressive_stats`.

## Why this matters

Before this PR the progressive path emitted only in-memory counters. The three-row "nudge strength vs call rate" comparison across compression strategies (the motivating analysis in #204) was unmeasurable for the progressive row because no persistent telemetry existed. After merge, every `trace_id` is joinable back to its read events for stratified analysis.

## Test plan

- [x] Unit tests for store aggregation: empty DB, single initial row, full follow-up rate, mixed follow-up rate, tool filter, coverage cap-at-1.0, close idempotency, post-close resilience (14 new cases in `tests/test_progressive_reads.py`).
- [x] Integration tests exercise the `ProxyManager` hot path end-to-end: `_apply_progressive` + `read_more` produce correctly-aggregated rows, no-tracker / closed-tracker do not break the response (4 new cases in `tests/test_progressive.py`).
- [x] MCP handler tests: `not enabled` path, formatted output with per-tool breakdown, tool-filter omits `by_tool` block (3 new cases in `tests/test_server_tools.py`).
- [x] `TestAdvertiseObservabilityFlagEndToEnd` extended to cover the new tool (11 model-facing + observability tools when flag is default-on).
- [x] Full CI filter (`uv run pytest -m "not ollama"`) passes: 1567 / 1567 on the final revision. One flaky pre-existing test (`TestAutoIndexStartupWarning::test_no_warning_when_compression_none`, MCP stdio subprocess race on `echo`) was observed on pre-change main as well, reproducible under the full suite and clean in isolation.
- [x] `uv run ruff check src && uv run ruff format --check src`: clean.
- [x] `uv run mypy src` (advisory): only 2 pre-existing unrelated errors in `proxy/manager.py` (lines 416, 794), neither touched by this PR.

Manual smoke:
```bash
uv run mms call <progressive-triggering-tool>
uv run mms call stm_proxy_read_more key=<k> offset=<n>
sqlite3 ~/.memtomem/stm_feedback.db \
    "SELECT key, offset, chars, served_to, total_chars FROM progressive_reads;"
uv run mms call stm_progressive_stats
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)