### PR TITLE
chore: sync uv.lock to 0.1.12

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "memtomem-stm"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Follow-up to #214 — the editable install row in `uv.lock` was still `0.1.11`. Trivial lockfile resync so `uv sync` on a fresh clone doesn't see a pyproject/lock mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)