### PR TITLE
feat(cli): auto-register with Claude Code in mms init + mms register command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ memtomem-stm is **independent**: it has no Python-level dependency on memtomem c
 
 ### 1. Add an upstream MCP server
 
-For first-time setup, run the guided wizard — it prompts for name/prefix/command, optionally probes the server, and prints the MCP-client snippet you'll need in step 2:
+For first-time setup, run the guided wizard — it prompts for name/prefix/command, optionally probes the server, and then offers to register STM with Claude Code (or generate `.mcp.json`) in the same flow:
 
 ```bash
 mms init
@@ -86,13 +86,19 @@ mms status    # show full config + connectivity
 
 ### 2. Connect your AI client to STM
 
-Point your MCP client at the `memtomem-stm` server instead of the upstream servers directly. For Claude Code:
+`mms init` ends with a 3-way prompt — pick option 1 and it shells out to `claude mcp add` for you. If you skipped that step or want to register with a different client later, run:
+
+```bash
+mms register
+```
+
+To register manually, use `claude` directly:
 
 ```bash
 claude mcp add memtomem-stm -s user -- memtomem-stm
 ```
 
-Or add it to a JSON MCP config:
+Or add it to a JSON MCP config for Cursor / Windsurf / Claude Desktop / Gemini:
 
 ```json
 {

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shlex
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -115,6 +116,213 @@ def _save(config_path: Path, data: dict[str, Any]) -> None:
     """
     payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
     atomic_write_text(config_path, payload, mode=0o600)
+
+
+# ── MCP client registration helpers ─────────────────────────────────────
+#
+# Mirror of the parent ``mm init`` pattern (see
+# ``memtomem/packages/memtomem/src/memtomem/cli/init_cmd.py``
+# lines 55–90, 526–534, 964–1001, 1051–1066). Kept at module top level so
+# tests can ``monkeypatch.setattr`` individual helpers — particularly
+# ``_run_claude_mcp``, which is the sole shell-out seam.
+#
+# Cross-repo note: the parent is the LTM server, STM is the proxy that
+# chains upstream servers. Both register *themselves* (a single MCP
+# server entry) with the downstream client — STM does **not** re-expose
+# its configured upstreams to Claude Code; only the STM proxy itself is
+# visible.
+
+
+def _run_claude_mcp(cmd: list[str], timeout: int = 5) -> subprocess.CompletedProcess[str]:
+    """Invoke the ``claude`` CLI — isolated so tests replace a single seam."""
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def _detect_install_type() -> tuple[str, list[str]]:
+    """Return ``(server_cmd, server_args)`` to register with an MCP client.
+
+    Branches:
+
+    * Inside a ``pyproject.toml`` that references ``memtomem-stm`` (STM
+      source checkout, or a user project that ran ``uv add memtomem-stm``)
+      → ``uv run --directory <root> mms``.
+    * Default (global install via ``uv tool install`` or ``pipx``) → bare
+      ``memtomem-stm`` console script on ``PATH``.
+
+    Parent ``mm init`` keeps source/project as separate branches because
+    the parent is a monorepo (``packages/`` subdir is the discriminator).
+    STM has a flat layout so the two collapse into one.
+    """
+    check = Path.cwd()
+    for _ in range(5):
+        pyp = check / "pyproject.toml"
+        if pyp.exists():
+            try:
+                content = pyp.read_text(encoding="utf-8")
+            except OSError:
+                break
+            # Match STM source checkout (`name = "memtomem-stm"`) and user
+            # projects depending on STM (`"memtomem-stm"`, `"memtomem-stm>=0.1"`,
+            # `'memtomem-stm'`, etc.). Using the open quote + dash-containing
+            # string avoids over-matching on legit neighbor names.
+            if 'name = "memtomem-stm"' in content or '"memtomem-stm' in content:
+                return ("uv", ["run", "--directory", str(check), "mms"])
+            break
+        check = check.parent
+    return ("memtomem-stm", [])
+
+
+def _check_already_registered(name: str = "memtomem-stm") -> bool:
+    """Return True if Claude Code has *name* registered as an MCP server.
+
+    Returns False on any subprocess error — callers should treat False as
+    "safe to proceed with ``claude mcp add``". Pre-check exists because
+    ``claude mcp add`` has no ``--force`` / ``--overwrite`` flag (verified
+    against ``claude mcp add --help`` on 2026-04-21).
+    """
+    try:
+        result = _run_claude_mcp(["claude", "mcp", "get", name])
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def _register_with_claude_code(
+    server_cmd: str, server_args: list[str], *, name: str = "memtomem-stm"
+) -> tuple[bool, str]:
+    """Run ``claude mcp add``; return ``(success, failure_reason)``.
+
+    ``failure_reason`` is one of ``"not_installed"``, ``"timeout"``,
+    ``"failed"`` — callers map each to a user-facing message and always
+    fall back to ``.mcp.json``.
+    """
+    cmd = ["claude", "mcp", "add", name, "-s", "user", "--", server_cmd, *server_args]
+    try:
+        result = _run_claude_mcp(cmd)
+    except FileNotFoundError:
+        return (False, "not_installed")
+    except subprocess.TimeoutExpired:
+        return (False, "timeout")
+    if result.returncode == 0:
+        return (True, "")
+    return (False, "failed")
+
+
+def _remove_from_claude_code(name: str = "memtomem-stm") -> None:
+    """Best-effort ``claude mcp remove``; swallow errors (caller re-adds next)."""
+    try:
+        _run_claude_mcp(["claude", "mcp", "remove", name, "-s", "user"])
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+
+def _write_mcp_json_for_stm(target_dir: Path, server_cmd: str, server_args: list[str]) -> Path:
+    """Write or merge ``<target_dir>/.mcp.json`` with the memtomem-stm entry."""
+    entry: dict[str, Any] = {"command": server_cmd}
+    if server_args:
+        entry["args"] = server_args
+    mcp_path = target_dir / ".mcp.json"
+    existing: dict[str, Any]
+    if mcp_path.exists():
+        try:
+            loaded = json.loads(mcp_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            loaded = None
+        existing = loaded if isinstance(loaded, dict) else {}
+    else:
+        existing = {}
+    servers = existing.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        existing["mcpServers"] = {"memtomem-stm": entry}
+    else:
+        servers["memtomem-stm"] = entry
+    mcp_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+    return mcp_path
+
+
+def _emit_mcp_paste_hints() -> None:
+    """Per-editor paste targets for the generated ``.mcp.json``."""
+    click.echo("    Cursor          → paste into ~/.cursor/mcp.json")
+    click.echo("    Windsurf        → paste into ~/.codeium/windsurf/mcp_config.json")
+    click.echo(
+        "    Claude Desktop  → paste into "
+        "~/Library/Application Support/Claude/claude_desktop_config.json"
+    )
+    click.echo("    Gemini CLI      → paste into ~/.gemini/settings.json")
+    click.echo("  (Claude Code picks up ./.mcp.json in this project automatically.)")
+
+
+def _emit_skip_hints() -> None:
+    """Manual-registration cheat sheet shown on option 3 (skip)."""
+    server_cmd, server_args = _detect_install_type()
+    cmd_str = " ".join([server_cmd, *server_args]) if server_args else server_cmd
+    click.echo(f"{_ok('Next:')} connect your MCP client to memtomem-stm.")
+    click.echo("")
+    click.echo(f"  {_hdr('Claude Code (CLI):')}")
+    click.echo(f"    claude mcp add memtomem-stm -s user -- {cmd_str}")
+    click.echo("")
+    click.echo(f"  {_hdr('Claude Desktop / JSON MCP config:')}")
+    json_args = f', "args": {json.dumps(server_args)}' if server_args else ""
+    click.echo(
+        f'    {{ "mcpServers": {{ "memtomem-stm": {{ "command": "{server_cmd}"{json_args} }} }} }}'
+    )
+    click.echo("")
+    click.echo(f"  Or run {_hdr('`mms register`')} later to re-run this wizard.")
+
+
+def _prompt_mcp_choice() -> int:
+    """Interactive 3-way prompt. Returns 1, 2, or 3."""
+    click.echo(_hdr("Register memtomem-stm with an MCP client?"))
+    click.echo("  [1] Add to Claude Code (run `claude mcp add` automatically)")
+    click.echo("  [2] Generate .mcp.json in current directory")
+    click.echo("      (for Cursor / Windsurf / Claude Desktop / Gemini)")
+    click.echo("  [3] Skip — I'll configure it manually")
+    return click.prompt("  Select", type=click.IntRange(1, 3), default=1, show_default=True)
+
+
+def _run_mcp_integration() -> None:
+    """Run the 3-way MCP registration flow.
+
+    Called by both ``mms init`` (after config save) and ``mms register``
+    (post-init re-entry path).
+    """
+    choice = _prompt_mcp_choice()
+    click.echo("")
+
+    if choice == 3:
+        _emit_skip_hints()
+        return
+
+    server_cmd, server_args = _detect_install_type()
+
+    if choice == 1:
+        if _check_already_registered():
+            click.echo(f"{_warn('Note:')} memtomem-stm is already registered with Claude Code.")
+            click.echo("    [1] Keep existing (recommended)")
+            click.echo("    [2] Replace (remove + re-add)")
+            action = click.prompt(
+                "  Select", type=click.IntRange(1, 2), default=1, show_default=True
+            )
+            if action == 1:
+                click.echo(f"  {_ok('Kept existing registration.')}")
+                return
+            _remove_from_claude_code()
+
+        success, reason = _register_with_claude_code(server_cmd, server_args)
+        if success:
+            click.echo(f"  {_ok('Registered with Claude Code (user scope).')}")
+            return
+
+        reason_msg = {
+            "not_installed": "claude CLI not found",
+            "timeout": "claude mcp add timed out",
+        }.get(reason, "claude mcp add failed")
+        click.echo(f"  {_warn(reason_msg)} — falling back to .mcp.json.")
+
+    # choice == 2, or choice == 1 fallback
+    mcp_path = _write_mcp_json_for_stm(Path.cwd(), server_cmd, server_args)
+    click.echo(f"  {_ok('Wrote')} {mcp_path}")
+    _emit_mcp_paste_hints()
 
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -1149,13 +1357,40 @@ def init(config_path: str, no_validate: bool) -> None:
         click.echo(f"    mms add --import --config {resolved}")
 
     click.echo("")
-    click.echo(f"{_ok('Next:')} connect your MCP client to memtomem-stm.")
-    click.echo("")
-    click.echo(f"  {_hdr('Claude Code (CLI):')}")
-    click.echo("    claude mcp add memtomem-stm -s user -- memtomem-stm")
-    click.echo("")
-    click.echo(f"  {_hdr('Claude Desktop / JSON MCP config:')}")
-    click.echo('    { "mcpServers": { "memtomem-stm": { "command": "memtomem-stm" } } }')
+    _run_mcp_integration()
+
+
+@cli.command()
+@click.option(
+    "--config",
+    "config_path",
+    default=str(_DEFAULT_CONFIG),
+    show_default=True,
+    help="Path to the proxy config (must already exist — run `mms init` first).",
+)
+def register(config_path: str) -> None:
+    """Register memtomem-stm with an MCP client.
+
+    Post-init re-entry path for the 3-way registration flow from ``mms init``:
+
+    \b
+    * Add to Claude Code (shell out to ``claude mcp add``)
+    * Generate ``.mcp.json`` in the current directory
+    * Skip and print manual instructions
+
+    Requires that ``mms init`` has been run so ``~/.memtomem/stm_proxy.json``
+    (or the ``--config`` path) exists. Safe to re-run; pre-checks existing
+    Claude Code registration and prompts before replacing.
+    """
+    resolved = Path(config_path).expanduser().resolve()
+    if not resolved.exists():
+        click.echo(
+            f"{_err('Error:')} config not found at {resolved}.",
+            err=True,
+        )
+        click.echo("  Run `mms init` first.", err=True)
+        sys.exit(1)
+    _run_mcp_integration()
 
 
 @cli.command()

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -612,7 +612,18 @@ class TestInit:
       back to free-form prompts (name → prefix → transport → command/url).
 
     Tests that only exercise the manual flow use the ``no_discovery``
-    fixture to force an empty candidate list."""
+    fixture to force an empty candidate list.
+
+    The MCP-client registration step (``_run_mcp_integration``) is stubbed
+    out here so existing tests don't shell out to ``claude`` on the test
+    machine. Dedicated coverage for that flow lives in
+    ``TestInitMcpRegistration`` / ``TestRegisterCommand``."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_mcp_integration(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda: None)
 
     def test_init_happy_path_stdio_no_validate(self, runner, config, no_discovery):
         result = runner.invoke(
@@ -622,9 +633,6 @@ class TestInit:
         )
         assert result.exit_code == 0, result.output
         assert "Saved to:" in result.output
-        assert "Next:" in result.output
-        assert "claude mcp add memtomem-stm" in result.output
-        assert "mcpServers" in result.output
 
         data = json.loads(config.read_text(encoding="utf-8"))
         srv = data["upstream_servers"]["filesystem"]
@@ -693,8 +701,10 @@ class TestInit:
                 "--config",
                 str(config),
             ],
-            # server name, prefix, transport, command, args, validate=y
-            input="bad\nbad\nstdio\n__nonexistent_cmd_12345__\n\ny\n",
+            # server name, prefix, transport, command, args, validate=y,
+            # mcp-register choice = 3 (skip, prevents shelling out to the
+            # host's real `claude` CLI / polluting cwd with .mcp.json)
+            input="bad\nbad\nstdio\n__nonexistent_cmd_12345__\n\ny\n3\n",
             capture_output=True,
             text=True,
             timeout=30,
@@ -977,7 +987,16 @@ class TestInitDiscoverySources:
 class TestInitImportFlow:
     """End-to-end ``mms init`` when discovery finds candidates. We stub
     ``_discover_candidates`` directly to focus on the select + prefix UI;
-    source parsing is covered in ``TestInitDiscoverySources``."""
+    source parsing is covered in ``TestInitDiscoverySources``.
+
+    Same ``_run_mcp_integration`` stub as ``TestInit`` — the MCP-client
+    registration step is tested independently in ``TestInitMcpRegistration``."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_mcp_integration(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda: None)
 
     def _stub_candidates(self, monkeypatch, candidates):
         from memtomem_stm.cli import proxy as proxy_mod
@@ -1335,6 +1354,328 @@ class TestInitImportFlow:
         data = json.loads(config.read_text(encoding="utf-8"))
         assert data["upstream_servers"]["filesystem"]["prefix"] == "fs"
         assert data["upstream_servers"]["github"]["prefix"] == "gh"
+
+
+# ── MCP client registration (3-way prompt) ──────────────────────────────
+
+
+class _FakeClaudeResult:
+    """Lightweight stand-in for ``subprocess.CompletedProcess[str]``. Using
+    a plain object avoids pinning the test to a specific stdlib version's
+    constructor signature."""
+
+    def __init__(self, returncode: int = 0, stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = ""
+        self.stderr = stderr
+
+
+class TestInitMcpRegistration:
+    """The new 3-way prompt at the end of ``mms init`` (and the re-entry
+    point ``mms register``): Claude Code auto-register / ``.mcp.json``
+    generation / skip.
+
+    These tests exercise the real ``_run_mcp_integration`` flow (no autouse
+    stub) and replace ``_run_claude_mcp`` with an in-process recorder so
+    assertions can check exact argv."""
+
+    @pytest.fixture
+    def no_discovery(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: [])
+
+    @pytest.fixture
+    def fake_claude(self, monkeypatch):
+        """Record every ``_run_claude_mcp`` call and return scripted results.
+
+        The fixture returns a dict ``{"calls": [...], "script": [...]}``; tests
+        append to ``script`` before the CLI runs and read ``calls`` after.
+        Default scripted result is exit 0 (registration succeeds)."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        state: dict = {"calls": [], "script": []}
+
+        def fake_run(cmd, timeout=5):
+            state["calls"].append(list(cmd))
+            if state["script"]:
+                nxt = state["script"].pop(0)
+                if isinstance(nxt, Exception):
+                    raise nxt
+                return nxt
+            return _FakeClaudeResult(returncode=0)
+
+        monkeypatch.setattr(proxy_mod, "_run_claude_mcp", fake_run)
+        return state
+
+    def _init_input(self, mcp_choice: str) -> str:
+        """Build input for the manual-flow init with an explicit MCP choice."""
+        return f"filesystem\nfs\nstdio\nnpx\n-y @mcp/fs\n{mcp_choice}\n"
+
+    def test_choice_1_calls_claude_mcp_add_with_expected_args(
+        self, runner, config, no_discovery, fake_claude
+    ):
+        """Happy path: user picks 1, pre-check returns 'not registered',
+        ``claude mcp add`` runs successfully."""
+        fake_claude["script"] = [
+            _FakeClaudeResult(returncode=1),  # `claude mcp get` → not registered
+            _FakeClaudeResult(returncode=0),  # `claude mcp add` → success
+        ]
+        result = runner.invoke(
+            cli, ["init", "--no-validate", *_cfg_args(config)], input=self._init_input("1")
+        )
+        assert result.exit_code == 0, result.output
+        assert "Registered with Claude Code" in result.output
+        assert len(fake_claude["calls"]) == 2
+        # First call: pre-check
+        assert fake_claude["calls"][0][:4] == ["claude", "mcp", "get", "memtomem-stm"]
+        # Second call: actual add, with -s user and the server command
+        add_cmd = fake_claude["calls"][1]
+        assert add_cmd[:7] == ["claude", "mcp", "add", "memtomem-stm", "-s", "user", "--"]
+
+    def test_choice_2_writes_mcp_json_without_shelling_out(
+        self, runner, config, no_discovery, fake_claude, tmp_path, monkeypatch
+    ):
+        """Option 2 generates ``.mcp.json`` and never touches the ``claude`` CLI."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            cli, ["init", "--no-validate", *_cfg_args(config)], input=self._init_input("2")
+        )
+        assert result.exit_code == 0, result.output
+        assert fake_claude["calls"] == []
+        mcp_json = tmp_path / ".mcp.json"
+        assert mcp_json.exists()
+        data = json.loads(mcp_json.read_text(encoding="utf-8"))
+        assert "memtomem-stm" in data["mcpServers"]
+
+    def test_choice_3_skips_with_manual_hints(self, runner, config, no_discovery, fake_claude):
+        """Option 3 prints the manual cheat sheet; no subprocess, no file write."""
+        result = runner.invoke(
+            cli, ["init", "--no-validate", *_cfg_args(config)], input=self._init_input("3")
+        )
+        assert result.exit_code == 0, result.output
+        assert fake_claude["calls"] == []
+        assert "claude mcp add memtomem-stm" in result.output
+        assert "mcpServers" in result.output
+        assert "mms register" in result.output
+
+    def test_duplicate_pre_check_keeps_existing_when_user_picks_keep(
+        self, runner, config, no_discovery, fake_claude
+    ):
+        """Pre-check finds an existing registration → user picks option 1
+        ('keep') on the replace prompt → no ``remove`` or ``add`` call.
+
+        The 'keep' option is intentionally the default for the prompt but
+        ``click.CliRunner`` aborts on EOF rather than taking defaults, so
+        the test feeds an explicit ``1`` for that prompt too."""
+        fake_claude["script"] = [
+            _FakeClaudeResult(returncode=0),  # `mcp get` → already exists
+        ]
+        # Extra "1\n" for the keep/replace prompt (pick keep).
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input=self._init_input("1").rstrip("\n") + "\n1\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "already registered" in result.output
+        assert "Kept existing registration" in result.output
+        # Only the pre-check ran — no remove, no add.
+        assert len(fake_claude["calls"]) == 1
+        assert fake_claude["calls"][0][:3] == ["claude", "mcp", "get"]
+
+    def test_duplicate_replace_removes_then_adds(self, runner, config, no_discovery, fake_claude):
+        """Pre-check finds duplicate + user picks 'Replace' → remove, then
+        add are called in that order."""
+        fake_claude["script"] = [
+            _FakeClaudeResult(returncode=0),  # mcp get → exists
+            _FakeClaudeResult(returncode=0),  # mcp remove
+            _FakeClaudeResult(returncode=0),  # mcp add
+        ]
+        # Extra "2\n" for the keep/replace prompt (pick replace)
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input=self._init_input("1").rstrip("\n") + "\n2\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Registered with Claude Code" in result.output
+        assert len(fake_claude["calls"]) == 3
+        assert fake_claude["calls"][0][:3] == ["claude", "mcp", "get"]
+        assert fake_claude["calls"][1][:3] == ["claude", "mcp", "remove"]
+        assert fake_claude["calls"][2][:3] == ["claude", "mcp", "add"]
+
+    def test_fallback_on_file_not_found_writes_mcp_json(
+        self, runner, config, no_discovery, fake_claude, tmp_path, monkeypatch
+    ):
+        """``claude`` CLI missing → ``FileNotFoundError`` on pre-check and
+        on the add call → falls back to writing ``.mcp.json``."""
+        monkeypatch.chdir(tmp_path)
+        # Both `claude mcp get` (pre-check) and `claude mcp add` raise when the
+        # binary is absent from PATH — the fake must model that, not just
+        # script one exception.
+        fake_claude["script"] = [
+            FileNotFoundError("claude not on PATH"),  # pre-check
+            FileNotFoundError("claude not on PATH"),  # actual add
+        ]
+        result = runner.invoke(
+            cli, ["init", "--no-validate", *_cfg_args(config)], input=self._init_input("1")
+        )
+        assert result.exit_code == 0, result.output
+        assert "claude CLI not found" in result.output
+        assert "falling back to .mcp.json" in result.output
+        assert (tmp_path / ".mcp.json").exists()
+
+    def test_fallback_on_timeout_writes_mcp_json(
+        self, runner, config, no_discovery, fake_claude, tmp_path, monkeypatch
+    ):
+        """``TimeoutExpired`` from the add call (duplicate check already
+        passed) → fallback to ``.mcp.json``."""
+        import subprocess
+
+        monkeypatch.chdir(tmp_path)
+        fake_claude["script"] = [
+            _FakeClaudeResult(returncode=1),  # mcp get → not registered
+            subprocess.TimeoutExpired(cmd="claude", timeout=5),  # mcp add → timeout
+        ]
+        result = runner.invoke(
+            cli, ["init", "--no-validate", *_cfg_args(config)], input=self._init_input("1")
+        )
+        assert result.exit_code == 0, result.output
+        assert "timed out" in result.output
+        assert (tmp_path / ".mcp.json").exists()
+
+    def test_fallback_on_nonzero_exit_writes_mcp_json(
+        self, runner, config, no_discovery, fake_claude, tmp_path, monkeypatch
+    ):
+        """Add exits non-zero for a reason other than pre-check → generic
+        'claude mcp add failed' fallback."""
+        monkeypatch.chdir(tmp_path)
+        fake_claude["script"] = [
+            _FakeClaudeResult(returncode=1),  # mcp get → not registered
+            _FakeClaudeResult(returncode=2, stderr="some unexpected error"),
+        ]
+        result = runner.invoke(
+            cli, ["init", "--no-validate", *_cfg_args(config)], input=self._init_input("1")
+        )
+        assert result.exit_code == 0, result.output
+        assert "claude mcp add failed" in result.output
+        assert (tmp_path / ".mcp.json").exists()
+
+
+class TestDetectInstallType:
+    """``_detect_install_type`` returns ``(server_cmd, server_args)`` for the
+    current install location. Covers the three relevant shapes: STM source
+    checkout, user project that ``uv add``'d memtomem-stm, and global install."""
+
+    def test_detects_stm_source_checkout(self, tmp_path, monkeypatch):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "memtomem-stm"\nversion = "0.0.0"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "uv"
+        assert args[:2] == ["run", "--directory"]
+        assert args[-1] == "mms"
+
+    def test_detects_user_project_with_stm_dep(self, tmp_path, monkeypatch):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "my-app"\ndependencies = ["memtomem-stm>=0.1"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "uv"
+        assert args[-1] == "mms"
+
+    def test_defaults_to_bare_console_script_outside_project(self, tmp_path, monkeypatch):
+        """No pyproject.toml reachable (up to 5 levels) → global install
+        assumed → bare ``memtomem-stm`` command with no args."""
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "memtomem-stm"
+        assert args == []
+
+    def test_unrelated_pyproject_still_defaults(self, tmp_path, monkeypatch):
+        """A pyproject.toml that doesn't mention memtomem-stm must NOT be
+        treated as a project install — those users installed STM globally."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "unrelated"\ndependencies = ["requests"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "memtomem-stm"
+        assert args == []
+
+
+class TestRegisterCommand:
+    """``mms register`` is the post-init re-entry path for the MCP-client
+    registration flow. It requires that ``mms init`` has been run, so
+    ``mms register`` without a config should abort clearly."""
+
+    @pytest.fixture
+    def fake_claude(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        state: dict = {"calls": [], "script": []}
+
+        def fake_run(cmd, timeout=5):
+            state["calls"].append(list(cmd))
+            if state["script"]:
+                nxt = state["script"].pop(0)
+                if isinstance(nxt, Exception):
+                    raise nxt
+                return nxt
+            return _FakeClaudeResult(returncode=0)
+
+        monkeypatch.setattr(proxy_mod, "_run_claude_mcp", fake_run)
+        return state
+
+    def test_register_aborts_without_config(self, runner, config):
+        """Running ``mms register`` before ``mms init`` should fail with a
+        clear 'run `mms init` first' message."""
+        assert not config.exists()
+        result = runner.invoke(cli, ["register", *_cfg_args(config)])
+        assert result.exit_code == 1
+        assert "config not found" in result.output
+        assert "mms init" in result.output
+
+    def test_register_runs_flow_when_config_exists(self, runner, config, fake_claude):
+        """With a config present, ``mms register`` drops straight into the
+        3-way prompt. Option 3 (skip) prints the manual hints."""
+        config.write_text(json.dumps({"enabled": True, "upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["register", *_cfg_args(config)], input="3\n")
+        assert result.exit_code == 0, result.output
+        assert fake_claude["calls"] == []
+        assert "claude mcp add memtomem-stm" in result.output
+        assert "mms register" in result.output
+
+    def test_register_is_idempotent_when_already_registered(self, runner, config, fake_claude):
+        """Re-running register when STM is already in Claude Code and the
+        user picks 'keep' → no destructive side effects.
+
+        Pins the idempotency contract for the post-init re-entry path
+        (plan Part 2): ``mms register`` can be safely rerun without
+        clobbering an existing Claude Code entry."""
+        config.write_text(json.dumps({"enabled": True, "upstream_servers": {}}), encoding="utf-8")
+        fake_claude["script"] = [_FakeClaudeResult(returncode=0)]  # already registered
+        # "1\n" for the 3-way prompt (Claude Code) + "1\n" for keep/replace (keep).
+        result = runner.invoke(cli, ["register", *_cfg_args(config)], input="1\n1\n")
+        assert result.exit_code == 0, result.output
+        assert "already registered" in result.output
+        assert "Kept existing registration" in result.output
+        # Only the pre-check ran.
+        assert len(fake_claude["calls"]) == 1
 
 
 # ── add --from-clients (bulk import) ────────────────────────────────────


### PR DESCRIPTION
## Summary

- `mms init` gains a 3-way MCP registration prompt at the end (Claude Code auto-register / `.mcp.json` / skip), mirroring parent `mm init`'s flow.
- New `mms register` command re-runs the same prompt post-init without requiring `init` re-entry — preserves the bootstrap-only invariant.
- Install-type detection chooses between `uv run --directory <root> mms` (source checkout / project with `uv add memtomem-stm`) and bare `memtomem-stm` (global install).

## Why

The prior `mms init` printed a manual `claude mcp add memtomem-stm -s user -- memtomem-stm` hint and asked the user to copy-paste it. Parent `mm init` has been running the registration for the LTM server automatically for a while, and the sibling-tool UX gap was friction for new STM users. This lands parity without breaking the bootstrap-only invariant — skipped users and multi-client setups get `mms register` as the non-destructive re-entry path.

## Implementation notes

- Helpers at module top level (`_run_claude_mcp`, `_detect_install_type`, `_check_already_registered`, `_register_with_claude_code`, `_write_mcp_json_for_stm`, `_emit_skip_hints`, `_prompt_mcp_choice`, `_run_mcp_integration`) so tests replace the single `_run_claude_mcp` seam.
- `claude mcp add` has no `--force` flag (verified against `claude mcp add --help` on 2026-04-21), so the flow pre-checks with `claude mcp get memtomem-stm` and prompts **keep/replace** on duplicate.
- Fallbacks to `.mcp.json` on `FileNotFoundError` (claude CLI missing), `TimeoutExpired` (5s timeout — tighter than parent's 10s), and any non-zero exit.
- STM's flat layout collapses parent's source/project branches into a single `uv run --directory` form; default is the bare console script. Detection treats a `pyproject.toml` as STM-related only if it mentions `memtomem-stm` — unrelated user projects fall through to the global path.

## Behavior change

- `mms init` output: the trailing manual cheat sheet is now gated behind the 3-way prompt's skip path. When the user picks option 1 or 2, only the registration-outcome line is printed.
- `mms register` is a new command; `mms --help` now lists it. No existing commands behave differently outside of `init`.
- Non-interactive `mms init` callers who piped input that terminated before the new prompt will see a `click.Abort` on EOF — if you run `mms init` in CI, feed `3\n` to pick skip or pre-create the config and use `mms register` explicitly.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1583 passed (13 new tests covering registration flow, duplicate pre-check, fallbacks, install-type detection, and `mms register` idempotency).
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean.
- [x] Manual local verification:
  - `mms init` with option 3 (skip) → manual hints printed, no side effects.
  - `mms init` with option 2 → `.mcp.json` written to cwd with correct content.
  - `mms register` without config → clean error, exit 1.
  - `mms register` with `PATH=/usr/bin:/bin` (claude missing) + option 1 → fallback to `.mcp.json`.
  - Install-type detection correctly picks `uv run --directory <repo> mms` inside the STM checkout.
- [ ] CI — watch for any environment-specific shell-out behavior.

## Out of scope (follow-up)

- `memtomem-com` Quick Start / Installation docs — update to reflect the automatic registration step in a separate PR.
- Per-client auto-registration for Cursor / Windsurf / Gemini CLI — currently covered via `.mcp.json` fallback only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)