### PR TITLE
fix: complete --mcp flag missed by #216 — skip interactive prompt for CI callers

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -280,13 +280,23 @@ def _prompt_mcp_choice() -> int:
     return click.prompt("  Select", type=click.IntRange(1, 3), default=1, show_default=True)
 
 
-def _run_mcp_integration() -> None:
+_MCP_MODE_TO_CHOICE = {"claude": 1, "json": 2, "skip": 3}
+
+
+def _run_mcp_integration(preselected: int | None = None) -> None:
     """Run the 3-way MCP registration flow.
 
     Called by both ``mms init`` (after config save) and ``mms register``
     (post-init re-entry path).
+
+    ``preselected`` bypasses the interactive 3-way prompt when set (1, 2,
+    or 3) — this is how ``--mcp`` / scripted callers skip stdin. When
+    ``preselected`` is 1 and a duplicate is detected, we default to
+    ``keep`` (non-destructive) rather than prompting, so CI / scripted
+    callers don't hit ``click.Abort`` on EOF.
     """
-    choice = _prompt_mcp_choice()
+    interactive = preselected is None
+    choice = preselected if preselected is not None else _prompt_mcp_choice()
     click.echo("")
 
     if choice == 3:
@@ -298,11 +308,16 @@ def _run_mcp_integration() -> None:
     if choice == 1:
         if _check_already_registered():
             click.echo(f"{_warn('Note:')} memtomem-stm is already registered with Claude Code.")
-            click.echo("    [1] Keep existing (recommended)")
-            click.echo("    [2] Replace (remove + re-add)")
-            action = click.prompt(
-                "  Select", type=click.IntRange(1, 2), default=1, show_default=True
-            )
+            if interactive:
+                click.echo("    [1] Keep existing (recommended)")
+                click.echo("    [2] Replace (remove + re-add)")
+                action = click.prompt(
+                    "  Select", type=click.IntRange(1, 2), default=1, show_default=True
+                )
+            else:
+                # Non-interactive: always keep. Replacing requires an
+                # explicit `claude mcp remove memtomem-stm` first.
+                action = 1
             if action == 1:
                 click.echo(f"  {_ok('Kept existing registration.')}")
                 return
@@ -1201,7 +1216,18 @@ def _add_from_clients(
     default=False,
     help="Skip the connectivity probe entirely (default: prompt, probe on yes).",
 )
-def init(config_path: str, no_validate: bool) -> None:
+@click.option(
+    "--mcp",
+    "mcp_mode",
+    type=click.Choice(["claude", "json", "skip"]),
+    default=None,
+    help=(
+        "Pre-answer the MCP-registration prompt for scripted runs: "
+        "'claude' = `claude mcp add`, 'json' = write .mcp.json, 'skip' = "
+        "no registration. Omit the flag for the interactive prompt."
+    ),
+)
+def init(config_path: str, no_validate: bool, mcp_mode: str | None) -> None:
     """Guided first-time setup for memtomem-stm.
 
     Prompts for a single upstream server and writes the config file. Aborts
@@ -1357,7 +1383,7 @@ def init(config_path: str, no_validate: bool) -> None:
         click.echo(f"    mms add --import --config {resolved}")
 
     click.echo("")
-    _run_mcp_integration()
+    _run_mcp_integration(_MCP_MODE_TO_CHOICE.get(mcp_mode) if mcp_mode else None)
 
 
 @cli.command()
@@ -1368,7 +1394,18 @@ def init(config_path: str, no_validate: bool) -> None:
     show_default=True,
     help="Path to the proxy config (must already exist — run `mms init` first).",
 )
-def register(config_path: str) -> None:
+@click.option(
+    "--mcp",
+    "mcp_mode",
+    type=click.Choice(["claude", "json", "skip"]),
+    default=None,
+    help=(
+        "Pre-answer the registration prompt for scripted runs: "
+        "'claude' = `claude mcp add`, 'json' = write .mcp.json, 'skip' = "
+        "print manual hints. Omit for the interactive prompt."
+    ),
+)
+def register(config_path: str, mcp_mode: str | None) -> None:
     """Register memtomem-stm with an MCP client.
 
     Post-init re-entry path for the 3-way registration flow from ``mms init``:
@@ -1380,7 +1417,7 @@ def register(config_path: str) -> None:
 
     Requires that ``mms init`` has been run so ``~/.memtomem/stm_proxy.json``
     (or the ``--config`` path) exists. Safe to re-run; pre-checks existing
-    Claude Code registration and prompts before replacing.
+    Claude Code registration and defaults to 'keep' when already registered.
     """
     resolved = Path(config_path).expanduser().resolve()
     if not resolved.exists():
@@ -1390,7 +1427,7 @@ def register(config_path: str) -> None:
         )
         click.echo("  Run `mms init` first.", err=True)
         sys.exit(1)
-    _run_mcp_integration()
+    _run_mcp_integration(_MCP_MODE_TO_CHOICE.get(mcp_mode) if mcp_mode else None)
 
 
 @cli.command()

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -623,7 +623,7 @@ class TestInit:
     def _stub_mcp_integration(self, monkeypatch):
         from memtomem_stm.cli import proxy as proxy_mod
 
-        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda: None)
+        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda *_a, **_kw: None)
 
     def test_init_happy_path_stdio_no_validate(self, runner, config, no_discovery):
         result = runner.invoke(
@@ -996,7 +996,7 @@ class TestInitImportFlow:
     def _stub_mcp_integration(self, monkeypatch):
         from memtomem_stm.cli import proxy as proxy_mod
 
-        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda: None)
+        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda *_a, **_kw: None)
 
     def _stub_candidates(self, monkeypatch, candidates):
         from memtomem_stm.cli import proxy as proxy_mod
@@ -1562,6 +1562,87 @@ class TestInitMcpRegistration:
         assert "claude mcp add failed" in result.output
         assert (tmp_path / ".mcp.json").exists()
 
+    # ── --mcp flag (non-interactive path) ────────────────────────────
+
+    def _init_input_without_mcp_choice(self) -> str:
+        """Manual-flow input that STOPS before the 3-way prompt (the flag
+        pre-answers it, so the prompt never fires)."""
+        return "filesystem\nfs\nstdio\nnpx\n-y @mcp/fs\n"
+
+    def test_mcp_flag_skip_bypasses_prompt(self, runner, config, no_discovery, fake_claude):
+        """--mcp skip pre-answers option 3; no stdin consumed past the
+        manual-flow prompts; no subprocess calls."""
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--mcp", "skip", *_cfg_args(config)],
+            input=self._init_input_without_mcp_choice(),
+        )
+        assert result.exit_code == 0, result.output
+        assert fake_claude["calls"] == []
+        # The interactive prompt header MUST NOT appear.
+        assert "Register memtomem-stm with an MCP client?" not in result.output
+        # Manual hints still printed (option 3 behavior).
+        assert "claude mcp add memtomem-stm" in result.output
+
+    def test_mcp_flag_json_writes_mcp_json_without_shell_out(
+        self, runner, config, no_discovery, fake_claude, tmp_path, monkeypatch
+    ):
+        """--mcp json pre-answers option 2; writes .mcp.json; no claude
+        shell-out."""
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--mcp", "json", *_cfg_args(config)],
+            input=self._init_input_without_mcp_choice(),
+        )
+        assert result.exit_code == 0, result.output
+        assert fake_claude["calls"] == []
+        assert "Register memtomem-stm with an MCP client?" not in result.output
+        assert (tmp_path / ".mcp.json").exists()
+
+    def test_mcp_flag_claude_registers_without_asking(
+        self, runner, config, no_discovery, fake_claude
+    ):
+        """--mcp claude pre-answers option 1; pre-check + add run without
+        the interactive prompt."""
+        fake_claude["script"] = [
+            _FakeClaudeResult(returncode=1),  # pre-check: not registered
+            _FakeClaudeResult(returncode=0),  # add: success
+        ]
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--mcp", "claude", *_cfg_args(config)],
+            input=self._init_input_without_mcp_choice(),
+        )
+        assert result.exit_code == 0, result.output
+        assert "Register memtomem-stm with an MCP client?" not in result.output
+        assert "Registered with Claude Code" in result.output
+        assert len(fake_claude["calls"]) == 2
+
+    def test_mcp_flag_claude_keeps_existing_on_duplicate_noninteractive(
+        self, runner, config, no_discovery, fake_claude
+    ):
+        """--mcp claude hits a duplicate → non-interactive default is
+        'keep'. No keep/replace prompt fires, no ``claude mcp remove`` or
+        ``add`` calls are made beyond the pre-check.
+
+        This is the load-bearing contract for CI callers: scripted runs
+        can re-assert 'register me' without clobbering whatever the user
+        had configured previously."""
+        fake_claude["script"] = [_FakeClaudeResult(returncode=0)]  # already registered
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--mcp", "claude", *_cfg_args(config)],
+            input=self._init_input_without_mcp_choice(),
+        )
+        assert result.exit_code == 0, result.output
+        assert "already registered" in result.output
+        assert "Kept existing registration" in result.output
+        # Prompts must NOT have fired.
+        assert "Keep existing" not in result.output.split("already registered")[1]
+        assert len(fake_claude["calls"]) == 1
+        assert fake_claude["calls"][0][:3] == ["claude", "mcp", "get"]
+
 
 class TestDetectInstallType:
     """``_detect_install_type`` returns ``(server_cmd, server_args)`` for the
@@ -1675,6 +1756,29 @@ class TestRegisterCommand:
         assert "already registered" in result.output
         assert "Kept existing registration" in result.output
         # Only the pre-check ran.
+        assert len(fake_claude["calls"]) == 1
+
+    # ── --mcp flag ─────────────────────────────────────────────────────
+
+    def test_register_mcp_flag_skip_bypasses_prompt(self, runner, config, fake_claude):
+        """--mcp skip skips the interactive prompt entirely. No stdin input
+        required — this is the shape CI callers use to confirm config is
+        set up without asking a human."""
+        config.write_text(json.dumps({"enabled": True, "upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["register", "--mcp", "skip", *_cfg_args(config)])
+        assert result.exit_code == 0, result.output
+        assert fake_claude["calls"] == []
+        assert "Register memtomem-stm with an MCP client?" not in result.output
+
+    def test_register_mcp_flag_claude_keeps_on_duplicate(self, runner, config, fake_claude):
+        """Scripted re-assertion of 'register me' when already registered
+        is a no-op — guarantees ``mms register --mcp claude`` is safe to
+        rerun from CI."""
+        config.write_text(json.dumps({"enabled": True, "upstream_servers": {}}), encoding="utf-8")
+        fake_claude["script"] = [_FakeClaudeResult(returncode=0)]  # already registered
+        result = runner.invoke(cli, ["register", "--mcp", "claude", *_cfg_args(config)])
+        assert result.exit_code == 0, result.output
+        assert "Kept existing registration" in result.output
         assert len(fake_claude["calls"]) == 1
 
 


### PR DESCRIPTION
## Summary

- Adds `--mcp claude|json|skip` to both `mms init` and `mms register`, pre-answering the 3-way registration prompt for scripted / CI callers.
- Matches parent `mm init --mcp` shape exactly.
- `--mcp claude` on a duplicate now defaults to 'keep' (non-destructive) without prompting — re-asserting registration from CI is a safe no-op.

## Why

PR #216 added an interactive 3-way prompt after config save, which broke any caller piping stdin to `mms init` that didn't feed an extra line. The `## Behavior change` section of #216 documented the workaround (feed `3\n`), but the parent-tool parity gap was the real fix. This closes it so CI users don't have to change their stdin scripts at all — they just add `--mcp skip` to the command line.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1589 passed (6 new tests covering `--mcp skip` / `--mcp json` / `--mcp claude` happy path and non-interactive duplicate → keep).
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean.
- [x] Manual verification:
  - `mms register --mcp skip` with no stdin → no prompt, manual hints printed.
  - `mms register --mcp json` in tmp dir → `.mcp.json` written.
  - `mms register --mcp claude` with already-registered → keeps existing, no destructive ops.

## Behavior

- Default behavior (no `--mcp` flag) is unchanged: interactive 3-way prompt.
- Non-interactive mode (`--mcp claude`) on a duplicate defaults to keep. Users wanting to replace must `claude mcp remove memtomem-stm` first, then re-run — matches the explicit-reversal ergonomics we already use for other destructive ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)