### PR TITLE
refactor(cli): tighten _detect_install_type with tomllib parse

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -138,34 +139,80 @@ def _run_claude_mcp(cmd: list[str], timeout: int = 5) -> subprocess.CompletedPro
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 
+# PEP 508 dependency specifier: the distribution name is the leading identifier
+# before any extras (`[...]`), version spec (`==`, `>=`, ...), marker (`;`), or
+# whitespace. Pinning the match to the start anchors the regex so `my-memtomem-stm`
+# or `memtomem-stm-extension` can't hide a match inside the name.
+_PEP508_NAME_RE = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def _dep_name(spec: str) -> str | None:
+    """Extract the package name from a PEP 508 dependency spec, or None.
+
+    ``"memtomem-stm>=0.1"`` → ``"memtomem-stm"``
+    ``"memtomem-stm[extra]==1.0"`` → ``"memtomem-stm"``
+    ``"memtomem-stm-extension"`` → ``"memtomem-stm-extension"`` (different pkg)
+    """
+    if not isinstance(spec, str):
+        return None
+    match = _PEP508_NAME_RE.match(spec.strip())
+    return match.group(1) if match else None
+
+
+def _pyproject_references_stm(pyp: Path) -> bool:
+    """True if ``pyp`` is STM's own pyproject.toml, or lists memtomem-stm as
+    a dep. Parses the TOML via ``tomllib`` so comments, descriptions, and
+    adjacent-name packages (``memtomem-stm-extension``) can't false-positive.
+    """
+    try:
+        data = tomllib.loads(pyp.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return False
+    if project.get("name") == "memtomem-stm":
+        return True
+    dep_lists: list[list[Any]] = []
+    deps = project.get("dependencies")
+    if isinstance(deps, list):
+        dep_lists.append(deps)
+    optional = project.get("optional-dependencies")
+    if isinstance(optional, dict):
+        dep_lists.extend(v for v in optional.values() if isinstance(v, list))
+    for dep_list in dep_lists:
+        for spec in dep_list:
+            if _dep_name(spec) == "memtomem-stm":
+                return True
+    return False
+
+
 def _detect_install_type() -> tuple[str, list[str]]:
     """Return ``(server_cmd, server_args)`` to register with an MCP client.
 
     Branches:
 
-    * Inside a ``pyproject.toml`` that references ``memtomem-stm`` (STM
-      source checkout, or a user project that ran ``uv add memtomem-stm``)
-      → ``uv run --directory <root> mms``.
-    * Default (global install via ``uv tool install`` or ``pipx``) → bare
-      ``memtomem-stm`` console script on ``PATH``.
+    * Inside a ``pyproject.toml`` that is STM's own source checkout OR a
+      user project that lists ``memtomem-stm`` in ``[project].dependencies``
+      / ``[project].optional-dependencies`` → ``uv run --directory <root> mms``.
+    * Default (global install via ``uv tool install`` / ``pipx``, or a cwd
+      with no relevant pyproject) → bare ``memtomem-stm`` console script.
 
     Parent ``mm init`` keeps source/project as separate branches because
     the parent is a monorepo (``packages/`` subdir is the discriminator).
     STM has a flat layout so the two collapse into one.
+
+    PEP 735 ``dependency-groups`` and tool-specific dev-dep tables (``[tool.uv
+    .dev-dependencies]``, ``[tool.poetry.group.*.dependencies]``) are
+    intentionally **not** matched — a dev-only dep usually means the user
+    wants `uv run --group <name>` which the registration command can't pick.
+    Bare ``memtomem-stm`` is the safer default; users can override manually.
     """
     check = Path.cwd()
     for _ in range(5):
         pyp = check / "pyproject.toml"
         if pyp.exists():
-            try:
-                content = pyp.read_text(encoding="utf-8")
-            except OSError:
-                break
-            # Match STM source checkout (`name = "memtomem-stm"`) and user
-            # projects depending on STM (`"memtomem-stm"`, `"memtomem-stm>=0.1"`,
-            # `'memtomem-stm'`, etc.). Using the open quote + dash-containing
-            # string avoids over-matching on legit neighbor names.
-            if 'name = "memtomem-stm"' in content or '"memtomem-stm' in content:
+            if _pyproject_references_stm(pyp):
                 return ("uv", ["run", "--directory", str(check), "mms"])
             break
         check = check.parent

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1698,6 +1698,92 @@ class TestDetectInstallType:
         assert cmd == "memtomem-stm"
         assert args == []
 
+    def test_detects_optional_dependencies(self, tmp_path, monkeypatch):
+        """A user project that has memtomem-stm in ``optional-dependencies``
+        (e.g. `[project.optional-dependencies].stm = ["memtomem-stm"]`)
+        should also resolve to ``uv run --directory ...``."""
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "my-app"\n'
+            "dependencies = []\n"
+            "[project.optional-dependencies]\n"
+            'stm = ["memtomem-stm>=0.1"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "uv"
+        assert args[-1] == "mms"
+
+    def test_adjacent_package_name_does_not_false_positive(self, tmp_path, monkeypatch):
+        """A project named `memtomem-stm-extension` (or similar dash-suffixed
+        neighbor) must NOT be treated as STM's own source checkout.
+
+        Pre-tightening heuristic matched the prefix string and would have
+        flagged this as an STM dep. The PEP 508 name extraction pins the
+        match to the exact package name."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "memtomem-stm-extension"\ndependencies = []\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "memtomem-stm"
+        assert args == []
+
+    def test_adjacent_dep_name_does_not_false_positive(self, tmp_path, monkeypatch):
+        """Same invariant for the dependency list: a dep like
+        ``memtomem-stm-adjacent>=0.1`` is a different package."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "my-app"\ndependencies = ["memtomem-stm-adjacent>=0.1"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "memtomem-stm"
+        assert args == []
+
+    def test_comment_mention_does_not_false_positive(self, tmp_path, monkeypatch):
+        """A pyproject.toml with ``memtomem-stm`` only in a comment or
+        free-form description string must not trigger uv-run mode.
+
+        Old string-match heuristic would false-positive here; the TOML parse
+        + exact-name match catches only real declarations."""
+        (tmp_path / "pyproject.toml").write_text(
+            "# Using memtomem-stm for memory proxying — see README.\n"
+            "[project]\n"
+            'name = "my-app"\n'
+            'description = "Uses memtomem-stm under the hood"\n'
+            'dependencies = ["requests"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "memtomem-stm"
+        assert args == []
+
+    def test_malformed_pyproject_falls_through(self, tmp_path, monkeypatch):
+        """A pyproject.toml we can't parse (malformed TOML, I/O error) should
+        break out of the walk and return the default — not crash."""
+        (tmp_path / "pyproject.toml").write_text(
+            "this is = [[not valid toml\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        cmd, args = _detect_install_type()
+        assert cmd == "memtomem-stm"
+        assert args == []
+
 
 class TestRegisterCommand:
     """``mms register`` is the post-init re-entry path for the MCP-client


### PR DESCRIPTION
## Summary

- Replaces the ``'"memtomem-stm' in content`` prefix-match heuristic in ``_detect_install_type`` with a proper ``tomllib`` parse + PEP 508 name extraction.
- Adds a ``_dep_name`` helper that handles extras and version specifiers (``memtomem-stm[extra]==1.0``, ``memtomem-stm>=0.1``, etc.) without matching adjacent-name packages.

## Why

Review feedback on #216 flagged the old string match as a potential false-positive source once neighbor packages like `memtomem-stm-bundle` or `memtomem-stm-extension` exist (or even just a comment mentioning the name in an unrelated `pyproject.toml`). Not blocking at ship time, but worth tightening before the first such incident rather than after.

## Behavior

- Semantics unchanged for the three shipped happy paths (STM source checkout / project with STM dep / global install).
- ``[project].optional-dependencies.*`` now explicitly matches — `[project.optional-dependencies].stm = ["memtomem-stm"]` resolves to ``uv run`` mode.
- PEP 735 ``dependency-groups`` and tool-specific dev-dep tables (``[tool.uv.dev-dependencies]``, ``[tool.poetry.group.*.dependencies]``) are **not** matched — dev-only deps usually want ``uv run --group <name>`` which the registration command can't synthesize. Bare ``memtomem-stm`` on PATH is the safer default; users can override manually.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1594 passed (5 new: optional-dependencies, adjacent package name, adjacent dep name, comment-only mention, malformed TOML).
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)