### PR TITLE
fix(cli): show OS-appropriate Claude Desktop config path in paste hints

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -287,14 +287,26 @@ def _write_mcp_json_for_stm(target_dir: Path, server_cmd: str, server_args: list
     return mcp_path
 
 
+def _claude_desktop_config_hint() -> str:
+    """Return the display path for Claude Desktop's config on the current OS.
+
+    Claude Desktop is the only target in the paste-hint block whose config
+    path is platform-specific — Cursor / Windsurf / Gemini all use the same
+    dot-directory under ``$HOME`` across OSes.
+    """
+    if sys.platform == "darwin":
+        return "~/Library/Application Support/Claude/claude_desktop_config.json"
+    if sys.platform == "win32":
+        return r"%APPDATA%\Claude\claude_desktop_config.json"
+    # Linux and other POSIX: XDG default.
+    return "~/.config/Claude/claude_desktop_config.json"
+
+
 def _emit_mcp_paste_hints() -> None:
     """Per-editor paste targets for the generated ``.mcp.json``."""
     click.echo("    Cursor          → paste into ~/.cursor/mcp.json")
     click.echo("    Windsurf        → paste into ~/.codeium/windsurf/mcp_config.json")
-    click.echo(
-        "    Claude Desktop  → paste into "
-        "~/Library/Application Support/Claude/claude_desktop_config.json"
-    )
+    click.echo(f"    Claude Desktop  → paste into {_claude_desktop_config_hint()}")
     click.echo("    Gemini CLI      → paste into ~/.gemini/settings.json")
     click.echo("  (Claude Code picks up ./.mcp.json in this project automatically.)")
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1785,6 +1785,48 @@ class TestDetectInstallType:
         assert args == []
 
 
+class TestClaudeDesktopConfigHint:
+    """``_claude_desktop_config_hint`` picks the right Claude Desktop config
+    path per OS. Displayed in the ``mms init`` / ``mms register`` paste-hint
+    block after option 2 (generate .mcp.json)."""
+
+    @pytest.mark.parametrize(
+        "platform,expected_fragment",
+        [
+            ("darwin", "Library/Application Support/Claude"),
+            ("linux", ".config/Claude"),
+            ("linux2", ".config/Claude"),  # older sys.platform label
+            ("freebsd14", ".config/Claude"),  # any non-darwin/non-win32 POSIX
+        ],
+    )
+    def test_posix_variants(self, monkeypatch, platform, expected_fragment):
+        monkeypatch.setattr("sys.platform", platform)
+        from memtomem_stm.cli.proxy import _claude_desktop_config_hint
+
+        assert expected_fragment in _claude_desktop_config_hint()
+
+    def test_windows(self, monkeypatch):
+        """Windows uses ``%APPDATA%`` + backslashes — displayed literally so
+        Windows users can paste the string into PowerShell / Explorer."""
+        monkeypatch.setattr("sys.platform", "win32")
+        from memtomem_stm.cli.proxy import _claude_desktop_config_hint
+
+        hint = _claude_desktop_config_hint()
+        assert "%APPDATA%" in hint
+        assert "\\Claude\\" in hint
+
+    def test_emitted_in_paste_hints(self, monkeypatch, capsys):
+        """Integration-level: ``_emit_mcp_paste_hints`` uses the per-OS path."""
+        monkeypatch.setattr("sys.platform", "linux")
+        from memtomem_stm.cli.proxy import _emit_mcp_paste_hints
+
+        _emit_mcp_paste_hints()
+        out = capsys.readouterr().out
+        assert ".config/Claude/claude_desktop_config.json" in out
+        # macOS-specific path must NOT leak when running on Linux.
+        assert "Library/Application Support" not in out
+
+
 class TestRegisterCommand:
     """``mms register`` is the post-init re-entry path for the MCP-client
     registration flow. It requires that ``mms init`` has been run, so


### PR DESCRIPTION
## Summary

- Adds ``_claude_desktop_config_hint()`` that returns the correct Claude Desktop config path per ``sys.platform`` (macOS / Linux / Windows).
- Wires it into ``_emit_mcp_paste_hints`` so users on Linux or Windows see the right path after ``mms init`` / ``mms register`` option 2.

## Why

Review feedback on #216 flagged the paste-hint block as macOS-only — it hardcoded ``~/Library/Application Support/Claude/...``, which is wrong for:

* Linux: ``~/.config/Claude/claude_desktop_config.json``
* Windows: ``%APPDATA%\Claude\claude_desktop_config.json``

A Linux user pasting that string would create an unused config file in a macOS-specific path and leave Claude Desktop with its existing (empty-of-memtomem-stm) config.

Cursor / Windsurf / Gemini targets are unchanged — those tools use the same dot-dir layout under ``$HOME`` across OSes, so their hint lines work as-is.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1600 passed (6 new in ``TestClaudeDesktopConfigHint`` covering darwin / linux / linux2 / freebsd14 / win32 + integration via ``_emit_mcp_paste_hints``).
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)