### PR TITLE
feat(cli): add `mms --version` flag and `mms list --json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Added
 
 - **`mms --version` flag** — idiomatic Click entry point alongside the existing `mms version` subcommand (kept for backwards compatibility). Both paths emit the same `memtomem-stm X.Y.Z` line, so scripts that grep the version string don't care which they invoke.
+- **`mms list --json`** — scriptable JSON output for the server list, mirroring the shape of `mms status --json` (`{config_path, servers}`; missing config returns `{error: "config_not_found", path}`). Closes the parity gap where `status` and `health` already supported `--json` but `list` required parsing the text table.
 
 ## [0.1.12] — 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mms --version` flag** — idiomatic Click entry point alongside the existing `mms version` subcommand (kept for backwards compatibility). Both paths emit the same `memtomem-stm X.Y.Z` line, so scripts that grep the version string don't care which they invoke.
+
 ## [0.1.12] — 2026-04-20
 
 ### Added

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -484,10 +484,31 @@ def status(config_path: str, *, as_json: bool = False) -> None:
 
 @cli.command(name="list")
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
-def list_servers(config_path: str) -> None:
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
+def list_servers(config_path: str, *, as_json: bool = False) -> None:
     """List configured upstream servers."""
-    data = _load(Path(config_path))
+    path = Path(config_path)
+    resolved = path.expanduser().resolve()
+
+    # Missing-config handling matches ``status --json`` so scripts can probe
+    # either command without branching on shape. Text path keeps the prior
+    # ``_load`` fallthrough (empty dict → "No upstream servers configured").
+    if as_json and not resolved.exists():
+        click.echo(json.dumps({"error": "config_not_found", "path": str(resolved)}))
+        return
+
+    data = _load(path)
     servers: dict[str, Any] = data.get("upstream_servers", {})
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {"config_path": str(resolved), "servers": servers},
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return
 
     if not servers:
         click.echo("No upstream servers configured.")

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -403,6 +403,11 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
+@click.version_option(
+    package_name="memtomem-stm",
+    prog_name="memtomem-stm",
+    message="%(prog)s %(version)s",
+)
 def cli() -> None:
     """memtomem-stm proxy gateway management.
 
@@ -410,6 +415,10 @@ def cli() -> None:
     """
 
 
+# ``version`` subcommand predates the ``--version`` flag (CHANGELOG #152) and
+# is kept for backwards compatibility. Both paths must produce the exact same
+# line so scripts that grep the version string don't care which entry point
+# they use.
 @cli.command()
 def version() -> None:
     """Show the installed memtomem-stm version."""

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -260,6 +260,10 @@ class TestListServers:
         data = json.loads(result.output)
         assert "fs" in data["servers"]
         assert str(config) in data["config_path"]
+        # ``enabled`` is proxy-wide state owned by ``status`` — its absence
+        # here is intentional. Pinning it prevents a future copy-paste from
+        # ``status --json`` silently widening the contract.
+        assert "enabled" not in data
 
     def test_json_empty_config(self, runner, config):
         """Empty config → empty ``servers`` object, not text fallback."""

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -53,6 +53,17 @@ class TestVersion:
         assert "memtomem-stm" in result.output
         assert result.output.strip().startswith("memtomem-stm ")
 
+    def test_version_flag_matches_subcommand(self, runner):
+        """``--version`` is the idiomatic Click entry point; the subcommand
+        predates it. Both must emit the identical line so scripts that grep
+        the version don't care which they invoke (CHANGELOG keeps the
+        subcommand for compatibility)."""
+        flag = runner.invoke(cli, ["--version"])
+        sub = runner.invoke(cli, ["version"])
+        assert flag.exit_code == 0
+        assert sub.exit_code == 0
+        assert flag.output.strip() == sub.output.strip()
+
 
 # ── style helpers / NO_COLOR contract ───────────────────────────────────
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -242,6 +242,41 @@ class TestListServers:
         result = runner.invoke(cli, ["list", *_cfg_args(config)])
         assert "example.com/mcp" in result.output
 
+    def test_json_output(self, runner, config):
+        """``list --json`` mirrors ``status --json`` shape for scripting."""
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {
+                        "fs": {"prefix": "fs", "command": "uvx", "args": ["mcp-server-fs"]},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["list", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "fs" in data["servers"]
+        assert str(config) in data["config_path"]
+
+    def test_json_empty_config(self, runner, config):
+        """Empty config → empty ``servers`` object, not text fallback."""
+        config.write_text(json.dumps({"enabled": True, "upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["list", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["servers"] == {}
+
+    def test_json_missing_config(self, runner, config):
+        """Missing config → same ``{error, path}`` shape as ``status --json``."""
+        result = runner.invoke(cli, ["list", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["error"] == "config_not_found"
+        assert str(config) in data["path"]
+
 
 # ── add command — validation paths ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two small CLI ergonomics fixes:

- **`mms --version` flag** — Click's idiomatic entry point for version output, added via `click.version_option` at the group level. The existing `mms version` subcommand (CHANGELOG #152) is untouched so scripts grepping the version string work against either path. Both emit `memtomem-stm X.Y.Z` verbatim.
- **`mms list --json`** — closes the parity gap where `status --json` and `health --json` were already scriptable but `list` forced parsing the text table. Shape mirrors `status --json`: `{config_path, servers}` on the happy path, `{error: "config_not_found", path}` when the config file is missing. `enabled` is intentionally omitted — it's proxy-wide state already surfaced by `status`; `list` is about the server collection.

Both changes are additive — no existing output or exit code changes.

## Test plan

- [x] `uv run pytest tests/cli/test_proxy_cli.py` — 136 passed (2 new: `test_version_flag_matches_subcommand`, 3 new list-JSON cases)
- [x] `uv run ruff check src tests/cli/` + `ruff format --check` — clean
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean
- [x] Manual: `uv run mms --version` and `uv run mms version` produce identical output; `uv run mms list --json --config <path>` parses with `jq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)