### PR TITLE
fix(cli): pretty-print `mms health --json` to match status / list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **`mms --version` flag** — idiomatic Click entry point alongside the existing `mms version` subcommand (kept for backwards compatibility). Both paths emit the same `memtomem-stm X.Y.Z` line, so scripts that grep the version string don't care which they invoke.
 - **`mms list --json`** — scriptable JSON output for the server list, mirroring the shape of `mms status --json` (`{config_path, servers}`; missing config returns `{error: "config_not_found", path}`). Closes the parity gap where `status` and `health` already supported `--json` but `list` required parsing the text table.
 
+### Changed
+
+- **`mms health --json` now pretty-prints (indent=2, ensure_ascii=False)** to match `mms status --json` and `mms list --json`. Previously emitted compact one-liners, leaving `health` as the odd one out when piping multiple `--json` commands through the same formatter. Shape is unchanged; parsers that ignore whitespace are unaffected.
+
 ## [0.1.12] — 2026-04-20
 
 ### Added

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -1623,9 +1623,12 @@ def health(config_path: str, *, as_json: bool = False, timeout: int = 10) -> Non
     data = _load(Path(config_path))
     servers: dict[str, Any] = data.get("upstream_servers", {})
 
+    # JSON output format matches ``status --json`` / ``list --json`` (indent=2,
+    # ensure_ascii=False) so scripts piping the three commands through the
+    # same formatter don't hit one compact-one-line outlier.
     if not servers:
         if as_json:
-            click.echo(json.dumps({"servers": {}}))
+            click.echo(json.dumps({"servers": {}}, indent=2, ensure_ascii=False))
         else:
             click.echo("No upstream servers configured.")
         return
@@ -1633,7 +1636,7 @@ def health(config_path: str, *, as_json: bool = False, timeout: int = 10) -> Non
     results = asyncio.run(_probe_servers(servers, timeout))
 
     if as_json:
-        click.echo(json.dumps({"servers": results}))
+        click.echo(json.dumps({"servers": results}, indent=2, ensure_ascii=False))
         return
 
     click.echo(_hdr("Upstream Server Health"))


### PR DESCRIPTION
## Summary

Closes a pre-existing parity gap flagged during review of #220: `mms status --json` and `mms list --json` both emit pretty-printed JSON (`indent=2, ensure_ascii=False`), but `mms health --json` was stuck on compact one-liners. When a shell pipeline runs all three through the same formatter, `health` is the odd one out.

This PR unifies on the pretty-printed shape. Output structure is unchanged; only whitespace differs. Parsers (`jq`, `json.loads`) that ignore whitespace see no difference.

```diff
- {"servers": {"fs": {"connected": true, "tools": 3, "error": null}}}
+ {
+   "servers": {
+     "fs": {
+       "connected": true,
+       "tools": 3,
+       "error": null
+     }
+   }
+ }
```

A short inline comment documents the intent so a future contributor doesn't regress `health` back to compact without realizing the other two commands set the convention.

## Test plan

- [x] `uv run pytest tests/cli/test_proxy_cli.py::TestHealth` — 4 passed (existing shape-only asserts unaffected)
- [x] `uv run ruff check src tests/cli/` + `ruff format --check` — clean
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean
- [x] Manual: `uv run mms health --json` output pipes cleanly through `jq '.'` (was already parseable; now pre-formatted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)