### PR TITLE
docs(cli): surface v0.1.13 additions in docs/cli.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To check what's happening, ask the agent to call `stm_proxy_stats`.
 | [Compression](https://github.com/memtomem/memtomem-stm/blob/main/docs/compression.md) | All 10 strategies — pick the right one for your content |
 | [Caching](https://github.com/memtomem/memtomem-stm/blob/main/docs/caching.md) | Skip repeated work with response caching |
 | [Configuration](https://github.com/memtomem/memtomem-stm/blob/main/docs/configuration.md) | Tune settings without touching code |
-| [CLI](https://github.com/memtomem/memtomem-stm/blob/main/docs/cli.md) | CLI commands and the 10 MCP tools |
+| [CLI](https://github.com/memtomem/memtomem-stm/blob/main/docs/cli.md) | CLI commands and the 11 MCP tools |
 
 ## Development
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,16 +26,24 @@ Usage: mms [OPTIONS] COMMAND [ARGS]...
 
   memtomem-stm proxy gateway management.
 
+Options:
+  --version   Show the version and exit.
+  -h, --help  Show this message and exit.
+
 Commands:
-  add     Add an upstream MCP server to the proxy configuration.
-  health  Check upstream server connectivity.
-  init    Guided first-time setup for memtomem-stm.
-  list    List configured upstream servers.
-  remove  Remove an upstream MCP server from the proxy configuration.
-  status  Show proxy gateway configuration and server list.
+  add       Add an upstream MCP server to the proxy configuration.
+  health    Check upstream server connectivity.
+  init      Guided first-time setup for memtomem-stm.
+  list      List configured upstream servers.
+  register  Register memtomem-stm with an MCP client.
+  remove    Remove an upstream MCP server from the proxy configuration.
+  status    Show proxy gateway configuration and server list.
+  version   Show the installed memtomem-stm version.
 ```
 
 All commands accept `--config TEXT` (default `~/.memtomem/stm_proxy.json`).
+
+`mms --version` and `mms version` both print `memtomem-stm X.Y.Z` — the flag is the idiomatic Click form, the subcommand is kept for backwards compatibility.
 
 Output is colorized when writing to a terminal; set `NO_COLOR=1` to disable. JSON output (`--json`) and non-TTY streams (pipes, CI) are never colored.
 
@@ -45,20 +53,58 @@ Output is colorized when writing to a terminal; set `NO_COLOR=1` to disable. JSO
 Usage: mms init [OPTIONS]
 
 Options:
-  --config TEXT   [default: ~/.memtomem/stm_proxy.json]
-  --no-validate   Skip the connectivity probe entirely (default: prompt,
-                  probe on yes).
+  --config TEXT             [default: ~/.memtomem/stm_proxy.json]
+  --no-validate             Skip the connectivity probe entirely (default:
+                            prompt, probe on yes).
+  --mcp [claude|json|skip]  Pre-answer the MCP-registration prompt for
+                            scripted runs: 'claude' = `claude mcp add`,
+                            'json' = write .mcp.json, 'skip' = no
+                            registration. Omit the flag for the interactive
+                            prompt.
 ```
 
-Interactive wizard for the first-time setup. Prompts for a single upstream server (name, prefix, transport, command/URL), optionally probes connectivity, writes the config, then prints an inline summary plus the MCP-client snippet you need to paste into Claude Code / Claude Desktop.
+Interactive wizard for the first-time setup. Prompts for a single upstream server (name, prefix, transport, command/URL), optionally probes connectivity, writes the config, then offers a 3-way MCP-client registration prompt:
 
-Aborts if the config file already exists — use [`add`](#add) to register additional servers or [`list`](#list) to inspect the current state. This makes `init` safe to run without clobbering existing configuration.
+1. **Add to Claude Code** — shells out to `claude mcp add` for you.
+2. **Generate `.mcp.json`** — writes a project-scoped snippet in the current directory.
+3. **Skip** — prints OS-appropriate paste hints (`claude mcp add` one-liner plus the Claude Desktop / Cursor / Windsurf / Gemini JSON snippet) so you can wire it up by hand later.
+
+Use `--mcp claude|json|skip` to pre-answer the prompt from scripts, CI, or any caller where stdin isn't a TTY — interactive callers should omit the flag.
+
+Aborts if the config file already exists — use [`register`](#register) to re-run the registration prompt, [`add`](#add) to register additional servers, or [`list`](#list) to inspect the current state. This makes `init` safe to run without clobbering existing configuration.
 
 Validation is **advisory**: probe failures are reported as warnings but the config is still written. That way a flaky network or a cold upstream doesn't block setup; re-run `mms health` later once things are up.
 
 ```bash
-mms init                # interactive wizard
-mms init --no-validate  # skip the connectivity probe prompt entirely
+mms init                 # interactive wizard
+mms init --no-validate   # skip the connectivity probe prompt entirely
+mms init --mcp claude    # scripted: auto-register with Claude Code
+mms init --mcp skip      # scripted: write config, print paste hints, exit
+```
+
+### `register`
+
+```
+Usage: mms register [OPTIONS]
+
+Options:
+  --config TEXT             Path to the proxy config (must already exist —
+                            run `mms init` first).  [default:
+                            ~/.memtomem/stm_proxy.json]
+  --mcp [claude|json|skip]  Pre-answer the registration prompt for scripted
+                            runs: 'claude' = `claude mcp add`, 'json' =
+                            write .mcp.json, 'skip' = print manual hints.
+                            Omit for the interactive prompt.
+```
+
+Re-runs the 3-way MCP-client registration prompt from `init` without re-entering the first-time setup wizard. Use this after `mms init` if you initially picked "skip", or when registering the same STM install with a second client.
+
+Requires that `mms init` has already been run so the config file exists — otherwise exits with an error and a hint. Safe to re-run: pre-checks existing Claude Code registration and defaults to **keep** when already registered (no-op — existing registration is preserved even with `--mcp claude`).
+
+```bash
+mms register              # interactive prompt
+mms register --mcp json   # scripted: write .mcp.json in CWD, exit
+mms register --mcp skip   # scripted: print manual paste hints, exit
 ```
 
 ### `add`
@@ -123,6 +169,7 @@ mms add filesystem \
 
 # List configured upstreams
 mms list
+mms list --json            # machine-readable: {config_path, servers}
 
 # Show full status
 mms status

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -110,13 +110,15 @@ mms register --mcp skip   # scripted: print manual paste hints, exit
 ### `add`
 
 ```
-Usage: mms add [OPTIONS] NAME
+Usage: mms add [OPTIONS] [NAME]
 
 Options:
+  --config TEXT                   [default: ~/.memtomem/stm_proxy.json]
   --command TEXT                  Executable command (stdio).
   --args TEXT                     Space-separated arguments.
   --prefix TEXT                   Tool namespace (e.g. 'fs' -> tools appear
-                                  as fs__read_file).  [required]
+                                  as fs__read_file). Required unless
+                                  --from-clients is used.
   --transport [stdio|sse|streamable_http]
                                   stdio for local processes,
                                   sse/streamable_http for remote.
@@ -126,15 +128,24 @@ Options:
   --compression [auto|none|truncate|selective|hybrid]
                                   'auto' picks strategy per response by
                                   content type.  [default: auto]
-  --max-chars INTEGER             [default: 8000]
+  --max-chars INTEGER RANGE       [default: 8000; x>=1]
   --validate                      Probe the server (MCP initialize +
                                   list-tools) before saving; abort on
                                   failure.
-  --timeout INTEGER               Connection timeout (seconds) when
-                                  --validate is set.  [default: 10]
+  --timeout INTEGER RANGE         Connection timeout (seconds) when
+                                  --validate is set.  [default: 10; x>=1]
+  --from-clients, --import        Import additional servers interactively
+                                  from existing MCP clients (Claude
+                                  Desktop / Code, project .mcp.json).
+                                  Reuses init's discovery + TUI flow.
+                                  Skips candidates already registered.
+                                  Incompatible with NAME / --prefix /
+                                  --command / --args / --url / --env.
 ```
 
 Use `--validate` to catch typos and misconfigurations at registration time instead of the next time the proxy starts. Without it `add` only writes the config — bad entries are discovered later via `mms health` or when the proxy fails to spawn.
+
+Use `--from-clients` (alias `--import`) to bulk-pick additional servers from the same MCP clients `mms init` scans: `~/.claude.json`, project `.mcp.json`, and `~/Library/Application Support/Claude/claude_desktop_config.json` (OS-appropriate). This is the post-init equivalent of the `init` discovery step — servers already registered in this config are filtered out by name and by `(transport, command, args)` / `(transport, url)` signature before the selection UI. `--validate` and `--timeout` work on the selected subset.
 
 > **Note**: The CLI's `--compression` flag exposes 5 of the 10 strategies. The remaining five (`extract_fields`, `schema_pruning`, `skeleton`, `progressive`, `llm_summary`) are configured by editing `stm_proxy.json` directly. See [Compression Strategies](compression.md).
 
@@ -167,6 +178,9 @@ mms add filesystem \
   --prefix fs \
   --validate
 
+# Bulk-import servers already configured in Claude Desktop / Code / .mcp.json
+mms add --import            # or --from-clients; skips anything already registered
+
 # List configured upstreams
 mms list
 mms list --json            # machine-readable: {config_path, servers}
@@ -189,14 +203,15 @@ mms health --timeout 5     # 5s per-server timeout (default: 10)
 Usage: mms health [OPTIONS]
 
 Options:
-  --config TEXT          [default: ~/.memtomem/stm_proxy.json]
-  --json                Output as JSON for scripting.
-  --timeout INTEGER     Per-server connection timeout in seconds.  [default: 10]
+  --config TEXT            [default: ~/.memtomem/stm_proxy.json]
+  --json                   Output as JSON for scripting.
+  --timeout INTEGER RANGE  Per-server connection timeout in seconds.
+                           [default: 10; x>=1]
 ```
 
 Connects to each configured upstream server (MCP initialize + list-tools) and reports whether it's reachable and how many tools it exposes. Unlike `stm_proxy_health` (the MCP tool), this command probes servers directly — the proxy does not need to be running.
 
-## MCP Tools (10 + proxied)
+## MCP Tools (11 + proxied)
 
 These are exposed by the `memtomem-stm` MCP server and become available to your agent once it's connected.
 
@@ -211,6 +226,7 @@ These are exposed by the `memtomem-stm` MCP server and become available to your 
 | `stm_surfacing_stats` | `tool?` | Surfacing event counts, feedback breakdown, helpfulness % |
 | `stm_compression_feedback` | `server`, `tool`, `missing`, `kind?`, `trace_id?` | Report missing info from a compressed response (learning signal) |
 | `stm_compression_stats` | `tool?` | Compression feedback counts by kind and tool |
+| `stm_progressive_stats` | `tool?` | Progressive-delivery follow-up rate, coverage, and per-tool breakdown |
 | `stm_tuning_recommendations` | `since_hours?`, `tool?` | Per-tool compression tuning recommendations from the auto-tuner |
 
 Plus all proxied tools named `{prefix}__{original_tool_name}` (e.g. `fs__read_file`, `gh__search_repositories`).
@@ -246,11 +262,11 @@ See [Configuration → General](configuration.md#general) for details.
 
 ## Trimming the advertised MCP tool surface
 
-STM advertises ten MCP tools by default. Six are operator-facing
+STM advertises eleven MCP tools by default. Seven are operator-facing
 (observability / admin) and accessible through this very CLI; the
 remaining four are model-facing (progressive-delivery unlocks and
 feedback channels). On clients that eager-load MCP tool schemas
-into the model context at session start, the six observability
+into the model context at session start, the seven observability
 tools pay schema tokens for calls the model rarely makes.
 
 Set the following to hide them from MCP (they stay callable via
@@ -273,7 +289,7 @@ export MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=false
   disabled_tools = [
     "stm_proxy_stats", "stm_proxy_health", "stm_proxy_cache_clear",
     "stm_surfacing_stats", "stm_compression_stats",
-    "stm_tuning_recommendations",
+    "stm_progressive_stats", "stm_tuning_recommendations",
   ]
   ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,8 +66,8 @@ Options:
 Interactive wizard for the first-time setup. Prompts for a single upstream server (name, prefix, transport, command/URL), optionally probes connectivity, writes the config, then offers a 3-way MCP-client registration prompt:
 
 1. **Add to Claude Code** — shells out to `claude mcp add` for you.
-2. **Generate `.mcp.json`** — writes a project-scoped snippet in the current directory.
-3. **Skip** — prints OS-appropriate paste hints (`claude mcp add` one-liner plus the Claude Desktop / Cursor / Windsurf / Gemini JSON snippet) so you can wire it up by hand later.
+2. **Generate `.mcp.json`** — writes a project-scoped snippet in the current directory, then prints per-client paste targets for Cursor, Windsurf, Claude Desktop (OS-appropriate path), and Gemini CLI.
+3. **Skip** — prints a manual-registration cheat sheet (`claude mcp add` one-liner plus a generic `mcpServers` JSON stanza) so you can wire it up by hand later.
 
 Use `--mcp claude|json|skip` to pre-answer the prompt from scripts, CI, or any caller where stdin isn't a TTY — interactive callers should omit the flag.
 

--- a/tests/test_qa_round3.py
+++ b/tests/test_qa_round3.py
@@ -162,18 +162,19 @@ class TestParseResultsRegex:
 
 
 class TestDocsToolCount:
-    def test_cli_md_has_10_tools(self):
+    def test_cli_md_has_11_tools(self):
         cli_md = Path(__file__).parent.parent / "docs" / "cli.md"
         content = cli_md.read_text()
-        assert "10 + proxied" in content
+        assert "11 + proxied" in content
         assert "stm_proxy_health" in content
         assert "stm_compression_feedback" in content
+        assert "stm_progressive_stats" in content
         assert "stm_tuning_recommendations" in content
 
-    def test_readme_has_10_tools(self):
+    def test_readme_has_11_tools(self):
         readme = Path(__file__).parent.parent / "README.md"
         content = readme.read_text()
-        assert "10 MCP tools" in content
+        assert "11 MCP tools" in content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related commits that sync `docs/cli.md` (the standalone CLI reference,
linked from the README docs table) to the real `mms ... --help` output.
One reviewer pass over the same file covers both.

- **Commit 1 — v0.1.13 surface** (`213767f`): `mms register` / `--mcp` /
  `--version` / `mms list --json` were in README + CHANGELOG but missing
  from `docs/cli.md`. Also replaces `init`'s pre-v0.1.13 "paste-only"
  narrative with the actual 3-way registration prompt.
- **Commit 2 — v0.1.12 leftovers** (`9a5d728`): `stm_progressive_stats`
  (v0.1.12 #213) was missing from both the MCP Tools table and the
  trimming-the-surface section. `mms add --import` / `--from-clients`
  (v0.1.12 #200) was only covered in README.md. A few `INTEGER` →
  `INTEGER RANGE` cosmetic drifts got pulled in at the same time.

No functional change. README / CHANGELOG / CONTRIBUTING / other
`docs/*.md` / the tutorial notebook were audited and confirmed already
up to date.

## Concrete gaps addressed

| # | Change | Source PR |
|---|---|---|
| 1 | Main-help block: add `--version` option and the `register` / `version` rows | #216, #220 |
| 2 | `init` Options: add `--mcp [claude\|json\|skip]` | #217 |
| 3 | `init` narrative: "paste-only" → actual 3-way registration prompt | #216 |
| 4 | New `### register` section + scripted examples | #216, #217 |
| 5 | Examples: `mms list --json` alongside the text-table invocation | #220 |
| 6 | MCP Tools table: add `stm_progressive_stats` row, bump "10 → 11" | v0.1.12 #213 |
| 7 | Trimming section: "Six → Seven" + `stm_progressive_stats` in Codex snippet | v0.1.12 #201 + #213 |
| 8 | `mms add`: add `--config`, `[NAME]`, `--prefix` conditional, `--from-clients, --import`, `INTEGER RANGE` drift | v0.1.12 #200 + Click upgrades |
| 9 | `mms add` prose + example for `--import` | v0.1.12 #200 |
| 10 | `mms health`: `INTEGER RANGE` cosmetic drift | Click upgrade |

## Verification

All Options blocks in the doc were regenerated from real Click output:

```bash
uv run mms --help                                     # Commands + top-level --version
uv run mms --version                                  # -> memtomem-stm 0.1.13
uv run mms init --help                                # --mcp flag shape
uv run mms register --help                            # --mcp flag + docstring
uv run mms add --help                                 # --from-clients / INTEGER RANGE / [NAME]
uv run mms health --help                              # INTEGER RANGE cosmetic
uv run mms list --config /tmp/stm_nope.json --json    # -> {"error": "config_not_found", "path": ...}
uv run ruff check src && uv run ruff format --check src  # passes (no code changed)
```

Operator-facing count re-derived from source: `rg '^@_obs_tool' src/memtomem_stm/server.py` → 7 hits
(`stm_proxy_stats`, `stm_proxy_cache_clear`, `stm_proxy_health`,
`stm_surfacing_stats`, `stm_compression_stats`, `stm_progressive_stats`,
`stm_tuning_recommendations`). Model-facing (`@mcp.tool()` direct) → 4 hits
(`stm_proxy_select_chunks`, `stm_proxy_read_more`, `stm_surfacing_feedback`,
`stm_compression_feedback`). Total = 11.

## Test plan

- [x] `ruff check` / `ruff format --check` pass (docs-only change, but verified)
- [x] Every Options block in the doc matches `uv run mms ... --help` byte-for-byte (modulo leading `-h, --help` which Click appends)
- [x] MCP Tools count (11) matches `@_obs_tool` + `@mcp.tool()` hit count in `server.py`
- [x] `mms list --json` against a missing config emits `{error, path}` as documented
- [ ] Reviewer: skim rendered `docs/cli.md` on GitHub for table/code-block alignment (especially the widest Options column in `mms add`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)