### PR TITLE
fix(cli): register memtomem-stm entrypoint, not the mms click group

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -194,9 +194,16 @@ def _detect_install_type() -> tuple[str, list[str]]:
 
     * Inside a ``pyproject.toml`` that is STM's own source checkout OR a
       user project that lists ``memtomem-stm`` in ``[project].dependencies``
-      / ``[project].optional-dependencies`` → ``uv run --directory <root> mms``.
+      / ``[project].optional-dependencies`` → ``uv run --directory <root>
+      memtomem-stm``.
     * Default (global install via ``uv tool install`` / ``pipx``, or a cwd
       with no relevant pyproject) → bare ``memtomem-stm`` console script.
+
+    Both branches spawn the ``memtomem-stm`` console script, not ``mms``:
+    ``mms`` is the click CLI group and exits 0 on no-subcommand, which closes
+    the stdio pipe immediately and the MCP client reports "Failed to
+    reconnect". ``memtomem-stm`` is the actual server entrypoint
+    (``memtomem_stm.server:main``).
 
     Parent ``mm init`` keeps source/project as separate branches because
     the parent is a monorepo (``packages/`` subdir is the discriminator).
@@ -213,7 +220,7 @@ def _detect_install_type() -> tuple[str, list[str]]:
         pyp = check / "pyproject.toml"
         if pyp.exists():
             if _pyproject_references_stm(pyp):
-                return ("uv", ["run", "--directory", str(check), "mms"])
+                return ("uv", ["run", "--directory", str(check), "memtomem-stm"])
             break
         check = check.parent
     return ("memtomem-stm", [])

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1710,7 +1710,11 @@ class TestDetectInstallType:
         cmd, args = _detect_install_type()
         assert cmd == "uv"
         assert args[:2] == ["run", "--directory"]
-        assert args[-1] == "mms"
+        # The entrypoint must be the ``memtomem-stm`` console script, not the
+        # ``mms`` click group — ``mms`` with no subcommand prints help and
+        # exits 0, which closes the MCP stdio pipe and the client reports
+        # "Failed to reconnect".
+        assert args[-1] == "memtomem-stm"
 
     def test_detects_user_project_with_stm_dep(self, tmp_path, monkeypatch):
         (tmp_path / "pyproject.toml").write_text(
@@ -1722,7 +1726,7 @@ class TestDetectInstallType:
 
         cmd, args = _detect_install_type()
         assert cmd == "uv"
-        assert args[-1] == "mms"
+        assert args[-1] == "memtomem-stm"
 
     def test_defaults_to_bare_console_script_outside_project(self, tmp_path, monkeypatch):
         """No pyproject.toml reachable (up to 5 levels) → global install
@@ -1765,7 +1769,7 @@ class TestDetectInstallType:
 
         cmd, args = _detect_install_type()
         assert cmd == "uv"
-        assert args[-1] == "mms"
+        assert args[-1] == "memtomem-stm"
 
     def test_adjacent_package_name_does_not_false_positive(self, tmp_path, monkeypatch):
         """A project named `memtomem-stm-extension` (or similar dash-suffixed
@@ -1833,6 +1837,32 @@ class TestDetectInstallType:
         cmd, args = _detect_install_type()
         assert cmd == "memtomem-stm"
         assert args == []
+
+    def test_never_emits_click_group_as_mcp_entrypoint(self, tmp_path, monkeypatch):
+        """Regression guard: neither branch may return ``mms`` as the command
+        the MCP client will spawn.
+
+        ``mms`` is the click CLI group (entrypoint
+        ``memtomem_stm.cli.proxy:cli``) — calling it with no subcommand
+        prints help and exits 0, the stdio pipe closes before ``initialize``,
+        and the client reports "Failed to reconnect". The actual server is
+        ``memtomem-stm`` (entrypoint ``memtomem_stm.server:main``). Pinning
+        the non-inclusion here because the three branch-specific tests above
+        could all flip together in a refactor and silently reintroduce the
+        regression."""
+        from memtomem_stm.cli.proxy import _detect_install_type
+
+        # Dev-checkout branch.
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "memtomem-stm"\nversion = "0.0.0"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        cmd, args = _detect_install_type()
+        assert "mms" not in [cmd, *args], (
+            "regression: _detect_install_type emits the click group — "
+            "MCP stdio will close on initialize"
+        )
 
 
 class TestClaudeDesktopConfigHint:


### PR DESCRIPTION
## Summary
- `_detect_install_type` returned `uv run --directory <root> mms` for the dev-checkout and user-project branches, but `mms` is the click CLI group (`memtomem_stm.cli.proxy:cli`): with no subcommand it prints help and exits 0, closing the MCP stdio pipe before `initialize`. The client reports "Failed to reconnect to memtomem-stm".
- Both branches now emit `memtomem-stm` (the actual server entrypoint, `memtomem_stm.server:main`) — the bare branch at `:219` already did this, so the fix aligns the `uv run` branch with it.
- Expands the `_detect_install_type` docstring to spell out why both branches must land on the server entrypoint, not the CLI group.

## Symptom / reproduction
A user following the README / `mms register` flow from inside their own project (or an STM source checkout) ends up with a broken `~/.claude.json` entry. `/mcp` shows "Failed to reconnect to memtomem-stm". Manual workaround was to hand-edit the final arg from `mms` → `memtomem-stm`.

## Behavior change
- Output of `_detect_install_type()` for the dev-checkout / `[project].dependencies` / `[project].optional-dependencies` branches changes from `("uv", ["run", "--directory", <root>, "mms"])` → `("uv", ["run", "--directory", <root>, "memtomem-stm"])`.
- `mms init` and `mms register` both consume this output, so configs written by either command change accordingly. Existing broken configs written by a prior version need to be re-run through `mms register` (or hand-edited) to pick up the fix.

## Tests
- Flipped the three existing `TestDetectInstallType` asserts that pinned the broken `"mms"` literal.
- Added `test_never_emits_click_group_as_mcp_entrypoint` as a dedicated regression guard — the three branch-specific tests could otherwise all flip together in a refactor and silently reintroduce the click-group command across every site.

## Test plan
- [x] `uv run pytest -m "not ollama"` — 1605 passed
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [ ] Reviewer: confirm `memtomem_stm.server:main` is the server entrypoint being invoked (not any wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)