### PR TITLE
feat(cli): prune source registrations after mms add --import (#226)

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -594,6 +594,16 @@ def list_servers(config_path: str, *, as_json: bool = False) -> None:
     "TUI flow. Skips candidates already registered in this config. "
     "Incompatible with NAME / --prefix / --command / --args / --url / --env.",
 )
+@click.option(
+    "--prune",
+    "prune",
+    is_flag=True,
+    default=False,
+    help="After a successful --from-clients/--import, remove the direct "
+    "registrations from each source MCP client so tools are only reachable "
+    "via STM. Default: interactive prompt on TTY, skip on non-TTY. Only "
+    "valid with --from-clients/--import.",
+)
 def add(
     name: str | None,
     config_path: str,
@@ -608,6 +618,7 @@ def add(
     validate: bool,
     validate_timeout: int,
     from_clients: bool,
+    prune: bool,
 ) -> None:
     """Add an upstream MCP server to the proxy configuration."""
     path = Path(config_path)
@@ -634,8 +645,14 @@ def add(
             raise click.UsageError(
                 f"--from-clients cannot be combined with: {', '.join(conflicts)}."
             )
-        _add_from_clients(path, validate=validate, validate_timeout=validate_timeout)
+        _add_from_clients(path, validate=validate, validate_timeout=validate_timeout, prune=prune)
         return
+
+    if prune:
+        # --prune only has semantics when we know which servers were just
+        # imported from which sources. The manual path has neither, so the
+        # flag would be a silent no-op — surface the mistake instead.
+        raise click.UsageError("--prune requires --from-clients/--import.")
 
     # Manual single-server path — NAME and --prefix were previously click-
     # required. Relaxed to optional above so --from-clients can omit them;
@@ -977,6 +994,190 @@ def _print_source_removal_hints(imported_candidates: list[dict[str, Any]]) -> No
         click.echo(f"        {line}")
 
 
+# ── Source-client prune (#226) ─────────────────────────────────────────────
+#
+# Deliberate, opt-in exception to the otherwise read-only source-client
+# contract (see ``_discover_candidates`` docstring and PR #203 for the hint-
+# only predecessor). Writer surface is kept tight: a ``claude mcp remove``
+# shell-out for Claude Code / ``.mcp.json`` scopes, and an atomic JSON
+# rewrite for Claude Desktop. Any failure is non-fatal — the import stays
+# put and the user is shown the manual-command fallback.
+
+
+def _claude_mcp_remove(name: str, scope: str) -> tuple[bool, str | None]:
+    """Shell out to ``claude mcp remove <name> -s <scope>``.
+
+    Returns ``(ok, error_message_or_None)``. Treats any non-zero exit or
+    subprocess error as a non-fatal failure so the caller can surface the
+    manual command instead of aborting the import.
+    """
+    try:
+        result = _run_claude_mcp(["claude", "mcp", "remove", name, "-s", scope], timeout=5)
+    except FileNotFoundError:
+        return (False, "`claude` CLI not on PATH")
+    except subprocess.TimeoutExpired:
+        return (False, "`claude mcp remove` timed out")
+    except OSError as exc:
+        return (False, f"OS error invoking `claude`: {exc}")
+    if result.returncode != 0:
+        msg = (result.stderr or result.stdout or "").strip()
+        return (False, msg or f"`claude mcp remove` exited {result.returncode}")
+    return (True, None)
+
+
+def _desktop_json_remove_entry(name: str) -> tuple[bool, str | None]:
+    """Delete ``mcpServers[name]`` from Claude Desktop's config, atomic write.
+
+    Returns ``(ok, error_message_or_None)``. The atomic write uses
+    :func:`atomic_write_text` for the same reason :func:`_save` does — a
+    running Claude Desktop instance may re-read the file mid-rewrite, and
+    ``os.replace`` is the only way to keep the update coherent.
+    """
+    path = _desktop_config_path()
+    if not path.exists():
+        return (False, f"{path} not found")
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return (False, f"read error: {exc}")
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        return (False, f"parse error: {exc}")
+    if not isinstance(data, dict):
+        return (False, f"{path} top-level is not an object")
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or name not in servers:
+        return (False, f"'{name}' not registered in {path}")
+    del servers[name]
+    try:
+        atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        return (False, f"write error: {exc}")
+    return (True, None)
+
+
+def _prune_from_source(name: str, source: str) -> tuple[bool, str | None]:
+    """Dispatch the prune action per source label used by ``_discover_candidates``.
+
+    Scope-label mapping matches :func:`_source_removal_hint` — the remediation
+    hint and the prune writer agree on which ``claude mcp remove -s <scope>``
+    flag maps to which label. Unknown sources are refused rather than guessed.
+    """
+    if source == "Claude Code (user)":
+        return _claude_mcp_remove(name, "user")
+    if source == "Claude Code (project)":
+        return _claude_mcp_remove(name, "local")
+    if source == ".mcp.json (project)":
+        return _claude_mcp_remove(name, "project")
+    if source == "Claude Desktop":
+        return _desktop_json_remove_entry(name)
+    return (False, f"unknown source label: {source}")
+
+
+def _prune_imported_candidates(
+    imported_candidates: list[dict[str, Any]],
+) -> tuple[list[tuple[str, str]], list[tuple[str, str, str]]]:
+    """Prune each imported candidate from every source that registered it.
+
+    A single candidate can show up in multiple sources (primary ``source``
+    plus ``duplicate_in``) — all are pruned so the dual-path collapses.
+    Returns ``(pruned, failed)`` where ``pruned`` is ``[(name, source), ...]``
+    and ``failed`` is ``[(name, source, error), ...]``.
+    """
+    pruned: list[tuple[str, str]] = []
+    failed: list[tuple[str, str, str]] = []
+    for cand in imported_candidates:
+        for src in [cand["source"], *(cand.get("duplicate_in") or [])]:
+            ok, err = _prune_from_source(cand["name"], src)
+            if ok:
+                pruned.append((cand["name"], src))
+            else:
+                failed.append((cand["name"], src, err or "unknown error"))
+    return pruned, failed
+
+
+def _confirm_prune_prompt(imported_candidates: list[dict[str, Any]]) -> bool:
+    """Post-import prompt offering to prune direct registrations. Default No.
+
+    Only called on TTY (callers gate via :func:`_should_use_tui`). Lists the
+    exact (name, source) pairs so the user can see what would be written
+    before consenting — the prompt is the point where the read-only invariant
+    relaxes and visibility matters.
+    """
+    click.echo("")
+    click.echo("The server(s) above are still registered directly in their source MCP client(s).")
+    click.echo("Removing the direct registrations routes the tools through STM only")
+    click.echo(
+        "(adds compression / caching / LTM surfacing; avoids duplicate tool advertisements)."
+    )
+    click.echo("Affected entries:")
+    seen: set[tuple[str, str]] = set()
+    for cand in imported_candidates:
+        for src in [cand["source"], *(cand.get("duplicate_in") or [])]:
+            key = (cand["name"], src)
+            if key in seen:
+                continue
+            seen.add(key)
+            click.echo(f"    {cand['name']} — {src}")
+    return click.confirm("Remove from source(s)?", default=False)
+
+
+def _handle_source_prune(
+    imported_candidates: list[dict[str, Any]],
+    *,
+    prune: bool,
+) -> None:
+    """Post-import prune + reporting.
+
+    Three paths based on the caller's ``prune`` flag and the TTY gate:
+
+    * ``prune=True`` → prune unconditionally.
+    * ``prune=False`` + TTY → interactive prompt, default No.
+    * ``prune=False`` + non-TTY → skip prune entirely, fall through to the
+      #203 hint-only warning.
+
+    Partial failures (e.g. one source prunes, another fails) surface a
+    per-entry warning plus the manual-command fallback for the failed rows
+    only, so the user always has a path forward even if the writer is
+    degraded.
+    """
+    if not imported_candidates:
+        return
+
+    if prune:
+        should_prune = True
+    elif _should_use_tui():
+        should_prune = _confirm_prune_prompt(imported_candidates)
+    else:
+        should_prune = False
+
+    if not should_prune:
+        _print_source_removal_hints(imported_candidates)
+        return
+
+    pruned, failed = _prune_imported_candidates(imported_candidates)
+
+    if pruned:
+        click.echo("")
+        click.echo(f"{_ok('Removed from source client(s):')}")
+        for name, src in pruned:
+            click.echo(f"  {name} — {src}")
+
+    if failed:
+        click.echo("")
+        click.echo(
+            f"{_warn('Warning:')} could not remove {len(failed)} direct registration(s):",
+            err=True,
+        )
+        for name, src, err in failed:
+            click.echo(f"  {name} ({src}): {err}", err=True)
+        click.echo("", err=True)
+        click.echo("Run the following to remove them manually:", err=True)
+        for name, src, _ in failed:
+            click.echo(f"  {_source_removal_hint(name, src)}", err=True)
+
+
 def _suggest_prefix(name: str, taken: set[str]) -> str:
     """Derive a valid-ish default prefix from a server name.
 
@@ -1200,6 +1401,7 @@ def _add_from_clients(
     *,
     validate: bool,
     validate_timeout: int,
+    prune: bool = False,
 ) -> None:
     """Interactive bulk-import path for ``mms add --from-clients``.
 
@@ -1296,12 +1498,13 @@ def _add_from_clients(
     for n, e in imported.items():
         click.echo(f"  {n:<20} prefix={e['prefix']}  {_format_candidate_detail(e)}")
 
-    # Imported servers stay registered in their source MCP clients: discovery
-    # is read-only, so removal is the user's call. Until they remove the
-    # direct registrations, tools are surfaced on two paths (client → upstream
-    # and client → STM → upstream) and the direct path bypasses compression,
-    # caching, and LTM surfacing entirely.
-    _print_source_removal_hints([new_candidates[i] for i in picks])
+    # Source clients still hold the direct registrations. Without a prune,
+    # tools surface on two paths (client → upstream and client → STM →
+    # upstream) and the direct path bypasses compression, caching, and LTM
+    # surfacing. ``_handle_source_prune`` picks between the --prune flag,
+    # the interactive prompt (TTY), and the hint-only fallback (non-TTY /
+    # user declined).
+    _handle_source_prune([new_candidates[i] for i in picks], prune=prune)
 
 
 @cli.command()

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -2334,6 +2334,324 @@ class TestAddFromClients:
         assert "claude mcp remove" not in result.output
 
 
+class TestAddFromClientsPrune:
+    """`mms add --from-clients --prune` (and the TTY prompt variant) removes
+    the direct registration from each source MCP client after a successful
+    import, closing the dual-path gap #203 left warning-only. See #226."""
+
+    def _stub_candidates(self, monkeypatch, candidates):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: candidates)
+
+    def _seed_config(self, config: Path, servers: dict) -> None:
+        config.write_text(
+            json.dumps({"enabled": True, "upstream_servers": servers}, indent=2),
+            encoding="utf-8",
+        )
+
+    @pytest.fixture
+    def fake_claude(self, monkeypatch):
+        """Record `claude mcp remove` invocations; default to exit 0."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        state: dict = {"calls": [], "script": []}
+
+        def fake_run(cmd, timeout=5):
+            state["calls"].append(list(cmd))
+            if state["script"]:
+                nxt = state["script"].pop(0)
+                if isinstance(nxt, Exception):
+                    raise nxt
+                return nxt
+            return _FakeClaudeResult(returncode=0)
+
+        monkeypatch.setattr(proxy_mod, "_run_claude_mcp", fake_run)
+        return state
+
+    def _all_cc_candidates(self):
+        """Candidate set covering every Claude Code scope the writer handles."""
+        return [
+            {
+                "name": "from-user",
+                "source": "Claude Code (user)",
+                "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@u"]},
+            },
+            {
+                "name": "from-local",
+                "source": "Claude Code (project)",
+                "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@l"]},
+            },
+            {
+                "name": "from-proj",
+                "source": ".mcp.json (project)",
+                "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@p"]},
+            },
+        ]
+
+    def test_prune_flag_shells_out_with_correct_scope_per_source(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """`--prune` invokes ``claude mcp remove <name> -s <scope>`` with the
+        same scope-label mapping `_source_removal_hint` uses for the manual
+        hint: user → user, project → local, .mcp.json → project."""
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, self._all_cc_candidates())
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n\n\n",  # pick all + accept each default prefix
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        # One remove call per source. Argv = [claude, mcp, remove, <name>, -s, <scope>].
+        pairs = {(c[3], c[5]) for c in argvs}
+        assert pairs == {
+            ("from-user", "user"),
+            ("from-local", "local"),
+            ("from-proj", "project"),
+        }
+        assert "Removed from source client(s)" in result.output
+
+    def test_prune_flag_writes_desktop_json_atomically(
+        self, runner, config, tmp_path, monkeypatch, fake_claude
+    ):
+        """Claude Desktop source → atomic JSON rewrite (no `claude` CLI call).
+        Verifies the entry is deleted, the file stays valid JSON, and
+        unrelated entries are preserved."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        desktop_path = tmp_path / "claude_desktop_config.json"
+        desktop_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "from-desktop": {"command": "npx", "args": ["-y", "@d"]},
+                        "keep-me": {"command": "other"},
+                    }
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(proxy_mod, "_desktop_config_path", lambda: desktop_path)
+
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "from-desktop",
+                    "source": "Claude Desktop",
+                    "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@d"]},
+                },
+            ],
+        )
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        # Claude Desktop must not go through `claude mcp remove`.
+        remove_calls = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        assert remove_calls == []
+
+        updated = json.loads(desktop_path.read_text(encoding="utf-8"))
+        assert "from-desktop" not in updated["mcpServers"]
+        assert "keep-me" in updated["mcpServers"]
+
+    def test_prune_flag_nonfatal_on_failure_falls_back_to_manual_hint(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """A failing `claude mcp remove` must not roll back the import — the
+        proxy config stays updated — and the user sees a warning plus the
+        exact manual command to retry."""
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "from-user",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@u"]},
+                },
+            ],
+        )
+        fake_claude["script"] = [_FakeClaudeResult(returncode=1, stderr="boom")]
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        # Import was not rolled back.
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "from-user" in data["upstream_servers"]
+
+        # Warning surfaces the failing entry and the manual command.
+        assert "could not remove 1 direct registration" in result.output
+        assert "boom" in result.output
+        assert "claude mcp remove from-user -s user" in result.output
+
+    def test_prune_flag_without_from_clients_is_usage_error(
+        self, runner, config, monkeypatch
+    ):
+        """`--prune` has no imported-candidate set to act on without
+        ``--from-clients``; silently ignoring it would be surprising."""
+        self._seed_config(config, {})
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "mysrv",
+                "--prefix",
+                "fs",
+                "--command",
+                "x",
+                "--prune",
+                *_cfg_args(config),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--prune requires --from-clients" in result.output
+
+    def test_tty_prompt_default_no_falls_back_to_hint(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """On TTY without `--prune`, user gets a confirm prompt defaulting to
+        No. Declining must skip the prune entirely and fall through to the
+        #203 hint so the user still has a manual path forward.
+
+        The pick step's questionary UI doesn't work under CliRunner, so we
+        stub ``_pick_imports`` directly and force the TUI gate True — what
+        we actually want to exercise is the prune prompt branch downstream
+        of pick, not pick itself."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+        monkeypatch.setattr(proxy_mod, "_pick_imports", lambda cands: list(range(len(cands))))
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "from-user",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+            # Inputs: prefix accept (\n), then decline prune (n\n).
+            input="\nn\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        # No `claude mcp remove` calls — user declined.
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+        # Hint still shown.
+        assert "claude mcp remove from-user -s user" in result.output
+
+    def test_tty_prompt_accept_prunes(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """On TTY, accepting the prompt prunes exactly like `--prune`. Stubs
+        ``_pick_imports`` for the same CliRunner-vs-questionary reason as
+        the default-No test above."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+        monkeypatch.setattr(proxy_mod, "_pick_imports", lambda cands: list(range(len(cands))))
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "from-user",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+            input="\ny\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        assert argvs == [["claude", "mcp", "remove", "from-user", "-s", "user"]]
+        assert "Removed from source client(s)" in result.output
+
+    def test_non_tty_without_flag_keeps_existing_hint_only_behavior(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """CliRunner stdin is non-TTY by default. Without `--prune` the prompt
+        must not fire and the #203 warning-only behavior must be preserved —
+        regression guard against accidentally flipping the default."""
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "from-user",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+        assert "claude mcp remove from-user -s user" in result.output
+        # Confirm prompt text must NOT appear — no silent auto-prune.
+        assert "Remove from source(s)?" not in result.output
+
+    def test_prune_acts_on_duplicate_in_sources_too(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """A candidate registered in more than one source is listed with
+        `duplicate_in`; `--prune` must remove it from every source, not just
+        the primary one, otherwise the dual-path survives."""
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                    "duplicate_in": ["Claude Code (project)"],
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        pairs = {(c[3], c[5]) for c in argvs}
+        assert pairs == {("filesystem", "user"), ("filesystem", "local")}
+
+
 # ── remove command ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #226.

## Summary

After `mms add --import`, the upstream MCP server stays registered in its source client (Claude Code user/local/project scope, or Claude Desktop), so tools surface on two paths — direct and via STM — and the direct path bypasses compression/caching/LTM. #203 surfaced a manual-command hint; this PR ships the A+B combo from #226 so the last-mile cleanup can happen inline.

- `mms add --from-clients --prune` — prune unconditionally, no prompt.
- Without `--prune` on a TTY — confirm prompt defaulting to **No**, listing the exact (name, source) pairs that would be written.
- Without `--prune` on non-TTY — existing #203 hint-only behavior, no silent auto-prune.

## Writer surface

Narrow on purpose (one code path per client type):

| Source | Writer |
|---|---|
| Claude Code (user) | `claude mcp remove <name> -s user` |
| Claude Code (project) | `claude mcp remove <name> -s local` |
| `.mcp.json` (project) | `claude mcp remove <name> -s project` |
| Claude Desktop | JSON rewrite via `atomic_write_text` |

Scope-label mapping matches `_source_removal_hint` (the existing hint printer) so the manual command and the automated prune agree on which scope is which. Claude Desktop uses `atomic_write_text` for the same reason `_save` does — a running Desktop process may re-read the file mid-rewrite, and `os.replace` is the only way to keep the update coherent.

## Failure handling

- Prune failure is non-fatal. The import stays put; a per-entry warning surfaces the failing (name, source) + error, and the exact `claude mcp remove …` or file-edit hint is printed so the user always has a path forward.
- `duplicate_in` sources (a candidate registered in more than one client) are pruned from every source, not just the primary — otherwise the dual-path survives.
- `--prune` without `--from-clients` is a `UsageError` (no imported-candidate set to act on; silently ignoring would be surprising).

## Behavior change

- `mms add --from-clients` on a TTY now prompts after a successful import; default No, so non-input flows (pipes, CI) still only write STM's own config.
- `mms add --from-clients --prune` is a new path that writes into source-client configs — a **deliberate, opt-in exception** to the otherwise read-only discovery contract. Covered in the new writer docstring + the internal memory note tied to #226.
- `mms add <NAME> --prune` (manual single-server path) is now a `UsageError` instead of being silently ignored.

## Tests

New `TestAddFromClientsPrune` class (8 tests) covers the acceptance criteria from #226:

- [x] `--prune` shells out with correct scope per source (user/local/project)
- [x] `--prune` writes Claude Desktop via atomic JSON rewrite, preserves unrelated entries
- [x] Prune failure: non-fatal, config still updated, manual-command hint shown
- [x] `--prune` without `--from-clients` → `UsageError`
- [x] TTY prompt: default No → hint-only path
- [x] TTY prompt: accept → prunes like flag path
- [x] Non-TTY without flag → #203 hint-only regression guard (no silent auto-prune)
- [x] `duplicate_in` sources are all pruned (not just primary)

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1613 passed (up from 1605)
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run pytest tests/cli/test_proxy_cli.py` — 145 passed
- [ ] Reviewer: exercise `mms add --import --prune` against a Claude Code install with a discovered server, confirm `~/.claude.json` is updated in-place by the `claude` CLI.
- [ ] Reviewer: exercise against a Claude Desktop install; confirm the JSON rewrite keeps unrelated `mcpServers` entries intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)