### PR TITLE
feat(server): advertise proxied tools before STM utility tools (#228 phase 1)

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -210,6 +210,10 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
                     info,
                 )
 
+            # Proxied tools are now in front; re-insert STM utility tools at
+            # the end so ``tools/list`` yields domain tools first (#228).
+            _move_stm_tools_to_end(server)
+
         ctx = STMContext(
             config=config,
             proxy_manager=proxy_manager,
@@ -297,6 +301,61 @@ def _obs_tool(fn):
     if _should_advertise_obs_tools():
         return mcp.tool()(fn)
     return fn
+
+
+# STM utility tools exposed over MCP. Kept as an explicit tuple (not a
+# ``stm_*`` prefix sweep) so the set is a deliberate choice and the
+# advertise-order regression test can pin the exact membership. Order
+# inside this tuple does not matter — only position *relative to proxied
+# tools* matters; see ``_move_stm_tools_to_end``.
+_STM_UTILITY_TOOL_NAMES: tuple[str, ...] = (
+    "stm_proxy_stats",
+    "stm_proxy_select_chunks",
+    "stm_proxy_read_more",
+    "stm_proxy_cache_clear",
+    "stm_proxy_health",
+    "stm_surfacing_feedback",
+    "stm_surfacing_stats",
+    "stm_compression_feedback",
+    "stm_compression_stats",
+    "stm_progressive_stats",
+    "stm_tuning_recommendations",
+)
+
+
+def _move_stm_tools_to_end(server: FastMCP) -> None:
+    """Re-insert STM utility tools so proxied tools advertise first (#228).
+
+    STM utility tools are registered at module import via ``@_obs_tool`` /
+    ``@mcp.tool()`` decorators, before ``app_lifespan`` runs; proxied tools
+    are registered inside the lifespan once upstream servers are reachable.
+    FastMCP's ``_tool_manager._tools`` is an insertion-ordered dict, so
+    without this step ``tools/list`` yields STM utility tools before the
+    domain tools users are actually reaching for — a picker-UX papercut
+    reported in #228.
+
+    This pops each STM utility entry and reinserts it, moving them to the
+    end of the insertion order without changing their attributes. Missing
+    entries (e.g. observability tools hidden by
+    ``MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=false``) are skipped
+    silently. Touches the same private ``_tool_manager._tools`` the proxy
+    already reaches into in ``_fastmcp_compat.py``; any FastMCP API shift
+    surfaces as a ``AttributeError`` and the reorder is skipped with a
+    warning rather than breaking server startup.
+    """
+    try:
+        tools_dict = server._tool_manager._tools
+    except AttributeError:
+        logger.warning(
+            "Cannot reorder advertise list — FastMCP internal API changed. "
+            "Tools are registered, but STM utility tools may appear before "
+            "proxied tools in the picker (#228)."
+        )
+        return
+    for name in _STM_UTILITY_TOOL_NAMES:
+        tool = tools_dict.pop(name, None)
+        if tool is not None:
+            tools_dict[name] = tool
 
 
 def _get_ctx(ctx: CtxType) -> STMContext:

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -693,6 +693,115 @@ class TestAdvertiseObservabilityFlagEndToEnd:
         assert callable(stm_tuning_recommendations)
 
 
+# ── advertise order — proxied before STM utility tools (#228) ─────────────
+
+
+class TestAdvertiseOrder:
+    """#228: STM utility tools register at module import; proxied tools
+    register later, inside ``app_lifespan``. Without a reorder step,
+    ``tools/list`` yields STM utility tools first and pushes proxied domain
+    tools to the end of the picker. ``_move_stm_tools_to_end`` pops each
+    STM utility entry from the insertion-ordered ``_tool_manager._tools``
+    dict and reinserts it, placing proxied tools first."""
+
+    def _make_server(self, tool_names):
+        """Build a stand-in FastMCP with an insertion-ordered `_tool_manager._tools`.
+
+        Only the attribute path `_tool_manager._tools` matters — the
+        function pops/inserts string keys and does not touch tool values,
+        so opaque sentinels suffice."""
+        from types import SimpleNamespace
+
+        tools = {name: SimpleNamespace(name=name) for name in tool_names}
+        return SimpleNamespace(_tool_manager=SimpleNamespace(_tools=tools))
+
+    def test_reorder_moves_stm_utility_tools_to_end(self):
+        """Mixed insertion: STM utility tools first, proxied tools second
+        (the production ordering before the fix). After ``_move_stm_tools_to_end``
+        runs, every proxied tool precedes every STM utility tool."""
+        from memtomem_stm.server import _move_stm_tools_to_end
+
+        initial = [
+            # STM utility tools (inserted first at module import)
+            "stm_proxy_stats",
+            "stm_proxy_read_more",
+            "stm_surfacing_feedback",
+            # Proxied tools (inserted later during lifespan)
+            "fs__read_file",
+            "gh__search_repositories",
+            "langchain__search_docs_by_lang_chain",
+        ]
+        server = self._make_server(initial)
+        _move_stm_tools_to_end(server)
+
+        final = list(server._tool_manager._tools.keys())
+        # All proxied tools are now ahead of every STM utility tool.
+        proxied = [n for n in final if "__" in n]
+        util = [n for n in final if n.startswith("stm_") and "__" not in n]
+        assert final[: len(proxied)] == proxied, (
+            f"proxied tools must lead the advertise list, got: {final}"
+        )
+        assert final[len(proxied) :] == util, (
+            f"STM utility tools must trail the advertise list, got: {final}"
+        )
+
+    def test_reorder_skips_missing_stm_tools(self):
+        """When ``MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=false`` hides
+        the 7 observability tools, ``_tool_manager._tools`` only holds the
+        4 model-facing STM tools. The reorder helper must not KeyError on
+        the absent names — ``.pop(name, None)`` is the contract."""
+        from memtomem_stm.server import _move_stm_tools_to_end
+
+        # Only the 4 model-facing stm_* tools + proxied.
+        initial = [
+            "stm_proxy_select_chunks",
+            "stm_proxy_read_more",
+            "stm_surfacing_feedback",
+            "stm_compression_feedback",
+            "fs__read_file",
+        ]
+        server = self._make_server(initial)
+        _move_stm_tools_to_end(server)
+
+        final = list(server._tool_manager._tools.keys())
+        assert final[0] == "fs__read_file"
+        assert set(final) == set(initial)  # nothing added or dropped
+
+    def test_reorder_survives_fastmcp_api_shift(self, caplog):
+        """If FastMCP renames/removes the private ``_tool_manager._tools``
+        attribute, the reorder must degrade to a warning-and-skip rather
+        than crashing server startup. Surfacing as a warning gives
+        operators a visible signal in the log."""
+        import logging
+        from types import SimpleNamespace
+
+        from memtomem_stm.server import _move_stm_tools_to_end
+
+        # No ``_tool_manager`` attribute at all → AttributeError branch.
+        server = SimpleNamespace()
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.server"):
+            _move_stm_tools_to_end(server)  # must not raise
+        assert any(
+            "FastMCP internal API changed" in rec.message for rec in caplog.records
+        ), [r.message for r in caplog.records]
+
+    def test_utility_tool_names_tuple_matches_registered_set(self):
+        """Exhaustiveness guard: every STM utility tool registered by the
+        ``@mcp.tool()`` / ``@_obs_tool`` decorators at module import must
+        be listed in ``_STM_UTILITY_TOOL_NAMES``. A new ``stm_*`` tool
+        that forgets to land in the tuple would silently skip the reorder
+        and slip ahead of proxied tools again."""
+        from memtomem_stm.server import _STM_UTILITY_TOOL_NAMES
+
+        expected = _MODEL_FACING_TOOLS | _OBSERVABILITY_TOOLS
+        assert set(_STM_UTILITY_TOOL_NAMES) == expected, (
+            "_STM_UTILITY_TOOL_NAMES drifted from the actual registered set; "
+            "add the new stm_* tool to the tuple so the advertise-order "
+            "reorder still covers it."
+        )
+
+
 # ── main() exception barrier (#209) ──────────────────────────────────────
 
 


### PR DESCRIPTION
Phase 1 from #228.

## Summary

STM utility tools register at module import (via `@mcp.tool()` / `@_obs_tool`); proxied tools register later, inside `app_lifespan` once upstream servers are reachable. FastMCP's `_tool_manager._tools` is an insertion-ordered dict, so `tools/list` has been yielding STM utility tools before the domain tools users actually reach for — the picker-UX papercut described in #228.

This ships the cheapest, lowest-risk alternative (A) from the design space in #228: flip the advertise order with no flag, no migration, no behavior change for callers. Proxied tools now lead the advertise list; STM utility tools trail it.

Phases 2 (`ADVERTISE_OBSERVABILITY_TOOLS` default flip) and 3 (mem-do-style grouping) stay open in #228 — they're gated on separate signals (usage survey for B; prototype + measurement for C).

## Implementation

After proxied tool registration at the end of `app_lifespan`, `_move_stm_tools_to_end` pops each STM utility entry from `_tool_manager._tools` and reinserts it, moving it to the end of insertion order without changing any tool attributes.

- Missing entries (e.g. observability tools hidden by `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=false`) are skipped silently via `.pop(name, None)`.
- FastMCP internal API shifts (the ``_tool_manager._tools`` private path disappears) degrade to a warning log and no reorder — server still starts. Mirrors the existing `try/except AttributeError` pattern in `proxy/_fastmcp_compat.py`.
- `_STM_UTILITY_TOOL_NAMES` is an explicit 11-name tuple, not a `stm_*` prefix sweep, so membership is deliberate and the exhaustiveness test can pin the list.

## Behavior change

- `tools/list` now yields every proxied tool before any STM utility tool. Pickers that preserve server order (Claude Code `/mcp`, similar) show domain tools at the top and STM control tools at the bottom.
- No change to: the tool set, names, schemas, annotations, or the `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS` flag semantics.
- Callers that iterate `tools/list` ordinally (rare) will see the order flip; callers that look up by name are unaffected.

## Tests

New `TestAdvertiseOrder` class (4 tests):

- [x] Mixed insertion → reorder → every proxied tool precedes every STM utility tool.
- [x] Missing STM entries (flag=false case) → `.pop(name, None)` is safe, no KeyError.
- [x] FastMCP API shift (no `_tool_manager` attribute) → warning log, no crash.
- [x] Exhaustiveness: `_STM_UTILITY_TOOL_NAMES` matches the registered set from `_MODEL_FACING_TOOLS | _OBSERVABILITY_TOOLS` — a new `stm_*` tool that forgets to land in the tuple is caught.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1617 passed (up from 1613)
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [ ] Reviewer: run `mms health` against a config with ≥1 upstream, open Claude Code `/mcp`, confirm proxied tool names appear before any `stm_*` entry in the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)