### PR TITLE
chore: release v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.14] — 2026-04-22
+
+### Added
+
+- **`mms add --import --prune` + interactive TTY confirm prompt** (#227, closes #226) — after a successful import, prune the direct registration from each source MCP client so tools are reachable via STM only. `--prune` runs unconditionally (scripted callers); without the flag, a TTY prompt (default **No**) lists the exact `(name, source)` pairs before writing. Non-TTY callers without `--prune` keep the existing #203 hint-only behavior — no silent auto-prune. Writer surface: `claude mcp remove <name> -s <scope>` for Claude Code user/local/project scopes, atomic JSON rewrite (`atomic_write_text`) for Claude Desktop. Prune failures are non-fatal: the import stays, a per-entry warning surfaces the error, and the exact manual command from `_source_removal_hint` is printed. `duplicate_in` sources (a candidate registered in more than one client) are pruned from every source, not just the primary. `--prune` without `--from-clients` is a `UsageError` rather than a silent no-op.
+
+### Changed
+
+- **Proxied tools now advertise before STM utility tools in `tools/list`** (#229, #228 phase 1) — STM utility tools register at module import (via `@mcp.tool()` / `@_obs_tool`); proxied tools register later, inside `app_lifespan`. FastMCP's insertion-ordered `_tool_manager._tools` previously yielded STM utility tools first, pushing the domain tools users actually reach for (`fs__…`, `gh__…`, `langchain__…`, etc.) to the bottom of pickers that preserve server order (Claude Code `/mcp`). After proxied registration, `_move_stm_tools_to_end` pops and reinserts each STM utility entry so proxied tools lead the advertise list. Missing entries (obs tools hidden by `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=false`) are skipped safely. Tool set, names, schemas, annotations, and the flag semantics are unchanged; only the order flips. Phases 2 (flag default flip) and 3 (mem-do-style grouping) from #228 remain open.
+
+### Fixed
+
+- **`_detect_install_type` registers the `memtomem-stm` server entrypoint, not the `mms` click group** (#225) — the dev-checkout / user-project branch emitted `uv run --directory <root> mms`, but `mms` is the click CLI group (`memtomem_stm.cli.proxy:cli`): invoked with no subcommand it printed help and exited 0, closing the MCP stdio pipe before `initialize` and the client reported "Failed to reconnect to memtomem-stm". Both branches now land on the actual server entrypoint (`memtomem_stm.server:main`). `mms init` / `mms register` now produce a working config in source-checkout and `uv add memtomem-stm` project setups out of the box; prior broken configs need to be re-run through `mms register` (or hand-edited) to pick up the fix.
+
 ## [0.1.13] — 2026-04-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem-stm"
-version = "0.1.13"
+version = "0.1.14"
 description = "Short-term memory proxy gateway with proactive memory surfacing for AI agents"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/src/memtomem_stm/__init__.py
+++ b/src/memtomem_stm/__init__.py
@@ -1,3 +1,3 @@
 """memtomem-stm — Short-term memory proxy gateway with proactive memory surfacing."""
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "memtomem-stm"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

v0.1.14 bundles three CLI/server fixes landed since v0.1.13:

- **`_detect_install_type` registers `memtomem-stm` server entrypoint, not the `mms` click group** (#225) — fixes the "Failed to reconnect" bug for dev-checkout / `uv add memtomem-stm` project installs. `mms` with no subcommand printed help and exited 0, closing the MCP stdio pipe before `initialize`. Both branches now emit the actual server entrypoint (`memtomem_stm.server:main`).
- **`mms add --import --prune` + TTY confirm prompt** (#227, closes #226) — after import, optionally prune the direct registration from each source MCP client so tools are reachable via STM only. Closes the last-mile automation gap that #203 had left warning-only. `--prune` unconditional; no flag on TTY → prompt (default No); non-TTY without flag → hint-only (existing behavior preserved). Writer via `claude mcp remove` shell-out + `atomic_write_text` for Claude Desktop; failures non-fatal.
- **Proxied tools advertise before STM utility tools** (#229, #228 phase 1) — `tools/list` now yields every proxied tool before any `stm_*` utility tool. Fixes the picker-UX papercut where STM control tools crowded the top of `/mcp`. Tool set, names, schemas, and flag semantics unchanged; only the order flips.

No pipeline / proxy behavior changes; CLI + advertise-order only.

## Behavior change

- `tools/list` order flip — pickers that preserve server order (Claude Code `/mcp`, similar) now show domain tools first and STM control tools at the bottom.
- `mms add --from-clients` on a TTY now prompts (default No) to remove direct registrations from source clients after import. Non-input flows (pipes, CI) still only write STM's own config.
- `mms add --from-clients --prune` is a new path that writes into source-client configs — a deliberate, opt-in exception to STM's otherwise read-only discovery contract.
- `mms init` / `mms register` inside a source checkout or `uv add memtomem-stm` project now produce a working MCP config on the first run. Pre-v0.1.14 broken configs need to be re-run through `mms register` (or hand-edited from `mms` → `memtomem-stm`) to pick up the fix.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1617 passed.
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run python -c "import memtomem_stm; print(memtomem_stm.__version__)"` → `0.1.14`.
- [x] `uv run mms --version` → `memtomem-stm 0.1.14`.
- [ ] After merge: push `v0.1.14` tag → PyPI publish workflow → `pypi` environment manual approve on GitHub web UI (trusted publisher / OIDC).
- [ ] After publish: `gh release create v0.1.14` with CHANGELOG excerpt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)