### PR TITLE
feat(proxy): tag annotations.title with source server for picker disambiguation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Proxied tool `annotations.title` is tagged with its source server** — MCP clients such as Claude Code's `/mcp` picker display `annotations.title` in place of the tool `name` when it is set. Upstream servers that populate `title` (e.g. Playwright's "Close browser") previously appeared unattributed in the picker, while servers that left it blank fell back to the prefixed `name` (e.g. `Context7__resolve-library-id`) — the same STM-hosted tool looked attributed or unattributed depending purely on whether the upstream author set `title`. The proxy now copy-on-writes `annotations.title` to `"[{server}] {original title}"` (e.g. `"[playwright] Close browser"`) so the source server is always visible in the picker. Invocation `name` (`playwright__browser_close`), input schema, description, and all other annotation hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) are unchanged — this is a display-layer change only, with no effect on how agents call the tool. When upstream `title` is absent/empty or annotations are `None`, the original value is returned unchanged (clients fall back to the already-prefixed `name`, preserving attribution).
+
 ## [0.1.14] — 2026-04-22
 
 ### Added

--- a/src/memtomem_stm/proxy/_fastmcp_compat.py
+++ b/src/memtomem_stm/proxy/_fastmcp_compat.py
@@ -38,18 +38,50 @@ _PASSTHROUGH_METADATA = FuncMetadata(
 )
 
 
+def _tag_annotations_title(annotations: Any, server_name: str) -> Any:
+    """Prepend ``[server_name]`` to ``annotations.title`` for picker disambiguation.
+
+    MCP clients such as Claude Code's ``/mcp`` picker display ``annotations.title``
+    in place of the tool ``name`` when it is set. Upstream servers that populate
+    ``title`` (e.g. Playwright's "Close browser") then appear unattributed in the
+    picker, while servers that leave it blank fall back to the prefixed ``name``
+    (e.g. "Context7__resolve-library-id"). Tagging the title with the source
+    server restores a uniform ``[server] original title`` display without
+    touching the invocation ``name`` or input schema.
+
+    Returns the original annotations unchanged when:
+    - ``annotations`` is ``None`` (clients fall back to the prefixed ``name``),
+    - ``title`` is missing or empty (same fallback path),
+    - the object is not a pydantic model with ``model_copy`` (unknown shape).
+    """
+    if annotations is None:
+        return None
+    title = getattr(annotations, "title", None)
+    if not title:
+        return annotations
+    new_title = f"[{server_name}] {title}"
+    model_copy = getattr(annotations, "model_copy", None)
+    if callable(model_copy):
+        try:
+            return model_copy(update={"title": new_title})
+        except Exception:
+            return annotations
+    return annotations
+
+
 def register_proxy_tool(
     server: FastMCP,
     handler: Any,
     info: Any,  # ProxyToolInfo
 ) -> None:
     """Register a proxy tool with the upstream's actual schema and annotations."""
+    tagged_annotations = _tag_annotations_title(info.annotations, info.server)
     try:
         server.add_tool(
             handler,
             name=info.prefixed_name,
             description=f"[proxied] {info.description}",
-            annotations=info.annotations,
+            annotations=tagged_annotations,
         )
     except Exception:
         import logging

--- a/tests/test_fastmcp_compat.py
+++ b/tests/test_fastmcp_compat.py
@@ -1,0 +1,70 @@
+"""Unit tests for the FastMCP compatibility layer.
+
+Focused on the ``_tag_annotations_title`` helper that prepends a ``[server]``
+scope tag to ``ToolAnnotations.title`` for ``/mcp`` picker disambiguation.
+"""
+
+from __future__ import annotations
+
+from mcp.types import ToolAnnotations
+
+from memtomem_stm.proxy._fastmcp_compat import _tag_annotations_title
+
+
+def test_tag_title_prepends_server_when_title_present() -> None:
+    annotations = ToolAnnotations(title="Close browser", destructiveHint=True)
+    tagged = _tag_annotations_title(annotations, "playwright")
+    assert tagged is not annotations  # copy-on-write
+    assert tagged.title == "[playwright] Close browser"
+
+
+def test_tag_title_preserves_other_hint_fields() -> None:
+    annotations = ToolAnnotations(
+        title="Read file",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+    tagged = _tag_annotations_title(annotations, "fs")
+    assert tagged.readOnlyHint is True
+    assert tagged.destructiveHint is False
+    assert tagged.idempotentHint is True
+    assert tagged.openWorldHint is False
+
+
+def test_tag_title_returns_none_unchanged_when_annotations_is_none() -> None:
+    assert _tag_annotations_title(None, "playwright") is None
+
+
+def test_tag_title_passthrough_when_title_missing() -> None:
+    annotations = ToolAnnotations(readOnlyHint=True)
+    tagged = _tag_annotations_title(annotations, "Context7")
+    assert tagged is annotations
+
+
+def test_tag_title_passthrough_when_title_empty_string() -> None:
+    annotations = ToolAnnotations(title="", readOnlyHint=True)
+    tagged = _tag_annotations_title(annotations, "Context7")
+    assert tagged is annotations
+
+
+def test_tag_title_passthrough_on_unknown_shape() -> None:
+    class _Opaque:
+        title = "Close browser"
+
+    opaque = _Opaque()
+    tagged = _tag_annotations_title(opaque, "playwright")
+    assert tagged is opaque
+
+
+def test_tag_title_falls_back_to_original_when_model_copy_raises() -> None:
+    class _BrokenCopy:
+        title = "Close browser"
+
+        def model_copy(self, update: dict | None = None) -> object:
+            raise RuntimeError("simulated copy failure")
+
+    broken = _BrokenCopy()
+    tagged = _tag_annotations_title(broken, "playwright")
+    assert tagged is broken

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -71,6 +71,7 @@ class TestRegisterProxyTool:
             description: str = "does things"
             input_schema: dict = None
             annotations: Any = None
+            server: str = "srv"
 
             def __post_init__(self):
                 if self.input_schema is None:
@@ -103,6 +104,7 @@ class TestRegisterProxyTool:
             description: str = "gone"
             input_schema: dict = None
             annotations: Any = None
+            server: str = "missing"
 
             def __post_init__(self):
                 if self.input_schema is None:


### PR DESCRIPTION
## Summary

MCP clients such as Claude Code's `/mcp` picker display `annotations.title` in place of the tool `name` when it is set. This PR copy-on-writes `annotations.title` to `"[{server}] {original title}"` so the source server is always visible in the picker. Invocation path is completely unchanged — this is a display-layer-only adjustment.

## Why now

Observed while dogfooding the v0.1.14 `mms add --import --prune` flow end-to-end. After importing `playwright` and `shadcn` through STM, `/mcp` rendered tools inconsistently:

```
Tools for memtomem-stm
41 tools
❯ 1. Context7__resolve-library-id  read-only     ← prefixed name (no annotations.title)
  2. Context7__query-docs          read-only
  3. Close browser                 destructive    ← upstream title, no source attribution
  4. Resize browser window         destructive
  5. Get console messages          read-only
```

Same STM-hosted surface, but the user can tell which server a tool came from only when the upstream forgot to set `title`. That is a UX regression as soon as any tool-heavy upstream (e.g. Playwright, Stripe, Linear MCP) is imported.

## Why not just let MCP spec handle it

The spec says `annotations.title` is "a human-readable title for the tool, useful for UI display" — that is exactly the behavior clients implement, and it is correct in isolation. But when a single host surface (STM) re-exports tools from multiple upstreams, honoring each upstream's title verbatim loses the one piece of context that actually matters in the aggregate view: which upstream produced this tool. STM is already injecting `[proxied]` into `description` for the same reason; tagging `title` with `[{server}]` is the consistent extension of that convention.

## Why not the mem-do grouping approach (#228 phase 3)

A separate design thread has been asking whether STM should fold each upstream into a single `{server}_do(action, params)` tool (the parent `memtomem` `mem_do` shape), which would collapse the picker to one entry per server and make attribution automatic. That direction is still open but has three costs this PR does not pay:

1. Upstream per-tool `readOnlyHint` / `destructiveHint` collapse to the most conservative value across actions, so agents would treat every read-only call as destructive.
2. STM's per-tool compression config (`playwright__browser_take_screenshot` = `none` / 500000 chars, `playwright__browser_snapshot` = `selective` / 8000 chars) would need to re-key on `(server, action)` tuples.
3. Description would have to enumerate actions to preserve discoverability, potentially inflating `tools/list` token usage above the current flat layout.

Those tradeoffs are worth working through, but they're orthogonal to "which server does this tool come from", which is the immediate UX pain. This PR solves the attribution axis at ~30 LOC and leaves the grouping axis for a future opt-in path (e.g. per-server `advertise_mode: flat | group`).

## Behavior change

**Display-only.** No behavior change for tool invocation:

- Invocation `name` (`playwright__browser_close`) — unchanged.
- `inputSchema` — unchanged.
- `description` (already prefixed with `[proxied]`) — unchanged.
- `annotations.readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` — unchanged.
- `annotations.title` — `"Close browser"` → `"[playwright] Close browser"`.

When upstream `title` is absent/empty or annotations are `None`, the original value is returned unchanged; clients fall back to the already-prefixed `name`, which keeps attribution intact.

## Implementation

`src/memtomem_stm/proxy/_fastmcp_compat.py`:

- New `_tag_annotations_title(annotations, server_name)` helper: copy-on-writes via pydantic `model_copy(update={...})`. Returns the original unchanged when there is nothing to tag or when the object is not a recognizable pydantic model.
- `register_proxy_tool` calls the helper once before `server.add_tool(...)`.

## Test plan

- [x] `tests/test_fastmcp_compat.py` — 7 cases covering: prepend on present title, preservation of other hint fields, `None` passthrough, missing-title passthrough, empty-string-title passthrough, unknown-shape passthrough, `model_copy` raises → fallback.
- [x] `tests/test_stm_remaining.py::TestRegisterProxyTool` — existing coverage retained; both `FakeInfo` dummies updated with the `server` field now that the registration path reads it.
- [x] `uv run pytest -m "not ollama"` — 1624/1624 pass locally.
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src/memtomem_stm/proxy/_fastmcp_compat.py` — clean (advisory).
- [ ] Manual `/mcp` picker smoke — will do on the PR author side after merge with a dev-build reinstall and a fresh playwright import; attach the screenshot to the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)