### PR TITLE
chore: release v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.15] — 2026-04-22
+
 ### Changed
 
-- **Proxied tool `annotations.title` is tagged with its source server** — MCP clients such as Claude Code's `/mcp` picker display `annotations.title` in place of the tool `name` when it is set. Upstream servers that populate `title` (e.g. Playwright's "Close browser") previously appeared unattributed in the picker, while servers that left it blank fell back to the prefixed `name` (e.g. `Context7__resolve-library-id`) — the same STM-hosted tool looked attributed or unattributed depending purely on whether the upstream author set `title`. The proxy now copy-on-writes `annotations.title` to `"[{server}] {original title}"` (e.g. `"[playwright] Close browser"`) so the source server is always visible in the picker. Invocation `name` (`playwright__browser_close`), input schema, description, and all other annotation hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) are unchanged — this is a display-layer change only, with no effect on how agents call the tool. When upstream `title` is absent/empty or annotations are `None`, the original value is returned unchanged (clients fall back to the already-prefixed `name`, preserving attribution).
+- **Proxied tool `annotations.title` is tagged with its source server** (#231) — MCP clients such as Claude Code's `/mcp` picker display `annotations.title` in place of the tool `name` when it is set. Upstream servers that populate `title` (e.g. Playwright's "Close browser") previously appeared unattributed in the picker, while servers that left it blank fell back to the prefixed `name` (e.g. `Context7__resolve-library-id`) — the same STM-hosted tool looked attributed or unattributed depending purely on whether the upstream author set `title`. The proxy now copy-on-writes `annotations.title` to `"[{server}] {original title}"` (e.g. `"[playwright] Close browser"`) so the source server is always visible in the picker. Invocation `name` (`playwright__browser_close`), input schema, description, and all other annotation hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) are unchanged — this is a display-layer change only, with no effect on how agents call the tool. When upstream `title` is absent/empty or annotations are `None`, the original value is returned unchanged (clients fall back to the already-prefixed `name`, preserving attribution).
 
 ## [0.1.14] — 2026-04-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem-stm"
-version = "0.1.14"
+version = "0.1.15"
 description = "Short-term memory proxy gateway with proactive memory surfacing for AI agents"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/src/memtomem_stm/__init__.py
+++ b/src/memtomem_stm/__init__.py
@@ -1,3 +1,3 @@
 """memtomem-stm — Short-term memory proxy gateway with proactive memory surfacing."""
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "memtomem-stm"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Single-change release following v0.1.14: proxy tags `annotations.title` with its source server (`[playwright] Close browser`) so the `/mcp` picker always shows which upstream a tool comes from (#231). Display-only — invocation `name`, schema, description, and all other annotation hints are unchanged.

## Changelog

### Changed

- **Proxied tool `annotations.title` is tagged with its source server** (#231) — MCP clients such as Claude Code's `/mcp` picker display `annotations.title` in place of the tool `name` when it is set. Upstream servers that populate `title` (e.g. Playwright's "Close browser") previously appeared unattributed in the picker, while servers that left it blank fell back to the prefixed `name` (e.g. `Context7__resolve-library-id`) — the same STM-hosted tool looked attributed or unattributed depending purely on whether the upstream author set `title`. The proxy now copy-on-writes `annotations.title` to `"[{server}] {original title}"` so the source server is always visible.

## Test plan

- [x] CI on #231 (6/6 green) — lint, typecheck, test, notebooks, bench_qa, CLA
- [x] Local full suite `uv run pytest -m "not ollama"` — 1624/1624 pass
- [x] Manual `/mcp` smoke test on dev-build (editable install) — `[playwright] Resize browser window`, `[playwright] Get console messages`, etc. rendered with tag; `Context7__*` passthrough preserved (upstream omits `title`)
- [ ] PyPI publish via OIDC on tag push (manual approval on `pypi` environment may gate)
- [ ] GitHub Release with CHANGELOG body

🤖 Generated with [Claude Code](https://claude.com/claude-code)