### PR TITLE
fix(config): fail-fast when langfuse.enabled=true but the extra is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **`LangfuseConfig.enabled=true` now fails fast when the `langfuse` package is not installed** (#233) — `LangfuseConfig` already rejects `enabled=true` without `public_key` / `secret_key` at config-load time via `_require_keys_when_enabled`. The parallel environment check was missing: a user who had all three fields set but didn't install the `[langfuse]` extra (e.g. after `uv tool install --reinstall memtomem-stm` dropped the extras) hit a silent `except ImportError: pass` branch in `server.py`, so the proxy started cleanly but produced no traces and surfaced no warning. A second `@model_validator(mode="after")` now probes `importlib.util.find_spec("langfuse")` whenever `enabled=true` and raises `ValueError` with an install hint (`uv tool install --reinstall 'memtomem-stm[langfuse]'` or `pip install 'memtomem-stm[langfuse]'`). Symmetric with the existing key-requirement validator — schema and environment are both checked at load time instead of one failing loud and the other failing silent. No behavior change for users with `enabled=false` (the new validator short-circuits before probing), or for users who already have the extra installed.
+
 ## [0.1.15] — 2026-04-22
 
 ### Changed

--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -32,6 +32,20 @@ class LangfuseConfig(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _require_langfuse_package_when_enabled(self) -> "LangfuseConfig":
+        if self.enabled:
+            from importlib.util import find_spec
+
+            if find_spec("langfuse") is None:
+                raise ValueError(
+                    "LangfuseConfig.enabled=true but the 'langfuse' package is not "
+                    "installed. Install the langfuse extra "
+                    "(e.g. `uv tool install --reinstall 'memtomem-stm[langfuse]'` "
+                    "or `pip install 'memtomem-stm[langfuse]'`)."
+                )
+        return self
+
 
 class STMConfig(BaseSettings):
     model_config = SettingsConfigDict(

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -68,12 +68,16 @@ class TestProxyNumericConstraints:
 
     def test_reconnect_delay_must_not_exceed_max(self) -> None:
         with pytest.raises(ValidationError):
-             UpstreamServerConfig(prefix="x", reconnect_delay_seconds=10, max_reconnect_delay_seconds=5)
+            UpstreamServerConfig(
+                prefix="x", reconnect_delay_seconds=10, max_reconnect_delay_seconds=5
+            )
 
     def test_reconnect_delay_equal_to_max_is_valid(self) -> None:
-        cfg = UpstreamServerConfig(prefix="x", reconnect_delay_seconds=5, max_reconnect_delay_seconds=5)
+        cfg = UpstreamServerConfig(
+            prefix="x", reconnect_delay_seconds=5, max_reconnect_delay_seconds=5
+        )
         assert cfg.reconnect_delay_seconds == 5
-    
+
 
 class TestLLMCompressorApiKey:
     """``provider=openai|anthropic`` with empty ``api_key`` used to send a
@@ -186,13 +190,64 @@ class TestLangfuseInterdepValidator:
         with pytest.raises(ValidationError, match="public_key and secret_key"):
             LangfuseConfig(enabled=True, secret_key="sk-lf-x")
 
-    def test_enabled_with_both_keys_ok(self) -> None:
+    def test_enabled_with_both_keys_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Stub out the package-availability validator — that axis is covered
+        # separately by ``TestLangfusePackageValidator``.
+        import importlib.util as importlib_util
+
+        real_find_spec = importlib_util.find_spec
+
+        def _fake_find_spec(name: str, package: str | None = None) -> object | None:
+            return object() if name == "langfuse" else real_find_spec(name, package)
+
+        monkeypatch.setattr("importlib.util.find_spec", _fake_find_spec)
         cfg = LangfuseConfig(enabled=True, public_key="pk-lf-x", secret_key="sk-lf-x")
         assert cfg.enabled is True
 
     def test_disabled_allows_empty_keys(self) -> None:
         cfg = LangfuseConfig(enabled=False)
         assert cfg.public_key == ""
+
+
+class TestLangfusePackageValidator:
+    """``LangfuseConfig.enabled=true`` must fail-fast when the langfuse extra is absent."""
+
+    def test_enabled_without_langfuse_package_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import importlib.util as importlib_util
+
+        def _fake_find_spec(name: str, package: str | None = None) -> object | None:
+            return None if name == "langfuse" else importlib_util.find_spec(name, package)
+
+        monkeypatch.setattr("importlib.util.find_spec", _fake_find_spec)
+        with pytest.raises(ValidationError, match="'langfuse' package is not installed"):
+            LangfuseConfig(enabled=True, public_key="pk-lf-x", secret_key="sk-lf-x")
+
+    def test_enabled_with_langfuse_package_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The validator only probes ``find_spec``; any non-None stand-in is
+        # sufficient. We patch rather than relying on the dev env because
+        # the langfuse extra is not included in ``uv sync`` by default.
+        import importlib.util as importlib_util
+
+        real_find_spec = importlib_util.find_spec
+
+        def _fake_find_spec(name: str, package: str | None = None) -> object | None:
+            return object() if name == "langfuse" else real_find_spec(name, package)
+
+        monkeypatch.setattr("importlib.util.find_spec", _fake_find_spec)
+        cfg = LangfuseConfig(enabled=True, public_key="pk-lf-x", secret_key="sk-lf-x")
+        assert cfg.enabled is True
+
+    def test_disabled_skips_package_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+
+        def _tracking_find_spec(name: str, package: str | None = None) -> object | None:
+            calls.append(name)
+            return None
+
+        monkeypatch.setattr("importlib.util.find_spec", _tracking_find_spec)
+        cfg = LangfuseConfig(enabled=False)
+        assert cfg.enabled is False
+        assert "langfuse" not in calls
 
 
 class TestLogLevel:


### PR DESCRIPTION
Closes #233.

## Summary

`LangfuseConfig` already rejects `enabled=true` without `public_key` / `secret_key` at config-load time via `_require_keys_when_enabled`. The parallel environment check was missing: a user with all three fields set but no `[langfuse]` extra installed hit a silent `except ImportError: pass` branch in `server.py` — the proxy started cleanly, produced no traces, surfaced no warning.

A second `@model_validator(mode="after")` now probes `importlib.util.find_spec("langfuse")` whenever `enabled=true` and raises `ValueError` with an install hint. Symmetric with the existing key-requirement validator: schema and environment are both checked at load time.

## Why now

Came up while auditing whether STM had the same "wizard detects but doesn't install" asymmetry the parent `memtomem` repo just triaged. STM has no install wizard step at risk, but this adjacent gap — `LangfuseConfig.enabled` schema validates loud, environment check fails silent — matches the same anti-pattern.

Concrete repro (from #233):

```bash
uv tool install --reinstall memtomem-stm        # no extras
cat > /tmp/stm.json <<'J'
{"langfuse": {"enabled": true, "public_key": "pk_x", "secret_key": "sk_x"}}
J
mms status --config /tmp/stm.json              # enabled=true, no mention tracing is dead
```

## Why not broader — `mms health` surfacing, LangChain handling

- **`mms health` "Optional Features" section** — Scope 2 in the research report. Valid follow-up but doesn't fail fast: a daemon-running server would silently skip traces until the next `mms health` run. Config-layer validator covers the fail-fast axis; CLI surfacing is additive. Kept out of scope here.
- **LangChain extra** — verified it's not orphaned; it's for the optional tutorial notebook `04_*_langchain.ipynb` (per `feedback_stm_notebook_format.md`). No runtime code imports it, so there's no symmetric silent-disable path to fix. Left as-is.
- **Runtime `RuntimeError` at first traced call** (httpx-style, `proxy/relevance.py:175-178`) — worse UX than fail-at-load. Rejected.

## Behavior change

- `enabled=true` + `[langfuse]` extra missing → **new**: `ValidationError` at config load with install-command hint. Previously: silent, no traces, no warning.
- `enabled=true` + extra present → unchanged.
- `enabled=false` → unchanged; the new validator short-circuits before probing `find_spec`, so no import probe cost and no regression when the extra is absent.

## Test plan

- [x] `tests/test_config_constraints.py::TestLangfusePackageValidator` — 3 new cases: missing → `ValidationError` with "'langfuse' package is not installed"; present (stubbed via `monkeypatch`) → pass; `enabled=false` → `find_spec` never called for `langfuse`.
- [x] Existing `TestLangfuseInterdepValidator::test_enabled_with_both_keys_ok` updated with the same `find_spec` stub — that test's axis is "keys required when enabled", which still holds; the package axis is covered separately so both validators can be exercised in isolation.
- [x] `uv run pytest -m "not ollama"` — 1627/1627 pass locally.
- [x] `uv run ruff check src tests/test_config_constraints.py && uv run ruff format --check src tests/test_config_constraints.py` — clean.
- [x] `uv run mypy src/memtomem_stm/config.py` — clean (advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)