### PR TITLE
fix(config): validate langfuse package is installed when enabled

### DIFF
--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -32,6 +32,19 @@ class LangfuseConfig(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _require_langfuse_package_when_enabled(self) -> "LangfuseConfig":
+        if self.enabled:
+            from importlib.util import find_spec
+            if find_spec("langfuse") is None:
+                raise ValueError(
+                    "LangfuseConfig.enabled=true but the 'langfuse' package is "
+                    "not installed. Install the langfuse extra "
+                    "(e.g. `uv tool install --reinstall 'memtomem-stm[langfuse]'` "
+                    "or `pip install 'memtomem-stm[langfuse]'`)."
+                )
+        return self
+
 
 class STMConfig(BaseSettings):
     model_config = SettingsConfigDict(


### PR DESCRIPTION
When `langfuse.enabled=true` but the `langfuse` extra is not installed, config validation passes silently and tracing is never initialized — with no warning or error surface for the user to discover the problem.

Add a `_require_langfuse_package_when_enabled` validator (alongside the existing `_require_keys_when_enabled`) that uses `importlib.util.find_spec` to check whether the package is importable at config-load time, and raises a clear `ValueError` with install instructions if not.

Fixes #233