### PR TITLE
chore: release v0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.16] — 2026-04-22
+
 ### Fixed
 
-- **`LangfuseConfig.enabled=true` now fails fast when the `langfuse` package is not installed** (#233) — `LangfuseConfig` already rejects `enabled=true` without `public_key` / `secret_key` at config-load time via `_require_keys_when_enabled`. The parallel environment check was missing: a user who had all three fields set but didn't install the `[langfuse]` extra (e.g. after `uv tool install --reinstall memtomem-stm` dropped the extras) hit a silent `except ImportError: pass` branch in `server.py`, so the proxy started cleanly but produced no traces and surfaced no warning. A second `@model_validator(mode="after")` now probes `importlib.util.find_spec("langfuse")` whenever `enabled=true` and raises `ValueError` with an install hint (`uv tool install --reinstall 'memtomem-stm[langfuse]'` or `pip install 'memtomem-stm[langfuse]'`). Symmetric with the existing key-requirement validator — schema and environment are both checked at load time instead of one failing loud and the other failing silent. No behavior change for users with `enabled=false` (the new validator short-circuits before probing), or for users who already have the extra installed.
+- **`LangfuseConfig.enabled=true` now fails fast when the `langfuse` package is not installed** (#234, closes #233) — `LangfuseConfig` already rejects `enabled=true` without `public_key` / `secret_key` at config-load time via `_require_keys_when_enabled`. The parallel environment check was missing: a user who had all three fields set but didn't install the `[langfuse]` extra (e.g. after `uv tool install --reinstall memtomem-stm` dropped the extras) hit a silent `except ImportError: pass` branch in `server.py`, so the proxy started cleanly but produced no traces and surfaced no warning. A second `@model_validator(mode="after")` now probes `importlib.util.find_spec("langfuse")` whenever `enabled=true` and raises `ValueError` with an install hint (`uv tool install --reinstall 'memtomem-stm[langfuse]'` or `pip install 'memtomem-stm[langfuse]'`). Symmetric with the existing key-requirement validator — schema and environment are both checked at load time instead of one failing loud and the other failing silent. No behavior change for users with `enabled=false` (the new validator short-circuits before probing), or for users who already have the extra installed.
 
 ## [0.1.15] — 2026-04-22
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem-stm"
-version = "0.1.15"
+version = "0.1.16"
 description = "Short-term memory proxy gateway with proactive memory surfacing for AI agents"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/src/memtomem_stm/__init__.py
+++ b/src/memtomem_stm/__init__.py
@@ -1,3 +1,3 @@
 """memtomem-stm — Short-term memory proxy gateway with proactive memory surfacing."""
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "memtomem-stm"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Single-change release following v0.1.15: `LangfuseConfig.enabled=true` now fails fast at config load when the `[langfuse]` extra is not installed (#234, closes #233). No behavior change for `enabled=false` or for users who have the extra.

## Changelog

### Fixed

- **`LangfuseConfig.enabled=true` now fails fast when the `langfuse` package is not installed** (#234, closes #233) — silent-disable path closed by adding a `find_spec("langfuse")` probe to the config validator, symmetric with the existing key-requirement validator.

## Test plan

- [x] CI on #234 (6/6 green)
- [x] Local full suite `uv run pytest -m "not ollama"` — 1627/1627 pass
- [x] E2E scenario matrix against dev-build (editable install, langfuse extra absent from dev env):
  - `enabled=true` + keys + no package → `ValidationError` with install hint (#233 target)
  - `enabled=false` → loads clean, validator short-circuits
  - `enabled=true` + no keys → existing keys-validator trips first (no regression)
  - `STMConfig(**{...})` full load → error surfaces at nested `loc=('langfuse',)` path
- [ ] PyPI publish via OIDC on tag push (manual approval on `pypi` environment may gate)
- [ ] GitHub Release with CHANGELOG body

🤖 Generated with [Claude Code](https://claude.com/claude-code)