### PR TITLE
docs: catch up cli/configuration refs for v0.1.9-v0.1.16

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -141,11 +141,20 @@ Options:
                                   Skips candidates already registered.
                                   Incompatible with NAME / --prefix /
                                   --command / --args / --url / --env.
+  --prune                         After a successful --import, remove the
+                                  direct registrations from source MCP
+                                  clients so tools are reachable via STM
+                                  only. TTY callers get a (name, source)
+                                  confirm prompt (default No); non-TTY
+                                  callers must pass the flag explicitly.
+                                  Requires --from-clients / --import.
 ```
 
 Use `--validate` to catch typos and misconfigurations at registration time instead of the next time the proxy starts. Without it `add` only writes the config — bad entries are discovered later via `mms health` or when the proxy fails to spawn.
 
 Use `--from-clients` (alias `--import`) to bulk-pick additional servers from the same MCP clients `mms init` scans: `~/.claude.json`, project `.mcp.json`, and `~/Library/Application Support/Claude/claude_desktop_config.json` (OS-appropriate). This is the post-init equivalent of the `init` discovery step — servers already registered in this config are filtered out by name and by `(transport, command, args)` / `(transport, url)` signature before the selection UI. `--validate` and `--timeout` work on the selected subset.
+
+To remove the original direct registrations after a successful import, pass `--prune`. On a TTY you get a `(name, source)` confirm prompt that defaults to **No** before any file edits; in non-TTY callers (CI, scripts) you must pass `--prune` explicitly — the flag never auto-fires on inferred consent. A candidate registered in more than one source client is pruned from every source, not just the one it was imported from. Prune failures are non-fatal: the import stays, and each failed entry prints the exact manual `claude mcp remove` or Claude Desktop edit to retry. `--prune` without `--from-clients` is a usage error rather than a silent no-op.
 
 > **Note**: The CLI's `--compression` flag exposes 5 of the 10 strategies. The remaining five (`extract_fields`, `schema_pruning`, `skeleton`, `progressive`, `llm_summary`) are configured by editing `stm_proxy.json` directly. See [Compression Strategies](compression.md).
 
@@ -180,6 +189,10 @@ mms add filesystem \
 
 # Bulk-import servers already configured in Claude Desktop / Code / .mcp.json
 mms add --import            # or --from-clients; skips anything already registered
+
+# Import AND prune originals from source clients
+mms add --import --prune    # TTY: per-entry confirm prompt (default No)
+                            # non-TTY: unconditional — pass --prune to opt in
 
 # List configured upstreams
 mms list
@@ -230,6 +243,8 @@ These are exposed by the `memtomem-stm` MCP server and become available to your 
 | `stm_tuning_recommendations` | `since_hours?`, `tool?` | Per-tool compression tuning recommendations from the auto-tuner |
 
 Plus all proxied tools named `{prefix}__{original_tool_name}` (e.g. `fs__read_file`, `gh__search_repositories`).
+
+Proxied tool **titles** — the `annotations.title` field rendered by MCP tool-pickers (e.g. Claude Code's `/mcp`) — are automatically prefixed with `[{server}]` for attribution: a `filesystem` server's `Read file` tool appears as `[filesystem] Read file`. This is separate from the `{prefix}__{tool}` name used when calling the tool, and it kicks in only when the upstream tool already provides an `annotations.title`; tools without one are unaffected.
 
 A typical agent session uses a mix of proxied tools and STM-specific control tools:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,9 +34,9 @@ apply changes.
 export MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true   # default
 ```
 
-When `false`, hides STM's six observability / admin tools
+When `false`, hides STM's seven observability / admin tools
 (`stm_proxy_stats`, `stm_proxy_health`, `stm_proxy_cache_clear`,
-`stm_surfacing_stats`, `stm_compression_stats`,
+`stm_surfacing_stats`, `stm_compression_stats`, `stm_progressive_stats`,
 `stm_tuning_recommendations`) from the MCP `tools/list` surface so
 eager-loading clients (e.g. OpenAI Codex CLI) don't pay schema
 tokens for tools the model rarely calls. The hidden tools remain
@@ -127,6 +127,8 @@ export MEMTOMEM_STM_LANGFUSE__SAMPLING_RATE=1.0                # 0.0–1.0, frac
 ```
 
 When enabled, every proxy tool invocation is wrapped in a `proxy_call` Langfuse observation with nested sub-spans for each pipeline stage (clean, compress, surface, index).
+
+Setting `MEMTOMEM_STM_LANGFUSE__ENABLED=true` without first installing the `[langfuse]` extra raises a `ValueError` at startup (fail-fast since v0.1.16) — install the extra first, or leave `enabled=false` / unset. The old silent-disable-with-WARNING behavior is gone, so a typo in your config no longer leaves tracing quietly off.
 
 ## Config File: `~/.memtomem/stm_proxy.json`
 

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -596,7 +596,7 @@ class TestLifespan:
 
 # ── advertise_observability_tools flag ──────────────────────────────────
 #
-# The flag hides 6 observability tools from the MCP ``tools/list`` surface
+# The flag hides 7 observability tools from the MCP ``tools/list`` surface
 # while keeping them importable from Python. Registration happens at
 # module import, so the end-to-end assertion uses a subprocess to get a
 # fresh interpreter under the intended env var.


### PR DESCRIPTION
## Summary

The v0.1.8 docs audit closed before v0.1.9 shipped. Eight point releases later, four user-facing changes were live in CHANGELOG but had never been mirrored into the per-feature reference docs. This patch syncs them in one place.

| Release | PR | Drift | Fix location |
|---------|----|-------|--------------|
| v0.1.12 | #213 | `stm_progressive_stats` brings obs-tool count 6 → 7 | `docs/configuration.md` prose + `tests/test_server_tools.py` comment |
| v0.1.14 | #227 | `mms add --import --prune` flag undocumented | `docs/cli.md` options table + paragraph + example |
| v0.1.15 | #231 | Proxied tool `annotations.title` `[server]` tag unexplained | `docs/cli.md` §MCP Tools |
| v0.1.16 | #234 | `LangfuseConfig` fail-fast when extra missing | `docs/configuration.md` §Langfuse |

No code changes — test-file comment fix is a sibling of the same literal (the `_OBSERVABILITY_TOOLS` set itself was already correct at 7). CHANGELOG entries already hold each feature's full spec; the docs now point the reader at the same ground truth.

## Non-drifts verified in-sync (untouched)

- `README.md` — "11 MCP tools", "10 compression strategies", `CLEAN → COMPRESS → SURFACE → INDEX` order all current
- `docs/cli.md` MCP tools table (all 11) + §Trimming (already uses "seven" / "four") — current
- `docs/surfacing.md` thresholds (`min_score` 0.02, clamp `[0.005, 0.05]`, `auto_tune_min_samples` 20, `auto_tune_score_increment` 0.002) — match code
- `docs/compression.md` constants (`chunk_size` 4000, `head_chars` 5000, `head_ratio` 0.6, …) — match code
- `docs/configuration.md` config-file example structure — matches pydantic model
- Notebook markdown cells — CLI patterns still valid

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge" -q` — 1617 passed
- [x] `rg -n 'six observability' docs/` → 0 hits
- [x] `rg -n 'stm_progressive_stats' docs/configuration.md` → 1 hit
- [x] `rg -n '\-\-prune' docs/cli.md` → 4 hits (table row + paragraph + 2 example lines)
- [x] `rg -n 'annotations\.title' docs/` → 1 hit
- [x] `rg -n 'fail-fast|ValueError' docs/configuration.md` → 1 hit
- [ ] Reviewer eyeball on GitHub preview for `docs/cli.md` and `docs/configuration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)