### PR TITLE
refactor(tracing): inline getattr results to drop three type: ignore[union-attr]

### DIFF
--- a/src/memtomem_stm/observability/tracing.py
+++ b/src/memtomem_stm/observability/tracing.py
@@ -33,12 +33,12 @@ def init_langfuse(config: object, *, service_name: str = _SERVICE_NAME) -> Any:
     _sampling_rate = getattr(config, "sampling_rate", 1.0)
 
     kwargs: dict[str, Any] = {}
-    if getattr(config, "public_key", ""):
-        kwargs["public_key"] = config.public_key  # type: ignore[union-attr]
-    if getattr(config, "secret_key", ""):
-        kwargs["secret_key"] = config.secret_key  # type: ignore[union-attr]
-    if getattr(config, "host", ""):
-        kwargs["host"] = config.host  # type: ignore[union-attr]
+    if public_key := getattr(config, "public_key", ""):
+        kwargs["public_key"] = public_key
+    if secret_key := getattr(config, "secret_key", ""):
+        kwargs["secret_key"] = secret_key
+    if host := getattr(config, "host", ""):
+        kwargs["host"] = host
 
     _langfuse_client = Langfuse(**kwargs)
     return _langfuse_client


### PR DESCRIPTION
## Summary

`init_langfuse` takes `config: object` (duck-typed so any settings source can
be passed), so mypy can't prove `config.public_key` / `.secret_key` / `.host`
exist after a `getattr(config, name, "")` truthy check — the check narrows a
local, not the attribute on `config`. The previous shape called `getattr` as a
guard and then accessed `config.attr` directly, which required suppressing
`union-attr` three times:

```python
kwargs: dict[str, Any] = {}
if getattr(config, "public_key", ""):
    kwargs["public_key"] = config.public_key  # type: ignore[union-attr]
if getattr(config, "secret_key", ""):
    kwargs["secret_key"] = config.secret_key  # type: ignore[union-attr]
if getattr(config, "host", ""):
    kwargs["host"] = config.host  # type: ignore[union-attr]
```

Fold the guard and the usage into a single walrus assignment so the checked
value is also the one assigned, dropping all three `# type: ignore[union-attr]`
comments:

```python
kwargs: dict[str, Any] = {}
if public_key := getattr(config, "public_key", ""):
    kwargs["public_key"] = public_key
if secret_key := getattr(config, "secret_key", ""):
    kwargs["secret_key"] = secret_key
if host := getattr(config, "host", ""):
    kwargs["host"] = host
```

No runtime behavior change: each attribute is read exactly once, `kwargs`
contains the same keys for the same inputs, and falsy-skip semantics are
preserved (empty string, `None`, and missing attribute all skipped because
`getattr` defaults to `""` and we truthy-check the local).

## Why this shape

- Keeps the `config: object` duck-typing contract — no import of a concrete
  `LangfuseConfig` type, no narrowing branch on `isinstance`.
- Walrus is idiomatic for "check the same value we're about to use" in py312.
- Drops three suppression comments, which are low-signal noise in a 75-line
  module.

Discovered during a code-smell sweep of `src/`; see triage note below. Only
actionable finding from that pass.

## Test plan

- [x] `uv run mypy src/memtomem_stm/observability/tracing.py` — clean (baseline and post-change)
- [x] `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"` — 1619 passed
- [x] `uv run ruff check src/memtomem_stm/observability/tracing.py` — clean
- [x] `uv run ruff format --check src/memtomem_stm/observability/tracing.py` — clean
- [ ] Full CI — delegated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)