### PR TITLE
docs(cli): add `list` subcommand section to fix broken #list anchor

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -158,6 +158,18 @@ To remove the original direct registrations after a successful import, pass `--p
 
 > **Note**: The CLI's `--compression` flag exposes 5 of the 10 strategies. The remaining five (`extract_fields`, `schema_pruning`, `skeleton`, `progressive`, `llm_summary`) are configured by editing `stm_proxy.json` directly. See [Compression Strategies](compression.md).
 
+### `list`
+
+```
+Usage: mms list [OPTIONS]
+
+Options:
+  --config TEXT  [default: ~/.memtomem/stm_proxy.json]
+  --json         Output as JSON for scripting.
+```
+
+Prints the configured upstream servers in a table — name, prefix, transport, compression strategy, and the command (stdio) or URL (SSE / HTTP). Reads the config only; does not probe connectivity (use `mms health` for that). With `--json` the output becomes `{"config_path": ..., "servers": {...}}` for scripting; a missing config file returns `{"error": "config_not_found", "path": ...}` instead of a text fallthrough so callers can branch on shape.
+
 ### Examples
 
 ```bash


### PR DESCRIPTION
## Summary
- `docs/cli.md` L74 referenced `` [`list`](#list) `` from the `init` description, but no matching `### list` heading existed — only a `mms list` example inside the shared Examples code block.
- Add a `### \`list\`` section between `### add` and `### Examples`, matching the pattern of `register` / `health`: Usage block + one-paragraph description covering read-only behavior, `--json` output shape, and the `config_not_found` JSON branch scripting callers can key off.
- Scope: this PR only fixes the one broken anchor surfaced by an internal link audit (12 tracked `.md` files scanned; this was the sole finding). Other undocumented commands (`status`, `remove`) remain out of scope.

## Test plan
- [x] Internal link audit: re-ran a relative-path + anchor scanner over all 12 tracked `.md` files — 0 broken, 0 empty-target.
- [x] Description cross-checked against `src/memtomem_stm/cli/proxy.py::list_servers` (L492–L539): read-only, no probe, `--json` shape, and `config_not_found` early-return are accurately reflected.
- [ ] Render preview on GitHub once the PR is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)