### PR TITLE
feat(cli): add `mms prune` + `init --prune-originals` to collapse dual-reg

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,7 @@ Commands:
   health    Check upstream server connectivity.
   init      Guided first-time setup for memtomem-stm.
   list      List configured upstream servers.
+  prune     Remove dual-registered upstreams from source MCP clients.
   register  Register memtomem-stm with an MCP client.
   remove    Remove an upstream MCP server from the proxy configuration.
   status    Show proxy gateway configuration and server list.
@@ -61,6 +62,11 @@ Options:
                             'json' = write .mcp.json, 'skip' = no
                             registration. Omit the flag for the interactive
                             prompt.
+  --prune-originals         After a successful import + registration, remove
+                            the direct registrations from source MCP clients
+                            so tools route through STM only. TTY callers get
+                            a single y/N prompt (default No); non-TTY
+                            scripted callers must pass the flag explicitly.
 ```
 
 Interactive wizard for the first-time setup. Prompts for a single upstream server (name, prefix, transport, command/URL), optionally probes connectivity, writes the config, then offers a 3-way MCP-client registration prompt:
@@ -75,11 +81,14 @@ Aborts if the config file already exists — use [`register`](#register) to re-r
 
 Validation is **advisory**: probe failures are reported as warnings but the config is still written. That way a flaky network or a cold upstream doesn't block setup; re-run `mms health` later once things are up.
 
+When you import servers that were already directly registered in a source MCP client (`~/.claude.json`, `.mcp.json`, Claude Desktop), `init` leaves the direct registrations in place by default — source-client configs are read-only unless you opt in. Pass `--prune-originals` to collapse the dual-path in the same session; on a TTY you instead get a single y/N prompt (default No). Skipped the prompt or didn't pass the flag? Run [`prune`](#prune) afterwards to clean up without re-running the wizard.
+
 ```bash
-mms init                 # interactive wizard
-mms init --no-validate   # skip the connectivity probe prompt entirely
-mms init --mcp claude    # scripted: auto-register with Claude Code
-mms init --mcp skip      # scripted: write config, print paste hints, exit
+mms init                          # interactive wizard
+mms init --no-validate            # skip the connectivity probe prompt entirely
+mms init --mcp claude             # scripted: auto-register with Claude Code
+mms init --mcp skip               # scripted: write config, print paste hints, exit
+mms init --mcp claude --prune-originals  # scripted: import, register, and remove direct registrations
 ```
 
 ### `register`
@@ -220,6 +229,32 @@ mms remove github
 mms health
 mms health --json          # machine-readable output
 mms health --timeout 5     # 5s per-server timeout (default: 10)
+```
+
+### `prune`
+
+```
+Usage: mms prune [OPTIONS] [NAMES]...
+
+Options:
+  --config TEXT  [default: ~/.memtomem/stm_proxy.json]
+  --all          Prune every dual-registered upstream. Required when no NAMES
+                 given.
+  -y, --yes      Skip the confirm prompt (scripts / CI / non-TTY callers).
+  --dry-run      Print what would be pruned; no writes.
+```
+
+Removes direct registrations for STM upstreams that are still registered in a source MCP client (`~/.claude.json`, `.mcp.json`, Claude Desktop). Use this to collapse the dual-path state that `mms init` and `mms add --import` leave behind when you didn't opt into pruning at import time — the tools then route through STM only, picking up compression, caching, and LTM surfacing.
+
+Scope selection is explicit by design: pass `--all` to act on every dual-registered upstream, or pass one or more `NAMES` to limit the action. Running `mms prune` with no arguments is a usage error rather than defaulting to "everything" — this is a destructive operation against external config files and the default should be visible.
+
+STM's own config (`stm_proxy.json`) is never modified. Only source-client files change. Failures are surfaced via non-zero exit and the exact manual `claude mcp remove` command for each failed entry, so scripting callers can retry.
+
+```bash
+mms prune --all              # remove every dual-registered upstream (TTY: confirm prompt)
+mms prune --all --yes        # same, skip the prompt (CI / scripts)
+mms prune --all --dry-run    # preview without writes
+mms prune docs-langchain     # target specific upstreams
 ```
 
 ### `health`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -248,6 +248,8 @@ Removes direct registrations for STM upstreams that are still registered in a so
 
 Scope selection is explicit by design: pass `--all` to act on every dual-registered upstream, or pass one or more `NAMES` to limit the action. Running `mms prune` with no arguments is a usage error rather than defaulting to "everything" — this is a destructive operation against external config files and the default should be visible.
 
+"Dual-registered" requires both the name **and** the identity to match: the source-client entry must share the STM upstream's `(transport, command, args)` or `(transport, url)` signature. If you've edited either side to point at a different server that happens to share a name, `mms prune` skips it rather than clobbering the unrelated entry.
+
 STM's own config (`stm_proxy.json`) is never modified. Only source-client files change. Failures are surfaced via non-zero exit and the exact manual `claude mcp remove` command for each failed entry, so scripting callers can retry.
 
 ```bash

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -1178,6 +1178,20 @@ def _handle_source_prune(
             click.echo(f"  {_source_removal_hint(name, src)}", err=True)
 
 
+def _find_dual_registered(stm_upstream_names: set[str], cwd: Path) -> list[dict[str, Any]]:
+    """Return source-client candidates whose name is also an STM upstream.
+
+    The shape matches :func:`_discover_candidates` so callers can pass the
+    result directly to :func:`_prune_imported_candidates` / the
+    ``_handle_source_prune`` machinery. Any upstream that isn't re-discovered
+    (i.e. already pruned, or registered with a different identity) is simply
+    absent from the return value — the caller treats "no dual-registered
+    servers" as a no-op rather than an error.
+    """
+    all_candidates = _discover_candidates(cwd)
+    return [c for c in all_candidates if c["name"] in stm_upstream_names]
+
+
 def _suggest_prefix(name: str, taken: set[str]) -> str:
     """Derive a valid-ish default prefix from a server name.
 
@@ -1526,7 +1540,24 @@ def _add_from_clients(
         "no registration. Omit the flag for the interactive prompt."
     ),
 )
-def init(config_path: str, no_validate: bool, mcp_mode: str | None) -> None:
+@click.option(
+    "--prune-originals",
+    "prune_originals",
+    is_flag=True,
+    default=False,
+    help=(
+        "After a successful import + registration, remove the direct "
+        "registrations from source MCP clients so tools route through STM "
+        "only. TTY callers get a single y/N prompt (default No); non-TTY "
+        "scripted callers must pass the flag explicitly."
+    ),
+)
+def init(
+    config_path: str,
+    no_validate: bool,
+    mcp_mode: str | None,
+    prune_originals: bool,
+) -> None:
     """Guided first-time setup for memtomem-stm.
 
     Prompts for a single upstream server and writes the config file. Aborts
@@ -1552,6 +1583,10 @@ def init(config_path: str, no_validate: bool, mcp_mode: str | None) -> None:
 
     candidates = _discover_candidates(Path.cwd())
     imported: dict[str, dict[str, Any]] = {}
+    # Parallel list of the source-client candidate dicts for entries we
+    # actually import. Needed so the end-of-flow prune step can address the
+    # exact ``(name, source, duplicate_in)`` triples via ``_handle_source_prune``.
+    imported_candidates: list[dict[str, Any]] = []
 
     if candidates:
         click.echo(_hdr(f"Found {len(candidates)} MCP server(s) in existing client configs:"))
@@ -1591,6 +1626,7 @@ def init(config_path: str, no_validate: bool, mcp_mode: str | None) -> None:
             used_prefixes.add(prefix)
             entry = {"prefix": prefix, **cand["entry"]}
             imported[cand["name"]] = entry
+            imported_candidates.append(cand)
     else:
         # Zero discovered candidates → true first-time user without any
         # existing MCP-client config. Full manual prompt flow.
@@ -1684,6 +1720,14 @@ def init(config_path: str, no_validate: bool, mcp_mode: str | None) -> None:
     click.echo("")
     _run_mcp_integration(_MCP_MODE_TO_CHOICE.get(mcp_mode) if mcp_mode else None)
 
+    # Post-registration prune of source-client originals, opt-in only.
+    # * ``--prune-originals`` → unconditional prune (scripted path).
+    # * TTY + no flag → single y/N confirm, default No.
+    # * non-TTY + no flag → skip; fall through to the #203 hint-only warning.
+    # Matches ``mms add --import --prune`` semantics via ``_handle_source_prune``.
+    if imported_candidates:
+        _handle_source_prune(imported_candidates, prune=prune_originals)
+
 
 @cli.command()
 @click.option(
@@ -1749,6 +1793,151 @@ def remove(name: str, config_path: str, yes: bool) -> None:
     del servers[name]
     _save(path, data)
     click.echo(f"{_ok('Removed')} server '{name}'.")
+
+
+# ── prune command ──────────────────────────────────────────────────────
+#
+# Post-hoc version of the prune step that ``mms add --import --prune`` does
+# inline. Needed because ``mms init`` intentionally leaves source-client
+# registrations untouched (bootstrap-only invariant + read-only discovery
+# contract — see PR #200 and #203), which means anyone who onboarded via
+# ``mms init`` ends up with dual-registered servers and no in-tree way to
+# collapse the dual path without manually running ``claude mcp remove`` per
+# entry. ``mms prune`` is the explicit opt-in command that closes that gap.
+
+
+@cli.command()
+@click.argument("names", nargs=-1)
+@click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
+@click.option(
+    "--all",
+    "all_servers",
+    is_flag=True,
+    help="Prune every dual-registered upstream. Required when no NAMES given.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the confirm prompt (scripts / CI / non-TTY callers).",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    help="Print what would be pruned; no writes.",
+)
+def prune(
+    names: tuple[str, ...],
+    config_path: str,
+    all_servers: bool,
+    assume_yes: bool,
+    dry_run: bool,
+) -> None:
+    """Remove direct registrations for STM upstreams that are dual-registered.
+
+    Finds every STM upstream that's still directly registered in a source
+    MCP client (``~/.claude.json``, project ``.mcp.json``, Claude Desktop)
+    and removes the direct registration so tool calls route through STM —
+    picking up compression, caching, and LTM surfacing, and collapsing the
+    duplicate tool advertisement. STM's own config is not touched.
+    """
+    if names and all_servers:
+        raise click.UsageError("--all cannot be combined with explicit NAMES.")
+    if not names and not all_servers:
+        raise click.UsageError(
+            "Pass upstream NAMES or --all. Use `mms list` to see what's configured."
+        )
+
+    path = Path(config_path)
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        click.echo(f"{_err('Error:')} config not found at {resolved}.", err=True)
+        click.echo("  Run `mms init` first.", err=True)
+        sys.exit(1)
+
+    data = _load(path)
+    stm_names = set(data.get("upstream_servers", {}).keys())
+    if not stm_names:
+        click.echo("No upstream servers configured.")
+        return
+
+    dual = _find_dual_registered(stm_names, Path.cwd())
+
+    if names:
+        dual_names = {c["name"] for c in dual}
+        missing = set(names) - dual_names
+        if missing:
+            click.echo(
+                f"{_err('Error:')} not dual-registered: {', '.join(sorted(missing))}.",
+                err=True,
+            )
+            click.echo(
+                "  These names are either not STM upstreams, not in any source "
+                "client, or already pruned.",
+                err=True,
+            )
+            sys.exit(1)
+        requested = set(names)
+        dual = [c for c in dual if c["name"] in requested]
+
+    if not dual:
+        click.echo("No dual-registered upstreams found.")
+        return
+
+    click.echo(_hdr(f"Dual-registered upstream(s): {len(dual)}"))
+    seen: set[tuple[str, str]] = set()
+    for cand in dual:
+        for src in [cand["source"], *(cand.get("duplicate_in") or [])]:
+            key = (cand["name"], src)
+            if key in seen:
+                continue
+            seen.add(key)
+            click.echo(f"  {cand['name']:<20} — {src}")
+
+    if dry_run:
+        click.echo("")
+        click.echo(f"{_ok('Dry run:')} no writes performed.")
+        return
+
+    if assume_yes:
+        proceed = True
+    elif _should_use_tui():
+        click.echo("")
+        proceed = click.confirm("Remove from source(s)?", default=False)
+    else:
+        click.echo(
+            f"{_err('Error:')} no TTY; pass --yes to confirm (or --dry-run to preview).",
+            err=True,
+        )
+        sys.exit(1)
+
+    if not proceed:
+        click.echo("Aborted. No changes made.")
+        return
+
+    pruned, failed = _prune_imported_candidates(dual)
+
+    if pruned:
+        click.echo("")
+        click.echo(f"{_ok('Removed from source client(s):')}")
+        for name, src in pruned:
+            click.echo(f"  {name} — {src}")
+
+    if failed:
+        click.echo("")
+        click.echo(
+            f"{_warn('Warning:')} could not remove {len(failed)} direct registration(s):",
+            err=True,
+        )
+        for name, src, err in failed:
+            click.echo(f"  {name} ({src}): {err}", err=True)
+        click.echo("", err=True)
+        click.echo("Run the following to remove them manually:", err=True)
+        for name, src, _ in failed:
+            click.echo(f"  {_source_removal_hint(name, src)}", err=True)
+        sys.exit(1)
 
 
 # ── health command ──────────────────────────────────────────────────────

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -1178,18 +1178,39 @@ def _handle_source_prune(
             click.echo(f"  {_source_removal_hint(name, src)}", err=True)
 
 
-def _find_dual_registered(stm_upstream_names: set[str], cwd: Path) -> list[dict[str, Any]]:
-    """Return source-client candidates whose name is also an STM upstream.
+def _find_dual_registered(
+    stm_upstreams: dict[str, dict[str, Any]], cwd: Path
+) -> list[dict[str, Any]]:
+    """Return source-client candidates whose name **and identity** match an STM upstream.
 
-    The shape matches :func:`_discover_candidates` so callers can pass the
-    result directly to :func:`_prune_imported_candidates` / the
-    ``_handle_source_prune`` machinery. Any upstream that isn't re-discovered
-    (i.e. already pruned, or registered with a different identity) is simply
-    absent from the return value — the caller treats "no dual-registered
-    servers" as a no-op rather than an error.
+    Name alone isn't enough: a user can register an unrelated server under
+    the same name in a source client (different command / URL / args) and
+    would reasonably expect ``mms prune`` not to touch it. Mirrors the dedup
+    logic :func:`_add_from_clients` uses in the other direction (name +
+    :func:`_server_signature` match), so the two sides of the import↔prune
+    round-trip agree on what "the same server" means.
+
+    An entry with no extractable signature (missing command / URL) is a
+    degraded match: we still include it on a name hit rather than silently
+    dropping it, since refusing to prune would surprise users who onboarded
+    via ``init`` and never edited the entry. The returned shape matches
+    :func:`_discover_candidates` so callers can pass the result directly to
+    :func:`_prune_imported_candidates` / the ``_handle_source_prune`` machinery.
     """
     all_candidates = _discover_candidates(cwd)
-    return [c for c in all_candidates if c["name"] in stm_upstream_names]
+    dual: list[dict[str, Any]] = []
+    for cand in all_candidates:
+        name = cand["name"]
+        if name not in stm_upstreams:
+            continue
+        stm_sig = _server_signature(stm_upstreams[name])
+        src_sig = _server_signature(cand["entry"])
+        # Both sides have a signature and they differ → intentionally distinct
+        # servers sharing a name. Skip rather than prune the unrelated entry.
+        if stm_sig is not None and src_sig is not None and stm_sig != src_sig:
+            continue
+        dual.append(cand)
+    return dual
 
 
 def _suggest_prefix(name: str, taken: set[str]) -> str:
@@ -1857,15 +1878,21 @@ def prune(
         click.echo("  Run `mms init` first.", err=True)
         sys.exit(1)
 
-    data = _load(path)
-    stm_names = set(data.get("upstream_servers", {}).keys())
-    if not stm_names:
+    data = _load(resolved)
+    upstreams: dict[str, dict[str, Any]] = data.get("upstream_servers", {})
+    if not upstreams:
         click.echo("No upstream servers configured.")
         return
 
-    dual = _find_dual_registered(stm_names, Path.cwd())
+    dual = _find_dual_registered(upstreams, Path.cwd())
 
     if names:
+        # ``not dual-registered`` subsumes three distinct states the user
+        # doesn't need to disambiguate up front: name absent from STM config,
+        # name present in STM but not in any source client, or name in both
+        # but with a divergent identity (``_find_dual_registered`` skipped it
+        # precisely because the source-client entry looks like a different
+        # server). The error surfaces all three branches in one message.
         dual_names = {c["name"] for c in dual}
         missing = set(names) - dual_names
         if missing:
@@ -1875,7 +1902,7 @@ def prune(
             )
             click.echo(
                 "  These names are either not STM upstreams, not in any source "
-                "client, or already pruned.",
+                "client, or registered with a different command/URL in the source.",
                 err=True,
             )
             sys.exit(1)
@@ -1886,15 +1913,21 @@ def prune(
         click.echo("No dual-registered upstreams found.")
         return
 
+    # Preview iteration must cover the same ``source + duplicate_in`` set
+    # that ``_prune_imported_candidates`` acts on — otherwise a user could
+    # approve fewer entries than get written. See
+    # ``test_duplicate_in_sources_all_pruned`` for the contract pin.
     click.echo(_hdr(f"Dual-registered upstream(s): {len(dual)}"))
+    name_width = max((len(c["name"]) for c in dual), default=0)
     seen: set[tuple[str, str]] = set()
     for cand in dual:
+        detail = _format_candidate_detail(cand["entry"])
         for src in [cand["source"], *(cand.get("duplicate_in") or [])]:
             key = (cand["name"], src)
             if key in seen:
                 continue
             seen.add(key)
-            click.echo(f"  {cand['name']:<20} — {src}")
+            click.echo(f"  {cand['name']:<{name_width}}  {detail}  — {src}")
 
     if dry_run:
         click.echo("")

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1040,13 +1040,17 @@ class TestInitImportFlow:
     source parsing is covered in ``TestInitDiscoverySources``.
 
     Same ``_run_mcp_integration`` stub as ``TestInit`` — the MCP-client
-    registration step is tested independently in ``TestInitMcpRegistration``."""
+    registration step is tested independently in ``TestInitMcpRegistration``.
+    ``_handle_source_prune`` is stubbed for the same reason: this class is
+    about the select + prefix UI, and prune coverage lives in
+    ``TestInitPruneOriginals`` / ``TestPruneCommand``."""
 
     @pytest.fixture(autouse=True)
-    def _stub_mcp_integration(self, monkeypatch):
+    def _stub_post_save(self, monkeypatch):
         from memtomem_stm.cli import proxy as proxy_mod
 
         monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda *_a, **_kw: None)
+        monkeypatch.setattr(proxy_mod, "_handle_source_prune", lambda *_a, **_kw: None)
 
     def _stub_candidates(self, monkeypatch, candidates):
         from memtomem_stm.cli import proxy as proxy_mod
@@ -2650,6 +2654,483 @@ class TestAddFromClientsPrune:
         argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
         pairs = {(c[3], c[5]) for c in argvs}
         assert pairs == {("filesystem", "user"), ("filesystem", "local")}
+
+
+# ── prune command ────────────────────────────────────────────────────────
+
+
+class TestPruneCommand:
+    """``mms prune`` — standalone post-hoc pruner for the ``init``-only dual-reg
+    gap. Covers the same writer surface as ``mms add --import --prune`` (see
+    ``TestAddFromClientsPrune``) plus its own argument/TTY contract."""
+
+    def _stub_candidates(self, monkeypatch, candidates):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: candidates)
+
+    def _seed_config(self, config: Path, server_names: list[str]) -> None:
+        servers = {
+            n: {"prefix": n, "transport": "stdio", "command": "npx"} for n in server_names
+        }
+        config.write_text(
+            json.dumps({"enabled": True, "upstream_servers": servers}, indent=2),
+            encoding="utf-8",
+        )
+
+    @pytest.fixture
+    def fake_claude(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        state: dict = {"calls": [], "script": []}
+
+        def fake_run(cmd, timeout=5):
+            state["calls"].append(list(cmd))
+            if state["script"]:
+                nxt = state["script"].pop(0)
+                if isinstance(nxt, Exception):
+                    raise nxt
+                return nxt
+            return _FakeClaudeResult(returncode=0)
+
+        monkeypatch.setattr(proxy_mod, "_run_claude_mcp", fake_run)
+        return state
+
+    def test_no_args_is_usage_error(self, runner, config):
+        """Destructive command with no scope: refuse instead of "everything"."""
+        self._seed_config(config, [])
+        result = runner.invoke(cli, ["prune", *_cfg_args(config)])
+        assert result.exit_code != 0
+        assert "Pass upstream NAMES or --all" in result.output
+
+    def test_all_with_names_is_usage_error(self, runner, config):
+        """``--all`` is the explicit "everything" flag; combining with NAMES
+        is an ambiguous request rather than a silent override."""
+        self._seed_config(config, [])
+        result = runner.invoke(cli, ["prune", "--all", "foo", *_cfg_args(config)])
+        assert result.exit_code != 0
+        assert "--all cannot be combined with explicit NAMES" in result.output
+
+    def test_missing_config_errors_with_init_hint(self, runner, tmp_path):
+        """Pointing at a non-existent config is a cold-start signal — surface
+        the init hint rather than failing on _load's generic empty-dict path."""
+        result = runner.invoke(
+            cli, ["prune", "--all", "--config", str(tmp_path / "nope.json")]
+        )
+        assert result.exit_code != 0
+        assert "config not found" in result.output
+        assert "mms init" in result.output
+
+    def test_no_upstream_servers_early_returns(self, runner, config):
+        """Empty STM config: no-op exit 0, not an error."""
+        self._seed_config(config, [])
+        result = runner.invoke(cli, ["prune", "--all", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "No upstream servers configured" in result.output
+
+    def test_no_dual_registered_early_returns(self, runner, config, monkeypatch):
+        """STM has upstreams but none are in source clients → clean no-op."""
+        self._seed_config(config, ["docs-langchain"])
+        self._stub_candidates(monkeypatch, [])  # source clients discovered: none
+        result = runner.invoke(cli, ["prune", "--all", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "No dual-registered upstreams found" in result.output
+
+    def test_names_filter_prunes_only_requested(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """Explicit NAMES must act only on the named subset — unrelated
+        dual-reg servers stay put."""
+        self._seed_config(config, ["docs-langchain", "langfuse-docs", "other"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+                {
+                    "name": "langfuse-docs",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "docs-langchain", "--yes", *_cfg_args(config)]
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        names = [c[3] for c in argvs]
+        assert names == ["docs-langchain"]
+
+    def test_unknown_name_errors_before_any_write(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """Any NAMES entry that isn't dual-registered fails the whole command
+        up front — half-applied writes are worse than a rejection."""
+        self._seed_config(config, ["docs-langchain"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "docs-langchain", "not-a-thing", "--yes", *_cfg_args(config)]
+        )
+        assert result.exit_code != 0
+        assert "not dual-registered" in result.output
+        assert "not-a-thing" in result.output
+        # Safety: docs-langchain was valid, but because one name was invalid
+        # we abort before any prune writes fire.
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+
+    def test_all_prunes_every_dual_registered(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """``--all`` = every (STM upstream ∩ source client) pair pruned from
+        the source that advertises it."""
+        self._seed_config(config, ["a", "b"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "a",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+                {
+                    "name": "b",
+                    "source": ".mcp.json (project)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "--all", "--yes", *_cfg_args(config)]
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        pairs = {(c[3], c[5]) for c in argvs}
+        assert pairs == {("a", "user"), ("b", "project")}
+
+    def test_dry_run_shows_preview_without_writes_or_prompt(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """``--dry-run`` must not shell out to ``claude`` or prompt — the
+        preview is for scripts that want to surface what *would* happen."""
+        self._seed_config(config, ["docs-langchain"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "--all", "--dry-run", *_cfg_args(config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert "docs-langchain" in result.output
+        assert "Claude Code (user)" in result.output
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+
+    def test_non_tty_without_yes_errors(self, runner, config, monkeypatch, fake_claude):
+        """CliRunner stdin is non-TTY; without ``--yes`` we must error out
+        rather than silently accept a destructive default or hang on a
+        prompt that has no way to be answered."""
+        self._seed_config(config, ["docs-langchain"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(cli, ["prune", "--all", *_cfg_args(config)])
+        assert result.exit_code != 0
+        assert "no TTY" in result.output
+        assert "--yes" in result.output
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+
+    def test_tty_prompt_accept_prunes(self, runner, config, monkeypatch, fake_claude):
+        """TTY path: prompt fires, default No but explicit ``y`` accepts."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+        self._seed_config(config, ["docs-langchain"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "--all", *_cfg_args(config)], input="y\n"
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        assert argvs == [["claude", "mcp", "remove", "docs-langchain", "-s", "user"]]
+
+    def test_tty_prompt_decline_no_writes(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """TTY path + No → clean exit, no writes. Default No is load-bearing
+        for destructive opt-in semantics."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+        self._seed_config(config, ["docs-langchain"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "--all", *_cfg_args(config)], input="n\n"
+        )
+        assert result.exit_code == 0, result.output
+        assert "Aborted" in result.output
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+
+    def test_duplicate_in_sources_all_pruned(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """A name registered in multiple sources (``source`` + ``duplicate_in``)
+        must be removed from every source or the dual-path survives."""
+        self._seed_config(config, ["filesystem"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "filesystem",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                    "duplicate_in": ["Claude Code (project)"],
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "--all", "--yes", *_cfg_args(config)]
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        pairs = {(c[3], c[5]) for c in argvs}
+        assert pairs == {("filesystem", "user"), ("filesystem", "local")}
+
+    def test_partial_failure_exits_nonzero_with_manual_hint(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """Unlike ``mms add --import --prune`` (import stays if prune fails,
+        exit 0), ``mms prune`` is *only* pruning — a failure is the whole
+        job failing and must surface via a non-zero exit for scripting.
+        The manual-command hint is still printed so the user can recover."""
+        self._seed_config(config, ["docs-langchain"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        fake_claude["script"] = [_FakeClaudeResult(returncode=1, stderr="boom")]
+
+        result = runner.invoke(
+            cli, ["prune", "--all", "--yes", *_cfg_args(config)]
+        )
+        assert result.exit_code != 0
+        assert "could not remove 1 direct registration" in result.output
+        assert "boom" in result.output
+        assert "claude mcp remove docs-langchain -s user" in result.output
+
+
+# ── init --prune-originals integration ───────────────────────────────────
+
+
+class TestInitPruneOriginals:
+    """``mms init --prune-originals`` (and the TTY prompt variant) — the
+    same ``_handle_source_prune`` machinery invoked inside the init flow so
+    onboarding users don't need a separate ``mms prune`` round-trip. Keeps
+    the bootstrap-only invariant: init still writes the STM config once,
+    but now additionally offers to collapse the dual-path it just created."""
+
+    def _stub_candidates(self, monkeypatch, candidates):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: candidates)
+
+    @pytest.fixture
+    def fake_claude(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        state: dict = {"calls": [], "script": []}
+
+        def fake_run(cmd, timeout=5):
+            state["calls"].append(list(cmd))
+            if state["script"]:
+                nxt = state["script"].pop(0)
+                if isinstance(nxt, Exception):
+                    raise nxt
+                return nxt
+            return _FakeClaudeResult(returncode=0)
+
+        monkeypatch.setattr(proxy_mod, "_run_claude_mcp", fake_run)
+        return state
+
+    @pytest.fixture(autouse=True)
+    def _stub_mcp_integration(self, monkeypatch):
+        """Disable the 3-way client-registration prompt — these tests are
+        only exercising the downstream prune step. ``TestInitMcpRegistration``
+        covers the registration half."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda *_a, **_kw: None)
+
+    def test_flag_prunes_scripted_non_tty(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """``--prune-originals`` in a non-TTY scripted run must fire the prune
+        unconditionally — this is the exact `mms init --mcp claude
+        --prune-originals` path that the bug report called out."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--prune-originals", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        assert argvs == [["claude", "mcp", "remove", "docs-langchain", "-s", "user"]]
+        assert "Removed from source client(s)" in result.output
+
+    def test_no_flag_non_tty_preserves_hint_only(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """Regression guard: the existing ``mms init`` scripted flow (no flag,
+        non-TTY) must not suddenly start pruning. The #203 read-only
+        invariant holds by default; only opt-in flips it."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+        # Hint remains so the user has a manual path.
+        assert "claude mcp remove docs-langchain -s user" in result.output
+        # And no auto-prompt fired.
+        assert "Remove from source(s)?" not in result.output
+
+    def test_tty_prompt_accept_prunes(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """TTY without flag → prompt fires, ``y`` accepts → prune."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+        # _pick_imports uses questionary on TTY; stub it the same way the
+        # add-prune tests do — we're exercising the post-pick prune branch,
+        # not the picker itself.
+        monkeypatch.setattr(proxy_mod, "_pick_imports", lambda cands: list(range(len(cands))))
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            # Inputs: accept default prefix (\n), then accept prune prompt (y\n).
+            input="\ny\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        argvs = [c for c in fake_claude["calls"] if c[:3] == ["claude", "mcp", "remove"]]
+        assert argvs == [["claude", "mcp", "remove", "docs-langchain", "-s", "user"]]
+
+    def test_tty_prompt_decline_no_prune(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """TTY + decline → no writes, manual hint still shown (same as the
+        non-TTY default path so user behavior is consistent across paths)."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+        monkeypatch.setattr(proxy_mod, "_pick_imports", lambda cands: list(range(len(cands))))
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs-langchain",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="\nn\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+        assert "claude mcp remove docs-langchain -s user" in result.output
 
 
 # ── remove command ───────────────────────────────────────────────────────

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -2944,6 +2944,88 @@ class TestPruneCommand:
         pairs = {(c[3], c[5]) for c in argvs}
         assert pairs == {("filesystem", "user"), ("filesystem", "local")}
 
+    def test_divergent_identity_not_dual_registered(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """Same name in STM and source client but different command → the
+        user has two intentionally distinct servers sharing a name, not a
+        dual-reg. Pruning the source entry would clobber unrelated config;
+        ``_find_dual_registered`` must skip it (mirrors the name+signature
+        dedup ``mms add --import`` uses in the other direction)."""
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {
+                        "docs": {
+                            "prefix": "docs",
+                            "transport": "stdio",
+                            "command": "npx",
+                            "args": ["-y", "@me/stm-imported"],
+                        }
+                    },
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        # Source client has a server also called ``docs`` but wired to a
+        # completely different command — treat as a separate registration.
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "docs",
+                    "source": "Claude Code (user)",
+                    "entry": {
+                        "transport": "stdio",
+                        "command": "python",
+                        "args": ["-m", "unrelated_server"],
+                    },
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "--all", "--yes", *_cfg_args(config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "No dual-registered upstreams found" in result.output
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+
+    def test_dry_run_with_names_filters_before_preview(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """Scope selection (NAMES) and preview-only (--dry-run) compose:
+        the preview must show only the named subset and still make no
+        writes. Lock in the contract so future refactors can't accidentally
+        preview the full set when the user asked for one."""
+        self._seed_config(config, ["a", "b"])
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "a",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+                {
+                    "name": "b",
+                    "source": ".mcp.json (project)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                },
+            ],
+        )
+        result = runner.invoke(
+            cli, ["prune", "a", "--dry-run", *_cfg_args(config)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        # Header should reflect the filtered count, not the full 2.
+        assert "Dual-registered upstream(s): 1" in result.output
+        assert "Claude Code (user)" in result.output
+        assert ".mcp.json (project)" not in result.output
+        assert not any(c[:3] == ["claude", "mcp", "remove"] for c in fake_claude["calls"])
+
     def test_partial_failure_exits_nonzero_with_manual_hint(
         self, runner, config, monkeypatch, fake_claude
     ):


### PR DESCRIPTION
## Summary

Close the dual-registration gap left by `mms init` (and by `mms add --import` without `--prune`): onboarding with `mms init --mcp claude` imports source-client upstreams into STM and registers STM with the client, but the original direct registrations stay in place — so tool calls bypass STM's compression, caching, and LTM surfacing whenever the direct path is taken.

Two entry points, both built on the existing `_handle_source_prune` / `_prune_imported_candidates` pipeline:

1. **`mms prune [NAMES...] [--all] [--yes] [--dry-run]`** — standalone post-hoc pruner. Refuses to run without explicit scope (`--all` or `NAMES`); unknown names abort before any writes; non-TTY callers must pass `--yes`; partial failures exit non-zero with per-row manual-command fallback.
2. **`mms init --prune-originals`** — opt-in flag for scripted onboarding; on TTY a single y/N prompt (default No). Non-TTY without the flag preserves the #203 hint-only default (regression-guarded).

New helper `_find_dual_registered` intersects STM upstream names with `_discover_candidates` output so the prune call site feeds directly into the shared source-removal machinery. STM's own `stm_proxy.json` is never touched; only source-client files change.

## Invariants preserved

- **bootstrap-only `mms init`** (#200): init still writes the STM config once. The new flag only adds a post-save step; it doesn't re-enter the wizard.
- **read-only discovery by default** (#203): scan + hint remains the non-opt-in path. `--prune-originals` / `mms prune` are the explicit opt-ins.
- **writer parity with `mms add --import --prune`** (#226): same `_prune_imported_candidates` pipeline, same per-source scope mapping, same non-fatal partial-failure handling — just surfaced via a new exit-code contract for the standalone command.

## Test plan
- [x] 14 new tests for `mms prune` covering: usage errors (no scope / `--all` + NAMES), missing config, no-op paths, NAMES filter with unknown-name rejection, `--all`, `--dry-run`, `--yes`, non-TTY error, TTY accept/decline, `duplicate_in`, partial failure exit non-zero.
- [x] 4 new tests for `mms init --prune-originals`: scripted non-TTY path, TTY accept, TTY decline, and a regression guard that the existing non-flag non-TTY default keeps the hint-only behavior.
- [x] `TestInitImportFlow` autouse fixture extended to also stub `_handle_source_prune` — keeps the pick-UI coverage focused; prune coverage lives in the new classes.
- [x] Full suite: `uv run pytest -m "not ollama"` → 1647 passed.
- [x] Lint: `uv run ruff check src` + `uv run ruff format --check src` clean.
- [x] Internal-link audit on `docs/cli.md` changes: new `#prune` anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)