### PR TITLE
fix(surfacing): per-tool min_score override now beats auto-tune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Per-tool `ToolSurfacingConfig.min_score` now takes precedence over the auto-tuner** — `surfacing.context_tools.<name>.min_score` was silently ignored whenever `auto_tune_enabled=true` (the default), because the engine consulted `AutoTuner.get_effective_min_score(tool)` first and that path only knew about the global `self._config.min_score` or a learned `_adjustments[tool]`, never the per-tool override. An operator who pinned `min_score=0.1` on a noisy tool saw the filter continue to fire at the 0.02 global default (or whatever the tuner had moved to inside `[0.005, 0.05]`). Precedence is now explicit — highest wins: (1) per-tool override, (2) auto-tuned value, (3) global default — and when a per-tool override is set the tuner's `maybe_adjust` is skipped for that tool so it does not learn a value that will never be applied. The same fix changes the truthy check (`tool_cfg.min_score`) to `is not None` on the auto-tune-disabled path, so an explicit `min_score=0.0` override is honored instead of falling through to the global default. New `TestPerToolMinScoreOverride` in `tests/test_surfacing_engine.py` pins all three precedence cases.
+
 ## [0.1.17] — 2026-04-24
 
 ### Added

--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -125,6 +125,8 @@ Fine-tune surfacing behavior per tool:
 
 Template variables: `{tool_name}`, `{server}`, `{arg.ARGUMENT_NAME}`
 
+**`min_score` precedence (highest wins):** per-tool `context_tools.<name>.min_score` → auto-tuned value (when `auto_tune_enabled=true`) → top-level `min_score`. An explicit per-tool override always wins, even with auto-tune on — set it when you want a fixed threshold that the tuner should not move.
+
 ## End-to-end Surface Call
 
 ```mermaid
@@ -270,6 +272,8 @@ flowchart LR
 ```
 
 Requires `auto_tune_min_samples` (default 20) feedback entries before adjusting. Score is capped between 0.005 and 0.05. **Cold-start fallback**: new tools with insufficient samples use the global ratio across all tools instead of waiting for 20 per-tool samples.
+
+**Per-tool override wins:** if `context_tools.<name>.min_score` is set, auto-tune is skipped for that tool entirely — the tuner is not consulted and does not learn from its feedback (see [`min_score` precedence](#per-tool-templates)).
 
 **Search boost from feedback**: when you rate memories as "helpful", their `access_count` is incremented in the core search index (once per surfacing event, capped at `max_boost=1.5`). This creates a positive feedback loop where useful memories rank higher in future searches.
 

--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -17,6 +17,8 @@ class ToolSurfacingConfig(BaseModel):
     query_template: str = ""
     namespace: str | None = None
     min_score: float | None = Field(default=None, ge=0.0, le=1.0)
+    """Per-tool override. Takes precedence over the auto-tuner when set,
+    even if ``auto_tune_enabled=True``."""
     max_results: int | None = Field(default=None, gt=0)
 
 

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -386,15 +386,17 @@ class SurfacingEngine:
         *,
         trace_id: str | None = None,
     ) -> str:
-        # Resolve effective config (auto-tuned if enabled)
+        # min_score precedence: tool_cfg override > auto-tune > global default.
+        # When the operator pins per-tool min_score, skip maybe_adjust so the
+        # tuner doesn't learn a value that will never be applied.
         tool_cfg = self._config.context_tools.get(tool)
-        if self._auto_tuner is not None:
+        if tool_cfg is not None and tool_cfg.min_score is not None:
+            min_score = tool_cfg.min_score
+        elif self._auto_tuner is not None:
             self._auto_tuner.maybe_adjust(tool)
             min_score = self._auto_tuner.get_effective_min_score(tool)
         else:
-            min_score = (
-                tool_cfg.min_score if tool_cfg and tool_cfg.min_score else self._config.min_score
-            )
+            min_score = self._config.min_score
         max_results = (
             tool_cfg.max_results
             if tool_cfg and tool_cfg.max_results

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -1357,3 +1357,109 @@ class TestLtmHintsObservability:
         # Must not raise
         out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert out is not None
+
+
+class TestPerToolMinScoreOverride:
+    """Per-tool `ToolSurfacingConfig.min_score` must win over the auto-tuner
+    and over the falsy-check trap on 0.0. Precedence: tool_cfg.min_score >
+    auto-tuned value > global default."""
+
+    def _make_tracker(self, tmp_path: Path, config: SurfacingConfig):
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+
+        return FeedbackTracker(config=config, db_path=tmp_path / "fb.db")
+
+    async def test_per_tool_override_wins_when_auto_tune_enabled(self, tmp_path: Path):
+        """tool_cfg.min_score=0.1 must filter results with score=0.05 even
+        though global default is 0.02 and auto-tune default min would accept."""
+        from memtomem_stm.surfacing.config import ToolSurfacingConfig
+
+        config = _make_config(
+            auto_tune_enabled=True,
+            min_score=0.02,
+            context_tools={"read_file": ToolSurfacingConfig(min_score=0.1)},
+        )
+        tracker = self._make_tracker(tmp_path, config)
+        try:
+            engine = SurfacingEngine(
+                config=config,
+                mcp_adapter=_make_mcp_adapter(
+                    [FakeSearchResult(chunk=FakeChunk(content="below override"), score=0.05)]
+                ),
+                feedback_tracker=tracker,
+            )
+            out = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            assert out == LONG_RESPONSE, (
+                "per-tool min_score=0.1 must filter score=0.05; got injection"
+            )
+        finally:
+            tracker.close()
+
+    async def test_per_tool_override_skips_auto_tune_learning(self, tmp_path: Path):
+        """When a per-tool override is set, the auto-tuner must not learn
+        (write to _adjustments) for that tool, even if feedback would
+        otherwise trigger an adjustment. A control tool without override
+        still gets adjusted."""
+        from memtomem_stm.surfacing.config import ToolSurfacingConfig
+
+        config = _make_config(
+            auto_tune_enabled=True,
+            auto_tune_min_samples=3,
+            min_score=0.02,
+            context_tools={"read_file": ToolSurfacingConfig(min_score=0.1)},
+        )
+        tracker = self._make_tracker(tmp_path, config)
+        try:
+            # Seed feedback that would trigger an auto-tune raise (>60%
+            # not_relevant) for BOTH the overridden tool and a control tool.
+            for i, tool_name in enumerate(["read_file", "list_dir"]):
+                sid = f"seed-{i}"
+                tracker.store.record_surfacing(sid, "gh", tool_name, "q", ["m1"], [0.5])
+                for _ in range(5):
+                    tracker.store.record_feedback(sid, "not_relevant")
+
+            engine = SurfacingEngine(
+                config=config,
+                mcp_adapter=_make_mcp_adapter([FakeSearchResult(chunk=FakeChunk(), score=0.5)]),
+                feedback_tracker=tracker,
+            )
+            # Exercise the overridden tool — should NOT invoke maybe_adjust.
+            await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            assert "read_file" not in engine._auto_tuner._adjustments, (
+                "auto-tuner must not learn for a tool with a per-tool override"
+            )
+
+            # Control: a tool WITHOUT override still gets adjusted.
+            await engine.surface(
+                "gh",
+                "list_dir",
+                {"path": "src/", "_context_query": "Flask architecture"},
+                LONG_RESPONSE,
+            )
+            assert engine._auto_tuner._adjustments.get("list_dir", 0) > 0.02, (
+                "control tool should have been raised above global default"
+            )
+        finally:
+            tracker.close()
+
+    async def test_per_tool_override_zero_respected(self, tmp_path: Path):
+        """Regression for the falsy-check trap: tool_cfg.min_score=0.0 is a
+        valid explicit override (Field ge=0.0). Must NOT fall through to
+        global default."""
+        from memtomem_stm.surfacing.config import ToolSurfacingConfig
+
+        config = _make_config(
+            auto_tune_enabled=False,
+            min_score=0.5,  # high global; tool_cfg should lower it to 0.0
+            context_tools={"read_file": ToolSurfacingConfig(min_score=0.0)},
+        )
+        engine = SurfacingEngine(
+            config=config,
+            mcp_adapter=_make_mcp_adapter(
+                [FakeSearchResult(chunk=FakeChunk(content="barely any score"), score=0.01)]
+            ),
+        )
+        out = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert "barely any score" in out, (
+            "per-tool min_score=0.0 must be respected (is-not-None, not truthy)"
+        )


### PR DESCRIPTION
## Summary

- `surfacing.context_tools.<name>.min_score` was silently ignored whenever `auto_tune_enabled=true` (the default) — the engine consulted `AutoTuner.get_effective_min_score(tool)` first, and that path only knew about the global `self._config.min_score` or a learned `_adjustments[tool]`, never the per-tool override. An operator who pinned `min_score=0.1` on a noisy tool saw the filter continue to fire at the 0.02 global default (clamped to `[0.005, 0.05]` by the tuner).
- Precedence is now explicit in `engine.py` — highest wins: (1) `tool_cfg.min_score`, (2) auto-tuned value, (3) global default. When a per-tool override is set, `auto_tuner.maybe_adjust(tool)` is skipped so the tuner does not learn a value that will never be applied.
- The same touched block switches from a truthy check (`tool_cfg.min_score`) to `is not None`, so an explicit `min_score=0.0` override is honored instead of falling through to the global default (`Field(ge=0.0)` accepts 0.0).

## Behavior change

Any deployment that set `surfacing.context_tools.<name>.min_score` expecting it to act as a per-tool threshold will now see that threshold enforced. Previously (v0.1.17 and earlier, with `auto_tune_enabled=true`) the value was silently ignored. Concretely:

- A tool with `min_score=0.1` configured now filters results below 0.1 (was: filtered below 0.02 or the auto-tuned value, whichever was higher within the clamp).
- `AutoTuner._adjustments[tool]` is no longer written for tools with a per-tool override — the tuner stops learning from that tool's feedback entirely. If an operator previously relied on the tuner continuing to learn while `tool_cfg.min_score` was also set (an unlikely double-configuration, since only one value was ever applied), they should remove either the override or `auto_tune_enabled=true`.
- `tool_cfg.min_score=0.0` now behaves as "accept any positive score" instead of falling through to the global default.

Global `min_score` default, auto-tune default enablement, and the `[0.005, 0.05]` tuner clamp are unchanged.

## Test plan

- [x] `uv run pytest tests/test_surfacing_engine.py::TestPerToolMinScoreOverride -v` — 3 new cases (override wins / tuner skips learning / 0.0 respected) all pass.
- [x] `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"` — 1642 passed, 0 regressed.
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src` (advisory) — only the 2 pre-existing errors in `proxy/manager.py` unrelated to this PR.

## Docs

- `docs/surfacing.md` — precedence callout added at the per-tool templates section, with a cross-link from the auto-tune section so readers arriving from either direction land on the same rule.
- `ToolSurfacingConfig.min_score` — one-line docstring noting the precedence.
- `CHANGELOG.md` — entry under Unreleased / Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)