### PR TITLE
docs(config): surface v0.1.12 timeout fields missed by #206/#207/#210

### DIFF
--- a/docs/compression.md
+++ b/docs/compression.md
@@ -239,12 +239,13 @@ Routes through an external LLM for intelligent summarization:
     "model": "gpt-4.1-mini",
     "api_key": "sk-...",
     "max_tokens": 500,
+    "llm_timeout_seconds": 60.0,
     "system_prompt": "Summarize concisely, preserving key information. Under {max_chars} chars."
   }
 }
 ```
 
-Providers: `openai`, `anthropic`, `ollama`. Falls back to truncation on API failure (circuit breaker protection).
+Providers: `openai`, `anthropic`, `ollama`. `llm_timeout_seconds` (default 60.0) bounds the per-call LLM wait — on timeout, privacy-pattern hit, circuit-breaker open, or any other API failure, compression falls back to `TruncateCompressor` and the strategy label is recorded as `llm_summary→timeout_fallback` / `→privacy_fallback` / `→circuit_breaker_fallback` / `→llm_error_fallback` in `proxy_metrics` so the fallback path is distinguishable in observability tools.
 
 Sensitive content (API keys, passwords, PII) is auto-detected and **never** sent to external LLMs — falls back to local truncation.
 

--- a/docs/compression.md
+++ b/docs/compression.md
@@ -245,7 +245,7 @@ Routes through an external LLM for intelligent summarization:
 }
 ```
 
-Providers: `openai`, `anthropic`, `ollama`. `llm_timeout_seconds` (default 60.0) bounds the per-call LLM wait — on timeout, privacy-pattern hit, circuit-breaker open, or any other API failure, compression falls back to `TruncateCompressor` and the strategy label is recorded as `llm_summary→timeout_fallback` / `→privacy_fallback` / `→circuit_breaker_fallback` / `→llm_error_fallback` in `proxy_metrics` so the fallback path is distinguishable in observability tools.
+Providers: `openai`, `anthropic`, `ollama`. `llm_timeout_seconds` (default 60.0) bounds the per-call LLM wait. On timeout, privacy-pattern hit, circuit-breaker open, or any other API failure, compression falls back to `TruncateCompressor` and records the strategy as `llm_summary→{timeout,privacy,circuit_breaker,llm_error}_fallback` in `proxy_metrics` for observability.
 
 Sensitive content (API keys, passwords, PII) is auto-detected and **never** sent to external LLMs — falls back to local truncation.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,6 +155,8 @@ Full example with all options:
       "max_retries": 3,
       "reconnect_delay_seconds": 1.0,
       "max_reconnect_delay_seconds": 30.0,
+      "call_timeout_seconds": 90.0,
+      "overall_deadline_seconds": 180.0,
       "max_description_chars": 200,
       "strip_schema_descriptions": false,
       "cleaning": {

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -111,3 +111,87 @@ def test_cli_docs_flag_desktop_discovery_is_macos_only() -> None:
         "`--import`. Without this caveat, Linux/Windows callers silently "
         "see zero Claude Desktop candidates from `mms add --import`."
     )
+
+
+def test_configuration_full_example_documents_upstream_timeouts() -> None:
+    """docs/configuration.md's full-example upstream block must list the
+    per-upstream timeout fields added in v0.1.12 (#206).
+
+    ``UpstreamServerConfig`` in ``src/memtomem_stm/proxy/config.py`` exposes
+    ``call_timeout_seconds`` and ``overall_deadline_seconds`` as the
+    bounded-hang knobs for upstream tool calls. If the "Full example"
+    block omits them, users who don't read CHANGELOG have no surface to
+    discover these tuning knobs and a silently-hung upstream looks like
+    a proxy bug rather than a tunable timeout. Scope the assertion to
+    the ``## Config File`` section so moving the fields into release
+    notes or env-var prose cannot satisfy the check.
+    """
+    config_md = _read("docs/configuration.md")
+    section_match = re.search(
+        r"##\s+Config File[^\n]*\n(.*?)(?=\n##\s|\Z)",
+        config_md,
+        re.DOTALL,
+    )
+    if not section_match:
+        pytest.fail(
+            "docs/configuration.md lost its `## Config File` H2 section — "
+            "either restructure the test or restore the section heading."
+        )
+    section_body = section_match.group(1)
+    block_match = re.search(r"```json\n(.*?)\n```", section_body, re.DOTALL)
+    if not block_match:
+        pytest.fail(
+            "docs/configuration.md `## Config File` section lost its "
+            "```json fenced example — either restructure the test or "
+            "restore the full-example block."
+        )
+    example = block_match.group(1)
+
+    required = ("call_timeout_seconds", "overall_deadline_seconds")
+    missing = [field for field in required if field not in example]
+    if missing:
+        pytest.fail(
+            f"docs/configuration.md full-example is missing upstream "
+            f"timeout field(s): {missing!r}. These exist on "
+            "UpstreamServerConfig (src/memtomem_stm/proxy/config.py, "
+            "defaults 90s / 180s) and were added in v0.1.12 (#206) to "
+            "bound silently-hung upstreams. Keep them visible next to "
+            "`max_retries` / `reconnect_delay_seconds` so operators "
+            "discover them when scanning the example."
+        )
+
+
+def test_compression_md_llm_section_documents_timeout_fallback() -> None:
+    """docs/compression.md's ``## LLM Compression`` section must surface
+    ``llm_timeout_seconds`` in the config example or fallback prose.
+
+    ``LLMCompressorConfig.llm_timeout_seconds``
+    (``src/memtomem_stm/proxy/config.py``, default 60.0) bounds the LLM
+    call; on timeout the compressor falls back to ``TruncateCompressor``
+    and records ``llm_summary→timeout_fallback`` in ``proxy_metrics``
+    (v0.1.12, #207/#210). Without this documented, users cannot tune the
+    timeout, cannot interpret the fallback label in metrics, and assume
+    "API failure (circuit breaker protection)" is the only fallback path.
+    """
+    comp_md = _read("docs/compression.md")
+    section_match = re.search(
+        r"##\s+LLM Compression[^\n]*\n(.*?)(?=\n##\s|\Z)",
+        comp_md,
+        re.DOTALL,
+    )
+    if not section_match:
+        pytest.fail(
+            "docs/compression.md lost its `## LLM Compression` H2 section — "
+            "either restructure the test or restore the section heading."
+        )
+    section_body = section_match.group(1)
+    if "llm_timeout_seconds" not in section_body:
+        pytest.fail(
+            "docs/compression.md `## LLM Compression` section must "
+            "mention `llm_timeout_seconds` — either in the JSON example "
+            "or the fallback prose. Without it, the timeout-bound LLM "
+            "compression path introduced in v0.1.12 (#207/#210) is "
+            "invisible to users reading the LLM section, and the "
+            "`llm_summary→timeout_fallback` metric label has no "
+            "documented origin."
+        )


### PR DESCRIPTION
## Summary

- Add `call_timeout_seconds` (90.0) and `overall_deadline_seconds` (180.0) to the `docs/configuration.md` full-example upstream block — per-upstream bounded-hang knobs introduced in #206 (v0.1.12).
- Add `llm_timeout_seconds` (60.0) to the `docs/compression.md` LLM Compression config example and rewrite the fallback prose to enumerate all four `llm_summary→*_fallback` metric labels (timeout / privacy / circuit_breaker / llm_error) — #207/#210 (v0.1.12).
- Add two paragraph-scoped regression tests to `tests/test_docs_sync.py`, pinned to the `## Config File` and `## LLM Compression` sections. Mutation-verified: stripping the field from the scoped section makes the test fail, so a whole-file grep match elsewhere (release notes, env-var prose) cannot false-pass.

## Why

CHANGELOG v0.1.12 announced the three timeout knobs, but the reference docs were never updated. A user reading `docs/configuration.md` "Full example with all options" or `docs/compression.md` LLM Compression section couldn't discover these tuning knobs or interpret the `llm_summary→timeout_fallback` label appearing in `proxy_metrics` / `stm_compression_stats`. Operators hitting a silently-hung upstream or a slow LLM endpoint were dependent on reading source or CHANGELOG to find the bounds.

The `llm_summary→*_fallback` label enumeration is especially load-bearing — the label appears in metrics but its four variants (timeout / privacy / circuit_breaker / llm_error) were previously split across unrelated CHANGELOG entries.

## Scope

`connect_timeout_seconds` (`src/memtomem_stm/proxy/config.py:271`) is also undocumented but predates the v0.1.12 cluster — left for a separate follow-up per the "drive-by fix belongs in a separate PR" convention.

## Test plan

- [x] `uv run pytest tests/test_docs_sync.py -v` — 4 passed (2 new, 2 pre-existing)
- [x] `uv run pytest -m "not ollama" -k "compression or fallback_ladder or ratio_guard or docs_sync"` — 169 passed, 1485 deselected
- [x] `uv run ruff check src tests` — all checks passed
- [x] `uv run ruff format --check src` — 45 files already formatted
- [x] Mutation-verify: removing the scoped field makes the regression test fail (confirmed locally for both new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)