### PR TITLE
docs(config): surface connect_timeout_seconds missed by #248

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,6 +155,7 @@ Full example with all options:
       "max_retries": 3,
       "reconnect_delay_seconds": 1.0,
       "max_reconnect_delay_seconds": 30.0,
+      "connect_timeout_seconds": 30.0,
       "call_timeout_seconds": 90.0,
       "overall_deadline_seconds": 180.0,
       "max_description_chars": 200,

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -115,16 +115,18 @@ def test_cli_docs_flag_desktop_discovery_is_macos_only() -> None:
 
 def test_configuration_full_example_documents_upstream_timeouts() -> None:
     """docs/configuration.md's full-example upstream block must list the
-    per-upstream timeout fields added in v0.1.12 (#206).
+    three per-upstream timeout knobs on ``UpstreamServerConfig``.
 
-    ``UpstreamServerConfig`` in ``src/memtomem_stm/proxy/config.py`` exposes
-    ``call_timeout_seconds`` and ``overall_deadline_seconds`` as the
-    bounded-hang knobs for upstream tool calls. If the "Full example"
-    block omits them, users who don't read CHANGELOG have no surface to
-    discover these tuning knobs and a silently-hung upstream looks like
-    a proxy bug rather than a tunable timeout. Scope the assertion to
-    the ``## Config File`` section so moving the fields into release
-    notes or env-var prose cannot satisfy the check.
+    ``src/memtomem_stm/proxy/config.py`` exposes ``connect_timeout_seconds``
+    (bounds ``session.initialize()``, #53), ``call_timeout_seconds`` (bounds
+    each ``session.call_tool()`` attempt, #206), and
+    ``overall_deadline_seconds`` (wall-clock budget across retries, #206).
+    If the "Full example" block omits any of them, users who don't read
+    CHANGELOG have no surface to discover these tuning knobs and a
+    silently-hung upstream looks like a proxy bug rather than a tunable
+    timeout. Scope the assertion to the ``## Config File`` section so
+    moving the fields into release notes or env-var prose cannot satisfy
+    the check.
     """
     config_md = _read("docs/configuration.md")
     section_match = re.search(
@@ -147,17 +149,21 @@ def test_configuration_full_example_documents_upstream_timeouts() -> None:
         )
     example = block_match.group(1)
 
-    required = ("call_timeout_seconds", "overall_deadline_seconds")
+    required = (
+        "connect_timeout_seconds",
+        "call_timeout_seconds",
+        "overall_deadline_seconds",
+    )
     missing = [field for field in required if field not in example]
     if missing:
         pytest.fail(
             f"docs/configuration.md full-example is missing upstream "
             f"timeout field(s): {missing!r}. These exist on "
             "UpstreamServerConfig (src/memtomem_stm/proxy/config.py, "
-            "defaults 90s / 180s) and were added in v0.1.12 (#206) to "
-            "bound silently-hung upstreams. Keep them visible next to "
-            "`max_retries` / `reconnect_delay_seconds` so operators "
-            "discover them when scanning the example."
+            "defaults 30s / 90s / 180s) and bound silently-hung upstreams "
+            "at the init, per-call, and overall-deadline layers. Keep "
+            "them visible next to `max_retries` / `reconnect_delay_seconds` "
+            "so operators discover them when scanning the example."
         )
 
 


### PR DESCRIPTION
## Summary

- Add `"connect_timeout_seconds": 30.0` to `docs/configuration.md`'s full-example upstream block, completing the init/per-call/overall-deadline timeout triad on `UpstreamServerConfig`.
- Extend the `test_configuration_full_example_documents_upstream_timeouts` regression test (added in #248) to require all three timeout fields.

## Why

#248 surfaced the two v0.1.12 timeout knobs (`call_timeout_seconds`, `overall_deadline_seconds`) but deliberately scoped out `connect_timeout_seconds` — it predates the v0.1.12 cluster (#53) and was left as a separate follow-up per the "drive-by fix belongs in a separate PR" convention. This PR closes that gap.

`connect_timeout_seconds` (default 30.0) bounds `session.initialize()` at `src/memtomem_stm/proxy/manager.py:240,273`. Without it documented, a user whose upstream hangs during MCP handshake has no surface to discover the knob — the silently-stuck initialize looks like a proxy bug rather than a tunable timeout.

## Scope

Ordered in the example example *before* `call_timeout_seconds` to mirror the source declaration order at `config.py:271-285` (init → per-call → overall deadline). The regression test now pins all three as a single tuple rather than adding a separate test — they form one semantic cluster ("upstream timeout knobs") and three tests for three similar fields would be over-decomposition.

Note: `connect_timeout_seconds` has no docstring on the field itself (unlike its siblings). Adding one is a separate, optional follow-up — this PR stays docs-only to keep the blame trail clean.

## Test plan

- [x] `uv run pytest tests/test_docs_sync.py -v` — 4 passed
- [x] `uv run ruff check tests/test_docs_sync.py` — clean
- [x] `uv run ruff format --check tests/test_docs_sync.py` — already formatted
- [x] Mutation-verify: stripping `"connect_timeout_seconds": 30.0` from the full example makes the regression test fail with `missing: ['connect_timeout_seconds']` and the three-layer guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)