### PR TITLE
fix(cli): distinguish missing config from empty config in `list` and `health` (#221)

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -497,11 +497,15 @@ def list_servers(config_path: str, *, as_json: bool = False) -> None:
     path = Path(config_path)
     resolved = path.expanduser().resolve()
 
-    # Missing-config handling matches ``status --json`` so scripts can probe
-    # either command without branching on shape. Text path keeps the prior
-    # ``_load`` fallthrough (empty dict → "No upstream servers configured").
-    if as_json and not resolved.exists():
-        click.echo(json.dumps({"error": "config_not_found", "path": str(resolved)}))
+    # Missing-config handling matches ``status`` so a user troubleshooting
+    # "why isn't my server listed?" can tell whether they're pointed at the
+    # wrong path vs. a real-but-empty config (#221).
+    if not resolved.exists():
+        if as_json:
+            click.echo(json.dumps({"error": "config_not_found", "path": str(resolved)}))
+        else:
+            click.echo(f"Config not found: {resolved}")
+            click.echo("Run `mms add` (or `mms init`) to create a configuration.")
         return
 
     data = _load(path)
@@ -2052,7 +2056,21 @@ async def _probe_servers(servers: dict[str, Any], timeout: float) -> dict[str, d
 )
 def health(config_path: str, *, as_json: bool = False, timeout: int = 10) -> None:
     """Check upstream server connectivity."""
-    data = _load(Path(config_path))
+    path = Path(config_path)
+    resolved = path.expanduser().resolve()
+
+    # Missing-config handling matches ``status`` / ``list`` so a user
+    # troubleshooting connectivity can tell wrong-path from empty-config
+    # without re-running ``status`` (#221, extended to ``health``).
+    if not resolved.exists():
+        if as_json:
+            click.echo(json.dumps({"error": "config_not_found", "path": str(resolved)}))
+        else:
+            click.echo(f"Config not found: {resolved}")
+            click.echo("Run `mms add` (or `mms init`) to create a configuration.")
+        return
+
+    data = _load(path)
     servers: dict[str, Any] = data.get("upstream_servers", {})
 
     # JSON output format matches ``status --json`` / ``list --json`` (indent=2,

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -137,11 +137,32 @@ class TestConfigLoad:
         assert result.exit_code == 1
         assert "'upstream_servers' must be an object" in result.output
 
+    def test_list_missing_config(self, runner, config):
+        """Missing file → ``list`` distinguishes from empty-config (#221)
+        so users troubleshooting wrong --config paths get a clear hint."""
+        result = runner.invoke(cli, ["list", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "Config not found" in result.output
+        assert "mms add" in result.output
+        assert "No upstream servers configured" not in result.output
+
     def test_list_empty_config(self, runner, config):
-        """No config → ``list`` prints the empty-state message and exits 0."""
+        """Empty (but present) config → ``list`` prints the empty-state
+        message — distinct from the missing-config branch above."""
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
         result = runner.invoke(cli, ["list", *_cfg_args(config)])
         assert result.exit_code == 0
         assert "No upstream servers configured" in result.output
+        assert "Config not found" not in result.output
+
+    def test_list_json_missing_config(self, runner, config):
+        """``list --json`` already returned ``config_not_found`` since #220;
+        pin it here next to the new text-path test for symmetry."""
+        result = runner.invoke(cli, ["list", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["error"] == "config_not_found"
+        assert str(config) in data["path"]
 
 
 # ── status command ───────────────────────────────────────────────────────
@@ -3281,6 +3302,26 @@ class TestHealth:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data == {"servers": {}}
+
+    def test_health_missing_config(self, runner, config):
+        """Missing file → distinguish from empty-config so a user pointing
+        at the wrong path gets a clear hint instead of a silent no-op
+        (compounding gap from #221, extended to ``health``)."""
+        result = runner.invoke(cli, ["health", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "Config not found" in result.output
+        assert "mms add" in result.output
+        assert "No upstream servers configured" not in result.output
+
+    def test_health_json_missing_config(self, runner, config):
+        """``health --json`` mirrors ``status --json`` / ``list --json`` for
+        missing-config so scripts piping any of the three through the same
+        formatter don't have to branch."""
+        result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["error"] == "config_not_found"
+        assert str(config) in data["path"]
 
     def test_health_unreachable_server(self, runner, config):
         """A server with a nonexistent command → DISCONNECTED."""


### PR DESCRIPTION
## Summary

- **Closes #221.** `mms list` text output now prints `Config not found: <path>` (with a `mms add`/`mms init` hint) when the config file is missing, instead of the same `No upstream servers configured.` message used for empty-but-present configs.
- **Compounding fix on `health`.** `mms health` had the identical bug class on both text and `--json` paths — caught while writing the regression tests for #221, so bundled here rather than filed as a separate issue. Same one-block change as `list`, identical message and JSON shape.
- `status` is left untouched — it already handled this correctly and is the pattern this PR mirrors.

## Behavior change

`list` and `health` (text + json) when `--config` points at a missing file:

| Path | Before | After |
| --- | --- | --- |
| `list` text | `No upstream servers configured.` (exit 0) | `Config not found: <path>` + hint (exit 0) |
| `list --json` | `{"error": "config_not_found", "path": "..."}` (already correct since #220) | unchanged |
| `health` text | `No upstream servers configured.` (exit 0) | `Config not found: <path>` + hint (exit 0) |
| `health --json` | `{"servers": {}}` (exit 0) | `{"error": "config_not_found", "path": "..."}` (exit 0) |

The empty-but-present case still prints `No upstream servers configured.` exactly as before — the new branch only fires when the file doesn't exist. Exit codes are unchanged across all branches.

`health --json`'s shape change is the one a script could grep on: anything currently doing `jq '.servers'` against a missing-config response will now hit `null`, since the top-level shape switches to `{error, path}`. Matches what `status --json` and `list --json` already returned, so a script piping all three through the same formatter is now consistent.

## Test plan

- [x] `uv run pytest tests/cli/test_proxy_cli.py -k 'list or health or status'` (21 passed, including 5 new tests)
- [x] `uv run pytest -m "not ollama"` (1658 passed)
- [x] `uv run ruff check src && uv run ruff format --check src` (clean)
- [x] Manual verify: `uv run mms list --config /tmp/_nope.json`, `mms list --json`, `mms health`, `mms health --json`, `mms list --config <empty>` (still says "No upstream servers configured.")

🤖 Generated with [Claude Code](https://claude.com/claude-code)