### PR TITLE
fix(cli): silence MCP SDK probe noise and unwrap TaskGroup error wrapper

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import re
 import shlex
 import subprocess
 import sys
 import tomllib
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -2008,6 +2011,35 @@ async def _probe_one(cfg: dict[str, Any], timeout: float) -> dict[str, Any]:
             }
 
 
+def _root_cause_message(exc: BaseException) -> str:
+    """Walk into ``BaseExceptionGroup`` (anyio TaskGroup wraps probe failures
+    as ``unhandled errors in a TaskGroup (N sub-exception)``) to surface the
+    first non-group leaf so users see the real cause instead of the wrapper.
+    """
+    seen: set[int] = set()
+    cur: BaseException = exc
+    while isinstance(cur, BaseExceptionGroup) and cur.exceptions and id(cur) not in seen:
+        seen.add(id(cur))
+        cur = cur.exceptions[0]
+    return str(cur) or type(cur).__name__
+
+
+@contextmanager
+def _silenced_mcp_sdk_logs() -> Iterator[None]:
+    """Temporarily raise the MCP SDK loggers above ``ERROR`` so probe-time
+    failures (which we already capture + report per-server) don't dump
+    multi-line ``logger.exception`` tracebacks to stderr — those corrupt
+    ``--json`` output for callers piping into ``jq`` / similar.
+    """
+    sdk_logger = logging.getLogger("mcp")
+    prior = sdk_logger.level
+    sdk_logger.setLevel(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        sdk_logger.setLevel(prior)
+
+
 async def _probe_servers(servers: dict[str, Any], timeout: float) -> dict[str, dict[str, Any]]:
     """Probe all servers in parallel, returning per-server results."""
 
@@ -2021,12 +2053,17 @@ async def _probe_servers(servers: dict[str, Any], timeout: float) -> dict[str, d
                 "error": f"timeout ({timeout}s)",
             }
         except Exception as exc:
-            err = str(exc) or type(exc).__name__
+            # anyio raises ``ExceptionGroup`` when probe failures bubble out
+            # of the TaskGroup; that's already an ``Exception`` subclass,
+            # so the existing catch surface is fine. ``_root_cause_message``
+            # walks the wrapper to surface the real cause.
+            err = _root_cause_message(exc)
             result = {"connected": False, "tools": 0, "error": err}
         return name, result
 
-    tasks = [_safe_probe(n, c) for n, c in servers.items()]
-    pairs = await asyncio.gather(*tasks)
+    with _silenced_mcp_sdk_logs():
+        tasks = [_safe_probe(n, c) for n, c in servers.items()]
+        pairs = await asyncio.gather(*tasks)
     return dict(pairs)
 
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3324,3 +3324,112 @@ class TestHealth:
         data = json.loads(result.output)
         assert data["servers"]["bad"]["connected"] is False
         assert data["servers"]["bad"]["error"]
+
+    def test_health_error_unwraps_taskgroup_wrapper(self, runner, config):
+        """Probe failures inside an anyio TaskGroup are wrapped as
+        ``BaseExceptionGroup`` and stringify as ``unhandled errors in a
+        TaskGroup (N sub-exception)`` — useless to a user. The CLI must
+        unwrap to the leaf cause.
+
+        Repro path: an upstream that starts cleanly (so ``stdio_client``
+        opens its TaskGroup) but doesn't speak JSON-RPC. ``echo`` exits
+        immediately, so the SDK detects ``Connection closed`` inside the
+        group. Bare ``__nonexistent_cmd__`` fails earlier (``OSError``
+        before the group opens) and so doesn't exercise this path.
+        """
+        config.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "echo": {
+                            "prefix": "echo",
+                            "transport": "stdio",
+                            "command": "echo",
+                            "args": ["hello"],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["health", "--json", "--timeout", "3", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        err = data["servers"]["echo"]["error"]
+        # The wrapper string was the symptom — explicitly assert it doesn't
+        # leak through. Any non-trivial leaf message is fine.
+        assert "TaskGroup" not in err
+        assert "sub-exception" not in err
+        assert err  # must be non-empty
+
+    def test_health_json_stderr_not_polluted_by_sdk_logs(self, runner, config):
+        """The MCP SDK calls ``logger.exception(...)`` on parse failures,
+        which dumps multi-line tracebacks to stderr. For ``health --json``
+        callers piping into ``jq`` / similar, that noise is just garbage
+        sharing the pipe — silence it for the duration of the probe.
+        """
+        config.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "echo": {
+                            "prefix": "echo",
+                            "transport": "stdio",
+                            "command": "echo",
+                            "args": ["hello"],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        # ``mix_stderr=False`` was removed in click 8.2 — instead, capture
+        # stderr explicitly via ``CliRunner(catch_exceptions=False)`` plus
+        # ``invoke``'s default behavior of teeing stderr into ``output``.
+        # We assert on the JSON body parse-cleanly: any stderr noise that
+        # was joined into stdout would break ``json.loads``.
+        result = runner.invoke(cli, ["health", "--json", "--timeout", "3", *_cfg_args(config)])
+        assert result.exit_code == 0
+        # If logger.exception had fired into the same stream, this would
+        # raise ``json.JSONDecodeError`` because the traceback prefix
+        # corrupts the JSON document.
+        data = json.loads(result.output)
+        assert data["servers"]["echo"]["connected"] is False
+
+
+# ── probe error helpers ──────────────────────────────────────────────────
+
+
+class TestRootCauseMessage:
+    """Unit-test ``_root_cause_message`` directly. Cheaper than driving the
+    whole CLI to exercise edge cases like deeply nested groups or
+    self-referential cycles."""
+
+    def test_returns_str_for_plain_exception(self):
+        from memtomem_stm.cli.proxy import _root_cause_message
+
+        assert _root_cause_message(ValueError("boom")) == "boom"
+
+    def test_falls_back_to_type_name_for_empty_str(self):
+        from memtomem_stm.cli.proxy import _root_cause_message
+
+        # ``str(asyncio.CancelledError())`` is empty; the helper should
+        # surface the type name rather than a useless empty string.
+        import asyncio
+
+        assert _root_cause_message(asyncio.CancelledError()) == "CancelledError"
+
+    def test_unwraps_baseexceptiongroup_to_first_leaf(self):
+        from memtomem_stm.cli.proxy import _root_cause_message
+
+        leaf = RuntimeError("real cause")
+        group = BaseExceptionGroup("unhandled errors in a TaskGroup", [leaf])
+        assert _root_cause_message(group) == "real cause"
+
+    def test_unwraps_nested_groups(self):
+        from memtomem_stm.cli.proxy import _root_cause_message
+
+        leaf = ConnectionError("network down")
+        inner = BaseExceptionGroup("inner", [leaf])
+        outer = BaseExceptionGroup("outer", [inner])
+        assert _root_cause_message(outer) == "network down"


### PR DESCRIPTION
## Summary

Two compounding gaps in ``mms health`` (and every other code path that calls ``_probe_servers``) caught while doing a detailed local exercise of the CLI.

### 1. stderr pollution corrupts ``--json`` callers

The MCP stdio SDK calls ``logger.exception("Failed to parse JSONRPC message from server")`` on every non-JSON line an upstream emits, so an ``echo``-typed entry (or any process that exits before speaking JSON-RPC) produces a multi-line pydantic ``ValidationError`` traceback **per line**. Repro on ``main``:

\`\`\`text
$ mms health --json --config /tmp/echo_upstream.json --timeout 2
Failed to parse JSONRPC message from server
Traceback (most recent call last):
  File ".../mcp/client/stdio/__init__.py", line 155, in stdout_reader
    message = types.JSONRPCMessage.model_validate_json(line)
  ...
pydantic_core._pydantic_core.ValidationError: 1 validation error for JSONRPCMessage
  Invalid JSON: expected value at line 1 column 1 [type=json_invalid, input_value='hello', input_type=str]
{
  "servers": { ... }
}
\`\`\`

Downstream ``jq`` / ``json.loads`` can choke on the merged stream, and even when stderr is separated the noise is just chatter — we already capture and report per-server failures, so the SDK-level log is redundant.

### 2. Probe error field shows the wrapper, not the cause

Probe failures bubble out of anyio's ``TaskGroup`` as an ``ExceptionGroup``, so the prior ``str(exc)`` returned ``"unhandled errors in a TaskGroup (1 sub-exception)"`` — the wrapper. The actual cause (``"Connection closed"``, ``"Invalid JSON: …"``, etc.) was buried at ``exc.exceptions[0]``.

\`\`\`text
$ mms health --config /tmp/echo_upstream.json
Upstream Server Health
==============================
  echo: DISCONNECTED — unhandled errors in a TaskGroup (1 sub-exception)   # before
  echo: DISCONNECTED — Connection closed                                    # after
\`\`\`

## Approach

Both fixes land in ``_probe_servers`` so every probe caller benefits — ``health``, ``add --validate``, ``init``'s import flow, ``--from-clients``. Runtime proxy logging is untouched: the silence is via a ``contextmanager`` scoped to the probe, restoring the prior log level on exit.

The unwrap walks ``BaseExceptionGroup`` recursively with a cycle guard, and falls back to the exception type name when the leaf's ``str()`` is empty (``CancelledError``, etc.).

The catch surface stays at ``except Exception`` rather than expanding to ``BaseException`` — ``ExceptionGroup`` is already an ``Exception`` subclass so the unwrap reaches it, while keeping ``CancelledError`` / ``KeyboardInterrupt`` propagating out of a probe (the desired behavior — we shouldn't swallow Ctrl-C).

## Behavior change

| Caller | Before (probe failure) | After |
| --- | --- | --- |
| ``mms health`` text | DISCONNECTED line + N stderr tracebacks | DISCONNECTED line, clean stderr, real cause in error |
| ``mms health --json`` | structured output + N stderr tracebacks merged into pipe | structured output, clean stderr, parseable JSON |
| ``mms add --validate`` | abort message wrapped as TaskGroup string | abort message with the real cause |
| ``mms init`` import probe | same wrapper | same fix — real cause |

Successful probes are unchanged. Empty-config, missing-config, and timeout paths are unchanged. Exit codes are unchanged across the board.

## Test plan

- [x] Two CLI-level regression tests pinning both behaviors against an ``echo`` upstream:
  - ``test_health_error_unwraps_taskgroup_wrapper`` — asserts ``"TaskGroup"`` / ``"sub-exception"`` are absent from the error field
  - ``test_health_json_stderr_not_polluted_by_sdk_logs`` — asserts the output parses cleanly as JSON (would ``JSONDecodeError`` if logger.exception leaked into the same stream)
- [x] Four unit tests for ``_root_cause_message`` covering plain exceptions, empty-str fallback, single-level group, nested group
- [x] ``uv run pytest -m "not ollama"`` (1660 passed)
- [x] ``uv run ruff check src && uv run ruff format --check src`` (clean)
- [x] ``uv run mypy src/memtomem_stm/cli/proxy.py`` (clean — advisory)
- [x] Manual: ``mms health`` against a real config (all upstreams connected — clean output unchanged) and against a synthetic ``echo`` upstream (clean stderr, real cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)