### PR TITLE
fix(cli): widen `mms list` TRANSPORT column to fit `streamable_http`

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -521,8 +521,14 @@ def list_servers(config_path: str, *, as_json: bool = False) -> None:
         click.echo("No upstream servers configured.")
         return
 
+    # ``streamable_http`` is 15 chars — wider than the prior ``<12``
+    # transport column, so rows for HTTP servers used to push the
+    # COMPRESSION and COMMAND/URL columns out of alignment with the
+    # header. ``<16`` fits every Choice value the ``--transport`` flag
+    # accepts (``stdio`` / ``sse`` / ``streamable_http``) with at least
+    # one space of padding.
     click.echo(
-        _hdr(f"{'NAME':<20} {'PREFIX':<10} {'TRANSPORT':<12} {'COMPRESSION':<12} COMMAND / URL")
+        _hdr(f"{'NAME':<20} {'PREFIX':<10} {'TRANSPORT':<16} {'COMPRESSION':<12} COMMAND / URL")
     )
     click.echo("-" * 80)
     for name, cfg in servers.items():
@@ -535,7 +541,7 @@ def list_servers(config_path: str, *, as_json: bool = False) -> None:
             detail = f"{cmd} {args_str}".strip()
         else:
             detail = cfg.get("url", "")
-        click.echo(f"{name:<20} {prefix:<10} {transport:<12} {compression:<12} {detail}")
+        click.echo(f"{name:<20} {prefix:<10} {transport:<16} {compression:<12} {detail}")
     click.echo(f"\n{len(servers)} server(s) configured.")
 
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -242,6 +242,37 @@ class TestListServers:
         result = runner.invoke(cli, ["list", *_cfg_args(config)])
         assert "example.com/mcp" in result.output
 
+    def test_list_streamable_http_row_aligns_with_header(self, runner, config):
+        """``streamable_http`` (15 chars) used to overflow the TRANSPORT
+        column and push COMPRESSION + COMMAND/URL out of alignment with
+        the header. Pin the header/row column boundaries so the regression
+        is caught — not just whether the URL appears.
+        """
+        runner.invoke(
+            cli,
+            [
+                "add",
+                "wide",
+                "--prefix",
+                "wd",
+                "--transport",
+                "streamable_http",
+                "--url",
+                "https://example.com/mcp",
+                *_cfg_args(config),
+            ],
+        )
+        result = runner.invoke(cli, ["list", *_cfg_args(config)])
+        assert result.exit_code == 0
+        lines = result.output.splitlines()
+        # Header is the first non-empty styled line; the row immediately
+        # follows the dashed separator.
+        header = next(line for line in lines if "NAME" in line and "TRANSPORT" in line)
+        row = next(line for line in lines if line.startswith("wide"))
+        # The COMPRESSION column starts at the same offset on header
+        # and row — drift used to put them several chars apart.
+        assert header.index("COMPRESSION") == row.index("auto")
+
     def test_json_output(self, runner, config):
         """``list --json`` mirrors ``status --json`` shape for scripting."""
         config.write_text(


### PR DESCRIPTION
## Summary

The TRANSPORT column in ``mms list`` was sized at ``<12`` chars, but ``streamable_http`` is 15 chars — so HTTP-typed upstream rows pushed COMPRESSION and COMMAND/URL out of alignment with the header. Repro on ``main``:

\`\`\`text
NAME                 PREFIX     TRANSPORT    COMPRESSION  COMMAND / URL
--------------------------------------------------------------------------------
fakeserver           fake       stdio        auto         echo hello
sse_demo             demo       sse          auto         https://example.com/sse
http_demo            httpd      streamable_http auto         https://example.com/mcp
                                              ^^^^^ row shifted 3 chars left of the header column
\`\`\`

``<16`` fits every value the ``--transport`` Choice flag accepts (``stdio``, ``sse``, ``streamable_http``) with at least one space of padding.

## Test plan

- [x] Regression test (``test_list_streamable_http_row_aligns_with_header``) pinning ``header.index("COMPRESSION") == row.index("auto")`` for a ``streamable_http`` row — would have caught the drift directly.
- [x] Mutation-verified: reverting the fix in-place produces ``AssertionError: 45 == 48`` (column 45 on header vs column 48 on row — exactly the 3-char shift). Re-applying the fix passes.
- [x] ``uv run pytest -m "not ollama"`` (1655 passed)
- [x] ``uv run ruff check src && uv run ruff format --check src`` (clean)

## Notes

- Drive-by from the same local exercise that produced #250 / #251; kept as a separate PR per the project's "drive-by belongs in a separate PR" convention.
- COMPRESSION column stays at ``<12`` — its longest value, ``selective``, is 9 chars and fits comfortably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)