### PR TITLE
feat(metrics): persist error message text in proxy_metrics.db (#253)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -65,7 +65,12 @@ from memtomem_stm.proxy.progressive import (
 )
 from memtomem_stm.proxy.progressive_reads import ProgressiveReadsTracker
 from memtomem_stm.proxy._locks import LockTimeoutError, bounded_lock
-from memtomem_stm.proxy.metrics import CallMetrics, ErrorCategory, TokenTracker
+from memtomem_stm.proxy.metrics import (
+    MAX_ERROR_MESSAGE_CHARS,
+    CallMetrics,
+    ErrorCategory,
+    TokenTracker,
+)
 from memtomem_stm.observability.tracing import traced
 
 # JSON-RPC error codes that indicate bad input, not connection problems.
@@ -1115,6 +1120,9 @@ class ProxyManager:
                         compressed_chars=0,
                         is_error=True,
                         error_category=ErrorCategory.TIMEOUT,
+                        error_message=(f"{type(deadline_exc).__name__}: {deadline_exc}")[
+                            :MAX_ERROR_MESSAGE_CHARS
+                        ],
                         trace_id=trace_id,
                     )
                 )
@@ -1148,6 +1156,9 @@ class ProxyManager:
                             compressed_chars=0,
                             is_error=True,
                             error_category=ErrorCategory.PROGRAMMING,
+                            error_message=(f"{type(exc).__name__}: {exc}")[
+                                :MAX_ERROR_MESSAGE_CHARS
+                            ],
                             trace_id=trace_id,
                         )
                     )
@@ -1169,6 +1180,9 @@ class ProxyManager:
                             is_error=True,
                             error_category=ErrorCategory.PROTOCOL,
                             error_code=err_code,
+                            error_message=(f"{type(exc).__name__}: {exc}")[
+                                :MAX_ERROR_MESSAGE_CHARS
+                            ],
                             trace_id=trace_id,
                         )
                     )
@@ -1197,6 +1211,9 @@ class ProxyManager:
                             compressed_chars=0,
                             is_error=True,
                             error_category=cat,
+                            error_message=(f"{type(exc).__name__}: {exc}")[
+                                :MAX_ERROR_MESSAGE_CHARS
+                            ],
                             trace_id=trace_id,
                         )
                     )
@@ -1299,6 +1316,7 @@ class ProxyManager:
                     compressed_chars=len(original_text),
                     is_error=True,
                     error_category=ErrorCategory.UPSTREAM_ERROR,
+                    error_message=original_text[:MAX_ERROR_MESSAGE_CHARS],
                     trace_id=trace_id,
                 )
             )

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -70,6 +70,7 @@ from memtomem_stm.proxy.metrics import (
     CallMetrics,
     ErrorCategory,
     TokenTracker,
+    format_error_message_from_exc,
 )
 from memtomem_stm.observability.tracing import traced
 
@@ -988,6 +989,13 @@ class ProxyManager:
                                 compressed_chars=0,
                                 trace_id=trace_id,
                                 error_category=pipeline_category,
+                                # LOCK_TIMEOUT bubbles out of ``bounded_lock``
+                                # before the per-stage ``index_error`` /
+                                # ``extract_error`` / ``surface_error`` columns
+                                # get populated, so without this the row is
+                                # all-NULL across diagnostic text — same gap
+                                # the rest of #253 closes for upstream errors.
+                                error_message=format_error_message_from_exc(exc),
                             )
                         )
                     except Exception:
@@ -1120,9 +1128,7 @@ class ProxyManager:
                         compressed_chars=0,
                         is_error=True,
                         error_category=ErrorCategory.TIMEOUT,
-                        error_message=(f"{type(deadline_exc).__name__}: {deadline_exc}")[
-                            :MAX_ERROR_MESSAGE_CHARS
-                        ],
+                        error_message=format_error_message_from_exc(deadline_exc),
                         trace_id=trace_id,
                     )
                 )
@@ -1156,9 +1162,7 @@ class ProxyManager:
                             compressed_chars=0,
                             is_error=True,
                             error_category=ErrorCategory.PROGRAMMING,
-                            error_message=(f"{type(exc).__name__}: {exc}")[
-                                :MAX_ERROR_MESSAGE_CHARS
-                            ],
+                            error_message=format_error_message_from_exc(exc),
                             trace_id=trace_id,
                         )
                     )
@@ -1180,9 +1184,7 @@ class ProxyManager:
                             is_error=True,
                             error_category=ErrorCategory.PROTOCOL,
                             error_code=err_code,
-                            error_message=(f"{type(exc).__name__}: {exc}")[
-                                :MAX_ERROR_MESSAGE_CHARS
-                            ],
+                            error_message=format_error_message_from_exc(exc),
                             trace_id=trace_id,
                         )
                     )
@@ -1211,9 +1213,7 @@ class ProxyManager:
                             compressed_chars=0,
                             is_error=True,
                             error_category=cat,
-                            error_message=(f"{type(exc).__name__}: {exc}")[
-                                :MAX_ERROR_MESSAGE_CHARS
-                            ],
+                            error_message=format_error_message_from_exc(exc),
                             trace_id=trace_id,
                         )
                     )

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 # long-lived daemons or multi-tenant gateways where upstream names churn.
 MAX_TRACKED_KEYS = 10_000
 
+# Cap for ``CallMetrics.error_message`` persisted in ``proxy_metrics.db``.
+# Long enough to retain typical JSON-RPC error payloads and short upstream
+# tool messages; short enough that a chatty upstream cannot blow up the DB.
+MAX_ERROR_MESSAGE_CHARS = 500
+
 
 class _BoundedCounterDict:
     """LRU-bounded counter map with defaultdict-style lazy insertion.
@@ -125,6 +130,13 @@ class CallMetrics:
     is_error: bool = False
     error_category: ErrorCategory | None = None
     error_code: int | None = None
+    # Free-form error text from the failing source. Populated by ProxyManager
+    # at the same call sites that set ``error_category`` so post-mortem
+    # inspection of ``proxy_metrics.db`` can distinguish *why* a call failed
+    # without re-running it (e.g. JSON-RPC -32602 with "Invalid params: foo"
+    # vs. an upstream tool returning ``isError=True`` with a slug-not-found
+    # message). Truncated by callers to ``MAX_ERROR_MESSAGE_CHARS``.
+    error_message: str | None = None
     # Compression fidelity tracking
     #
     # ``compression_strategy`` records the *effective* strategy used for this

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -26,6 +26,17 @@ MAX_TRACKED_KEYS = 10_000
 MAX_ERROR_MESSAGE_CHARS = 500
 
 
+def format_error_message_from_exc(exc: BaseException) -> str:
+    """Format an exception for ``CallMetrics.error_message`` (capped).
+
+    Used at every exception-driven capture site in ``ProxyManager.call_tool``
+    (PROGRAMMING / PROTOCOL / TRANSPORT / TIMEOUT / LOCK_TIMEOUT /
+    INTERNAL_ERROR). UPSTREAM_ERROR uses ``original_text`` directly because
+    its source is the upstream tool's text payload, not a Python exception.
+    """
+    return f"{type(exc).__name__}: {exc}"[:MAX_ERROR_MESSAGE_CHARS]
+
+
 class _BoundedCounterDict:
     """LRU-bounded counter map with defaultdict-style lazy insertion.
 
@@ -136,6 +147,13 @@ class CallMetrics:
     # without re-running it (e.g. JSON-RPC -32602 with "Invalid params: foo"
     # vs. an upstream tool returning ``isError=True`` with a slug-not-found
     # message). Truncated by callers to ``MAX_ERROR_MESSAGE_CHARS``.
+    #
+    # Privacy posture: this is operator-local (lives only in the on-disk
+    # ``proxy_metrics.db``, never returned over MCP) and the cap limits
+    # worst-case leakage size, but content is *not* sanitized — same risk
+    # class as the existing ``index_error`` / ``extract_error`` /
+    # ``surface_error`` columns. Don't add a redactor here without reviewing
+    # all four sites together.
     error_message: str | None = None
     # Compression fidelity tracking
     #

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -124,6 +124,9 @@ class MetricsStore:
             "surface_error": (
                 "ALTER TABLE proxy_metrics ADD COLUMN surface_error TEXT DEFAULT NULL"
             ),
+            "error_message": (
+                "ALTER TABLE proxy_metrics ADD COLUMN error_message TEXT DEFAULT NULL"
+            ),
         }
         for col, ddl in migrations.items():
             if col not in existing:
@@ -143,12 +146,12 @@ class MetricsStore:
             self._db.execute(
                 "INSERT INTO proxy_metrics "
                 "(server, tool, original_chars, compressed_chars, cleaned_chars, "
-                "is_error, error_category, error_code, trace_id, "
+                "is_error, error_category, error_code, error_message, trace_id, "
                 "compression_strategy, ratio_violation, scorer_fallback, "
                 "index_ok, index_error, chunks_indexed, "
                 "extract_ok, extract_error, "
                 "surfacing_on_progressive_ok, surface_error, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     metrics.server,
                     metrics.tool,
@@ -158,6 +161,7 @@ class MetricsStore:
                     int(metrics.is_error),
                     metrics.error_category.value if metrics.error_category else None,
                     metrics.error_code,
+                    metrics.error_message,
                     metrics.trace_id,
                     metrics.compression_strategy,
                     int(metrics.ratio_violation),

--- a/tests/test_error_metrics.py
+++ b/tests/test_error_metrics.py
@@ -593,6 +593,45 @@ class TestErrorMessagePersistence:
         ).fetchone()
         assert row == (0, None)
 
+    async def test_internal_error_persists_message(self, tmp_path):
+        """A pipeline-stage exception (CLEAN/COMPRESS/SURFACE/INDEX) escaping
+        ``_call_tool_inner`` is recorded as INTERNAL_ERROR by the outer wrapper.
+        The per-stage error column may not be set on every path — error_message
+        gives a single column to query for any pipeline failure text."""
+        mgr = _make_manager_with_store(tmp_path)
+        mgr._connections["srv"].session.call_tool.return_value = _make_result("hello")
+        with patch.object(
+            mgr, "_apply_compression", new_callable=AsyncMock, side_effect=RuntimeError("boom")
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await mgr.call_tool("srv", "tool", {})
+        cat, _code, msg = _read_error_row(mgr)
+        assert cat == "internal_error"
+        assert msg == "RuntimeError: boom"
+
+    async def test_lock_timeout_persists_message(self, tmp_path):
+        """LockTimeoutError (#208) escapes ``bounded_lock`` *before* the
+        per-stage ``index_error`` / ``extract_error`` / ``surface_error``
+        columns get populated. Without ``error_message`` the lock_timeout row
+        was all-NULL across diagnostic text, defeating the post-mortem use
+        case this PR is meant to enable."""
+        from memtomem_stm.proxy._locks import LockTimeoutError
+
+        mgr = _make_manager_with_store(tmp_path)
+        with patch.object(
+            mgr,
+            "_call_tool_guarded",
+            new_callable=AsyncMock,
+            side_effect=LockTimeoutError("stm_lock", 5.0),
+        ):
+            with pytest.raises(LockTimeoutError):
+                await mgr.call_tool("srv", "tool", {})
+        cat, _code, msg = _read_error_row(mgr)
+        assert cat == "lock_timeout"
+        assert msg is not None
+        assert "stm_lock" in msg
+        assert msg.startswith("LockTimeoutError")
+
 
 # ── CircuitBreaker properties ────────────────────────────────────────────
 

--- a/tests/test_error_metrics.py
+++ b/tests/test_error_metrics.py
@@ -12,7 +12,12 @@ import pytest
 
 from memtomem_stm.proxy.config import CompressionStrategy, ProxyConfig, UpstreamServerConfig
 from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
-from memtomem_stm.proxy.metrics import CallMetrics, ErrorCategory, TokenTracker
+from memtomem_stm.proxy.metrics import (
+    MAX_ERROR_MESSAGE_CHARS,
+    CallMetrics,
+    ErrorCategory,
+    TokenTracker,
+)
 from memtomem_stm.proxy.metrics_store import MetricsStore
 from memtomem_stm.utils.circuit_breaker import CircuitBreaker
 
@@ -320,6 +325,56 @@ class TestMetricsStoreMigration:
         assert row == (0, None, None)
         store.close()
 
+    def test_fresh_db_has_error_message_column(self, tmp_path):
+        store = MetricsStore(tmp_path / "test.db")
+        store.initialize()
+        cols = {row[1] for row in store._db.execute("PRAGMA table_info(proxy_metrics)")}
+        assert "error_message" in cols
+        store.close()
+
+    def test_existing_db_migrates_error_message(self, tmp_path):
+        """Pre-existing DB without error_message gets migrated."""
+        import sqlite3
+
+        db_path = tmp_path / "old.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE proxy_metrics ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "server TEXT NOT NULL, tool TEXT NOT NULL, "
+            "original_chars INTEGER NOT NULL, compressed_chars INTEGER NOT NULL, "
+            "cleaned_chars INTEGER NOT NULL DEFAULT 0, created_at REAL NOT NULL)"
+        )
+        conn.commit()
+        conn.close()
+
+        store = MetricsStore(db_path)
+        store.initialize()
+        cols = {row[1] for row in store._db.execute("PRAGMA table_info(proxy_metrics)")}
+        assert "error_message" in cols
+        store.close()
+
+    def test_record_persists_error_message(self, tmp_path):
+        store = MetricsStore(tmp_path / "test.db")
+        store.initialize()
+        store.record(
+            CallMetrics(
+                server="srv",
+                tool="tool",
+                original_chars=0,
+                compressed_chars=0,
+                is_error=True,
+                error_category=ErrorCategory.PROTOCOL,
+                error_code=-32602,
+                error_message="ValueError: Invalid params: page_path",
+            )
+        )
+        row = store._db.execute(
+            "SELECT error_category, error_code, error_message FROM proxy_metrics"
+        ).fetchone()
+        assert row == ("protocol", -32602, "ValueError: Invalid params: page_path")
+        store.close()
+
 
 # ── ProxyManager integration ─────────────────────────────────────────────
 
@@ -413,6 +468,130 @@ class TestManagerErrorRecording:
         s = mgr.tracker.get_summary()
         assert s["total_errors"] == 0
         assert s["total_calls"] == 1
+
+
+# ── error_message persistence (issue #253) ───────────────────────────────
+
+
+def _make_manager_with_store(tmp_path: Path, max_retries: int = 0) -> ProxyManager:
+    """Like ``_make_manager`` but with a real MetricsStore so SQL assertions work."""
+    server_cfg = UpstreamServerConfig(
+        prefix="test",
+        compression=CompressionStrategy.NONE,
+        max_result_chars=50000,
+        max_retries=max_retries,
+        reconnect_delay_seconds=0.0,
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=Path("/tmp/proxy.json"),
+        upstream_servers={"srv": server_cfg},
+    )
+    store = MetricsStore(tmp_path / "metrics.db")
+    store.initialize()
+    tracker = TokenTracker(metrics_store=store)
+    mgr = ProxyManager(proxy_cfg, tracker)
+    mgr._connections["srv"] = UpstreamConnection(
+        name="srv",
+        config=server_cfg,
+        session=AsyncMock(),
+        tools=[],
+    )
+    mgr._test_store = store  # noqa: SLF001 — held for SQL assertions in tests
+    return mgr
+
+
+def _read_error_row(mgr: ProxyManager) -> tuple:
+    return mgr._test_store._db.execute(  # noqa: SLF001
+        "SELECT error_category, error_code, error_message FROM proxy_metrics"
+    ).fetchone()
+
+
+class TestErrorMessagePersistence:
+    """Each ErrorCategory writes ``error_message`` to ``proxy_metrics.db``.
+
+    Without this, post-mortem inspection cannot distinguish (e.g.) a wrong
+    argument name from a rate-limit hit when both surface as ``upstream_error``
+    or ``protocol`` rows. See issue #253.
+    """
+
+    async def test_programming_persists_message(self, tmp_path):
+        mgr = _make_manager_with_store(tmp_path)
+        mgr._connections["srv"].session.call_tool.side_effect = TypeError("bad arg")
+        with pytest.raises(TypeError):
+            await mgr.call_tool("srv", "tool", {})
+        cat, code, msg = _read_error_row(mgr)
+        assert cat == "programming"
+        assert code is None
+        assert msg == "TypeError: bad arg"
+
+    async def test_protocol_persists_message_with_code(self, tmp_path):
+        mgr = _make_manager_with_store(tmp_path)
+        exc = Exception("Invalid params: page_path")
+        exc.error = SimpleNamespace(code=-32602)
+        mgr._connections["srv"].session.call_tool.side_effect = exc
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            with pytest.raises(Exception):
+                await mgr.call_tool("srv", "tool", {})
+        cat, code, msg = _read_error_row(mgr)
+        assert cat == "protocol"
+        assert code == -32602
+        assert msg is not None and "Invalid params: page_path" in msg
+
+    async def test_transport_persists_message(self, tmp_path):
+        mgr = _make_manager_with_store(tmp_path, max_retries=0)
+        mgr._connections["srv"].session.call_tool.side_effect = ConnectionError("down")
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            with pytest.raises(ConnectionError):
+                await mgr.call_tool("srv", "tool", {})
+        cat, _code, msg = _read_error_row(mgr)
+        assert cat == "transport"
+        assert msg == "ConnectionError: down"
+
+    async def test_timeout_persists_message(self, tmp_path):
+        mgr = _make_manager_with_store(tmp_path, max_retries=0)
+        mgr._connections["srv"].session.call_tool.side_effect = asyncio.TimeoutError()
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            with pytest.raises(asyncio.TimeoutError):
+                await mgr.call_tool("srv", "tool", {})
+        cat, _code, msg = _read_error_row(mgr)
+        assert cat == "timeout"
+        assert msg is not None and msg.startswith("TimeoutError")
+
+    async def test_upstream_error_persists_original_text(self, tmp_path):
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        mgr = _make_manager_with_store(tmp_path)
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(
+            "Error: page slug 'foo' not found", is_error=True
+        )
+        with pytest.raises(ToolError):
+            await mgr.call_tool("srv", "tool", {})
+        cat, _code, msg = _read_error_row(mgr)
+        assert cat == "upstream_error"
+        assert msg == "Error: page slug 'foo' not found"
+
+    async def test_message_truncated_at_cap(self, tmp_path):
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        mgr = _make_manager_with_store(tmp_path)
+        long_text = "x" * (MAX_ERROR_MESSAGE_CHARS + 250)
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(
+            long_text, is_error=True
+        )
+        with pytest.raises(ToolError):
+            await mgr.call_tool("srv", "tool", {})
+        _cat, _code, msg = _read_error_row(mgr)
+        assert msg is not None
+        assert len(msg) == MAX_ERROR_MESSAGE_CHARS
+
+    async def test_success_persists_null_message(self, tmp_path):
+        mgr = _make_manager_with_store(tmp_path)
+        mgr._connections["srv"].session.call_tool.return_value = _make_result("ok")
+        await mgr.call_tool("srv", "tool", {})
+        row = mgr._test_store._db.execute(  # noqa: SLF001
+            "SELECT is_error, error_message FROM proxy_metrics"
+        ).fetchone()
+        assert row == (0, None)
 
 
 # ── CircuitBreaker properties ────────────────────────────────────────────


### PR DESCRIPTION
Closes #253.

## Summary

- Adds `error_message TEXT DEFAULT NULL` column to `proxy_metrics.db`, populated at all five capture sites in `ProxyManager.call_tool` (PROGRAMMING / PROTOCOL / TRANSPORT / TIMEOUT / UPSTREAM_ERROR).
- Capped at 500 chars (`MAX_ERROR_MESSAGE_CHARS` in `proxy/metrics.py`) — long enough to retain typical JSON-RPC envelopes, short enough that a chatty upstream cannot blow up the DB.
- Migration is idempotent (matches the existing per-column `PRAGMA table_info` pattern), so existing `~/.memtomem/proxy_metrics.db` files migrate transparently on next start.

## Behavior change

Operator-visible only: `proxy_metrics.db` now stores the error text alongside `error_category` / `error_code`. No surfacing change in MCP responses (the same text already reaches the caller via `ToolError(original_text)` for `UPSTREAM_ERROR`, or via re-raised exception for the other categories).

Removes the asymmetry where `index_error` / `extract_error` / `surface_error` already stored TEXT but the upstream/protocol/transport/timeout categories did not.

## Test plan

- [x] `tests/test_error_metrics.py::TestErrorMessagePersistence` — one test per ErrorCategory triggers the failure path through `ProxyManager.call_tool` with a real `MetricsStore`, then SQL-asserts the persisted `error_message` matches the expected text.
- [x] Truncation test: a >`MAX_ERROR_MESSAGE_CHARS` upstream message is capped at the boundary.
- [x] Success path persists `error_message=NULL`.
- [x] Schema layer: fresh-DB column existence + migration of a pre-existing schema-less DB.
- [x] Full suite: `uv run pytest -m "not ollama"` → 1675 passed.
- [x] `uv run ruff check src tests` → clean. `ruff format` of touched files → clean.

## Out of scope

- No new query path, CLI command, or `mms status` field — separate follow-up once the column exists and we know what queries are useful.
- No surfacing change in MCP tool responses.
- No structured field extraction; opaque text is enough for the post-mortem use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)