### PR TITLE
docs: surface Phase 1 observability sections in surfacing/cli docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -285,7 +285,7 @@ These are exposed by the `memtomem-stm` MCP server and become available to your 
 | `stm_proxy_cache_clear` | `server?`, `tool?` | Clear response cache (all, by server, by tool, or by server+tool) |
 | `stm_proxy_health` | — | Upstream server connectivity and circuit breaker status |
 | `stm_surfacing_feedback` | `surfacing_id`, `rating`, `memory_id?` | Rate surfaced memories (`helpful` / `not_relevant` / `already_known`) |
-| `stm_surfacing_stats` | `tool?` | Surfacing event counts, feedback breakdown, helpfulness % |
+| `stm_surfacing_stats` | `tool?` | Surfacing event counts, feedback breakdown, helpfulness %, plus per-tool skip reasons / outcomes / cache hit ratio (since process start) |
 | `stm_compression_feedback` | `server`, `tool`, `missing`, `kind?`, `trace_id?` | Report missing info from a compressed response (learning signal) |
 | `stm_compression_stats` | `tool?` | Compression feedback counts by kind and tool |
 | `stm_progressive_stats` | `tool?` | Progressive-delivery follow-up rate, coverage, and per-tool breakdown |

--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -291,4 +291,65 @@ By rating:
   already_known: 3
 
 Helpfulness: 73.7%
+
+Skip reasons (since process start):
+  __total__:
+    response_too_short: 142
+    gate_cooldown: 18
+    gate_write_tool: 89
+  read_file:
+    response_too_short: 142
+    gate_cooldown: 18
+  write_file:
+    gate_write_tool: 89
+
+Outcomes (since process start):
+  __total__:
+    surfaced_cache_miss: 14
+    surfaced_cache_hit: 9
+  read_file:
+    surfaced_cache_miss: 14
+    surfaced_cache_hit: 9
+
+Cache (since process start): hits 9, misses 14, hit ratio 39.1%
 ```
+
+The first block (totals + ratings + helpfulness) is read from
+`stm_feedback.db` and persists across restarts. The lower three
+sections — `Skip reasons`, `Outcomes`, `Cache` — are in-memory
+counters from `SurfacingObservability` and reset whenever the
+proxy process restarts. They are suppressed entirely when the
+proxy has not yet attempted any surfacing call, so the legacy
+output stays byte-for-byte for zero-traffic deployments.
+
+Each `surface()` call records exactly one skip reason **or** one
+outcome (no double-counting). Cache hit/miss is incremented on
+every cache lookup independently of what the lookup ultimately
+renders, so the hit ratio reflects raw cache behavior rather
+than post-filter results. A reject path that an operator might
+hit:
+
+- `response_too_short` — tool response below `min_response_chars`
+  (default 5000).
+- `gate_write_tool` / `gate_excluded_tool` / `gate_tool_disabled`
+  / `gate_rate_limit` / `gate_cooldown` — a `RelevanceGate`
+  reject; check the gate config for the offending bucket.
+- `circuit_open` — repeated upstream failures opened the circuit
+  breaker. Surfacing pauses for `circuit_reset_seconds` (default
+  60s) before retrying.
+- `no_query` — `ContextExtractor` could not synthesize a query
+  from the tool arguments and fell below `min_query_tokens`.
+- `no_results_score` — LTM returned results, none above
+  `min_score`. Lower the threshold for that tool via
+  `context_tools.<name>.min_score` if the tool is consistently
+  missed.
+- `no_results_dedup` — every result was already surfaced this
+  session and dropped by `_surfaced_ids`. Distinct from
+  `no_results_score` so an operator can tell whether to lower
+  `min_score` or whether session-dedup is over-aggressive on
+  long sessions.
+- `no_results_invalidated` — every memory in a cache hit was
+  rated `not_relevant` / `already_known` within the cache TTL.
+- `no_results_empty_cache` — the cache stored an empty list
+  (deliberate zero-result entry from a prior LTM miss) and the
+  repeat call hit it.

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -167,6 +167,115 @@ def test_configuration_full_example_documents_upstream_timeouts() -> None:
         )
 
 
+def test_surfacing_md_documents_phase_1_observability_sample() -> None:
+    """docs/surfacing.md's ``stm_surfacing_stats`` example must include
+    the Phase 1 ``Skip reasons`` / ``Outcomes`` / ``Cache`` sections.
+
+    The header strings ship in ``server.py::_format_observability_sections``
+    (v0.1.19 / PR #256). If a future operator regenerates the sample
+    output and only captures the legacy event-counts block, readers
+    of `docs/surfacing.md` lose the only operator-facing surface that
+    explains *why* surfacing skipped, and the RFC's "no more
+    DEBUG-log only skips" promise becomes invisible. Scope the
+    assertion to the fenced code block immediately after the
+    "Check effectiveness with `stm_surfacing_stats`" prose so a
+    new section pasted into an unrelated part of the file cannot
+    satisfy the check.
+    """
+    server_src = _read("src/memtomem_stm/server.py")
+    # Pin the exact header literals server.py emits — if they ever
+    # rename, the test fails loudly here rather than silently passing
+    # against stale docs.
+    required_headers = ("Skip reasons", "Outcomes", "Cache (since process start)")
+    missing_in_source = [h for h in required_headers if h not in server_src]
+    if missing_in_source:
+        pytest.fail(
+            f"server.py no longer emits header(s) {missing_in_source!r} — "
+            "_format_observability_sections was likely renamed or its "
+            "literals changed. Update this test and docs/surfacing.md "
+            "together."
+        )
+
+    surfacing_md = _read("docs/surfacing.md")
+    # Locate the fenced sample block right after the "Check
+    # effectiveness" sentence. Splitting on triple-backtick fences and
+    # picking the one preceded by that phrase keeps the check tied to
+    # the operator-facing example, not any other code block in the
+    # file (e.g. a config snippet that happens to mention surfacing).
+    anchor = "Check effectiveness with `stm_surfacing_stats`:"
+    if anchor not in surfacing_md:
+        pytest.fail(
+            f"docs/surfacing.md no longer contains the {anchor!r} "
+            "anchor — the section was renamed or removed. Update this "
+            "test alongside the docs restructure."
+        )
+    after_anchor = surfacing_md.split(anchor, 1)[1]
+    block_match = re.search(r"```\n(.*?)\n```", after_anchor, re.DOTALL)
+    if not block_match:
+        pytest.fail(
+            "docs/surfacing.md no longer has a fenced sample block "
+            "after the 'Check effectiveness' anchor — restore the "
+            "stm_surfacing_stats example or update this test."
+        )
+    block = block_match.group(1)
+
+    missing_in_docs = [h for h in required_headers if h not in block]
+    if missing_in_docs:
+        pytest.fail(
+            f"docs/surfacing.md `stm_surfacing_stats` sample block is "
+            f"missing Phase 1 observability header(s): {missing_in_docs!r}. "
+            "These ship in server.py's _format_observability_sections "
+            "and are the operator-facing surface for skip reasons, "
+            "outcomes, and cache hit ratio (v0.1.19, #256). Without "
+            "them in the sample, readers cannot tell what the new "
+            "sections look like or what counters to expect."
+        )
+
+
+def test_cli_md_describes_surfacing_observability_columns() -> None:
+    """docs/cli.md's ``stm_surfacing_stats`` row in the observability
+    tools table must mention the Phase 1 axes (skip / outcome / cache)
+    in addition to the legacy event/feedback summary.
+
+    The MCP tool keeps its name and arguments shape across v0.1.18 →
+    v0.1.19, so a quick scan of the table description is the only
+    surface that tells an operator "this also reports skip reasons /
+    outcomes / cache hit ratio now." A description frozen at the
+    pre-#256 wording is silent drift — the tool is still listed, the
+    arg is still ``tool?``, but the new axes are invisible to anyone
+    not reading CHANGELOG. Scope the assertion to the row that names
+    `stm_surfacing_stats` to avoid false-passing on prose elsewhere
+    in the file.
+    """
+    cli_md = _read("docs/cli.md")
+    # Markdown table rows are single-line. Match the row that names
+    # ``stm_surfacing_stats`` in a backtick to avoid hitting prose
+    # references that happen to mention the tool.
+    row_match = re.search(r"^\|\s*`stm_surfacing_stats`\s*\|.*$", cli_md, re.MULTILINE)
+    if not row_match:
+        pytest.fail(
+            "docs/cli.md no longer has a `stm_surfacing_stats` row in "
+            "the observability tools table — the table was restructured "
+            "or the tool was renamed. Update this test alongside the "
+            "docs change."
+        )
+    row = row_match.group(0).lower()
+    # All three axes must be reachable from this row. Match
+    # case-insensitively and accept either singular or plural forms so
+    # a prose tweak ("skip reason" vs "skip reasons") doesn't false-fail.
+    required_axes = ("skip", "outcome", "cache")
+    missing_axes = [a for a in required_axes if a not in row]
+    if missing_axes:
+        pytest.fail(
+            f"docs/cli.md `stm_surfacing_stats` row is missing Phase 1 "
+            f"axis keyword(s): {missing_axes!r}. The row description "
+            "must surface skip reasons / outcomes / cache hit ratio "
+            "alongside the legacy event/feedback summary so operators "
+            "scanning the table see all axes the tool reports "
+            "(v0.1.19, #256)."
+        )
+
+
 def test_compression_md_llm_section_documents_timeout_fallback() -> None:
     """docs/compression.md's ``## LLM Compression`` section must surface
     ``llm_timeout_seconds`` in the config example or fallback prose.


### PR DESCRIPTION
## Summary

PR #256 (v0.1.19) added three new sections to ``stm_surfacing_stats``
output — ``Skip reasons``, ``Outcomes``, ``Cache`` — but the
operator-facing docs had only the legacy event/feedback example.
An operator who reads ``docs/surfacing.md`` or scans the
``docs/cli.md`` observability tools table sees the same wording as
v0.1.18 and has no surface to discover the new counters short of
running the tool or reading CHANGELOG.

## Changes

- **``docs/surfacing.md``** — sample block after the
  ``Check effectiveness with stm_surfacing_stats:`` anchor extended
  with the three new sections in the exact format
  ``server.py::_format_observability_sections`` emits (totals,
  per-tool, descending sort, ``__total__`` first). Followed by a
  short prose guide to each reject path so an operator who hits,
  say, ``no_results_dedup`` can interpret it as ``min_score`` vs.
  session-dedup tension and tune accordingly.
- **``docs/cli.md``** — observability tools table row description
  for ``stm_surfacing_stats`` now mentions skip reasons / outcomes /
  cache hit ratio alongside the legacy event/feedback summary, so a
  reader scanning the table sees all axes the tool reports.
- **``tests/test_docs_sync.py``** — two regression tests pinning
  each doc to its source-of-truth:
  - ``test_surfacing_md_documents_phase_1_observability_sample``
    extracts the fenced sample block after the
    ``Check effectiveness`` anchor and asserts each Phase 1 header
    literal (``Skip reasons`` / ``Outcomes`` / ``Cache (since process
    start)``) appears in both ``server.py`` and that block. Header
    literals are cross-checked against ``server.py`` first so a
    rename in source surfaces here loudly rather than silently
    passing against stale docs.
  - ``test_cli_md_describes_surfacing_observability_columns``
    matches the markdown table row that names ``stm_surfacing_stats``
    and asserts ``skip`` / ``outcome`` / ``cache`` are all in that
    row's description (case-insensitive, accepting plural/singular
    forms).
  - Both follow the ``feedback_docs_drift_regression_test.md``
    pattern: paragraph/row-scoped (avoids false-pass on whole-file
    grep), ``pytest.fail`` over bare ``assert`` so the failure
    message can point operators back to the test and the doc
    section, mutation-friendly (a header rename in source or a
    description revert in docs both fail).

## Test plan

- [x] ``uv run pytest tests/test_docs_sync.py -v`` — 6/6 pass
      (4 existing + 2 new)
- [x] ``uv run ruff check src tests`` — clean
- [x] ``uv run ruff format`` — touched files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)