### PR TITLE
fix(cli): unify entry-point dispatch so all three boot the MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **All three console scripts (`memtomem-stm`, `memtomem-stm-proxy`, `mms`) now boot the MCP stdio server when invoked bare with a piped stdin** (#260) — previously only `memtomem-stm` worked as an MCP-server registration target because it pointed straight at `server.main`, while `memtomem-stm-proxy` and `mms` resolved to the Click group whose bare invocation printed help and exited 2. An MCP client config like `{"command": "mms"}` therefore failed with `: calling "initialize": EOF` even though the package documentation calls these names interchangeable. The `cli` Click group now uses `invoke_without_command=True` and dispatches based on `sys.stdin.isatty()`: a TTY still prints the help text (now exit 0, matching Click's default `get_help` flow), and a non-TTY (the MCP-client stdio case, CliRunner, pipes) lazy-imports `memtomem_stm.server.main` and runs it. All three `[project.scripts]` entry points in `pyproject.toml` now resolve to `memtomem_stm.cli.proxy:cli`, so registering any of them in an MCP client's config works identically — closing the parity gap that surprised first-time Antigravity adopters.
+
 ## [0.1.19] — 2026-04-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,13 @@ The `ollama` marker auto-skips when Ollama isn't running; CI always uses
 
 - **No Python-level dependency on `memtomem` core.** STM talks to the LTM
   server only through the MCP protocol. Don't `import memtomem` from `src/`.
-- **`mms` ≡ `memtomem-stm-proxy`.** Both entry points in `pyproject.toml`
-  resolve to the same CLI — keep them in sync, don't diverge behavior.
+- **`mms` ≡ `memtomem-stm-proxy` ≡ `memtomem-stm`.** All three
+  `[project.scripts]` entry points in `pyproject.toml` resolve to
+  `memtomem_stm.cli.proxy:cli` (#260). The Click group's
+  `invoke_without_command=True` callback dispatches bare invocations on
+  `sys.stdin.isatty()`: TTY → help, non-TTY → `server.main` (the MCP stdio
+  server). Don't diverge behavior between the three names — registering
+  any of them as an MCP client's `command` must work identically.
 - **Pipeline order is CLEAN → COMPRESS → SURFACE → INDEX** — comments in
   `src/memtomem_stm/proxy/` are the source of truth for the per-stage
   contracts; full architecture write-up lives in the private

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,12 @@ langchain = [
 ]
 
 [project.scripts]
-memtomem-stm = "memtomem_stm.server:main"
+# All three entry points resolve to the same Click group. The group's
+# ``invoke_without_command=True`` callback dispatches bare invocations to
+# ``server.main`` when stdin isn't a TTY (the MCP-client stdio case),
+# otherwise prints help — so registering any of these three names in an
+# MCP client's config works identically. See #260.
+memtomem-stm = "memtomem_stm.cli.proxy:cli"
 memtomem-stm-proxy = "memtomem_stm.cli.proxy:cli"
 mms = "memtomem_stm.cli.proxy:cli"
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -412,17 +412,45 @@ def _run_mcp_integration(preselected: int | None = None) -> None:
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
+def _stdin_is_tty() -> bool:
+    """Indirection so tests can monkeypatch this seam.
+
+    Same pattern as ``_should_use_tui`` (CHANGELOG #143) — Click's CliRunner
+    replaces ``sys.stdin`` with a StringIO whose ``isatty()`` is False, so
+    monkeypatching the function attribute directly doesn't reach the module's
+    bound reference.
+    """
+    return bool(sys.stdin.isatty())
+
+
+@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
 @click.version_option(
     package_name="memtomem-stm",
     prog_name="memtomem-stm",
     message="%(prog)s %(version)s",
 )
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context) -> None:
     """memtomem-stm proxy gateway management.
 
     Output is colorized when writing to a terminal. Set NO_COLOR=1 to disable.
+
+    Bare invocation (no subcommand) dispatches based on stdin: a TTY shows
+    this help text, while a piped stdin (the MCP-client stdio case) boots
+    the proxy as an MCP server. This lets any of the three entry points
+    (``memtomem-stm``, ``memtomem-stm-proxy``, ``mms``) be registered as
+    the MCP server command interchangeably (#260).
     """
+    if ctx.invoked_subcommand is not None:
+        return
+    if _stdin_is_tty():
+        click.echo(ctx.get_help())
+        ctx.exit(0)
+    # Non-TTY stdin → MCP client invocation. Lazy import keeps ``mms list`` /
+    # ``mms add`` etc. from paying the server module's startup cost.
+    from memtomem_stm.server import main as server_main
+
+    server_main()
 
 
 # ``version`` subcommand predates the ``--version`` flag (CHANGELOG #152) and

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -110,6 +110,42 @@ class TestBareInvocationDispatch:
         assert result.exit_code == 0
         assert "memtomem-stm" in result.output
 
+    def test_unknown_subcommand_does_not_dispatch_server(self, runner, monkeypatch):
+        """An unknown positional (``mms doesnotexist``) under non-TTY stdin
+        must NOT fall through to ``server.main``. Click raises ``UsageError``
+        before the group callback runs, so the dispatch is skipped — but
+        ``invoked_subcommand`` semantics are easy to misremember (set only
+        for *known* subcommands? for any positional?), so pin the invariant
+        here. Regression cost: a stray non-TTY user typo silently boots an
+        MCP server instead of erroring."""
+
+        def boom() -> None:
+            raise AssertionError("server.main reached via an unknown-subcommand path")
+
+        monkeypatch.setattr("memtomem_stm.cli.proxy._stdin_is_tty", lambda: False)
+        monkeypatch.setattr("memtomem_stm.server.main", boom)
+        result = runner.invoke(cli, ["doesnotexist"])
+        assert result.exit_code != 0
+
+    def test_version_flag_with_pipe_does_not_dispatch_server(self, runner, monkeypatch):
+        """``mms --version`` under a piped stdin must short-circuit on the
+        eager ``--version`` option, not boot the MCP server. Click's
+        ``version_option`` is eager and exits before the group callback,
+        so the dispatch never runs — but adding ``invoke_without_command=True``
+        is exactly the kind of change that could shift evaluation order, so
+        pin the contract. Regression cost: anyone scripting ``mms --version``
+        for a quick install check would suddenly hang waiting for stdio
+        JSON-RPC."""
+
+        def boom() -> None:
+            raise AssertionError("--version must short-circuit before dispatch")
+
+        monkeypatch.setattr("memtomem_stm.cli.proxy._stdin_is_tty", lambda: False)
+        monkeypatch.setattr("memtomem_stm.server.main", boom)
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "memtomem-stm" in result.output
+
 
 # ── style helpers / NO_COLOR contract ───────────────────────────────────
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -65,6 +65,52 @@ class TestVersion:
         assert flag.output.strip() == sub.output.strip()
 
 
+# ── bare invocation dispatch (#260) ─────────────────────────────────────
+
+
+class TestBareInvocationDispatch:
+    """Bare ``mms`` / ``memtomem-stm-proxy`` / ``memtomem-stm`` (no subcommand)
+    must dispatch on stdin: a TTY prints help so an interactive user discovers
+    the CLI, but a piped stdin (the MCP-client stdio case) boots the proxy
+    MCP server. This lets any of the three entry points be registered
+    interchangeably in an MCP client config — closing the surprise from #260
+    where only ``memtomem-stm`` worked as a registration target."""
+
+    def test_bare_with_tty_prints_help(self, runner, monkeypatch):
+        monkeypatch.setattr("memtomem_stm.cli.proxy._stdin_is_tty", lambda: True)
+        result = runner.invoke(cli, [])
+        assert result.exit_code == 0
+        assert "proxy gateway management" in result.output
+        # Help body should list the subcommands so users can discover them.
+        assert "Commands:" in result.output
+
+    def test_bare_with_pipe_dispatches_to_mcp_server(self, runner, monkeypatch):
+        called: list[bool] = []
+
+        def fake_server_main() -> None:
+            called.append(True)
+
+        monkeypatch.setattr("memtomem_stm.cli.proxy._stdin_is_tty", lambda: False)
+        monkeypatch.setattr("memtomem_stm.server.main", fake_server_main)
+        result = runner.invoke(cli, [])
+        assert result.exit_code == 0
+        assert called == [True], "non-TTY bare invocation must boot server.main"
+
+    def test_subcommand_skips_dispatch(self, runner, monkeypatch):
+        """``mms version`` (or any subcommand) must NOT trip the MCP-server
+        dispatch even if stdin happens to be non-TTY (CI, pipes). The
+        ``invoked_subcommand`` guard in the group callback enforces this."""
+
+        def boom() -> None:
+            raise AssertionError("server.main should not be called when a subcommand runs")
+
+        monkeypatch.setattr("memtomem_stm.cli.proxy._stdin_is_tty", lambda: False)
+        monkeypatch.setattr("memtomem_stm.server.main", boom)
+        result = runner.invoke(cli, ["version"])
+        assert result.exit_code == 0
+        assert "memtomem-stm" in result.output
+
+
 # ── style helpers / NO_COLOR contract ───────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Registering `mms` (or `memtomem-stm-proxy`) as an MCP client's `command` failed with `: calling "initialize": EOF` because those entry points resolved to the Click group, whose bare invocation printed help and exited 2. Only `memtomem-stm` worked because it pointed straight at `server.main`. The three names are documented as interchangeable, so the divergence was a real surprise — surfaced during Antigravity onboarding.

This change makes the Click group `invoke_without_command=True` and dispatches bare calls on `sys.stdin.isatty()`:

- **TTY** (`mms` in a terminal) → prints help, exit 0
- **Non-TTY** (MCP-client stdio pipes, CliRunner, shell pipes) → lazy-imports `memtomem_stm.server.main` and runs it

All three `[project.scripts]` entry points now resolve to `memtomem_stm.cli.proxy:cli` — registering any of them as an MCP server's `command` works identically.

## Why the previous behavior was wrong

`README.md`/docs and the existing `CLAUDE.md` invariant call `mms` and `memtomem-stm-proxy` interchangeable. But:

| Entry | Before this PR |
|-------|----------------|
| `memtomem-stm` | → `server.main` (worked as MCP server, no CLI) |
| `memtomem-stm-proxy` | → Click group help, exit 2 (broken as MCP server) |
| `mms` | → Click group help, exit 2 (broken as MCP server) |

After:

| Entry | After this PR |
|-------|---------------|
| `memtomem-stm` | → `cli.proxy:cli` (TTY=help, non-TTY=server.main; full CLI surface available) |
| `memtomem-stm-proxy` | → `cli.proxy:cli` (same) |
| `mms` | → `cli.proxy:cli` (same) |

## Backward compatibility

- `memtomem-stm` registered in MCP configs (Claude Code, Gemini CLI, Antigravity) → still works (non-TTY → `server.main`).
- `memtomem-stm` invoked in a terminal with no args was previously a hang (waiting for stdio MCP messages). Now prints help — strictly better for that pathological case.
- `memtomem-stm <random_arg>` previously was ignored (server.main doesn't read sys.argv); now Click parses it as a subcommand. Anyone passing extra args to `memtomem-stm` was already in undefined-behavior territory; the new behavior is at worst a clearer error.
- `mms list`, `mms add`, etc. — unchanged (subcommand path skips the new dispatch via the `invoked_subcommand` guard).

## Tests

`TestBareInvocationDispatch` covers all three branches:

- `test_bare_with_tty_prints_help` — TTY → help text on stdout, exit 0
- `test_bare_with_pipe_dispatches_to_mcp_server` — non-TTY → `server.main` is called
- `test_subcommand_skips_dispatch` — `mms version` (subcommand) must NOT trip the dispatch even when stdin is non-TTY (the `invoked_subcommand` guard)

The `_stdin_is_tty()` indirection follows the existing `_should_use_tui` seam pattern (CliRunner replaces `sys.stdin` so monkeypatching the function attribute directly doesn't reach the module's bound reference — `feedback_clirunner_isatty_seam.md` for the parent repo's parallel finding).

## Test plan

- [x] `uv run pytest tests/cli/test_proxy_cli.py` (179/179 pass)
- [x] `uv run pytest -m "not ollama"` full suite (1714/1714 pass on this branch — same as main)
- [x] `uv run ruff check src tests` + `ruff format --check` on touched files
- [ ] Smoke: install from this branch, register as `mms` in an MCP client, observe the proxy boots without `EOF` error

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)