### PR TITLE
docs: surface mms health --names and upstream prefix invariants

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -271,9 +271,9 @@ Options:
                            [default: 10; x>=1]
   --names                  Also report any upstream tool whose composed
                            proxied name (`mcp__<server>__<prefix>__<tool>`)
-                           would exceed the 64-char MCP limit. Useful when
-                           one tool from an upstream silently went missing
-                           after registration (#261).
+                           would exceed the 64-char MCP limit. Useful when one
+                           tool from an upstream silently went missing after
+                           registration (#261).
 ```
 
 Connects to each configured upstream server (MCP initialize + list-tools) and reports whether it's reachable and how many tools it exposes. Unlike `stm_proxy_health` (the MCP tool), this command probes servers directly — the proxy does not need to be running.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -271,7 +271,9 @@ Options:
                            [default: 10; x>=1]
   --names                  Also report any upstream tool whose composed
                            proxied name (`mcp__<server>__<prefix>__<tool>`)
-                           would exceed the 64-char MCP limit.
+                           would exceed the 64-char MCP limit. Useful when
+                           one tool from an upstream silently went missing
+                           after registration (#261).
 ```
 
 Connects to each configured upstream server (MCP initialize + list-tools) and reports whether it's reachable and how many tools it exposes. Unlike `stm_proxy_health` (the MCP tool), this command probes servers directly — the proxy does not need to be running.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -269,9 +269,14 @@ Options:
   --json                   Output as JSON for scripting.
   --timeout INTEGER RANGE  Per-server connection timeout in seconds.
                            [default: 10; x>=1]
+  --names                  Also report any upstream tool whose composed
+                           proxied name (`mcp__<server>__<prefix>__<tool>`)
+                           would exceed the 64-char MCP limit.
 ```
 
 Connects to each configured upstream server (MCP initialize + list-tools) and reports whether it's reachable and how many tools it exposes. Unlike `stm_proxy_health` (the MCP tool), this command probes servers directly — the proxy does not need to be running.
+
+`--names` re-runs the same composed-name overflow check the proxy applies at boot (#261), so an operator diagnosing "one tool from server X went silently missing after registration" can answer the question without restarting STM. The flag uses the default client server name `memtomem-stm` (12 chars) for the `mcp__<client-server>__…` template; if you registered STM under a shorter alias like `mms`, set `MMS_CLIENT_SERVER_NAME=mms` so the budget calculation matches the surface name your client actually composes.
 
 ## MCP Tools (11 + proxied)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,6 +238,17 @@ Full example with all options:
 }
 ```
 
+### Upstream prefix invariants
+
+Each `upstream_servers.<key>.prefix` must be **non-empty** and **unique across all upstreams** — both are enforced at config load and raise `ValidationError` on violation:
+
+- Empty or whitespace-only prefix produces composed tool names like `__list_items` and skews the 64-char overflow guard. (#266)
+- Two upstreams sharing a prefix collide on `<prefix>__<tool>` and used to silently drop the second-loaded duplicate at startup with only a `logger.warning`. The validator now names every offending upstream key in one error so the typo surfaces at config load. (#265)
+
+Hot-reload (`ProxyConfigLoader`) keeps the previously cached config when a reloaded edit fails validation, so a running proxy stays serving its last known-good upstreams instead of going dark on a typo.
+
+### Hot-reload
+
 The config file is **hot-reloaded** — changes take effect on the next tool call without restarting STM. Adding or removing upstream servers still requires a server restart because transport connections are established once at startup.
 
 | Setting group | Hot-reload? | Notes |


### PR DESCRIPTION
Pre-v0.1.20 docs sync. Three Unreleased PRs added user-visible behavior whose docs lagged:

| PR | Behavior | Doc gap closed |
|----|----------|----------------|
| #261 | `mms health --names` re-runs the boot-time composed-name overflow check | Flag was in `--help` but absent from `docs/cli.md` |
| #265 | Duplicate upstream prefix → `ValidationError` at config load | `docs/configuration.md` had no prefix-uniqueness statement |
| #266 | Empty / whitespace-only upstream prefix → `ValidationError` at config load | Same — non-empty invariant was undocumented |

## Changes

- `docs/cli.md` — add the `--names` line to the `mms health` Options block (verbatim from `mms health --help`) plus a paragraph naming the use case (overflow-skip diagnosis) and the `MMS_CLIENT_SERVER_NAME` env var users hit when they registered STM under a shorter alias.
- `docs/configuration.md` — new `### Upstream prefix invariants` subsection under the config file walkthrough, naming both invariants and the hot-reload safety pattern (`ProxyConfigLoader` retains the last-good config on validation failure) so an operator who triggers either error during an edit knows the proxy didn't go dark. The pre-existing hot-reload paragraph that previously sat as bare prose under `## Config File:` is also promoted to its own `### Hot-reload` subheading so the new prefix subsection has a structural peer rather than dangling above an unheaded paragraph.

## Out of scope

- `mms add` boot-time prefix-length rejection (#261, layer 1) is a less common case than `--names` and lives in CLI error messages already; doc coverage is a separate driveby if it matters.
- README registration example was updated as part of #261 itself; no further README change here.
- No CHANGELOG entry — these features are already announced under their original PRs (#261 / #265 / #266); this PR just makes the docs match.

## Verification

- `git diff --stat docs/` → `+19/-1` across the two intended files; no other surface touched.
- `uv run ruff check src && uv run ruff format --check src` → clean (sanity, even though docs-only).
- `--names` block in `docs/cli.md` matches `mms health --help` byte-for-byte (full two-sentence flag description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)