### PR TITLE
chore: release v0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.20] — 2026-04-27
+
 ### Changed
 
 - **`ProxyConfig` now rejects upstreams with empty or whitespace-only `prefix`** (#266) — `UpstreamServerConfig.prefix: str` had no min-length, so `""` validated fine and produced composed tool names like `__list_items` that surfaced in `tools/list` as visually broken entries. The empty prefix also skewed `tool_name_budget.composed_length("", t.name)` (the prefix portion is zero), so the 64-char overflow guard added in #261 underestimated the real surface name a client sees, and a single empty prefix slipped past the duplicate-prefix validator added in #265 (which only fires on collisions). A new `@model_validator(mode="after")` on `ProxyConfig` raises `ValidationError` at config load with every offending upstream key listed together — `Empty upstream prefix in upstreams: ['blank', 'spaces']` — so the user fixes them all in a single round-trip without the uniqueness validator firing as second-iteration noise. Whitespace-only (`"   "`) is treated the same as empty since both are typo classes. **Behavior change:** configs that previously loaded with broken composed names now fail at startup; hot-reload (`ProxyConfigLoader.get`) retains the previous good config on validation failure, matching the behavior introduced for #265.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem-stm"
-version = "0.1.19"
+version = "0.1.20"
 description = "Short-term memory proxy gateway with proactive memory surfacing for AI agents"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "memtomem-stm"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release v0.1.20. Two new config-load validators harden upstream prefix handling, plus a CLI dispatch parity fix, the 64-char tool name overflow guard, and a test-suite flake fix accumulated since v0.1.19.

## Headline

- **Duplicate upstream prefix → `ValidationError` at config load** (#265). Two upstreams sharing a prefix used to silently drop the second-loaded duplicate at `ProxyManager.start()` with only a `logger.warning`. The new `@model_validator(mode="after")` on `ProxyConfig` raises with every collision group named in one error so both the upstream dict keys (what the user edited) and the prefix value (what collides) surface together. Hot-reload (`ProxyConfigLoader.get`) keeps the previous good config on validation failure.
- **Empty / whitespace-only upstream prefix → `ValidationError` at config load** (#266). `prefix=""` used to validate fine and produce composed names like `__list_items` that surfaced as broken entries in `tools/list`, also skewing the 64-char overflow guard. Sibling validator placed before the uniqueness check so a `prefix=""`/`prefix=""` pair surfaces the more actionable empty error rather than the duplicate one.
- **Tool name overflow check against the 64-char MCP limit** (#261). Three layers: `mms add` rejects prefixes that guarantee overflow; `ProxyManager._connect_server` per-tool checks the composed length at boot and skips offending tools (better one missing tool than the whole upstream); `mms health --names` re-runs the check on demand. `MMS_CLIENT_SERVER_NAME` env var lets users who registered STM under a shorter alias get accurate budget arithmetic.
- **All three console scripts now boot the MCP stdio server when invoked bare with a piped stdin** (#260). Previously only `memtomem-stm` worked as an MCP-server registration target; `memtomem-stm-proxy` and `mms` resolved to the Click group whose bare invocation printed help and exited 2. Now all three `[project.scripts]` entry points dispatch identically based on `sys.stdin.isatty()`.

## Internal

- **`TestAutoIndexStartupWarning` no longer flakes under full-suite event-loop pressure** (#264). The MCP SDK's stdio reader can surface `echo`-upstream handshake failure as `asyncio.CancelledError` (`BaseException`); `try/except Exception` didn't catch it. Catch widened to `(Exception, asyncio.CancelledError)` with a comment naming the SDK cancellation path. No production code touched.
- **Docs sync** (#270). `mms health --names` flag and the new prefix invariants are now documented in `docs/cli.md` and `docs/configuration.md` respectively. The pre-existing hot-reload paragraph was promoted to its own subheading so the new prefix invariants subsection has a structural peer.

## Behavior change

- Configs that used to load with silent partial drops (#265) or visually broken composed names from `prefix=""` (#266) now fail at startup with `ValidationError`. Hot-reload retains the last-good config on validation failure, so a running proxy keeps serving its last known-good upstreams instead of going dark.
- Upstreams whose composed name exceeds 64 chars are now skipped at boot with a `WARNING` log naming the tool and the suggested fix; previously the tool just disappeared from the client's catalogue.
- `mms` and `memtomem-stm-proxy` registered as an MCP client's `command` now boot the stdio server identically to `memtomem-stm` instead of failing with `: calling "initialize": EOF`.
- No SQLite migration. No env-var rename. No new MCP tool.

## Test plan

- [x] `uv run pytest -m "not ollama" -q` — 1751/1751 pass on this branch
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv lock` resolves cleanly, `memtomem-stm` package version bumped to 0.1.20

## Post-merge release steps

1. Tag `v0.1.20` and push — trusted-publisher OIDC publishes to PyPI (PyPI environment approval gate required, see `reference_pypi_publish.md`).
2. `gh release create v0.1.20` (Release is not auto-created from the tag — `reference_github_release.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)