### PR TITLE
docs(readme): add coverage section on what STM proxies (and what it doesn't)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ Your agent now sees proxied tools (`fs__read_file`, `gh__search_repositories`, e
 
 To check what's happening, ask the agent to call `stm_proxy_stats`.
 
+## What STM proxies — and what it doesn't
+
+STM is an MCP proxy: it sees a tool call only if the client routes that call through the MCP protocol. Coverage depends on **how your client invokes the tool**, not on what the tool does.
+
+**STM sees:** any MCP server you register with `mms add` — every tool under the `mcp__<server>__<prefix>__<tool>` namespace — plus LTM surfacing calls to a configured memtomem server.
+
+**STM does NOT see:**
+- **Claude Code's built-in tools** — `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `WebFetch`. They run inside the client and never reach an MCP server, so their token spend is invisible to STM and unaffected by compression or caching.
+- **Cursor / Windsurf / Claude Desktop built-ins** — same principle: anything the client provides natively bypasses the MCP layer.
+- **Sub-agent built-in calls** — the parent's MCP wiring is inherited, but built-in tool calls inside an `Agent` / `Task` invocation stay client-internal.
+
+To bring file or shell operations under STM, register an MCP server that exposes them (the [filesystem example](#1-add-an-upstream-mcp-server) above is the most common case) and steer the agent toward the proxied alias instead of the built-in. This is the same boundary every MCP proxy lives within — it's not specific to STM.
+
 ## Tutorial notebooks
 
 > **Try it without wiring into your AI client first.** A [quickstart Jupyter notebook](notebooks/01_quickstart_proxy_setup.ipynb) registers an upstream MCP server, calls a proxied tool, and reads `stm_proxy_stats` end-to-end. Clone the repo, `uv sync`, and `uv run jupyter lab notebooks/` — no external services needed.


### PR DESCRIPTION
## Summary

- Add a top-level README section that names the MCP-proxy boundary explicitly: Claude Code built-in tools (`Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `WebFetch`), Cursor / Windsurf / Claude Desktop built-ins, and built-in calls inside sub-agent (`Agent` / `Task`) invocations all bypass STM.
- Cross-reference the filesystem MCP example already in Quick Start as the standard workaround for bringing file/shell operations under STM.
- Pure documentation — no code or behavior change.

## Why now

The README headlines "typically cuts token usage by 20–80%" and lists Claude Code as a supported client. A reader on Claude Code can reasonably assume STM intercepts their `Read`/`Bash` traffic; in fact STM only sees what the client routes through MCP, so a meaningful share of that traffic stays invisible. That coverage boundary is currently undocumented (no hits for "native" / "built-in" / "filesystem MCP" in `README.md` or `docs/`), which makes adoption decisions less informed than they should be.

## Why README, not a footnote in `docs/`

The boundary affects expected ROI. A user comparing STM to alternatives needs this on the same page as the savings claim, not three clicks deeper. The section sits between Quick Start and Tutorial Notebooks so it lands right when the reader has just connected and is forming a mental model of "what's covered now."

## Why this minimal scope

Two follow-ups belong in separate PRs and are intentionally out of scope here:

1. A `docs/integrations/claude-code-filesystem-mcp.md` recipe with concrete hook config for redirecting `Read` to a filesystem MCP server.
2. A `stm-health` Skill or similar tooling that surfaces "what fraction of your tool traffic STM is actually seeing."

This PR only states the boundary so the next conversations have a shared reference point.

## Test plan

- [x] Section structure preserved — `grep -n '^#' README.md` confirms the new `## What STM proxies — and what it doesn't` lands between `### 3. Use the proxied tools` (line 124) and `## Tutorial notebooks` (line 143).
- [x] Anchor link `#1-add-an-upstream-mcp-server` resolves to the existing `### 1. Add an upstream MCP server` heading on GitHub.
- [ ] Reviewer sanity check: read the new section cold and confirm the boundary statement matches your mental model (especially the sub-agent bullet — that one is the easiest to miss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)