### PR TITLE
feat(cli): mms init --lang ko writes Korean token-aware preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mms init --lang ko` writes a Korean-tuned token-aware budget preset** — closes the discoverability gap left open by PR #274. PR #274 shipped the mechanism (`max_result_tokens`, `chars_per_token` at proxy/server/tool levels) but required Korean operators to manually transcribe four numeric fields per server. The new `--lang` option (and matching interactive prompt on TTY) writes the calibrated KO preset directly: `chars_per_token=1.85`, `default_max_result_chars=8500`, `min_response_chars=230` at proxy level, and `max_result_tokens=2000` + `chars_per_token=1.85` on every imported upstream. Numbers come from PR #274's empirical 13-pair EN/KO doc-corpus calibration against `cl100k_base` (median 1.85 chars/tok for KO, vs 4.03 for EN). EN (default) is intentionally a no-op — config matches code defaults exactly without per-key noise. ZH/JA placeholders are deliberately omitted until analogous corpus measurements land — guessing by typology would defeat PR #274's empirical-calibration framing. Non-TTY callers without `--lang` get EN silently (load-bearing for backward compat with existing `mms init` tests); explicit `--lang` is the scriptable path. The interactive prompt uses `questionary.select` on a TTY and falls back to `click.prompt` with a `Choice` for `MMS_NO_TUI=1` users.
+
 ## [0.1.20] — 2026-04-27
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -278,6 +278,42 @@ A token budget caps context spend, not information throughput. Korean content en
 
 If your goal is equal information throughput rather than equal spend, scale KO budgets ~1.5× upward (and CJK-ideograph budgets accordingly).
 
+#### Bootstrap shortcut: `mms init --lang ko`
+
+For first-time setup of a Korean-content STM proxy, `mms init` accepts a `--lang` flag that writes the calibrated KO preset directly so you don't need to transcribe the numeric fields above:
+
+```bash
+mms init --lang ko
+```
+
+This writes:
+
+- **Proxy-level**: `chars_per_token=1.85`, `min_response_chars=230`, `default_max_result_chars=8500`
+- **Per-imported-server**: `max_result_tokens=2000`, `chars_per_token=1.85`
+
+Equivalent JSON (what ends up in `~/.memtomem/stm_proxy.json`):
+
+```json
+{
+  "enabled": true,
+  "chars_per_token": 1.85,
+  "min_response_chars": 230,
+  "default_max_result_chars": 8500,
+  "upstream_servers": {
+    "ko_docs": {
+      "prefix": "kr",
+      "command": "...",
+      "max_result_tokens": 2000,
+      "chars_per_token": 1.85
+    }
+  }
+}
+```
+
+Without `--lang`, an interactive prompt fires on a TTY (questionary select; falls back to `click` Choice prompt under `MMS_NO_TUI=1`). Non-TTY callers without `--lang` get EN (no preset) silently — `--lang ko` is the scriptable opt-in. `--lang en` is supported for explicit "no preset" intent and writes nothing language-specific.
+
+Only EN and KO are shipped: KO is the only language with empirical calibration in PR #274's measurement corpus. ZH/JA are intentionally omitted until analogous calibration lands.
+
 ### Upstream prefix invariants
 
 Each `upstream_servers.<key>.prefix` must be **non-empty** and **unique across all upstreams** — both are enforced at config load and raise `ValidationError` on violation:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,7 +291,7 @@ This writes:
 - **Proxy-level**: `chars_per_token=1.85`, `min_response_chars=230`, `default_max_result_chars=8500`
 - **Per-imported-server**: `max_result_tokens=2000`, `chars_per_token=1.85`
 
-Equivalent JSON (what ends up in `~/.memtomem/stm_proxy.json`):
+Equivalent JSON (what ends up in `~/.memtomem/stm_proxy.json`). The server key (`<your-server-name>` below) and `prefix` come from whatever `mms init` discovered or you typed in the manual flow — `--lang ko` only adds the four token-aware fields, never invents server names:
 
 ```json
 {
@@ -300,8 +300,8 @@ Equivalent JSON (what ends up in `~/.memtomem/stm_proxy.json`):
   "min_response_chars": 230,
   "default_max_result_chars": 8500,
   "upstream_servers": {
-    "ko_docs": {
-      "prefix": "kr",
+    "<your-server-name>": {
+      "prefix": "<your-prefix>",
       "command": "...",
       "max_result_tokens": 2000,
       "chars_per_token": 1.85

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -1620,6 +1620,71 @@ def _add_from_clients(
     _handle_source_prune([new_candidates[i] for i in picks], prune=prune)
 
 
+# Token-aware budget presets keyed by primary content language. KO is the
+# only language with empirical calibration shipped here (PR #274's 13-pair
+# EN/KO doc corpus measured against ``cl100k_base``); EN is intentionally
+# empty so the resulting config matches the existing code defaults exactly
+# without per-key noise. ZH/JA placeholders are deliberately omitted until
+# an analogous measurement lands — guessing by typology would defeat the
+# point of the empirical-calibration framing in PR #274.
+_LANG_PRESET_KO = "Korean (chars_per_token=1.85, max_result_tokens=2000 per server)"
+_LANG_PRESET_EN = "English (no language-specific tuning — code defaults)"
+_LANG_PRESETS: dict[str, dict[str, Any]] = {
+    "en": {},
+    "ko": {
+        "chars_per_token": 1.85,
+        "min_response_chars": 230,
+        "default_max_result_chars": 8500,
+        "_per_server": {
+            "max_result_tokens": 2000,
+            "chars_per_token": 1.85,
+        },
+    },
+}
+
+
+def _prompt_language() -> str:
+    """Single-choice language preset prompt with TUI / click fallback.
+
+    Returns ``"en"`` on non-TTY (CliRunner tests, pipes, CI) — the
+    scriptable path is ``--lang``, not stdin emulation. TTY with TUI
+    available → questionary select. TTY with ``MMS_NO_TUI=1`` (or
+    questionary import failure) → ``click.prompt`` with a Choice.
+    """
+    if not sys.stdin.isatty():
+        return "en"
+
+    if _should_use_tui():
+        try:
+            import questionary
+
+            choice = questionary.select(
+                "Primary content language for token-aware budgets:",
+                choices=[
+                    questionary.Choice(title=_LANG_PRESET_EN, value="en"),
+                    questionary.Choice(title=_LANG_PRESET_KO, value="ko"),
+                ],
+                default="en",
+                style=_tui_style(),
+                use_arrow_keys=True,
+                use_jk_keys=True,
+                use_emacs_keys=True,
+            ).ask()
+            return choice if choice in _LANG_PRESETS else "en"
+        except Exception:
+            # Fall through to click prompt if questionary blows up
+            # (terminal incompatibility, etc.). Same defensive pattern as
+            # ``_pick_imports`` already uses.
+            pass
+
+    return click.prompt(
+        "Primary content language",
+        type=click.Choice(list(_LANG_PRESETS)),
+        default="en",
+        show_default=True,
+    )
+
+
 @cli.command()
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
 @click.option(
@@ -1651,11 +1716,25 @@ def _add_from_clients(
         "scripted callers must pass the flag explicitly."
     ),
 )
+@click.option(
+    "--lang",
+    type=click.Choice(list(_LANG_PRESETS)),
+    default=None,
+    help=(
+        "Primary content language preset for token-aware budgets. "
+        "'en' (default) writes no language-specific fields. 'ko' sets "
+        "chars_per_token=1.85, default_max_result_chars=8500, "
+        "min_response_chars=230, and adds max_result_tokens=2000 + "
+        "chars_per_token=1.85 to each imported server. Omit for the "
+        "interactive prompt; defaults to 'en' on non-TTY callers."
+    ),
+)
 def init(
     config_path: str,
     no_validate: bool,
     mcp_mode: str | None,
     prune_originals: bool,
+    lang: str | None,
 ) -> None:
     """Guided first-time setup for memtomem-stm.
 
@@ -1784,6 +1863,26 @@ def init(
 
         imported[name] = entry
 
+    # Resolve the language preset before validate so the prompt sequence
+    # stays predictable for scripted callers ("which prompt fires next?").
+    # Non-TTY callers without ``--lang`` get "en" silently — see
+    # ``_prompt_language``.
+    selected_lang = lang if lang is not None else _prompt_language()
+    preset = _LANG_PRESETS[selected_lang]
+    proxy_fields = {k: v for k, v in preset.items() if not k.startswith("_")}
+    per_server_fields = preset.get("_per_server", {})
+    if per_server_fields:
+        for entry in imported.values():
+            for key, value in per_server_fields.items():
+                # ``setdefault`` preserves any operator-explicit value the
+                # import flow already produced (an upstream MCP config could
+                # in principle carry these keys). Manual flow's hardcoded
+                # ``max_result_chars=8000`` is left in place; the token
+                # budget wins via ``ProxyManager._resolve_tool_config``
+                # precedence (PR #274), so the char value is dead code in
+                # the resolved budget but kept visible in the saved config.
+                entry.setdefault(key, value)
+
     if not no_validate and click.confirm("Validate connection(s) now?", default=True):
         probe_map = {n: e for n, e in imported.items()}
         click.echo(f"Validating {len(probe_map)} server(s) (timeout=10s)...")
@@ -1795,7 +1894,7 @@ def init(
                 click.echo(f"  {_warn('Warning:')} {n} — probe failed: {probe['error']}", err=True)
                 click.echo("  Saving config anyway. Run `mms health` later to retry.", err=True)
 
-    data = {"enabled": True, "upstream_servers": imported}
+    data: dict[str, Any] = {"enabled": True, **proxy_fields, "upstream_servers": imported}
     _save(path, data)
 
     click.echo("")

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -974,6 +974,131 @@ class TestInit:
         assert "bad" in data["upstream_servers"]
 
 
+# ── init: language preset (--lang) ──────────────────────────────────────
+
+
+class TestInitLangPreset:
+    """``mms init --lang`` selects a token-aware budget preset.
+
+    PR #274 ships KO calibration; EN is the empty-default preset. The
+    flag is the scriptable path — non-TTY callers without ``--lang`` get
+    "en" silently, which keeps the entire ``TestInit`` suite (and any
+    third-party scripted caller) from needing to feed an extra prompt
+    line. Existing tests in ``TestInit`` already pin that contract by
+    not supplying any lang input and still passing.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stub_mcp_integration(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda *_a, **_kw: None)
+
+    def test_lang_ko_writes_proxy_and_per_server_fields(self, runner, config, no_discovery):
+        """KO preset writes proxy-level chars_per_token / min_response_chars /
+        default_max_result_chars AND per-server max_result_tokens +
+        chars_per_token. The hardcoded manual-flow ``max_result_chars=8000``
+        stays in place — token budget wins via PR #274 precedence."""
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--lang", "ko", *_cfg_args(config)],
+            input="filesystem\nfs\nstdio\nnpx\n-y @modelcontextprotocol/server-fs\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+
+        # Proxy-level fields
+        assert data["chars_per_token"] == 1.85
+        assert data["min_response_chars"] == 230
+        assert data["default_max_result_chars"] == 8500
+
+        # Per-server fields
+        srv = data["upstream_servers"]["filesystem"]
+        assert srv["max_result_tokens"] == 2000
+        assert srv["chars_per_token"] == 1.85
+        # Manual-flow hardcode preserved (token wins at resolution time)
+        assert srv["max_result_chars"] == 8000
+
+    def test_lang_en_writes_no_language_specific_fields(self, runner, config, no_discovery):
+        """EN preset is a no-op on the data dict — config matches pre-PR
+        behavior exactly. This is the contract that lets existing TestInit
+        tests pass without supplying a lang prompt."""
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--lang", "en", *_cfg_args(config)],
+            input="filesystem\nfs\nstdio\nnpx\n-y @modelcontextprotocol/server-fs\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "chars_per_token" not in data
+        assert "min_response_chars" not in data
+        assert "default_max_result_chars" not in data
+
+        srv = data["upstream_servers"]["filesystem"]
+        assert "max_result_tokens" not in srv
+        assert "chars_per_token" not in srv
+
+    def test_no_lang_flag_non_tty_defaults_to_en(self, runner, config, no_discovery):
+        """Non-TTY callers (CliRunner is non-TTY) skip the prompt and get EN.
+
+        This pins the contract that the lang prompt does not consume a
+        stdin line in scripted contexts — load-bearing for backward
+        compat with TestInit."""
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="filesystem\nfs\nstdio\nnpx\n-y @modelcontextprotocol/server-fs\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "chars_per_token" not in data
+        srv = data["upstream_servers"]["filesystem"]
+        assert "max_result_tokens" not in srv
+
+    def test_lang_invalid_choice_rejected(self, runner, config, no_discovery):
+        """Click validates --lang against the preset list; bad value aborts
+        before any prompt fires (no config side-effect)."""
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--lang", "xx", *_cfg_args(config)],
+            input="filesystem\nfs\nstdio\nnpx\n\n",
+        )
+        assert result.exit_code != 0
+        assert not config.exists()
+
+    def test_lang_ko_with_no_servers_imported_writes_nothing(self, runner, config, monkeypatch):
+        """If discovery yields candidates and the user picks none, the wizard
+        returns early before save — no config is written even with --lang.
+        Pins that --lang doesn't sneak past the empty-pick guard."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        # Force discovery to surface a candidate (so the import flow runs)
+        # but stub _pick_imports to return [] (user toggled nothing).
+        monkeypatch.setattr(
+            proxy_mod,
+            "_discover_candidates",
+            lambda _cwd: [
+                {
+                    "name": "fs",
+                    "entry": {"command": "npx", "args": ["-y", "fs"]},
+                    "source": "test",
+                }
+            ],
+        )
+        monkeypatch.setattr(proxy_mod, "_pick_imports", lambda _c: [])
+
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", "--lang", "ko", *_cfg_args(config)],
+        )
+        assert result.exit_code == 0
+        assert "No servers selected" in result.output
+        assert not config.exists()
+
+
 # ── init: discovery + import helpers ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Add `mms init --lang {en,ko}` to write a token-aware budget preset directly during first-time setup.

- **`ko` preset** writes proxy-level `chars_per_token=1.85`, `default_max_result_chars=8500`, `min_response_chars=230`, plus `max_result_tokens=2000` + `chars_per_token=1.85` on every imported upstream.
- **`en` preset** is a no-op on the data dict — config matches code defaults exactly.
- Numbers come from #274's empirical 13-pair EN/KO doc-corpus calibration against `cl100k_base` (median 1.85 chars/tok for KO, vs 4.03 for EN).

## Why now

#274 shipped the **mechanism** (token-equivalent budgets at proxy / server / tool levels) but a Korean operator had to manually transcribe four numeric fields per server. That's a known onboarding tax for the only language with calibrated numbers in the PR. `--lang ko` collapses it to one flag.

## Why only `en` and `ko` (not `zh` / `ja`)

#274's measurement corpus is EN/KO only. The numbers shipped here are empirical for KO. Adding `zh` / `ja` presets without analogous corpus measurement would silently re-introduce the typology-guessing failure mode #274 was specifically built to eliminate. ZH/JA are tracked for a follow-up that ships its own measurement, not bundled here.

## Behavior contracts pinned by tests

- **`--lang en` writes nothing language-specific** — config dict matches pre-feature behavior exactly. This is load-bearing: it's why every existing `TestInit` test still passes without supplying a new prompt line.
- **Non-TTY callers without `--lang` get EN silently** — `_prompt_language` short-circuits on `not sys.stdin.isatty()`. CliRunner is non-TTY, so the existing 59 init-related tests don't see the new prompt.
- **`--lang` is the scriptable path** — Click validates the choice against the preset list; bad value aborts before any config side-effect.
- **TTY interactive prompt** uses `questionary.select` (same key-binding palette as `_pick_imports_tui`); `MMS_NO_TUI=1` or any questionary import/runtime failure falls through to `click.prompt` with a Choice. Defensive fallback mirrors `_pick_imports`.
- **`setdefault` for per-server preset** preserves any operator-explicit value the import flow already produced.

## Test plan

- [x] `tests/cli/test_proxy_cli.py::TestInitLangPreset` — 5 tests, all green:
  - `test_lang_ko_writes_proxy_and_per_server_fields` — full KO preset shape
  - `test_lang_en_writes_no_language_specific_fields` — EN no-op contract
  - `test_no_lang_flag_non_tty_defaults_to_en` — non-TTY silent fallback
  - `test_lang_invalid_choice_rejected` — Click validation
  - `test_lang_ko_with_no_servers_imported_writes_nothing` — `--lang` doesn't sneak past the empty-pick guard
- [x] Full CLI test class: 193 passed (existing 188 + 5 new), no regressions.
- [x] Full suite (post-rebase onto current `main` which contains #274): all green.
- [x] `uv run ruff check src tests` → clean.
- [ ] Reviewer manual sanity check (TTY only): `mms init --config /tmp/test.json` should fire the questionary select prompt; `MMS_NO_TUI=1 mms init --config /tmp/test.json` should fall back to `click.prompt` with a Choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)