### PR TITLE
feat(mms): W1 PR1 — project state CRUD (`mms project init/show/list/enable/disable`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mms project` subgroup — W1 of project-scoped MCP management RFC v0.3** — five Click subcommands (`init`, `show`, `list`, `enable`, `disable`) that manage *which MCP servers a given project sees*, separate from the STM proxy gateway config. State lives in a new dotdir, `~/.mms/`, with three TOML files: a global registry (`~/.mms/registry.toml`, secrets in env, gitignored), an auto-managed projects index (`~/.mms/projects.toml`, gitignored), and per-project enabled-MCP lists (`<project>/.mms/project.toml`, commit-recommended). All three start at `schema_version = 1`; `mms upgrade-config` (the migration entry point per RFC §16) is a W2+ separate code path. `~/.mms/` is intentionally separate from `~/.memtomem/` — STM proxy bootstrap (`stm_proxy.json`) and mms project state (`registry.toml`) are *fully disjoint mutation paths* in W1: `mms add` writes only to `stm_proxy.json`, and (W1 PR2's) `mms import --apply` writes only to `registry.toml`. Until PR2 lands the registry stays empty by default; `mms project enable X` against an empty registry surfaces a *friendly error* pointing at `mms import --from <host>` instead of crashing — the literal text is pinned by tests so any rewording is a single-place edit. Project detection (used by `show` / `enable` / `disable` without `--project`) walks parents in fixed order: `.mms/project.toml` marker → `.git` directory or worktree file → cwd fallback (anonymous). A marker beats git even if git is closer to cwd, since markers are explicit declarations and git roots are inference; malformed markers raise rather than silently falling through to git/cwd, per RFC §6.1. Pydantic models reject unknown TOML fields (`extra="forbid"`) so a typo in `[project]` or `[mcp]` fails loud at load time. Adds `tomli-w >= 1.0` to dependencies for writes (reads stay on stdlib `tomllib`); `tomlkit` would have brought a comment-preservation feature with no W1 use case.
+
 ## [0.1.21] — 2026-04-29
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,7 @@ Commands:
   health    Check upstream server connectivity.
   init      Guided first-time setup for memtomem-stm.
   list      List configured upstream servers.
+  project   Project-scoped MCP management (RFC §7.1).
   prune     Remove dual-registered upstreams from source MCP clients.
   register  Register memtomem-stm with an MCP client.
   remove    Remove an upstream MCP server from the proxy configuration.
@@ -279,6 +280,80 @@ Options:
 Connects to each configured upstream server (MCP initialize + list-tools) and reports whether it's reachable and how many tools it exposes. Unlike `stm_proxy_health` (the MCP tool), this command probes servers directly — the proxy does not need to be running.
 
 `--names` re-runs the same composed-name overflow check the proxy applies at boot (#261), so an operator diagnosing "one tool from server X went silently missing after registration" can answer the question without restarting STM. The flag uses the default client server name `memtomem-stm` (12 chars) for the `mcp__<client-server>__…` template; if you registered STM under a shorter alias like `mms`, set `MMS_CLIENT_SERVER_NAME=mms` so the budget calculation matches the surface name your client actually composes.
+
+## `mms project` — project-scoped MCP management
+
+`mms project` is a Click subgroup that manages **which MCP servers a given project sees**, separately from the STM proxy gateway config. It writes to a new dotdir, `~/.mms/`, so it doesn't interfere with `~/.memtomem/stm_proxy.json` (the STM proxy bootstrap) — see RFC §5 for the full data model.
+
+W1 ships five subcommands. State lives in three TOML files:
+
+| Path | Purpose | Commit? |
+|------|---------|---------|
+| `~/.mms/registry.toml` | Global MCP definition catalog (filled by `mms import` in W1 PR2; not by `mms add` in W1) | **No** — gitignore |
+| `~/.mms/projects.toml` | Auto-managed projects index (path + last_seen) | **No** — gitignore |
+| `<project>/.mms/project.toml` | Per-project enabled MCP names | **Yes** |
+
+```
+Usage: mms project [OPTIONS] COMMAND [ARGS]...
+
+  Project-scoped MCP management (RFC §7.1).
+
+Commands:
+  init     Create <path>/.mms/project.toml (default path = cwd) and add to index.
+  show     Show the detected (or named) project, with init hints when no marker.
+  list     List known projects from the index. Mark current cwd's project with `*`.
+  enable   Add MCP names to the project's enabled list (RFC §7.1).
+  disable  Remove MCP names from the project's enabled list.
+```
+
+### `mms project init`
+
+```
+Usage: mms project init [OPTIONS] [PATH]
+
+Options:
+  --name TEXT   Override project name (default: dir basename).
+  --force       Overwrite an existing .mms/project.toml.
+```
+
+Creates `<PATH>/.mms/project.toml` (default: cwd) and appends the project to `~/.mms/projects.toml`. Aborts if the marker exists, unless `--force` is passed.
+
+### `mms project show`
+
+```
+Usage: mms project show [OPTIONS] [NAME]
+
+Options:
+  --json   Machine-readable output.
+```
+
+Without `NAME`: runs the §6 detection algorithm against cwd (marker walk-up → git walk-up → cwd fallback). With `NAME`: looks up the project in the index and shows its marker. When no marker is detected, prints an init hint pointing at `mms project init`.
+
+### `mms project list`
+
+```
+Usage: mms project list [OPTIONS]
+
+Options:
+  --prune  Remove entries whose path no longer exists.
+  --json   Machine-readable output.
+```
+
+Prints all known projects with the current cwd's project marked `*`. `--prune` removes entries whose `path` no longer points at a directory and reports each pruned entry by name.
+
+### `mms project enable` / `mms project disable`
+
+```
+Usage: mms project enable [OPTIONS] MCPS...
+Usage: mms project disable [OPTIONS] MCPS...
+
+Options:
+  --project TEXT  Target project (default: detect from cwd).
+```
+
+`enable` adds MCP names to the project's `[mcp].enabled` list; `disable` removes them. Both require either a marker at cwd (or up the tree) or an explicit `--project NAME`. `enable` additionally requires a non-empty `~/.mms/registry.toml` — until W1 PR2 (`mms import`) lands, this surfaces as a friendly error pointing at the import command. `disable` works regardless of registry state since it only mutates project state.
+
+The MCP-name validity check (does this name actually exist in the registry?) is intentionally deferred to sync time (W2) per RFC §7.1, so `enable` accepts any name as long as the registry is non-empty.
 
 ## MCP Tools (11 + proxied)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "httpx>=0.28",
     "click>=8.1",
     "questionary>=2.0",
+    "tomli-w>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/memtomem_stm/cli/mms_project.py
+++ b/src/memtomem_stm/cli/mms_project.py
@@ -1,0 +1,365 @@
+"""``mms project`` Click subgroup — W1 project state CRUD (RFC §7.1).
+
+Five subcommands: ``init / show / list / enable / disable``. All
+reads/writes go through :mod:`memtomem_stm.mms.state`; project
+detection through :mod:`memtomem_stm.mms.detect`.
+
+The W1 contract for ``enable`` against an empty registry is a
+*graceful friendly error* (not a crash) — the registry is filled by
+``mms import --apply`` (PR2). The literal message is pinned by tests.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+
+import click
+
+from memtomem_stm.mms import state
+from memtomem_stm.mms.detect import Project, Source, detect_project
+
+# ---------------------------------------------------------------------------
+# Pinned UX strings — kept here as constants so tests assert against the
+# *symbol* and any rewording is a single-place edit.
+# ---------------------------------------------------------------------------
+
+_REGISTRY_EMPTY_MSG = (
+    "Registry is empty.\n"
+    "  Run `mms import --from <host>` (W1 PR2) to import existing MCP definitions,\n"
+    "  or wait for the integrated `mms add` path (planned post-W1).\n"
+)
+
+
+def _show_no_marker_no_git_text(cwd: Path) -> str:
+    return (
+        f"No project marker (.mms/project.toml) or git repo found at {cwd}.\n"
+        f"Cwd-fallback project: '{cwd.name}' (anonymous, not registered).\n"
+        f"  Run `mms project init` here to create .mms/project.toml.\n"
+    )
+
+
+def _show_git_no_marker_text(root: Path) -> str:
+    return (
+        f"Detected via git: {root}\n"
+        f"No project marker (.mms/project.toml) yet.\n"
+        f"  Run `mms project init` here to create one.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group + helpers
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="project")
+def project_group() -> None:
+    """Project-scoped MCP management (RFC §7.1).
+
+    Commands operate on the project containing the current working
+    directory unless ``--project NAME`` is passed (where supported).
+    """
+
+
+def _project_payload(p: Project) -> dict:
+    """Render a :class:`Project` as the JSON shape used by ``--json`` output."""
+    payload = {
+        "name": p.name,
+        "root": str(p.root),
+        "source": p.source.value,
+        "marker": str(p.marker_path) if p.marker_path else None,
+        "enabled": list(p.config.mcp.enabled) if p.config else [],
+    }
+    return payload
+
+
+def _resolve_project_for_mutation(project_name: str | None) -> Project:
+    """Resolve which project a mutation (enable/disable) targets.
+
+    Without ``--project NAME``: detect from cwd; require a marker
+    (init suggested otherwise). With ``--project NAME``: look up in
+    the projects index and load that project's marker.
+    """
+    if project_name is None:
+        p = detect_project(Path.cwd())
+        if p.source is not Source.MARKER:
+            raise click.ClickException(
+                f"No project marker at {p.root} (detected via {p.source.value}). "
+                "Run `mms project init` here first."
+            )
+        return p
+
+    # --project NAME path
+    idx = state.load_projects_index()
+    matches = [entry for entry in idx.projects if entry.name == project_name]
+    if not matches:
+        raise click.ClickException(
+            f"Project '{project_name}' not found in {state.projects_index_path()}. "
+            "Run `mms project list` to see known projects."
+        )
+    if len(matches) > 1:
+        raise click.ClickException(
+            f"Project name '{project_name}' is ambiguous ({len(matches)} matches). "
+            "Use `mms project show NAME` from inside the target project root instead."
+        )
+    entry = matches[0]
+    marker = Path(entry.path) / state.PROJECT_MARKER_RELPATH
+    if not marker.is_file():
+        raise click.ClickException(
+            f"Project '{project_name}' indexed at {entry.path} but marker file is missing. "
+            "The directory may have been moved or the marker deleted; "
+            "run `mms project list --prune` to clean up."
+        )
+    cfg = state.load_project_config(marker)
+    return Project(
+        root=Path(entry.path),
+        source=Source.MARKER,
+        name=cfg.project.name,
+        marker_path=marker,
+        config=cfg,
+    )
+
+
+def _refresh_index(name: str, root: Path) -> None:
+    """Upsert ``(name, root)`` into the projects index."""
+    idx = state.load_projects_index()
+    idx = state.upsert_project_in_index(idx, name=name, path=str(root))
+    state.save_projects_index(idx)
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+
+@project_group.command("init")
+@click.argument(
+    "path",
+    required=False,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+@click.option(
+    "--name", "name_opt", default=None, help="Override project name (default: dir basename)."
+)
+@click.option("--force", is_flag=True, help="Overwrite an existing .mms/project.toml.")
+def init_cmd(path: Path | None, name_opt: str | None, force: bool) -> None:
+    """Create ``<path>/.mms/project.toml`` (default path = cwd) and add to index."""
+    target_root = (path or Path.cwd()).expanduser().resolve()
+    if not target_root.is_dir():
+        raise click.ClickException(f"Not a directory: {target_root}")
+
+    marker = target_root / state.PROJECT_MARKER_RELPATH
+    if marker.is_file() and not force:
+        raise click.ClickException(
+            f"{marker} already exists. Use --force to overwrite, or edit it directly."
+        )
+
+    project_name = name_opt or target_root.name
+    cfg = state.ProjectConfig(
+        project=state.ProjectMeta(name=project_name),
+        mcp=state.ProjectMcp(enabled=[]),
+    )
+    state.save_project_config(cfg, marker)
+    _refresh_index(project_name, target_root)
+    click.echo(f"Created {marker}")
+    click.echo(f"Indexed in {state.projects_index_path()}")
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+@project_group.command("show")
+@click.argument("name", required=False)
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def show_cmd(name: str | None, json_output: bool) -> None:
+    """Show the detected (or named) project, with init hints when no marker."""
+    if name is not None:
+        idx = state.load_projects_index()
+        matches = [e for e in idx.projects if e.name == name]
+        if not matches:
+            raise click.ClickException(
+                f"Project '{name}' not found in {state.projects_index_path()}."
+            )
+        entry = matches[0]
+        marker = Path(entry.path) / state.PROJECT_MARKER_RELPATH
+        if not marker.is_file():
+            raise click.ClickException(
+                f"Project '{name}' indexed at {entry.path} but marker is missing."
+            )
+        cfg = state.load_project_config(marker)
+        proj = Project(
+            root=Path(entry.path),
+            source=Source.MARKER,
+            name=cfg.project.name,
+            marker_path=marker,
+            config=cfg,
+        )
+        _emit_show(proj, json_output, cwd=Path(entry.path))
+        return
+
+    cwd = Path.cwd().resolve()
+    proj = detect_project(cwd)
+    _emit_show(proj, json_output, cwd=cwd)
+
+
+def _emit_show(proj: Project, json_output: bool, *, cwd: Path) -> None:
+    if json_output:
+        click.echo(_json.dumps(_project_payload(proj), indent=2))
+        return
+
+    if proj.source is Source.MARKER:
+        click.echo(f"Project: {proj.name}")
+        click.echo(f"Root: {proj.root}")
+        click.echo("Detected via: marker")
+        enabled = proj.config.mcp.enabled if proj.config else []
+        if enabled:
+            click.echo(f"Enabled MCPs: {', '.join(enabled)}")
+        else:
+            click.echo("Enabled MCPs: (none)")
+        return
+
+    if proj.source is Source.GIT:
+        click.echo(_show_git_no_marker_text(proj.root), nl=False)
+        return
+
+    # Source.CWD
+    click.echo(_show_no_marker_no_git_text(cwd), nl=False)
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@project_group.command("list")
+@click.option("--prune", is_flag=True, help="Remove entries whose path no longer exists.")
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def list_cmd(prune: bool, json_output: bool) -> None:
+    """List known projects from the index. Mark current cwd's project with ``*``."""
+    idx = state.load_projects_index()
+    cwd = Path.cwd().resolve()
+
+    pruned: list[state.ProjectIndexEntry] = []
+    if prune:
+        kept: list[state.ProjectIndexEntry] = []
+        for entry in idx.projects:
+            if Path(entry.path).is_dir():
+                kept.append(entry)
+            else:
+                pruned.append(entry)
+        if pruned:
+            new_idx = state.ProjectsIndex(schema_version=idx.schema_version, projects=kept)
+            state.save_projects_index(new_idx)
+            idx = new_idx
+
+    def _is_current(entry: state.ProjectIndexEntry) -> bool:
+        return Path(entry.path).resolve() == cwd
+
+    if json_output:
+        payload = {
+            "projects": [
+                {
+                    "name": e.name,
+                    "path": e.path,
+                    "last_seen": e.last_seen,
+                    "current": _is_current(e),
+                }
+                for e in idx.projects
+            ],
+            "pruned": [{"name": e.name, "path": e.path} for e in pruned],
+        }
+        click.echo(_json.dumps(payload, indent=2))
+        return
+
+    for entry in pruned:
+        click.echo(f"pruned: {entry.name} ({entry.path})")
+    if pruned:
+        click.echo(f"Pruned {len(pruned)} stale entr{'y' if len(pruned) == 1 else 'ies'}.")
+    if not idx.projects:
+        click.echo("No projects indexed yet. Run `mms project init` in a project directory.")
+        return
+    for entry in idx.projects:
+        marker = "*" if _is_current(entry) else " "
+        click.echo(f"{marker} {entry.name}\t{entry.path}\t(last seen {entry.last_seen})")
+
+
+# ---------------------------------------------------------------------------
+# enable / disable
+# ---------------------------------------------------------------------------
+
+
+@project_group.command("enable")
+@click.argument("mcps", nargs=-1, required=True)
+@click.option(
+    "--project", "project_name", default=None, help="Target project (default: detect from cwd)."
+)
+def enable_cmd(mcps: tuple[str, ...], project_name: str | None) -> None:
+    """Add MCP names to the project's enabled list (RFC §7.1)."""
+    proj = _resolve_project_for_mutation(project_name)
+
+    registry = state.load_registry()
+    if not registry.servers:
+        # PR1 graceful contract — empty registry is the dominant W1 failure
+        # mode (PR2 has not landed yet). Pinned literal text per plan.
+        click.echo(_REGISTRY_EMPTY_MSG, nl=False, err=True)
+        raise click.exceptions.Exit(1)
+
+    assert proj.config is not None  # _resolve_project_for_mutation guarantees MARKER
+    current = list(proj.config.mcp.enabled)
+    added: list[str] = []
+    for mcp in mcps:
+        if mcp not in current:
+            current.append(mcp)
+            added.append(mcp)
+
+    new_cfg = state.ProjectConfig(
+        schema_version=proj.config.schema_version,
+        project=proj.config.project,
+        mcp=state.ProjectMcp(enabled=current),
+    )
+    assert proj.marker_path is not None
+    state.save_project_config(new_cfg, proj.marker_path)
+    _refresh_index(proj.name, proj.root)
+
+    if added:
+        click.echo(f"Enabled in '{proj.name}': {', '.join(added)}")
+    else:
+        click.echo(f"No changes to '{proj.name}' (all already enabled).")
+
+
+@project_group.command("disable")
+@click.argument("mcps", nargs=-1, required=True)
+@click.option(
+    "--project", "project_name", default=None, help="Target project (default: detect from cwd)."
+)
+def disable_cmd(mcps: tuple[str, ...], project_name: str | None) -> None:
+    """Remove MCP names from the project's enabled list.
+
+    Runs against the project state only — does not consult the registry,
+    so disable works even when the registry is empty.
+    """
+    proj = _resolve_project_for_mutation(project_name)
+
+    assert proj.config is not None
+    current = list(proj.config.mcp.enabled)
+    removed: list[str] = []
+    for mcp in mcps:
+        if mcp in current:
+            current.remove(mcp)
+            removed.append(mcp)
+
+    new_cfg = state.ProjectConfig(
+        schema_version=proj.config.schema_version,
+        project=proj.config.project,
+        mcp=state.ProjectMcp(enabled=current),
+    )
+    assert proj.marker_path is not None
+    state.save_project_config(new_cfg, proj.marker_path)
+    _refresh_index(proj.name, proj.root)
+
+    if removed:
+        click.echo(f"Disabled in '{proj.name}': {', '.join(removed)}")
+    else:
+        click.echo(f"No changes to '{proj.name}' (none of {list(mcps)} were enabled).")

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import click
 
+from memtomem_stm.cli.mms_project import project_group as _mms_project_group
 from memtomem_stm.proxy import tool_name_budget
 from memtomem_stm.utils.fileio import atomic_write_text
 
@@ -2338,3 +2339,8 @@ def health(
                     click.echo("    all tool names fit")
         else:
             click.echo(f"  {name}: {_bad('DISCONNECTED')} — {info['error']}")
+
+
+# `mms project ...` — RFC §7.1, lives in src/memtomem_stm/cli/mms_project.py
+# to keep this file from accreting another ~700 lines for the W1 surface.
+cli.add_command(_mms_project_group)

--- a/src/memtomem_stm/mms/__init__.py
+++ b/src/memtomem_stm/mms/__init__.py
@@ -1,0 +1,12 @@
+"""mms — project-scoped MCP management.
+
+A layer above the STM proxy that decides *which* MCP servers a given
+project sees. Spec: ``memtomem-docs/memtomem-stm/planning/stm-mms-project-scoped-rfc.md``.
+
+W1 ships project state CRUD (``mms project ...``) plus host import
+(``mms import``). The two systems — STM proxy bootstrap (``~/.memtomem/``)
+and mms project state (``~/.mms/``) — are intentionally disjoint in W1;
+``mms add`` writes only ``stm_proxy.json`` and ``mms import --apply``
+writes only ``registry.toml``. Unification is a W2+ trigger-driven
+follow-up (RFC §14 W2-Q2).
+"""

--- a/src/memtomem_stm/mms/detect.py
+++ b/src/memtomem_stm/mms/detect.py
@@ -1,0 +1,114 @@
+"""Project detection — RFC §6.
+
+The algorithm walks parents in a fixed order and stops at the first
+match:
+
+1. ``.mms/project.toml`` marker (anywhere up the tree)
+2. ``.git`` directory (innermost wins)
+3. cwd fallback — anonymous project, ``mms project show`` will suggest
+   running ``mms project init``
+
+Edge cases per RFC §6.1:
+
+* git submodule — innermost ``.git`` (the submodule's) wins
+* git worktree — ``.git`` is a *file* pointing at the main repo's
+  worktree dir, treated as a regular git repo
+* monorepo with single marker — nearest marker wins; sub-projects must
+  add their own marker to be distinct
+* malformed marker — propagated as :class:`mms.state.CorruptedConfig`
+  / :class:`mms.state.SchemaVersionMismatch`; detection does *not*
+  silently fall through to the next strategy (RFC §6.1 "거부, 백업
+  위치 안내, 자동 복구 X")
+
+The Project returned is enough to (a) know which marker file (if any)
+backs the detection so save operations land in the right place, and
+(b) report the detection source to ``mms project show`` for the
+init-hint UX.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from memtomem_stm.mms.state import (
+    PROJECT_MARKER_RELPATH,
+    ProjectConfig,
+    load_project_config,
+)
+
+
+class Source(Enum):
+    """Where the detection algorithm decided the project lives."""
+
+    MARKER = "marker"  # .mms/project.toml found
+    GIT = "git"  # .git found, no marker yet — init suggested
+    CWD = "cwd"  # neither marker nor git — anonymous fallback
+
+
+@dataclass(frozen=True)
+class Project:
+    """A detected project's location + identity.
+
+    ``root`` is the directory containing the marker (MARKER source) or
+    the git root (GIT source) or simply ``cwd`` (CWD source).
+
+    ``marker_path`` is set only when ``source is Source.MARKER``;
+    callers performing reads/writes should use this. For non-MARKER
+    sources, the path where ``mms project init`` would create the
+    marker is ``root / .mms / project.toml``.
+
+    ``config`` is the parsed ``ProjectConfig`` for MARKER sources only.
+    For GIT/CWD sources the project is "anonymous" and ``config`` is
+    ``None`` — the CLI surfaces an init hint instead of an enabled list.
+
+    ``name`` defaults to ``root.name`` for non-MARKER sources, or to
+    the marker's recorded ``[project] name`` for MARKER sources.
+    """
+
+    root: Path
+    source: Source
+    name: str
+    marker_path: Path | None = None
+    config: ProjectConfig | None = None
+
+
+def _is_git_dir(path: Path) -> bool:
+    """``.git`` may be a directory (regular repo / submodule) or a file
+    (git worktree pointing at the main repo's worktree dir). Both count.
+    """
+    g = path / ".git"
+    return g.is_dir() or g.is_file()
+
+
+def detect_project(cwd: Path) -> Project:
+    """Run the §6 detection algorithm and return the result.
+
+    Walks ``cwd`` and its parents in order; the *innermost* (closest to
+    cwd) match wins. The marker walk and the git walk are independent
+    — a marker anywhere up the tree beats a git root anywhere up the
+    tree, even if the git root is closer.
+    """
+    resolved = cwd.expanduser().resolve()
+
+    # 1. marker walk-up
+    for p in [resolved, *resolved.parents]:
+        marker = p / PROJECT_MARKER_RELPATH
+        if marker.is_file():
+            cfg = load_project_config(marker)  # may raise — propagate per §6.1
+            return Project(
+                root=p,
+                source=Source.MARKER,
+                name=cfg.project.name,
+                marker_path=marker,
+                config=cfg,
+            )
+
+    # 2. git root walk-up — innermost
+    for p in [resolved, *resolved.parents]:
+        if _is_git_dir(p):
+            return Project(root=p, source=Source.GIT, name=p.name)
+
+    # 3. cwd fallback
+    return Project(root=resolved, source=Source.CWD, name=resolved.name)

--- a/src/memtomem_stm/mms/state.py
+++ b/src/memtomem_stm/mms/state.py
@@ -1,0 +1,266 @@
+"""Pydantic models + atomic TOML I/O for the three mms config files.
+
+Spec: RFC §5.3 — three TOML files form W1's persistent state:
+
+* ``~/.mms/registry.toml`` — global MCP definition catalog (secrets in env)
+* ``~/.mms/projects.toml`` — auto-managed projects index
+* ``<project>/.mms/project.toml`` — per-project enabled MCP names
+
+All three start with ``schema_version = 1``. Loading a higher version
+raises :class:`SchemaVersionMismatch` (W1 has no migration logic — RFC
+§16's ``mms upgrade-config`` is a W2+ separate code path).
+
+Path resolution goes through :func:`mms_home` etc. so tests can
+``monkeypatch.setenv("HOME", tmp_path)`` and have everything land in a
+sandbox.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import tomli_w
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from memtomem_stm.utils.fileio import atomic_write_text
+
+SCHEMA_VERSION = 1
+
+# Mode bits — registry holds secrets, projects index holds paths only,
+# per-project file is committed and intentionally world-readable.
+_REGISTRY_MODE = 0o600
+_PROJECTS_INDEX_MODE = 0o600
+_PROJECT_FILE_MODE: int | None = None  # respect user umask
+
+
+# ---------------------------------------------------------------------------
+# Path helpers — resolved at call time so monkeypatched HOME works in tests.
+# ---------------------------------------------------------------------------
+
+
+def mms_home() -> Path:
+    """Global mms state directory (``~/.mms``)."""
+    return Path.home() / ".mms"
+
+
+def registry_path() -> Path:
+    return mms_home() / "registry.toml"
+
+
+def projects_index_path() -> Path:
+    return mms_home() / "projects.toml"
+
+
+PROJECT_MARKER_RELPATH = Path(".mms") / "project.toml"
+"""Per-project marker relative path. Detection walks parents looking for this."""
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class MmsConfigError(Exception):
+    """Base for mms config load/save errors."""
+
+
+class SchemaVersionMismatch(MmsConfigError):
+    """Persisted ``schema_version`` differs from what this mms supports.
+
+    W1 only handles ``schema_version = 1``. Higher versions need ``mms
+    upgrade-config`` (W2+); lower versions are not yet possible (no W0).
+    Raised by every loader so the CLI can present a single message.
+    """
+
+    def __init__(self, path: Path, found: int) -> None:
+        super().__init__(
+            f"{path}: schema_version={found}, this mms supports {SCHEMA_VERSION}. "
+            "Run `mms upgrade-config` (planned for W2+) to migrate, or downgrade mms."
+        )
+        self.path = path
+        self.found = found
+
+
+class CorruptedConfig(MmsConfigError):
+    """TOML parse failure or pydantic validation failure on load."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        super().__init__(f"{path}: {reason}")
+        self.path = path
+        self.reason = reason
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class RegistryServer(BaseModel):
+    """A single MCP server definition stored in ``registry.toml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    command: str
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    prefix: str
+
+
+class RegistryConfig(BaseModel):
+    """Top-level model for ``~/.mms/registry.toml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = SCHEMA_VERSION
+    servers: dict[str, RegistryServer] = Field(default_factory=dict)
+
+
+class ProjectIndexEntry(BaseModel):
+    """One row in ``projects.toml`` — auto-managed, do not hand-edit."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    path: str
+    last_seen: str  # ISO 8601 UTC, e.g. "2026-05-01T13:24:03Z"
+
+
+class ProjectsIndex(BaseModel):
+    """Top-level model for ``~/.mms/projects.toml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = SCHEMA_VERSION
+    projects: list[ProjectIndexEntry] = Field(default_factory=list)
+
+
+class ProjectMeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+
+
+class ProjectMcp(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    enabled: list[str] = Field(default_factory=list)
+
+
+class ProjectConfig(BaseModel):
+    """Top-level model for ``<project>/.mms/project.toml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = SCHEMA_VERSION
+    project: ProjectMeta
+    mcp: ProjectMcp = Field(default_factory=ProjectMcp)
+
+
+# ---------------------------------------------------------------------------
+# Load helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_toml_dict(path: Path) -> dict:
+    try:
+        with path.open("rb") as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise CorruptedConfig(path, f"TOML parse error: {e}") from e
+
+
+def _check_schema_version(path: Path, raw: dict) -> None:
+    found = raw.get("schema_version")
+    if found is None:
+        raise CorruptedConfig(path, "missing top-level `schema_version`")
+    if not isinstance(found, int):
+        raise CorruptedConfig(path, f"`schema_version` must be int, got {type(found).__name__}")
+    if found != SCHEMA_VERSION:
+        raise SchemaVersionMismatch(path, found)
+
+
+def load_registry(path: Path | None = None) -> RegistryConfig:
+    """Load ``registry.toml``. Returns empty config if file is missing."""
+    p = path or registry_path()
+    if not p.is_file():
+        return RegistryConfig()
+    raw = _load_toml_dict(p)
+    _check_schema_version(p, raw)
+    try:
+        return RegistryConfig.model_validate(raw)
+    except ValidationError as e:
+        raise CorruptedConfig(p, f"schema validation: {e}") from e
+
+
+def load_projects_index(path: Path | None = None) -> ProjectsIndex:
+    """Load ``projects.toml``. Returns empty index if file is missing."""
+    p = path or projects_index_path()
+    if not p.is_file():
+        return ProjectsIndex()
+    raw = _load_toml_dict(p)
+    _check_schema_version(p, raw)
+    try:
+        return ProjectsIndex.model_validate(raw)
+    except ValidationError as e:
+        raise CorruptedConfig(p, f"schema validation: {e}") from e
+
+
+def load_project_config(path: Path) -> ProjectConfig:
+    """Load a per-project ``project.toml``. Raises if file is missing."""
+    if not path.is_file():
+        raise CorruptedConfig(path, "file not found")
+    raw = _load_toml_dict(path)
+    _check_schema_version(path, raw)
+    try:
+        return ProjectConfig.model_validate(raw)
+    except ValidationError as e:
+        raise CorruptedConfig(path, f"schema validation: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Save helpers
+# ---------------------------------------------------------------------------
+
+
+def save_registry(config: RegistryConfig, path: Path | None = None) -> None:
+    """Atomically write ``registry.toml`` with mode 0o600 (contains secrets)."""
+    p = path or registry_path()
+    atomic_write_text(p, tomli_w.dumps(config.model_dump()), mode=_REGISTRY_MODE)
+
+
+def save_projects_index(index: ProjectsIndex, path: Path | None = None) -> None:
+    """Atomically write ``projects.toml`` with mode 0o600 (paths are private)."""
+    p = path or projects_index_path()
+    atomic_write_text(p, tomli_w.dumps(index.model_dump()), mode=_PROJECTS_INDEX_MODE)
+
+
+def save_project_config(config: ProjectConfig, path: Path) -> None:
+    """Atomically write a per-project ``project.toml`` (committed file, default mode)."""
+    atomic_write_text(path, tomli_w.dumps(config.model_dump()), mode=_PROJECT_FILE_MODE)
+
+
+# ---------------------------------------------------------------------------
+# Index mutation helpers (used by `mms project init` to auto-add)
+# ---------------------------------------------------------------------------
+
+
+def utc_now_iso() -> str:
+    """ISO 8601 UTC string with seconds precision and trailing Z."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def upsert_project_in_index(
+    index: ProjectsIndex, *, name: str, path: str, now: str | None = None
+) -> ProjectsIndex:
+    """Return a new index with the (name, path) row upserted.
+
+    Match key is ``path`` (canonical), not name — same path with a renamed
+    project is the same entry. ``last_seen`` is refreshed on every upsert.
+    """
+    ts = now or utc_now_iso()
+    new_entry = ProjectIndexEntry(name=name, path=path, last_seen=ts)
+    others = [p for p in index.projects if p.path != path]
+    return ProjectsIndex(
+        schema_version=index.schema_version,
+        projects=[*others, new_entry],
+    )

--- a/tests/cli/test_mms_project.py
+++ b/tests/cli/test_mms_project.py
@@ -321,6 +321,26 @@ def test_disable_noop_when_not_enabled(runner, sandbox):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Wire-in smoke — `mms project ...` is reachable through the top-level cli
+# ---------------------------------------------------------------------------
+
+
+def test_project_group_wired_into_top_level_cli(runner):
+    """`mms project --help` lists all five W1 subcommands.
+
+    Pins the wiring in proxy.py — if the import or `add_command` line is
+    accidentally removed, this test catches it before the §12 e2e
+    acceptance test does (faster signal).
+    """
+    from memtomem_stm.cli.proxy import cli
+
+    res = runner.invoke(cli, ["project", "--help"])
+    assert res.exit_code == 0, res.output
+    for name in ["init", "show", "list", "enable", "disable"]:
+        assert name in res.output, f"subcommand '{name}' missing from `mms project --help`"
+
+
 def test_enable_project_flag_missing_marker_complains(runner, sandbox):
     other = sandbox["home"] / "other-proj"
     other.mkdir()

--- a/tests/cli/test_mms_project.py
+++ b/tests/cli/test_mms_project.py
@@ -1,0 +1,334 @@
+"""CliRunner tests for ``mms project ...`` (RFC §7.1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem_stm.cli.mms_project import (
+    _REGISTRY_EMPTY_MSG,
+    _show_git_no_marker_text,
+    _show_no_marker_no_git_text,
+    project_group,
+)
+from memtomem_stm.mms import state
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """Pin HOME so ``~/.mms`` is sandboxed; chdir to a fresh project dir.
+
+    Returns a dict with the sandbox HOME and the cwd directory so tests
+    can do path assertions.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    proj_dir = tmp_path / "proj"
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    return {"home": tmp_path, "cwd": proj_dir}
+
+
+def _seed_registry(*names: str) -> None:
+    cfg = state.RegistryConfig(
+        servers={n: state.RegistryServer(command="echo", prefix=n[:2]) for n in names}
+    )
+    state.save_registry(cfg)
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+
+def test_init_creates_marker_and_indexes(runner, sandbox):
+    res = runner.invoke(project_group, ["init"])
+    assert res.exit_code == 0, res.output
+
+    marker = sandbox["cwd"] / state.PROJECT_MARKER_RELPATH
+    assert marker.is_file()
+
+    cfg = state.load_project_config(marker)
+    assert cfg.project.name == "proj"
+    assert cfg.mcp.enabled == []
+
+    idx = state.load_projects_index()
+    assert len(idx.projects) == 1
+    assert idx.projects[0].name == "proj"
+    assert Path(idx.projects[0].path) == sandbox["cwd"]
+
+
+def test_init_with_explicit_path_and_name(runner, sandbox):
+    other = sandbox["home"] / "other-proj"
+    other.mkdir()
+    res = runner.invoke(project_group, ["init", str(other), "--name", "custom"])
+    assert res.exit_code == 0, res.output
+
+    marker = other / state.PROJECT_MARKER_RELPATH
+    assert marker.is_file()
+    assert state.load_project_config(marker).project.name == "custom"
+
+
+def test_init_aborts_when_marker_exists(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    res = runner.invoke(project_group, ["init"])
+    assert res.exit_code != 0
+    assert "already exists" in res.output
+    assert "--force" in res.output
+
+
+def test_init_force_overwrites(runner, sandbox):
+    runner.invoke(project_group, ["init", "--name", "first"])
+    res = runner.invoke(project_group, ["init", "--name", "second", "--force"])
+    assert res.exit_code == 0, res.output
+    marker = sandbox["cwd"] / state.PROJECT_MARKER_RELPATH
+    assert state.load_project_config(marker).project.name == "second"
+
+
+def test_init_rejects_nonexistent_path(runner, sandbox):
+    nope = sandbox["home"] / "does-not-exist"
+    res = runner.invoke(project_group, ["init", str(nope)])
+    assert res.exit_code != 0
+    assert "Not a directory" in res.output or "does not exist" in res.output
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+def test_show_no_marker_no_git_friendly_text(runner, sandbox):
+    """RFC §6.1 — pinned literal text used by `mms project show` UX."""
+    res = runner.invoke(project_group, ["show"])
+    assert res.exit_code == 0, res.output
+    expected = _show_no_marker_no_git_text(sandbox["cwd"].resolve())
+    assert res.output == expected
+
+
+def test_show_git_no_marker_friendly_text(runner, sandbox):
+    (sandbox["cwd"] / ".git").mkdir()
+    res = runner.invoke(project_group, ["show"])
+    assert res.exit_code == 0, res.output
+    expected = _show_git_no_marker_text(sandbox["cwd"].resolve())
+    assert res.output == expected
+
+
+def test_show_marker_renders_enabled_list(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    _seed_registry("filesystem", "github")
+    runner.invoke(project_group, ["enable", "filesystem", "github"])
+    res = runner.invoke(project_group, ["show"])
+    assert res.exit_code == 0, res.output
+    assert "Project: proj" in res.output
+    assert "Detected via: marker" in res.output
+    assert "Enabled MCPs: filesystem, github" in res.output
+
+
+def test_show_marker_with_no_enabled(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    res = runner.invoke(project_group, ["show"])
+    assert "Enabled MCPs: (none)" in res.output
+
+
+def test_show_json_marker(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    _seed_registry("filesystem")
+    runner.invoke(project_group, ["enable", "filesystem"])
+    res = runner.invoke(project_group, ["show", "--json"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload["name"] == "proj"
+    assert payload["source"] == "marker"
+    assert payload["enabled"] == ["filesystem"]
+
+
+def test_show_json_cwd_fallback(runner, sandbox):
+    res = runner.invoke(project_group, ["show", "--json"])
+    payload = json.loads(res.output)
+    assert payload["source"] == "cwd"
+    assert payload["enabled"] == []
+
+
+def test_show_marker_walk_up(runner, sandbox, monkeypatch):
+    runner.invoke(project_group, ["init"])
+    sub = sandbox["cwd"] / "sub" / "deep"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+    res = runner.invoke(project_group, ["show"])
+    assert "Detected via: marker" in res.output
+    assert "Project: proj" in res.output
+
+
+def test_show_by_name(runner, sandbox):
+    other = sandbox["home"] / "other-proj"
+    other.mkdir()
+    runner.invoke(project_group, ["init", str(other), "--name", "elsewhere"])
+    res = runner.invoke(project_group, ["show", "elsewhere"])
+    assert res.exit_code == 0
+    assert "Project: elsewhere" in res.output
+
+
+def test_show_by_name_not_found(runner, sandbox):
+    res = runner.invoke(project_group, ["show", "missing"])
+    assert res.exit_code != 0
+    assert "not found" in res.output
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_empty(runner, sandbox):
+    res = runner.invoke(project_group, ["list"])
+    assert res.exit_code == 0
+    assert "No projects indexed" in res.output
+
+
+def test_list_marks_current(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    other = sandbox["home"] / "other-proj"
+    other.mkdir()
+    runner.invoke(project_group, ["init", str(other), "--name", "other"])
+
+    res = runner.invoke(project_group, ["list"])
+    assert res.exit_code == 0, res.output
+    lines = res.output.strip().splitlines()
+    # current cwd is /tmp/.../proj — should be marked with *
+    cwd_line = next(line for line in lines if "proj\t" in line and "other-proj" not in line)
+    assert cwd_line.startswith("*")
+    other_line = next(line for line in lines if "other-proj" in line)
+    assert other_line.startswith(" ")
+
+
+def test_list_json(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    res = runner.invoke(project_group, ["list", "--json"])
+    payload = json.loads(res.output)
+    assert len(payload["projects"]) == 1
+    assert payload["projects"][0]["name"] == "proj"
+    assert payload["projects"][0]["current"] is True
+    assert payload["pruned"] == []
+
+
+def test_list_prune_removes_stale(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+
+    stale_dir = sandbox["home"] / "stale"
+    stale_dir.mkdir()
+    runner.invoke(project_group, ["init", str(stale_dir), "--name", "stale"])
+
+    # Now delete the stale dir on disk; index still has it.
+    import shutil
+
+    shutil.rmtree(stale_dir)
+
+    res = runner.invoke(project_group, ["list", "--prune"])
+    assert res.exit_code == 0, res.output
+    assert "pruned: stale" in res.output
+    assert "Pruned 1" in res.output
+
+    # Index should now have only the live project.
+    idx = state.load_projects_index()
+    names = {e.name for e in idx.projects}
+    assert names == {"proj"}
+
+
+# ---------------------------------------------------------------------------
+# enable / disable
+# ---------------------------------------------------------------------------
+
+
+def test_enable_against_empty_registry_friendly_error(runner, sandbox):
+    """Pinned graceful-error contract from W1 PR1 plan."""
+    runner.invoke(project_group, ["init"])
+    res = runner.invoke(project_group, ["enable", "filesystem"])
+    assert res.exit_code != 0
+    # stderr in CliRunner with mix_stderr=True (default) lands in res.output
+    assert _REGISTRY_EMPTY_MSG.strip() in res.output
+
+
+def test_enable_requires_marker(runner, sandbox):
+    _seed_registry("filesystem")  # registry non-empty so the check passes
+    res = runner.invoke(project_group, ["enable", "filesystem"])
+    assert res.exit_code != 0
+    assert "No project marker" in res.output
+    assert "mms project init" in res.output
+
+
+def test_enable_appends_unique(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    _seed_registry("a", "b", "c")
+    runner.invoke(project_group, ["enable", "a", "b"])
+    runner.invoke(project_group, ["enable", "b", "c"])  # b is dup
+
+    cfg = state.load_project_config(sandbox["cwd"] / state.PROJECT_MARKER_RELPATH)
+    assert cfg.mcp.enabled == ["a", "b", "c"]
+
+
+def test_enable_with_project_flag(runner, sandbox):
+    other = sandbox["home"] / "other-proj"
+    other.mkdir()
+    runner.invoke(project_group, ["init", str(other), "--name", "elsewhere"])
+    _seed_registry("filesystem")
+    res = runner.invoke(project_group, ["enable", "filesystem", "--project", "elsewhere"])
+    assert res.exit_code == 0, res.output
+
+    other_marker = other / state.PROJECT_MARKER_RELPATH
+    assert state.load_project_config(other_marker).mcp.enabled == ["filesystem"]
+
+
+def test_disable_removes_listed(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    _seed_registry("a", "b")
+    runner.invoke(project_group, ["enable", "a", "b"])
+    runner.invoke(project_group, ["disable", "a"])
+
+    cfg = state.load_project_config(sandbox["cwd"] / state.PROJECT_MARKER_RELPATH)
+    assert cfg.mcp.enabled == ["b"]
+
+
+def test_disable_works_with_empty_registry(runner, sandbox):
+    """Disable doesn't require a populated registry — it only mutates project state."""
+    runner.invoke(project_group, ["init"])
+    _seed_registry("a")
+    runner.invoke(project_group, ["enable", "a"])
+    # Now wipe the registry.
+    state.save_registry(state.RegistryConfig())
+
+    res = runner.invoke(project_group, ["disable", "a"])
+    assert res.exit_code == 0, res.output
+    cfg = state.load_project_config(sandbox["cwd"] / state.PROJECT_MARKER_RELPATH)
+    assert cfg.mcp.enabled == []
+
+
+def test_disable_noop_when_not_enabled(runner, sandbox):
+    runner.invoke(project_group, ["init"])
+    res = runner.invoke(project_group, ["disable", "never-enabled"])
+    assert res.exit_code == 0
+    assert "No changes" in res.output
+
+
+# ---------------------------------------------------------------------------
+# Project resolution edge case — --project name with stale index
+# ---------------------------------------------------------------------------
+
+
+def test_enable_project_flag_missing_marker_complains(runner, sandbox):
+    other = sandbox["home"] / "other-proj"
+    other.mkdir()
+    runner.invoke(project_group, ["init", str(other), "--name", "elsewhere"])
+    # Simulate user deleting the marker directly without pruning the index.
+    (other / state.PROJECT_MARKER_RELPATH).unlink()
+    _seed_registry("filesystem")
+    res = runner.invoke(project_group, ["enable", "filesystem", "--project", "elsewhere"])
+    assert res.exit_code != 0
+    assert "marker file is missing" in res.output
+    assert "list --prune" in res.output

--- a/tests/mms/test_detect.py
+++ b/tests/mms/test_detect.py
@@ -1,0 +1,164 @@
+"""Tests for ``mms.detect`` — RFC §6 algorithm + §6.1 edge cases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.mms import state
+from memtomem_stm.mms.detect import Project, Source, detect_project
+
+
+def _write_marker(root: Path, name: str = "proj", enabled: list[str] | None = None) -> Path:
+    marker = root / state.PROJECT_MARKER_RELPATH
+    cfg = state.ProjectConfig(
+        project=state.ProjectMeta(name=name),
+        mcp=state.ProjectMcp(enabled=enabled or []),
+    )
+    state.save_project_config(cfg, marker)
+    return marker
+
+
+def _make_git(root: Path) -> None:
+    (root / ".git").mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: each of the 3 source branches
+# ---------------------------------------------------------------------------
+
+
+def test_marker_at_cwd_wins(tmp_path):
+    _write_marker(tmp_path, name="proj-a", enabled=["filesystem"])
+    p = detect_project(tmp_path)
+    assert p.source is Source.MARKER
+    assert p.root == tmp_path.resolve()
+    assert p.name == "proj-a"
+    assert p.marker_path == (tmp_path / state.PROJECT_MARKER_RELPATH).resolve()
+    assert p.config is not None
+    assert p.config.mcp.enabled == ["filesystem"]
+
+
+def test_marker_walk_up_finds_parent(tmp_path):
+    _write_marker(tmp_path, name="parent-proj")
+    nested = tmp_path / "sub" / "deep"
+    nested.mkdir(parents=True)
+    p = detect_project(nested)
+    assert p.source is Source.MARKER
+    assert p.root == tmp_path.resolve()
+    assert p.name == "parent-proj"
+
+
+def test_git_fallback_when_no_marker(tmp_path):
+    _make_git(tmp_path)
+    p = detect_project(tmp_path)
+    assert p.source is Source.GIT
+    assert p.root == tmp_path.resolve()
+    assert p.name == tmp_path.name
+    assert p.marker_path is None
+    assert p.config is None
+
+
+def test_cwd_fallback_when_no_marker_no_git(tmp_path):
+    p = detect_project(tmp_path)
+    assert p.source is Source.CWD
+    assert p.root == tmp_path.resolve()
+    assert p.name == tmp_path.name
+
+
+# ---------------------------------------------------------------------------
+# §6 ordering: marker beats git, even if git is closer
+# ---------------------------------------------------------------------------
+
+
+def test_marker_beats_closer_git(tmp_path):
+    _write_marker(tmp_path, name="outer-marker")
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    _make_git(inner)  # .git is closer to cwd, but marker should still win
+    p = detect_project(inner)
+    assert p.source is Source.MARKER
+    assert p.name == "outer-marker"
+    assert p.root == tmp_path.resolve()
+
+
+# ---------------------------------------------------------------------------
+# §6.1 edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_git_submodule_innermost_wins(tmp_path):
+    """Two .git dirs in the walk; innermost (the submodule) wins."""
+    _make_git(tmp_path)  # outer repo
+    sub = tmp_path / "vendor" / "thing"
+    sub.mkdir(parents=True)
+    _make_git(sub)  # submodule
+    p = detect_project(sub)
+    assert p.source is Source.GIT
+    assert p.root == sub.resolve()
+
+
+def test_git_worktree_with_dot_git_as_file(tmp_path):
+    """`.git` is a file in a worktree — still detected as a git repo."""
+    (tmp_path / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    p = detect_project(tmp_path)
+    assert p.source is Source.GIT
+    assert p.root == tmp_path.resolve()
+
+
+def test_monorepo_single_marker_at_root(tmp_path):
+    """One marker at the monorepo root; sub-package without its own marker
+    inherits the same project (RFC §6.1 "가장 가까운 marker가 진실")."""
+    _write_marker(tmp_path, name="monorepo")
+    pkg = tmp_path / "packages" / "pkg-a"
+    pkg.mkdir(parents=True)
+    p = detect_project(pkg)
+    assert p.source is Source.MARKER
+    assert p.name == "monorepo"
+    assert p.root == tmp_path.resolve()
+
+
+def test_malformed_marker_propagates_corruption(tmp_path):
+    """RFC §6.1 — malformed marker is rejected, not silently bypassed."""
+    marker = tmp_path / state.PROJECT_MARKER_RELPATH
+    marker.parent.mkdir(parents=True)
+    marker.write_text("this is = not [valid toml\n", encoding="utf-8")
+    with pytest.raises(state.CorruptedConfig):
+        detect_project(tmp_path)
+
+
+def test_schema_mismatch_marker_propagates(tmp_path):
+    """Detection must NOT silently fall through to git/cwd on schema mismatch."""
+    marker = tmp_path / state.PROJECT_MARKER_RELPATH
+    marker.parent.mkdir(parents=True)
+    marker.write_text(
+        'schema_version = 99\n[project]\nname = "x"\n[mcp]\nenabled = []\n',
+        encoding="utf-8",
+    )
+    _make_git(tmp_path)  # git would otherwise match
+    with pytest.raises(state.SchemaVersionMismatch):
+        detect_project(tmp_path)
+
+
+def test_cwd_is_root_filesystem_falls_back_to_cwd(monkeypatch, tmp_path):
+    """Walk-up reaching `/` without a hit returns CWD source, not raise."""
+    # Use tmp_path (no marker, no git) to simulate. We don't actually walk
+    # to the real `/` — pathlib stops at root naturally.
+    # The contract: even if walk reaches root, no exception.
+    p = detect_project(tmp_path)
+    assert p.source is Source.CWD
+
+
+# ---------------------------------------------------------------------------
+# Marker shape sanity — Project carries the parsed config
+# ---------------------------------------------------------------------------
+
+
+def test_marker_project_carries_parsed_config(tmp_path):
+    _write_marker(tmp_path, name="p", enabled=["a", "b", "c"])
+    p = detect_project(tmp_path)
+    assert isinstance(p, Project)
+    assert p.config is not None
+    assert p.config.mcp.enabled == ["a", "b", "c"]
+    assert p.config.project.name == "p"

--- a/tests/mms/test_state.py
+++ b/tests/mms/test_state.py
@@ -1,0 +1,262 @@
+"""Tests for ``mms.state`` — pydantic models + atomic TOML round-trip."""
+
+from __future__ import annotations
+
+import stat
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.mms import state
+
+
+@pytest.fixture
+def sandbox_home(tmp_path, monkeypatch):
+    """Repoint ``~/.mms`` at a sandbox dir; yield it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def test_mms_home_resolves_under_home(sandbox_home):
+    assert state.mms_home() == sandbox_home / ".mms"
+    assert state.registry_path() == sandbox_home / ".mms" / "registry.toml"
+    assert state.projects_index_path() == sandbox_home / ".mms" / "projects.toml"
+
+
+def test_project_marker_relpath_is_dot_mms_project_toml():
+    assert state.PROJECT_MARKER_RELPATH == Path(".mms") / "project.toml"
+
+
+# ---------------------------------------------------------------------------
+# Registry round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_load_registry_returns_empty_when_missing(sandbox_home):
+    cfg = state.load_registry()
+    assert cfg.servers == {}
+    assert cfg.schema_version == state.SCHEMA_VERSION
+
+
+def test_registry_round_trip(sandbox_home):
+    cfg = state.RegistryConfig(
+        servers={
+            "filesystem": state.RegistryServer(
+                command="npx",
+                args=["-y", "@modelcontextprotocol/server-filesystem", "/home/user"],
+                prefix="fs",
+            ),
+            "github": state.RegistryServer(
+                command="npx",
+                args=["-y", "@mcp/github"],
+                env={"GITHUB_TOKEN": "ghp_secret"},
+                prefix="gh",
+            ),
+        }
+    )
+    state.save_registry(cfg)
+    loaded = state.load_registry()
+    assert loaded == cfg
+
+
+def test_save_registry_uses_0o600(sandbox_home):
+    cfg = state.RegistryConfig(servers={"foo": state.RegistryServer(command="echo", prefix="f")})
+    state.save_registry(cfg)
+    mode = stat.S_IMODE(state.registry_path().stat().st_mode)
+    assert mode == 0o600
+
+
+# ---------------------------------------------------------------------------
+# Projects index round-trip + upsert
+# ---------------------------------------------------------------------------
+
+
+def test_load_projects_index_returns_empty_when_missing(sandbox_home):
+    idx = state.load_projects_index()
+    assert idx.projects == []
+
+
+def test_projects_index_round_trip(sandbox_home):
+    idx = state.ProjectsIndex(
+        projects=[
+            state.ProjectIndexEntry(
+                name="proj-a", path="/tmp/proj-a", last_seen="2026-05-01T13:24:03Z"
+            ),
+            state.ProjectIndexEntry(
+                name="proj-b", path="/tmp/proj-b", last_seen="2026-04-29T09:11:00Z"
+            ),
+        ]
+    )
+    state.save_projects_index(idx)
+    loaded = state.load_projects_index()
+    assert loaded == idx
+
+
+def test_upsert_project_replaces_by_path(sandbox_home):
+    idx = state.ProjectsIndex(
+        projects=[
+            state.ProjectIndexEntry(
+                name="old-name", path="/tmp/proj", last_seen="2026-01-01T00:00:00Z"
+            ),
+        ]
+    )
+    new_idx = state.upsert_project_in_index(
+        idx, name="new-name", path="/tmp/proj", now="2026-05-01T13:24:03Z"
+    )
+    assert len(new_idx.projects) == 1
+    assert new_idx.projects[0].name == "new-name"
+    assert new_idx.projects[0].last_seen == "2026-05-01T13:24:03Z"
+
+
+def test_upsert_project_appends_new_path(sandbox_home):
+    idx = state.ProjectsIndex(
+        projects=[
+            state.ProjectIndexEntry(
+                name="proj-a", path="/tmp/proj-a", last_seen="2026-01-01T00:00:00Z"
+            ),
+        ]
+    )
+    new_idx = state.upsert_project_in_index(
+        idx, name="proj-b", path="/tmp/proj-b", now="2026-05-01T13:24:03Z"
+    )
+    assert len(new_idx.projects) == 2
+    assert {p.name for p in new_idx.projects} == {"proj-a", "proj-b"}
+
+
+def test_utc_now_iso_format(sandbox_home):
+    s = state.utc_now_iso()
+    # 2026-05-01T13:24:03Z
+    assert len(s) == 20
+    assert s.endswith("Z")
+    assert s[10] == "T"
+
+
+# ---------------------------------------------------------------------------
+# ProjectConfig round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_project_config_round_trip(tmp_path):
+    target = tmp_path / ".mms" / "project.toml"
+    cfg = state.ProjectConfig(
+        project=state.ProjectMeta(name="memtomem-stm"),
+        mcp=state.ProjectMcp(enabled=["filesystem", "github"]),
+    )
+    state.save_project_config(cfg, target)
+    loaded = state.load_project_config(target)
+    assert loaded == cfg
+
+
+def test_project_config_load_missing_raises(tmp_path):
+    target = tmp_path / "nope.toml"
+    with pytest.raises(state.CorruptedConfig) as exc_info:
+        state.load_project_config(target)
+    assert "file not found" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Schema version + corruption errors
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_mismatch_distinct_from_corruption(tmp_path):
+    target = tmp_path / "project.toml"
+    target.write_text(
+        'schema_version = 2\n[project]\nname = "x"\n[mcp]\nenabled = []\n', encoding="utf-8"
+    )
+    with pytest.raises(state.SchemaVersionMismatch) as exc_info:
+        state.load_project_config(target)
+    assert exc_info.value.found == 2
+    assert exc_info.value.path == target
+    # And: message points at upgrade-config (W2+)
+    assert "upgrade-config" in str(exc_info.value)
+
+
+def test_missing_schema_version_is_corruption(tmp_path):
+    target = tmp_path / "project.toml"
+    target.write_text('[project]\nname = "x"\n[mcp]\nenabled = []\n', encoding="utf-8")
+    with pytest.raises(state.CorruptedConfig) as exc_info:
+        state.load_project_config(target)
+    assert "schema_version" in exc_info.value.reason
+    # And: not a SchemaVersionMismatch — a different code path
+    assert not isinstance(exc_info.value, state.SchemaVersionMismatch)
+
+
+def test_toml_parse_error_is_corruption(tmp_path):
+    target = tmp_path / "project.toml"
+    target.write_text("this is = not [valid toml\n", encoding="utf-8")
+    with pytest.raises(state.CorruptedConfig) as exc_info:
+        state.load_project_config(target)
+    assert "TOML parse error" in exc_info.value.reason
+
+
+def test_extra_field_rejected(tmp_path):
+    target = tmp_path / "project.toml"
+    target.write_text(
+        'schema_version = 1\n[project]\nname = "x"\nextra_unknown = "boom"\n[mcp]\nenabled = []\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(state.CorruptedConfig):
+        state.load_project_config(target)
+
+
+def test_schema_version_wrong_type(tmp_path):
+    target = tmp_path / "project.toml"
+    target.write_text(
+        'schema_version = "1"\n[project]\nname = "x"\n[mcp]\nenabled = []\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(state.CorruptedConfig) as exc_info:
+        state.load_project_config(target)
+    assert "must be int" in exc_info.value.reason
+
+
+# ---------------------------------------------------------------------------
+# TOML on-disk shape sanity (matches RFC §5.3 examples)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_on_disk_shape_matches_rfc(sandbox_home):
+    cfg = state.RegistryConfig(
+        servers={
+            "filesystem": state.RegistryServer(command="npx", args=["-y", "@mcp/fs"], prefix="fs")
+        }
+    )
+    state.save_registry(cfg)
+    raw = tomllib.loads(state.registry_path().read_text(encoding="utf-8"))
+    assert raw["schema_version"] == 1
+    assert raw["servers"]["filesystem"]["command"] == "npx"
+    assert raw["servers"]["filesystem"]["prefix"] == "fs"
+
+
+def test_projects_index_on_disk_shape_matches_rfc(sandbox_home):
+    idx = state.ProjectsIndex(
+        projects=[
+            state.ProjectIndexEntry(name="x", path="/tmp/x", last_seen="2026-05-01T13:24:03Z")
+        ]
+    )
+    state.save_projects_index(idx)
+    raw = tomllib.loads(state.projects_index_path().read_text(encoding="utf-8"))
+    assert raw["schema_version"] == 1
+    # RFC §5.3 uses [[projects]] array-of-tables
+    assert isinstance(raw["projects"], list)
+    assert raw["projects"][0]["name"] == "x"
+
+
+def test_project_config_on_disk_shape_matches_rfc(tmp_path):
+    target = tmp_path / "project.toml"
+    cfg = state.ProjectConfig(
+        project=state.ProjectMeta(name="proj"),
+        mcp=state.ProjectMcp(enabled=["a", "b"]),
+    )
+    state.save_project_config(cfg, target)
+    raw = tomllib.loads(target.read_text(encoding="utf-8"))
+    assert raw["schema_version"] == 1
+    assert raw["project"]["name"] == "proj"
+    assert raw["mcp"]["enabled"] == ["a", "b"]

--- a/uv.lock
+++ b/uv.lock
@@ -1486,6 +1486,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "questionary" },
+    { name = "tomli-w" },
 ]
 
 [package.optional-dependencies]
@@ -1523,6 +1524,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "questionary", specifier = ">=2.0" },
+    { name = "tomli-w", specifier = ">=1.0" },
 ]
 provides-extras = ["langfuse", "langchain"]
 
@@ -2699,6 +2701,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First of two PRs implementing **W1** of the project-scoped MCP management RFC v0.3 (memtomem-docs#29 + #30). PR1 lands the **project state CRUD** half — five `mms project` subcommands plus the persistence and detection layers underneath. PR2 (separate, follow-up) lands `mms import` and the host scanners.

| Layer | File | What it does |
|---|---|---|
| Persistence | `src/memtomem_stm/mms/state.py` | Pydantic models + atomic TOML I/O for the three W1 config files. `extra="forbid"` rejects unknown fields. `SchemaVersionMismatch` is a distinct exception from `CorruptedConfig` so the CLI can route the two failure modes separately (RFC §6.1). |
| Detection | `src/memtomem_stm/mms/detect.py` | RFC §6 algorithm: marker walk-up → git walk-up → cwd fallback. Marker beats git even if git is closer to cwd. Malformed markers raise rather than falling through to git/cwd (§6.1 contract: "거부, 백업 위치 안내, 자동 복구 X"). |
| CLI | `src/memtomem_stm/cli/mms_project.py` | The five subcommands. Pinned UX strings (`_REGISTRY_EMPTY_MSG`, `_show_no_marker_no_git_text`, `_show_git_no_marker_text`) live as module constants so tests assert against the symbol — any wording change is one-place. |
| Wiring | `src/memtomem_stm/cli/proxy.py` (+6 lines) | Two-line wiring (import + `cli.add_command`) plus a smoke test that fails fast if the wiring breaks in a future refactor. |

## State files (RFC §5)

| Path | Role | Commit? |
|------|------|---------|
| `~/.mms/registry.toml` | Global MCP catalog (filled by `mms import` — PR2) | **No** — gitignore |
| `~/.mms/projects.toml` | Auto-managed projects index | **No** — gitignore |
| `<project>/.mms/project.toml` | Per-project enabled MCP names | **Yes** |

`~/.mms/` is intentionally separate from `~/.memtomem/` — see RFC §5.1 and the W1 boundary discussion in §14 W2-Q2 (added by `memtomem-docs#31`). `mms add` writes only `stm_proxy.json`; `mms import` (PR2) writes only `registry.toml`. Two disjoint mutation paths in W1.

## Behavior change

None to existing commands. The new `mms project` subgroup is purely additive.

The W1-specific quirk an early adopter may hit:

- **`mms project enable X` against an empty registry** surfaces a *graceful friendly error* pointing at `mms import --from <host>` (PR2). This is intentional per the W1 PR1 plan — until PR2 lands, the registry has no canonical writer, so any other UX would either lie or crash. The literal message text is pinned by tests.

## Why now

mms RFC v0.3 (with v0.3 polish round) merged 2026-05-01; W1 coding was the single next trigger. Pre-coding work also landed: a memory-note capturing the `~/.mms/` decision rationale (rejected `~/.memtomem/mms/` and `~/.config/mms/`) and the `memtomem-docs` follow-up PR that added the §12 W1-scope banner and the §14 W2-Q2 unification trigger.

## Why two PRs (PR1 / PR2 split)

W1 totals ~1100 LOC of new code. Splitting at the project-state / host-import boundary keeps each PR's reviewer mental model focused on one domain — PR1 is state machine + filesystem layout, PR2 is parsing + secret classification + 4-host adapter dispatch. Rollback granularity is also better — if PR2 turns up a flaw in secret classification, PR1's state model isn't entangled.

## Test plan

- [x] `uv run pytest -m "not ollama"` — full suite, 1856 passed (zero new failures).
- [x] `tests/mms/test_state.py` — 20 tests (round-trip, mode 0o600, schema-version vs corruption distinction, `extra="forbid"`, RFC §5.3 on-disk shape).
- [x] `tests/mms/test_detect.py` — 12 tests (marker/git/cwd happy paths, marker beats closer git, submodule innermost wins, worktree `.git` as file, monorepo single root marker, malformed marker propagates, schema mismatch propagates, cwd at root).
- [x] `tests/cli/test_mms_project.py` — 26 tests + 1 wire-in smoke (CliRunner against `init`, `show`, `list`, `enable`, `disable` with sandboxed HOME via `monkeypatch.setenv`).
- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run mypy src/memtomem_stm/mms/ src/memtomem_stm/cli/mms_project.py` — clean.

## Manual dogfood (sandboxed HOME)

```bash
HOME=/tmp/mms-dogfood uv run mms project show
# → No project marker (.mms/project.toml) or git repo found at /tmp/mms-dogfood.
#   Cwd-fallback project: 'mms-dogfood' (anonymous, not registered).
#     Run `mms project init` here to create .mms/project.toml.

HOME=/tmp/mms-dogfood mkdir -p /tmp/mms-dogfood/proj && cd /tmp/mms-dogfood/proj
HOME=/tmp/mms-dogfood uv run mms project init
HOME=/tmp/mms-dogfood uv run mms project enable nonexistent
# → Registry is empty.
#     Run `mms import --from <host>` (W1 PR2) to import existing MCP definitions, ...

HOME=/tmp/mms-dogfood uv run mms project list --json
```

Cleanup: `rm -rf /tmp/mms-dogfood`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)