### PR TITLE
feat(mms): W2 PR1 — drift-hash foundation (canonical form + sidecar)

### DIFF
--- a/src/memtomem_stm/mms/drift.py
+++ b/src/memtomem_stm/mms/drift.py
@@ -1,0 +1,53 @@
+"""Drift hash for imported MCP servers (W2 host-sync foundation).
+
+W2 needs a stable per-entry fingerprint so ``mms import`` can detect when a
+host's MCP config drifted (got edited externally) since the last import. The
+hash must absorb cosmetic JSON/TOML re-formatting (host serializers vary)
+but flip on any semantic edit (new arg, swapped command, mutated env).
+
+Canonical form: ``command`` + ordered ``args`` + key-sorted ``env``. The
+``prefix`` field is mms-derived metadata and intentionally excluded — a
+future tweak to ``_derive_prefix`` must not false-flag drift on every
+imported server.
+
+Hash representation: ``"sha256:" + hex[:16]``. 64 bits of entropy is plenty
+per-server-name; the algorithm prefix future-proofs a swap (e.g. blake3)
+without ambiguity in the sidecar TOML.
+
+W1 import already coerces args/env to canonical Python types
+(``list[str]`` / ``dict[str, str]``) and applies pydantic defaults for the
+empty-vs-absent equivalence rule, so this module needs no defensive
+parsing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from memtomem_stm.mms.state import RegistryServer
+
+HASH_VERSION = 1
+HASH_PREFIX = "sha256"
+HASH_HEX_LEN = 16
+
+
+def canonical_form(server: RegistryServer) -> str:
+    """Return the JSON canonical form whose SHA-256 is the drift hash.
+
+    Exposed for debuggability — callers should not parse this; treat it as
+    opaque. The exact serialization is locked by tests so any future change
+    is loud.
+    """
+    payload = {
+        "command": server.command,
+        "args": list(server.args),
+        "env": dict(sorted(server.env.items())),
+    }
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+
+
+def compute_drift_hash(server: RegistryServer) -> str:
+    """Return ``"sha256:<16hex>"`` for ``server``'s canonical form."""
+    digest = hashlib.sha256(canonical_form(server).encode("utf-8")).hexdigest()
+    return f"{HASH_PREFIX}:{digest[:HASH_HEX_LEN]}"

--- a/src/memtomem_stm/mms/state.py
+++ b/src/memtomem_stm/mms/state.py
@@ -1,21 +1,19 @@
 """Pydantic models + atomic TOML I/O for the mms config files.
 
-Spec: RFC §5.3 — three TOML files form W1's persistent state:
+Three RFC §5.3 files plus one W2 sidecar form mms's persistent state:
 
 * ``~/.mms/registry.toml`` — global MCP definition catalog (secrets in env)
 * ``~/.mms/projects.toml`` — auto-managed projects index
 * ``<project>/.mms/project.toml`` — per-project enabled MCP names
-
-W2 adds a fourth, sidecar-only file:
-
-* ``~/.mms/import_state.toml`` — drift-detection baseline; per-server
+* ``~/.mms/import_state.toml`` — W2 drift-detection sidecar; per-server
   ``drift_hash`` (foundation in PR1, populated by ``mms import`` in PR2).
 
-All three start with ``schema_version = 1``. Loading a higher version
-raises :class:`SchemaVersionMismatch` (W1 has no migration logic — RFC
-§16's ``mms upgrade-config`` is a W2+ separate code path). The sidecar
-has its own independent ``schema_version`` (also 1) — sidecar evolution
-is decoupled from registry evolution.
+The first three share ``SCHEMA_VERSION``; the sidecar carries its own
+``IMPORT_STATE_SCHEMA_VERSION`` so a future drift-hash algorithm bump
+doesn't invalidate registries (and vice versa). Loading a file whose
+recorded version differs from the matching constant raises
+:class:`SchemaVersionMismatch` (W1/W2 have no migration logic — RFC
+§16's ``mms upgrade-config`` is a separate code path).
 
 Path resolution goes through :func:`mms_home` etc. so tests can
 ``monkeypatch.setenv("HOME", tmp_path)`` and have everything land in a
@@ -34,6 +32,16 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from memtomem_stm.utils.fileio import atomic_write_text
 
 SCHEMA_VERSION = 1
+"""Version constant for the three RFC §5.3 files (registry / projects index /
+per-project config). Bump in lockstep when any of those shapes change.
+
+The W2 sidecar has its own :data:`IMPORT_STATE_SCHEMA_VERSION` so a drift-hash
+algorithm change can roll forward without forcing a registry migration."""
+
+IMPORT_STATE_SCHEMA_VERSION = 1
+"""Version constant for ``~/.mms/import_state.toml`` only. Bump when the
+sidecar shape (entry fields, hash format) changes — does **not** force a
+registry version bump."""
 
 # Mode bits — registry holds secrets, projects index holds paths only,
 # per-project file is committed and intentionally world-readable.
@@ -84,18 +92,23 @@ class MmsConfigError(Exception):
 class SchemaVersionMismatch(MmsConfigError):
     """Persisted ``schema_version`` differs from what this mms supports.
 
-    W1 only handles ``schema_version = 1``. Higher versions need ``mms
-    upgrade-config`` (W2+); lower versions are not yet possible (no W0).
-    Raised by every loader so the CLI can present a single message.
+    Each loader carries its own ``expected`` constant (registry/projects
+    /project share :data:`SCHEMA_VERSION`; the sidecar uses
+    :data:`IMPORT_STATE_SCHEMA_VERSION`) so the error message names the
+    *right* number — a sidecar bump doesn't print "registry expects X".
+
+    Higher versions need ``mms upgrade-config`` (planned for W2+); lower
+    versions are not yet possible (no W0).
     """
 
-    def __init__(self, path: Path, found: int) -> None:
+    def __init__(self, path: Path, found: int, expected: int) -> None:
         super().__init__(
-            f"{path}: schema_version={found}, this mms supports {SCHEMA_VERSION}. "
+            f"{path}: schema_version={found}, this mms supports {expected}. "
             "Run `mms upgrade-config` (planned for W2+) to migrate, or downgrade mms."
         )
         self.path = path
         self.found = found
+        self.expected = expected
 
 
 class CorruptedConfig(MmsConfigError):
@@ -180,27 +193,27 @@ class ImportStateEntry(BaseModel):
     timestamp, and the human-readable host-source label that was shown in
     the ``--plan`` output. PR3 reads this row to classify the next scan's
     candidate as idempotent / drift / removed.
+
+    The ``drift_hash`` regex is locked to the format
+    :func:`memtomem_stm.mms.drift.compute_drift_hash` produces, so a typo
+    or hand-edit that breaks the format surfaces as ``CorruptedConfig``
+    on load instead of a confusing comparison failure later.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    drift_hash: str
-    drift_hash_version: int
+    drift_hash: str = Field(pattern=r"^sha256:[0-9a-f]{16}$")
+    drift_hash_version: int = Field(ge=1)
     last_imported: str  # ISO 8601 UTC, same shape as ProjectIndexEntry.last_seen
     source_label: str  # e.g. "Claude Code (user)", "Codex CLI"
 
 
 class ImportState(BaseModel):
-    """Top-level model for ``~/.mms/import_state.toml`` (W2 sidecar).
-
-    Sidecar versioning is independent of the registry's ``SCHEMA_VERSION``:
-    a future drift-hash algorithm change bumps this without touching
-    registry shape, and vice versa.
-    """
+    """Top-level model for ``~/.mms/import_state.toml`` (W2 sidecar)."""
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = SCHEMA_VERSION
+    schema_version: int = IMPORT_STATE_SCHEMA_VERSION
     entries: dict[str, ImportStateEntry] = Field(default_factory=dict)
 
 
@@ -217,14 +230,14 @@ def _load_toml_dict(path: Path) -> dict:
         raise CorruptedConfig(path, f"TOML parse error: {e}") from e
 
 
-def _check_schema_version(path: Path, raw: dict) -> None:
+def _check_schema_version(path: Path, raw: dict, expected: int) -> None:
     found = raw.get("schema_version")
     if found is None:
         raise CorruptedConfig(path, "missing top-level `schema_version`")
     if not isinstance(found, int):
         raise CorruptedConfig(path, f"`schema_version` must be int, got {type(found).__name__}")
-    if found != SCHEMA_VERSION:
-        raise SchemaVersionMismatch(path, found)
+    if found != expected:
+        raise SchemaVersionMismatch(path, found, expected)
 
 
 def load_registry(path: Path | None = None) -> RegistryConfig:
@@ -233,7 +246,7 @@ def load_registry(path: Path | None = None) -> RegistryConfig:
     if not p.is_file():
         return RegistryConfig()
     raw = _load_toml_dict(p)
-    _check_schema_version(p, raw)
+    _check_schema_version(p, raw, SCHEMA_VERSION)
     try:
         return RegistryConfig.model_validate(raw)
     except ValidationError as e:
@@ -246,7 +259,7 @@ def load_projects_index(path: Path | None = None) -> ProjectsIndex:
     if not p.is_file():
         return ProjectsIndex()
     raw = _load_toml_dict(p)
-    _check_schema_version(p, raw)
+    _check_schema_version(p, raw, SCHEMA_VERSION)
     try:
         return ProjectsIndex.model_validate(raw)
     except ValidationError as e:
@@ -258,7 +271,7 @@ def load_project_config(path: Path) -> ProjectConfig:
     if not path.is_file():
         raise CorruptedConfig(path, "file not found")
     raw = _load_toml_dict(path)
-    _check_schema_version(path, raw)
+    _check_schema_version(path, raw, SCHEMA_VERSION)
     try:
         return ProjectConfig.model_validate(raw)
     except ValidationError as e:
@@ -268,6 +281,10 @@ def load_project_config(path: Path) -> ProjectConfig:
 def load_import_state(path: Path | None = None) -> ImportState:
     """Load the import-state sidecar. Returns empty state if file is missing.
 
+    Uses :data:`IMPORT_STATE_SCHEMA_VERSION` — independent of registry's
+    :data:`SCHEMA_VERSION` so a future drift-hash algorithm bump doesn't
+    invalidate registries written under the same mms version.
+
     Sidecar absence is the normal "no baseline yet" case (e.g. brand-new
     install, or pre-W2 user upgrading) — same idiom as :func:`load_registry`.
     """
@@ -275,7 +292,7 @@ def load_import_state(path: Path | None = None) -> ImportState:
     if not p.is_file():
         return ImportState()
     raw = _load_toml_dict(p)
-    _check_schema_version(p, raw)
+    _check_schema_version(p, raw, IMPORT_STATE_SCHEMA_VERSION)
     try:
         return ImportState.model_validate(raw)
     except ValidationError as e:

--- a/src/memtomem_stm/mms/state.py
+++ b/src/memtomem_stm/mms/state.py
@@ -1,4 +1,4 @@
-"""Pydantic models + atomic TOML I/O for the three mms config files.
+"""Pydantic models + atomic TOML I/O for the mms config files.
 
 Spec: RFC §5.3 — three TOML files form W1's persistent state:
 
@@ -6,9 +6,16 @@ Spec: RFC §5.3 — three TOML files form W1's persistent state:
 * ``~/.mms/projects.toml`` — auto-managed projects index
 * ``<project>/.mms/project.toml`` — per-project enabled MCP names
 
+W2 adds a fourth, sidecar-only file:
+
+* ``~/.mms/import_state.toml`` — drift-detection baseline; per-server
+  ``drift_hash`` (foundation in PR1, populated by ``mms import`` in PR2).
+
 All three start with ``schema_version = 1``. Loading a higher version
 raises :class:`SchemaVersionMismatch` (W1 has no migration logic — RFC
-§16's ``mms upgrade-config`` is a W2+ separate code path).
+§16's ``mms upgrade-config`` is a W2+ separate code path). The sidecar
+has its own independent ``schema_version`` (also 1) — sidecar evolution
+is decoupled from registry evolution.
 
 Path resolution goes through :func:`mms_home` etc. so tests can
 ``monkeypatch.setenv("HOME", tmp_path)`` and have everything land in a
@@ -30,9 +37,12 @@ SCHEMA_VERSION = 1
 
 # Mode bits — registry holds secrets, projects index holds paths only,
 # per-project file is committed and intentionally world-readable.
+# Import-state sidecar reveals per-server source attribution + timestamps;
+# treat as private even though the hash itself is opaque.
 _REGISTRY_MODE = 0o600
 _PROJECTS_INDEX_MODE = 0o600
 _PROJECT_FILE_MODE: int | None = None  # respect user umask
+_IMPORT_STATE_MODE = 0o600
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +61,11 @@ def registry_path() -> Path:
 
 def projects_index_path() -> Path:
     return mms_home() / "projects.toml"
+
+
+def import_state_path() -> Path:
+    """Drift-detection sidecar (W2). One file per host machine."""
+    return mms_home() / "import_state.toml"
 
 
 PROJECT_MARKER_RELPATH = Path(".mms") / "project.toml"
@@ -156,6 +171,39 @@ class ProjectConfig(BaseModel):
     mcp: ProjectMcp = Field(default_factory=ProjectMcp)
 
 
+class ImportStateEntry(BaseModel):
+    """Drift-detection baseline for one imported MCP server.
+
+    Populated by ``mms import --apply`` (PR2): when an entry is written to
+    ``registry.toml``, the corresponding sidecar row records the
+    :func:`memtomem_stm.mms.drift.compute_drift_hash` value, the import
+    timestamp, and the human-readable host-source label that was shown in
+    the ``--plan`` output. PR3 reads this row to classify the next scan's
+    candidate as idempotent / drift / removed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    drift_hash: str
+    drift_hash_version: int
+    last_imported: str  # ISO 8601 UTC, same shape as ProjectIndexEntry.last_seen
+    source_label: str  # e.g. "Claude Code (user)", "Codex CLI"
+
+
+class ImportState(BaseModel):
+    """Top-level model for ``~/.mms/import_state.toml`` (W2 sidecar).
+
+    Sidecar versioning is independent of the registry's ``SCHEMA_VERSION``:
+    a future drift-hash algorithm change bumps this without touching
+    registry shape, and vice versa.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = SCHEMA_VERSION
+    entries: dict[str, ImportStateEntry] = Field(default_factory=dict)
+
+
 # ---------------------------------------------------------------------------
 # Load helpers
 # ---------------------------------------------------------------------------
@@ -217,6 +265,23 @@ def load_project_config(path: Path) -> ProjectConfig:
         raise CorruptedConfig(path, f"schema validation: {e}") from e
 
 
+def load_import_state(path: Path | None = None) -> ImportState:
+    """Load the import-state sidecar. Returns empty state if file is missing.
+
+    Sidecar absence is the normal "no baseline yet" case (e.g. brand-new
+    install, or pre-W2 user upgrading) — same idiom as :func:`load_registry`.
+    """
+    p = path or import_state_path()
+    if not p.is_file():
+        return ImportState()
+    raw = _load_toml_dict(p)
+    _check_schema_version(p, raw)
+    try:
+        return ImportState.model_validate(raw)
+    except ValidationError as e:
+        raise CorruptedConfig(p, f"schema validation: {e}") from e
+
+
 # ---------------------------------------------------------------------------
 # Save helpers
 # ---------------------------------------------------------------------------
@@ -237,6 +302,12 @@ def save_projects_index(index: ProjectsIndex, path: Path | None = None) -> None:
 def save_project_config(config: ProjectConfig, path: Path) -> None:
     """Atomically write a per-project ``project.toml`` (committed file, default mode)."""
     atomic_write_text(path, tomli_w.dumps(config.model_dump()), mode=_PROJECT_FILE_MODE)
+
+
+def save_import_state(state: ImportState, path: Path | None = None) -> None:
+    """Atomically write ``import_state.toml`` with mode 0o600."""
+    p = path or import_state_path()
+    atomic_write_text(p, tomli_w.dumps(state.model_dump()), mode=_IMPORT_STATE_MODE)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mms/fixtures/host_configs/claude_code_project.json
+++ b/tests/mms/fixtures/host_configs/claude_code_project.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "uvx",
+      "args": ["mcp-server-postgres", "--readonly"],
+      "env": {
+        "PG_CONNECTION_STRING": "postgresql://localhost/dev"
+      }
+    }
+  }
+}

--- a/tests/mms/fixtures/host_configs/claude_code_user.json
+++ b/tests/mms/fixtures/host_configs/claude_code_user.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_PLACEHOLDER_REDACTED_FOR_FIXTURE"
+      }
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp/sandbox"]
+    }
+  },
+  "projects": {}
+}

--- a/tests/mms/fixtures/host_configs/claude_desktop_macos.json
+++ b/tests/mms/fixtures/host_configs/claude_desktop_macos.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_PLACEHOLDER_REDACTED_FOR_FIXTURE"
+      }
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"]
+    }
+  }
+}

--- a/tests/mms/fixtures/host_configs/codex_global.toml
+++ b/tests/mms/fixtures/host_configs/codex_global.toml
@@ -1,0 +1,15 @@
+# Sample ~/.codex/config.toml fixture for cross-host hash equivalence tests.
+# The `github` entry is the anchor — its command/args/env must match the
+# corresponding entry in claude_code_user.json / cursor_user.json /
+# claude_desktop_macos.json so all four hash to the same drift_hash.
+
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp_servers.github.env]
+GITHUB_TOKEN = "ghp_PLACEHOLDER_REDACTED_FOR_FIXTURE"
+
+[mcp_servers.fetch]
+command = "uvx"
+args = ["mcp-server-fetch"]

--- a/tests/mms/fixtures/host_configs/cursor_project_scoped.json
+++ b/tests/mms/fixtures/host_configs/cursor_project_scoped.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+    }
+  }
+}

--- a/tests/mms/fixtures/host_configs/cursor_user.json
+++ b/tests/mms/fixtures/host_configs/cursor_user.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_PLACEHOLDER_REDACTED_FOR_FIXTURE"
+      }
+    },
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "BSA_PLACEHOLDER_REDACTED_FOR_FIXTURE"
+      }
+    }
+  }
+}

--- a/tests/mms/fixtures/host_configs/perturbations/claude_code_user_4space.json
+++ b/tests/mms/fixtures/host_configs/perturbations/claude_code_user_4space.json
@@ -1,0 +1,23 @@
+{
+    "mcpServers": {
+        "github": {
+            "command": "npx",
+            "args": [
+                "-y",
+                "@modelcontextprotocol/server-github"
+            ],
+            "env": {
+                "GITHUB_TOKEN": "ghp_PLACEHOLDER_REDACTED_FOR_FIXTURE"
+            }
+        },
+        "filesystem": {
+            "command": "npx",
+            "args": [
+                "-y",
+                "@modelcontextprotocol/server-filesystem",
+                "/tmp/sandbox"
+            ]
+        }
+    },
+    "projects": {}
+}

--- a/tests/mms/fixtures/host_configs/perturbations/claude_code_user_keyreorder.json
+++ b/tests/mms/fixtures/host_configs/perturbations/claude_code_user_keyreorder.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "github": {
+      "env": {
+        "GITHUB_TOKEN": "ghp_PLACEHOLDER_REDACTED_FOR_FIXTURE"
+      },
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "command": "npx"
+    },
+    "filesystem": {
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp/sandbox"],
+      "command": "npx"
+    }
+  },
+  "projects": {}
+}

--- a/tests/mms/fixtures/host_configs/perturbations/cursor_user_trailing_newline.json
+++ b/tests/mms/fixtures/host_configs/perturbations/cursor_user_trailing_newline.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_PLACEHOLDER_REDACTED_FOR_FIXTURE"
+      }
+    }
+  }
+}
+
+

--- a/tests/mms/test_drift.py
+++ b/tests/mms/test_drift.py
@@ -1,0 +1,120 @@
+"""Tests for ``mms.drift`` — canonical form + stable hash.
+
+The hash is the foundation for W2's drift detection. These tests pin its
+shape so that future canonical-form changes are loud (the golden hex assert)
+and that the documented invariants hold (env-order indifference, args-order
+sensitivity, prefix exclusion, empty-vs-absent equivalence).
+
+Cross-host fixture-driven tests are added in a follow-up commit — they
+validate that the parse-stage funnel (``_to_registry_server``) makes the
+hash host-format-agnostic in practice, not just in theory.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from memtomem_stm.mms.drift import (
+    HASH_HEX_LEN,
+    HASH_PREFIX,
+    canonical_form,
+    compute_drift_hash,
+)
+from memtomem_stm.mms.state import RegistryServer
+
+# ---------------------------------------------------------------------------
+# Hash invariants
+# ---------------------------------------------------------------------------
+
+
+def test_hash_is_stable_across_runs():
+    server = RegistryServer(command="npx", args=["-y", "@mcp/fs"], prefix="fs")
+    h1 = compute_drift_hash(server)
+    h2 = compute_drift_hash(server)
+    assert h1 == h2
+    # Golden — any change to the canonical form must update this string,
+    # which forces a deliberate review of every existing sidecar's hash.
+    assert h1 == "sha256:40c96f4ab4762ceb"
+
+
+def test_canonical_form_shape():
+    server = RegistryServer(
+        command="npx", args=["-y", "@mcp/fs"], env={"B": "2", "A": "1"}, prefix="fs"
+    )
+    canon = canonical_form(server)
+    # Round-trip through json to assert structure rather than byte-equality
+    parsed = json.loads(canon)
+    assert parsed == {"args": ["-y", "@mcp/fs"], "command": "npx", "env": {"A": "1", "B": "2"}}
+    # Top-level keys are sorted (sort_keys=True): args < command < env
+    assert canon.index('"args"') < canon.index('"command"') < canon.index('"env"')
+
+
+def test_env_order_does_not_affect_hash():
+    a = RegistryServer(command="x", env={"A": "1", "B": "2"}, prefix="x")
+    b = RegistryServer(command="x", env={"B": "2", "A": "1"}, prefix="x")
+    assert compute_drift_hash(a) == compute_drift_hash(b)
+
+
+def test_args_order_does_affect_hash():
+    a = RegistryServer(command="x", args=["-y", "@mcp/fs"], prefix="x")
+    b = RegistryServer(command="x", args=["@mcp/fs", "-y"], prefix="x")
+    assert compute_drift_hash(a) != compute_drift_hash(b)
+
+
+def test_empty_and_absent_args_env_equivalent():
+    """Pydantic defaults make absent fields equivalent to empty collections.
+
+    This is load-bearing: if a host config omits ``args`` and another spells
+    it as ``"args": []``, both must produce the same hash post-import.
+    """
+    a = RegistryServer(command="x", prefix="x")
+    b = RegistryServer(command="x", args=[], env={}, prefix="x")
+    assert compute_drift_hash(a) == compute_drift_hash(b)
+
+
+def test_prefix_excluded_from_hash():
+    """Prefix is mms-derived metadata; ``_derive_prefix`` algorithm changes
+    or user hand-edits to ``prefix`` must not look like host-side drift."""
+    a = RegistryServer(command="x", prefix="short")
+    b = RegistryServer(command="x", prefix="much_longer_prefix")
+    assert compute_drift_hash(a) == compute_drift_hash(b)
+
+
+def test_command_change_flips_hash():
+    a = RegistryServer(command="npx", prefix="x")
+    b = RegistryServer(command="uvx", prefix="x")
+    assert compute_drift_hash(a) != compute_drift_hash(b)
+
+
+def test_env_value_change_flips_hash():
+    a = RegistryServer(command="x", env={"TOKEN": "v1"}, prefix="x")
+    b = RegistryServer(command="x", env={"TOKEN": "v2"}, prefix="x")
+    assert compute_drift_hash(a) != compute_drift_hash(b)
+
+
+def test_env_key_addition_flips_hash():
+    a = RegistryServer(command="x", env={"A": "1"}, prefix="x")
+    b = RegistryServer(command="x", env={"A": "1", "B": "2"}, prefix="x")
+    assert compute_drift_hash(a) != compute_drift_hash(b)
+
+
+def test_unicode_env_value_stable():
+    """Non-ASCII env values must hash identically across runs.
+
+    ``ensure_ascii=False`` guards against silent canonical-form drift if a
+    future Python version changes JSON escape defaults.
+    """
+    server = RegistryServer(command="x", env={"FOO": "命令"}, prefix="x")
+    h = compute_drift_hash(server)
+    # Re-compute fresh — same input must yield same hash within the run.
+    assert compute_drift_hash(server) == h
+    # Canonical form contains the literal CJK chars, not \\u escapes.
+    assert "命令" in canonical_form(server)
+    assert "\\u" not in canonical_form(server)
+
+
+def test_hash_format_matches_advertised_shape():
+    server = RegistryServer(command="x", prefix="x")
+    h = compute_drift_hash(server)
+    assert re.fullmatch(rf"{HASH_PREFIX}:[0-9a-f]{{{HASH_HEX_LEN}}}", h)

--- a/tests/mms/test_drift.py
+++ b/tests/mms/test_drift.py
@@ -5,15 +5,22 @@ shape so that future canonical-form changes are loud (the golden hex assert)
 and that the documented invariants hold (env-order indifference, args-order
 sensitivity, prefix exclusion, empty-vs-absent equivalence).
 
-Cross-host fixture-driven tests are added in a follow-up commit — they
-validate that the parse-stage funnel (``_to_registry_server``) makes the
-hash host-format-agnostic in practice, not just in theory.
+Cross-host fixture-driven tests below validate that the parse-stage funnel
+(``_to_registry_server``) makes the hash host-format-agnostic in practice,
+not just in theory — a "github" server defined in claude-code JSON, cursor
+JSON, codex TOML, and claude-desktop JSON with identical command/args/env
+must hash identically.
 """
 
 from __future__ import annotations
 
 import json
 import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
 
 from memtomem_stm.mms.drift import (
     HASH_HEX_LEN,
@@ -21,6 +28,7 @@ from memtomem_stm.mms.drift import (
     canonical_form,
     compute_drift_hash,
 )
+from memtomem_stm.mms.import_hosts import _to_registry_server
 from memtomem_stm.mms.state import RegistryServer
 
 # ---------------------------------------------------------------------------
@@ -118,3 +126,113 @@ def test_hash_format_matches_advertised_shape():
     server = RegistryServer(command="x", prefix="x")
     h = compute_drift_hash(server)
     assert re.fullmatch(rf"{HASH_PREFIX}:[0-9a-f]{{{HASH_HEX_LEN}}}", h)
+
+
+# ---------------------------------------------------------------------------
+# Cross-host fixtures — same logical server in different host formats
+# must produce the same drift hash after going through ``_to_registry_server``
+# ---------------------------------------------------------------------------
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "host_configs"
+
+
+def _load_json(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _load_toml(name: str) -> dict[str, Any]:
+    with (FIXTURES / name).open("rb") as f:
+        return tomllib.load(f)
+
+
+def _hash_from_host_entry(name: str, raw: dict[str, Any]) -> str:
+    server = _to_registry_server(name, raw)
+    assert server is not None, f"_to_registry_server rejected {name}: {raw}"
+    return compute_drift_hash(server)
+
+
+def test_cross_host_same_logical_server_same_hash():
+    """The ``github`` MCP defined in claude-code JSON, cursor JSON, codex
+    TOML, and claude-desktop JSON — same command/args/env — hashes
+    identically after the parse-stage funnel. This is the load-bearing
+    assertion that ``drift.py`` is host-format-agnostic."""
+    cc = _load_json("claude_code_user.json")["mcpServers"]["github"]
+    cu = _load_json("cursor_user.json")["mcpServers"]["github"]
+    co = _load_toml("codex_global.toml")["mcp_servers"]["github"]
+    cd = _load_json("claude_desktop_macos.json")["mcpServers"]["github"]
+
+    h_cc = _hash_from_host_entry("github", cc)
+    h_cu = _hash_from_host_entry("github", cu)
+    h_co = _hash_from_host_entry("github", co)
+    h_cd = _hash_from_host_entry("github", cd)
+
+    assert h_cc == h_cu == h_co == h_cd
+
+
+def test_perturbations_hash_identically_to_base():
+    """Same logical content with cosmetic JSON differences (4-space indent,
+    env-key insertion order, trailing newline) parses to the same
+    ``RegistryServer`` and so hashes identically. Cosmetic quirks die at
+    parse time — no normalization in ``drift.py`` is needed for them.
+    """
+    base = _load_json("claude_code_user.json")["mcpServers"]["github"]
+    p_indent = _load_json("perturbations/claude_code_user_4space.json")["mcpServers"]["github"]
+    p_keys = _load_json("perturbations/claude_code_user_keyreorder.json")["mcpServers"]["github"]
+    p_newline = _load_json("perturbations/cursor_user_trailing_newline.json")["mcpServers"][
+        "github"
+    ]
+
+    h_base = _hash_from_host_entry("github", base)
+    assert _hash_from_host_entry("github", p_indent) == h_base
+    assert _hash_from_host_entry("github", p_keys) == h_base
+    assert _hash_from_host_entry("github", p_newline) == h_base
+
+
+def test_semantic_edit_changes_hash():
+    """Smoke test for 'drift detection actually detects drift' — every
+    flavor of host-side semantic edit (added arg, mutated env value,
+    removed env key, swapped command) flips the hash."""
+    base = _load_json("claude_code_user.json")["mcpServers"]["github"]
+    h_base = _hash_from_host_entry("github", base)
+
+    edited_args = {**base, "args": [*base["args"], "--verbose"]}
+    assert _hash_from_host_entry("github", edited_args) != h_base
+
+    edited_env = {**base, "env": {**base["env"], "GITHUB_TOKEN": "ghp_rotated"}}
+    assert _hash_from_host_entry("github", edited_env) != h_base
+
+    stripped = {**base, "env": {}}
+    assert _hash_from_host_entry("github", stripped) != h_base
+
+    swapped = {**base, "command": "uvx"}
+    assert _hash_from_host_entry("github", swapped) != h_base
+
+
+@pytest.mark.parametrize(
+    "host_file",
+    [
+        "claude_code_user.json",
+        "claude_code_project.json",
+        "cursor_user.json",
+        "cursor_project_scoped.json",
+        "claude_desktop_macos.json",
+    ],
+)
+def test_every_json_fixture_round_trips(host_file: str):
+    """Every committed JSON fixture must parse and produce a well-formed
+    hash for each MCP entry. Guards against a fixture being silently
+    dropped by ``_to_registry_server`` (e.g. typo eliding ``command``)."""
+    raw = _load_json(host_file)["mcpServers"]
+    assert isinstance(raw, dict) and raw, f"{host_file} has no MCP entries"
+    for name, entry in raw.items():
+        h = _hash_from_host_entry(name, entry)
+        assert re.fullmatch(rf"{HASH_PREFIX}:[0-9a-f]{{{HASH_HEX_LEN}}}", h)
+
+
+def test_codex_toml_fixture_round_trips():
+    raw = _load_toml("codex_global.toml")["mcp_servers"]
+    assert isinstance(raw, dict) and raw, "codex_global.toml has no MCP entries"
+    for name, entry in raw.items():
+        h = _hash_from_host_entry(name, entry)
+        assert re.fullmatch(rf"{HASH_PREFIX}:[0-9a-f]{{{HASH_HEX_LEN}}}", h)

--- a/tests/mms/test_state.py
+++ b/tests/mms/test_state.py
@@ -194,6 +194,50 @@ def test_import_state_schema_version_mismatch(tmp_path):
         state.load_import_state(target)
     assert exc_info.value.found == 2
     assert exc_info.value.path == target
+    # Error message names the *sidecar* expected version, not the registry's
+    # — proves the SchemaVersionMismatch.expected plumbing reaches the user.
+    assert exc_info.value.expected == state.IMPORT_STATE_SCHEMA_VERSION
+    assert f"this mms supports {state.IMPORT_STATE_SCHEMA_VERSION}" in str(exc_info.value)
+
+
+def test_sidecar_version_decoupled_from_registry(tmp_path, monkeypatch):
+    """Bumping ``SCHEMA_VERSION`` (registry/projects/project) must NOT
+    invalidate sidecars written under ``IMPORT_STATE_SCHEMA_VERSION = 1``.
+    Guards the docstring claim that the two version axes are independent.
+    """
+    # Simulate a future mms where registry shape evolved to v2 but the
+    # sidecar shape stayed at v1.
+    monkeypatch.setattr(state, "SCHEMA_VERSION", 2)
+    target = tmp_path / "import_state.toml"
+    target.write_text(
+        "schema_version = 1\n[entries.foo]\n"
+        'drift_hash = "sha256:0123456789abcdef"\n'
+        "drift_hash_version = 1\n"
+        'last_imported = "2026-05-01T13:24:03Z"\n'
+        'source_label = "test"\n',
+        encoding="utf-8",
+    )
+    loaded = state.load_import_state(target)
+    assert "foo" in loaded.entries
+    assert loaded.schema_version == 1
+
+
+def test_sidecar_rejects_when_only_sidecar_version_bumps(tmp_path, monkeypatch):
+    """Symmetric to the previous: bumping only the sidecar version must
+    flip sidecar load to mismatch *without* affecting the registry path.
+    """
+    monkeypatch.setattr(state, "IMPORT_STATE_SCHEMA_VERSION", 2)
+    # Old sidecar (v1) under new code (expects v2) → mismatch
+    target = tmp_path / "import_state.toml"
+    target.write_text("schema_version = 1\n[entries]\n", encoding="utf-8")
+    with pytest.raises(state.SchemaVersionMismatch) as exc_info:
+        state.load_import_state(target)
+    assert exc_info.value.expected == 2
+
+    # Registry under same monkeypatched env is unaffected — uses SCHEMA_VERSION (still 1)
+    reg_path = tmp_path / "registry.toml"
+    reg_path.write_text("schema_version = 1\n[servers]\n", encoding="utf-8")
+    assert state.load_registry(reg_path).servers == {}
 
 
 def test_import_state_extra_field_rejected(tmp_path):
@@ -207,6 +251,51 @@ def test_import_state_extra_field_rejected(tmp_path):
         'last_imported = "2026-05-01T13:24:03Z"\n'
         'source_label = "test"\n'
         'unknown = "boom"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(state.CorruptedConfig):
+        state.load_import_state(target)
+
+
+@pytest.mark.parametrize(
+    "bad_hash",
+    [
+        "garbage",  # no prefix, no hex
+        "sha256:GHIJ567890ABCDEF",  # non-hex chars
+        "sha256:abc123",  # too short
+        "sha256:0123456789abcdef0",  # too long
+        "md5:0123456789abcdef",  # wrong algorithm prefix
+        "0123456789abcdef",  # missing prefix
+    ],
+)
+def test_import_state_rejects_malformed_drift_hash(tmp_path, bad_hash: str):
+    """Pydantic ``Field(pattern=...)`` rejects sidecars with hashes that
+    don't match the format ``compute_drift_hash`` produces. Catches PR2
+    typos / hand-edits at load time instead of at comparison time."""
+    target = tmp_path / "import_state.toml"
+    target.write_text(
+        f"schema_version = 1\n[entries.foo]\n"
+        f'drift_hash = "{bad_hash}"\n'
+        "drift_hash_version = 1\n"
+        'last_imported = "2026-05-01T13:24:03Z"\n'
+        'source_label = "test"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(state.CorruptedConfig):
+        state.load_import_state(target)
+
+
+@pytest.mark.parametrize("bad_version", [0, -1])
+def test_import_state_rejects_non_positive_drift_hash_version(tmp_path, bad_version: int):
+    """``Field(ge=1)`` excludes 0 / negative — our ``HASH_VERSION`` starts
+    at 1 and only grows."""
+    target = tmp_path / "import_state.toml"
+    target.write_text(
+        f"schema_version = 1\n[entries.foo]\n"
+        'drift_hash = "sha256:0123456789abcdef"\n'
+        f"drift_hash_version = {bad_version}\n"
+        'last_imported = "2026-05-01T13:24:03Z"\n'
+        'source_label = "test"\n',
         encoding="utf-8",
     )
     with pytest.raises(state.CorruptedConfig):

--- a/tests/mms/test_state.py
+++ b/tests/mms/test_state.py
@@ -27,6 +27,7 @@ def test_mms_home_resolves_under_home(sandbox_home):
     assert state.mms_home() == sandbox_home / ".mms"
     assert state.registry_path() == sandbox_home / ".mms" / "registry.toml"
     assert state.projects_index_path() == sandbox_home / ".mms" / "projects.toml"
+    assert state.import_state_path() == sandbox_home / ".mms" / "import_state.toml"
 
 
 def test_project_marker_relpath_is_dot_mms_project_toml():
@@ -135,6 +136,100 @@ def test_utc_now_iso_format(sandbox_home):
     assert len(s) == 20
     assert s.endswith("Z")
     assert s[10] == "T"
+
+
+# ---------------------------------------------------------------------------
+# Import-state sidecar (W2 drift-detection foundation)
+# ---------------------------------------------------------------------------
+
+
+def test_load_import_state_returns_empty_when_missing(sandbox_home):
+    s = state.load_import_state()
+    assert s.entries == {}
+    assert s.schema_version == state.SCHEMA_VERSION
+
+
+def test_import_state_round_trip(sandbox_home):
+    s = state.ImportState(
+        entries={
+            "filesystem": state.ImportStateEntry(
+                drift_hash="sha256:40c96f4ab4762ceb",
+                drift_hash_version=1,
+                last_imported="2026-05-01T13:24:03Z",
+                source_label="Claude Code (user)",
+            ),
+            "github": state.ImportStateEntry(
+                drift_hash="sha256:1234567890abcdef",
+                drift_hash_version=1,
+                last_imported="2026-05-01T13:24:03Z",
+                source_label="Codex CLI",
+            ),
+        }
+    )
+    state.save_import_state(s)
+    loaded = state.load_import_state()
+    assert loaded == s
+
+
+def test_save_import_state_uses_0o600(sandbox_home):
+    s = state.ImportState(
+        entries={
+            "x": state.ImportStateEntry(
+                drift_hash="sha256:0123456789abcdef",
+                drift_hash_version=1,
+                last_imported="2026-05-01T13:24:03Z",
+                source_label="Cursor (user)",
+            )
+        }
+    )
+    state.save_import_state(s)
+    mode = stat.S_IMODE(state.import_state_path().stat().st_mode)
+    assert mode == 0o600
+
+
+def test_import_state_schema_version_mismatch(tmp_path):
+    target = tmp_path / "import_state.toml"
+    target.write_text("schema_version = 2\n[entries]\n", encoding="utf-8")
+    with pytest.raises(state.SchemaVersionMismatch) as exc_info:
+        state.load_import_state(target)
+    assert exc_info.value.found == 2
+    assert exc_info.value.path == target
+
+
+def test_import_state_extra_field_rejected(tmp_path):
+    """Sidecar shape is locked by ``extra="forbid"`` — an unknown column on
+    an entry must be a CorruptedConfig, not a silent accept."""
+    target = tmp_path / "import_state.toml"
+    target.write_text(
+        "schema_version = 1\n[entries.foo]\n"
+        'drift_hash = "sha256:0000000000000000"\n'
+        "drift_hash_version = 1\n"
+        'last_imported = "2026-05-01T13:24:03Z"\n'
+        'source_label = "test"\n'
+        'unknown = "boom"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(state.CorruptedConfig):
+        state.load_import_state(target)
+
+
+def test_import_state_on_disk_shape(sandbox_home):
+    s = state.ImportState(
+        entries={
+            "filesystem": state.ImportStateEntry(
+                drift_hash="sha256:40c96f4ab4762ceb",
+                drift_hash_version=1,
+                last_imported="2026-05-01T13:24:03Z",
+                source_label="Claude Code (user)",
+            )
+        }
+    )
+    state.save_import_state(s)
+    raw = tomllib.loads(state.import_state_path().read_text(encoding="utf-8"))
+    assert raw["schema_version"] == 1
+    assert raw["entries"]["filesystem"]["drift_hash"] == "sha256:40c96f4ab4762ceb"
+    assert raw["entries"]["filesystem"]["drift_hash_version"] == 1
+    assert raw["entries"]["filesystem"]["source_label"] == "Claude Code (user)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

W2 PR1: foundation for host sync's drift detection. Introduces a stable
per-entry fingerprint (`drift_hash`) and a sidecar file
(`~/.mms/import_state.toml`) to persist baselines, with **no CLI wiring
yet** — subsequent PRs build on this scaffolding.

- New module `mms/drift.py`: `canonical_form` + `compute_drift_hash`. Hash
  scope = `command` + ordered `args` + key-sorted `env`; excludes
  `prefix` (mms-derived metadata) and host-level fields. Format:
  `sha256:<16hex>` with algorithm prefix for forward compat.
- New sidecar `~/.mms/import_state.toml`: `ImportStateEntry` rows
  (`drift_hash`, `drift_hash_version`, `last_imported`, `source_label`),
  mirroring the existing registry I/O patterns at mode `0o600`. Sidecar
  has its own independent `schema_version = 1`, decoupling its evolution
  from the registry's.
- Tests pin canonical-form stability (golden hex), env-order
  indifference, args-order sensitivity, empty/absent equivalence, prefix
  exclusion, unicode env values, and the `sha256:[0-9a-f]{16}` format.
- Real-host fixtures under `tests/mms/fixtures/host_configs/` model what
  each of the four W1 host scanners actually writes (claude-code,
  cursor, codex, claude-desktop) plus three perturbation variants
  (4-space indent, env-key reorder, trailing newline). Cross-host
  equivalence test verifies the same logical `github` server hashes
  identically across all four host formats.

## Behavior change

**None in this PR.** The sidecar is written by no path yet — wiring into
`mms import --apply` lands in PR2; the drift bucket and user-facing UX
land in PR3. Foundation is intentionally split so each review's mental
model is tight to one layer (normalization rules vs. atomic write
semantics vs. drift UX).

## Why these decisions

- **Sidecar over `RegistryServer` schema bump** — keeps `registry.toml`
  human-readable (no opaque sha256 strings cluttering the file users
  edit by hand) and avoids a v1→v2 registry migration. Sidecar absent =
  empty baseline (same idiom as `load_registry`), no migration needed
  for W1-only users.
- **Excluding `prefix` from the hash** — `prefix` is mms-derived
  metadata. A future tweak to `_derive_prefix` (e.g. RFC §5.3 algorithm
  refinement) must not false-flag drift on every previously imported
  server.
- **Truncated 64-bit hash with prefix marker** — collision space is
  per-server-name, not global; 64 bits is plenty. Prefix marker
  (`sha256:`) future-proofs an algorithm swap without ambiguity in the
  sidecar TOML.
- **JSON canonical form with `ensure_ascii=False`** — guards against
  silent canonical-form drift if a future Python version changes JSON
  escape defaults; non-ASCII env values (e.g. `命令`) hash stably.

## Test plan

- [x] `uv run pytest tests/mms/test_drift.py -v` — 20/20 pass
- [x] `uv run pytest tests/mms/test_state.py -v` — 26/26 pass (4 new
      sidecar tests + 1 path-helper line + existing registry tests)
- [x] `uv run pytest -m "not ollama"` — 1972/1972 pass
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] Manual: `python -c "from memtomem_stm.mms.drift import
      compute_drift_hash; from memtomem_stm.mms.state import RegistryServer;
      print(compute_drift_hash(RegistryServer(command='npx',
      args=['-y','@mcp/fs'], prefix='fs')))"` → `sha256:40c96f4ab4762ceb`
      (matches golden test pin)
- [x] Sanity: `mms project show` and other read-only commands still work
      — sidecar absence breaks nothing since nothing consumes it yet

## Out of scope (deferred)

- **PR2** — wire `compute_drift_hash` into `cli/mms_import.py --apply`,
  populate sidecar on every successful write
- **PR3** — drift bucket in `_classify_against_registry`,
  `--accept-drift` flag, per-field diff renderer
- **PR4** — "removed at host" detection (sidecar entry exists, candidate
  set excludes it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)