### PR TITLE
feat(mms): W2 PR2 — wire drift-hash into `mms import --apply`

### DIFF
--- a/src/memtomem_stm/cli/mms_import.py
+++ b/src/memtomem_stm/cli/mms_import.py
@@ -15,6 +15,15 @@ already in the registry): **first-import-wins**. Identical re-imports
 are idempotent (no-op + "already up to date" message); a same-name
 entry with a *different* `command`/`args`/`env` is reported as a
 conflict and skipped.
+
+Atomicity (sidecar): registry write precedes sidecar write. If the
+process crashes between, the sidecar is stale for the entries written.
+Next ``--apply`` with **unchanged host input** re-writes them
+(idempotent recovery). If host input changes between crash and
+recovery, the stale entries persist until manually corrected — a
+``--force`` option lands in W3+; today's mitigation is to re-run
+``--apply`` against the same host snapshot before editing host
+configs further. No transaction.
 """
 
 from __future__ import annotations
@@ -24,6 +33,7 @@ from pathlib import Path
 import click
 
 from memtomem_stm.mms import state
+from memtomem_stm.mms.drift import HASH_VERSION, compute_drift_hash
 from memtomem_stm.mms.import_hosts import (
     ALL_HOSTS,
     ImportCandidate,
@@ -177,11 +187,28 @@ def import_command(from_host: str, is_plan: bool, show_imported: bool) -> None:
         click.echo("Already up to date. Registry unchanged.")
         return
 
+    # Single timestamp for the whole apply — matches `upsert_project_in_index`
+    # idiom and avoids per-entry skew on slow hosts.
+    now = state.utc_now_iso()
     new_servers = {**registry.servers}
+    new_entries: dict[str, state.ImportStateEntry] = {}
     for cand in new:
         new_servers[cand.name] = cand.server
+        new_entries[cand.name] = state.ImportStateEntry(
+            drift_hash=compute_drift_hash(cand.server),
+            drift_hash_version=HASH_VERSION,
+            last_imported=now,
+            source_label=cand.source_label,
+        )
     new_registry = state.RegistryConfig(schema_version=registry.schema_version, servers=new_servers)
     state.save_registry(new_registry)
+
+    existing_state = state.load_import_state()
+    merged_state = state.ImportState(
+        schema_version=existing_state.schema_version,
+        entries={**existing_state.entries, **new_entries},
+    )
+    state.save_import_state(merged_state)
 
     click.echo("")
     click.echo(

--- a/src/memtomem_stm/cli/mms_import.py
+++ b/src/memtomem_stm/cli/mms_import.py
@@ -33,6 +33,11 @@ wired apply", which is the only moment the hash can be authoritatively
 computed. Backfill row hashes are byte-equal to what a fresh
 ``--apply`` would compute against the same canonical_form.
 
+Backfill row attribution (``source_label``) reflects the apply that
+observed the entry, not the original import — the host scanner only
+sees what's there now, and "original import host" isn't recorded
+anywhere we can recover from.
+
 Registry write still precedes sidecar write within a single apply;
 no transaction. A ``--force`` option to re-stamp existing sidecar
 rows (resetting timestamps after a host edit you've already

--- a/src/memtomem_stm/cli/mms_import.py
+++ b/src/memtomem_stm/cli/mms_import.py
@@ -16,14 +16,27 @@ are idempotent (no-op + "already up to date" message); a same-name
 entry with a *different* `command`/`args`/`env` is reported as a
 conflict and skipped.
 
-Atomicity (sidecar): registry write precedes sidecar write. If the
-process crashes between, the sidecar is stale for the entries written.
-Next ``--apply`` with **unchanged host input** re-writes them
-(idempotent recovery). If host input changes between crash and
-recovery, the stale entries persist until manually corrected — a
-``--force`` option lands in W3+; today's mitigation is to re-run
-``--apply`` against the same host snapshot before editing host
-configs further. No transaction.
+Sidecar population & recovery: every registry entry observed by an
+``--apply`` run that is missing from ``~/.mms/import_state.toml``
+gets stamped during that run. New entries (registry-additive) are
+stamped from their candidate; idempotent entries (registry already
+matches host) are *backfilled* from the same canonical hash. This
+makes sidecar population idempotent-recoverable across:
+
+* a crash between the registry and sidecar writes within one apply,
+* a sidecar deleted out-of-band,
+* a registry imported under a pre-PR2 mms (no wire existed yet).
+
+Backfill timestamps reflect the recovery moment, not the original
+import — the sidecar's ``last_imported`` is "first observation by a
+wired apply", which is the only moment the hash can be authoritatively
+computed. Backfill row hashes are byte-equal to what a fresh
+``--apply`` would compute against the same canonical_form.
+
+Registry write still precedes sidecar write within a single apply;
+no transaction. A ``--force`` option to re-stamp existing sidecar
+rows (resetting timestamps after a host edit you've already
+acknowledged) lands in W3+.
 """
 
 from __future__ import annotations
@@ -182,35 +195,60 @@ def import_command(from_host: str, is_plan: bool, show_imported: bool) -> None:
         return
 
     # --apply
-    if not new:
+    # Load existing sidecar up front — needed to decide whether any
+    # idempotent entries require backfill (sidecar row missing for an
+    # entry that is already in the registry).
+    existing_state = state.load_import_state()
+
+    # Single timestamp captured at the action boundary — shared by every
+    # row written this run (new + backfill) so PR3 can read "all rows
+    # with timestamp T were observed in the same --apply".
+    now = state.utc_now_iso()
+
+    backfill_entries: dict[str, state.ImportStateEntry] = {}
+    for cand in idempotent:
+        if cand.name not in existing_state.entries:
+            backfill_entries[cand.name] = state.ImportStateEntry(
+                drift_hash=compute_drift_hash(cand.server),
+                drift_hash_version=HASH_VERSION,
+                last_imported=now,
+                source_label=cand.source_label,
+            )
+
+    if not new and not backfill_entries:
         click.echo("")
         click.echo("Already up to date. Registry unchanged.")
         return
 
-    # Single timestamp for the whole apply — matches `upsert_project_in_index`
-    # idiom and avoids per-entry skew on slow hosts.
-    now = state.utc_now_iso()
-    new_servers = {**registry.servers}
     new_entries: dict[str, state.ImportStateEntry] = {}
-    for cand in new:
-        new_servers[cand.name] = cand.server
-        new_entries[cand.name] = state.ImportStateEntry(
-            drift_hash=compute_drift_hash(cand.server),
-            drift_hash_version=HASH_VERSION,
-            last_imported=now,
-            source_label=cand.source_label,
+    if new:
+        new_servers = {**registry.servers}
+        for cand in new:
+            new_servers[cand.name] = cand.server
+            new_entries[cand.name] = state.ImportStateEntry(
+                drift_hash=compute_drift_hash(cand.server),
+                drift_hash_version=HASH_VERSION,
+                last_imported=now,
+                source_label=cand.source_label,
+            )
+        new_registry = state.RegistryConfig(
+            schema_version=registry.schema_version, servers=new_servers
         )
-    new_registry = state.RegistryConfig(schema_version=registry.schema_version, servers=new_servers)
-    state.save_registry(new_registry)
+        state.save_registry(new_registry)
 
-    existing_state = state.load_import_state()
     merged_state = state.ImportState(
         schema_version=existing_state.schema_version,
-        entries={**existing_state.entries, **new_entries},
+        entries={**existing_state.entries, **new_entries, **backfill_entries},
     )
     state.save_import_state(merged_state)
 
     click.echo("")
-    click.echo(
-        f"Wrote {len(new)} new entr{'y' if len(new) == 1 else 'ies'} to {state.registry_path()}"
-    )
+    if new:
+        click.echo(
+            f"Wrote {len(new)} new entr{'y' if len(new) == 1 else 'ies'} to {state.registry_path()}"
+        )
+    if backfill_entries:
+        click.echo(
+            f"Backfilled {len(backfill_entries)} sidecar "
+            f"row{'' if len(backfill_entries) == 1 else 's'} to {state.import_state_path()}"
+        )

--- a/tests/cli/test_mms_import.py
+++ b/tests/cli/test_mms_import.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+import re
+import stat
+from datetime import datetime, timezone
 
 import pytest
 from click.testing import CliRunner
 
 from memtomem_stm.cli.mms_import import import_command
-from memtomem_stm.mms import state
+from memtomem_stm.mms import drift, state
+from memtomem_stm.mms.drift import compute_drift_hash
 from memtomem_stm.mms.secrets import REDACTED_DISPLAY
 
 
@@ -84,6 +88,15 @@ class TestPlan:
         # No --apply → registry is still empty (no file)
         assert not state.registry_path().exists()
 
+    def test_plan_does_not_write_import_state(self, runner, sandbox):
+        """Mirror of ``test_plan_does_not_write_registry`` for the W2 sidecar.
+        ``--plan`` returns at the early echo before the sidecar write block,
+        so no ``import_state.toml`` should appear on disk.
+        """
+        _seed_claude_code(sandbox, {"foo": {"command": "echo"}})
+        runner.invoke(import_command, ["--from", "claude-code"])
+        assert not state.import_state_path().exists()
+
     def test_plan_summary_counts(self, runner, sandbox):
         _seed_claude_code(
             sandbox,
@@ -127,6 +140,8 @@ class TestApply:
     def test_apply_then_replay_idempotent(self, runner, sandbox):
         _seed_claude_code(sandbox, {"foo": {"command": "echo"}})
         runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        # Snapshot sidecar after the first apply — second apply must not change it.
+        sidecar_after_first = state.load_import_state()
 
         res = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
         assert res.exit_code == 0, res.output
@@ -135,6 +150,12 @@ class TestApply:
         # Registry unchanged — same single entry.
         cfg = state.load_registry()
         assert list(cfg.servers.keys()) == ["foo"]
+
+        # Sidecar idempotent too — first-import-wins semantics extended to the
+        # sidecar means an unchanged-host re-apply is a true no-op including
+        # ``last_imported``. PR3 drift detection assumes the sidecar carries
+        # the timestamp of *first* import, not of last invocation.
+        assert state.load_import_state() == sidecar_after_first
 
     def test_apply_first_import_wins_on_conflict(self, runner, sandbox):
         # Pre-seed registry with `foo` pointing at one command.
@@ -153,6 +174,14 @@ class TestApply:
         # Registry should NOT have been overwritten.
         cfg = state.load_registry()
         assert cfg.servers["foo"].command == "first-cmd"
+
+        # Sidecar must NOT contain the rejected candidate. Without this pin,
+        # a future refactor that builds sidecar entries from `candidates`
+        # instead of `new` would silently poison the sidecar with a hash of
+        # a server the registry just refused — and PR3 drift detection
+        # would then compare a host's "second-cmd" against its own hash and
+        # see "no drift" forever.
+        assert "foo" not in state.load_import_state().entries
 
     def test_apply_writes_new_alongside_existing(self, runner, sandbox):
         # Pre-seed registry with one entry.
@@ -175,6 +204,79 @@ class TestApply:
         assert res.exit_code == 0, res.output
         cfg = state.load_registry()
         assert set(cfg.servers.keys()) == {"existing", "newcomer"}
+
+    def test_apply_writes_import_state_sidecar(self, runner, sandbox):
+        """Wire-in counter test for ``compute_drift_hash`` — every accepted
+        candidate must appear in the sidecar with a hash that matches the
+        canonical implementation. Per ``feedback_wire_in_test_asserts_counters``,
+        behavior-only assertions silently pass after a wire is removed; the
+        oracle assertion (#4) is the kill-switch — a stub sidecar passes
+        (1)-(3) but fails it.
+        """
+        _seed_claude_code(
+            sandbox,
+            {
+                "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+                "github": {
+                    "command": "npx",
+                    "env": {"GITHUB_TOKEN": "ghp_realsecret"},
+                },
+            },
+        )
+        before = datetime.now(timezone.utc)
+        res = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        assert res.exit_code == 0, res.output
+        after = datetime.now(timezone.utc)
+
+        # 1. file + permissions
+        assert state.import_state_path().exists()
+        mode = stat.S_IMODE(state.import_state_path().stat().st_mode)
+        assert mode == 0o600
+
+        # 2. counter assertion: cardinality AND identity, both axes
+        cfg = state.load_registry()
+        loaded = state.load_import_state()
+        assert len(loaded.entries) == len(cfg.servers)
+        assert set(loaded.entries.keys()) == set(cfg.servers.keys())
+
+        for name, entry in loaded.entries.items():
+            # 3. format
+            assert re.fullmatch(r"sha256:[0-9a-f]{16}", entry.drift_hash), entry.drift_hash
+            # 4. oracle (kill-switch): hash matches canonical implementation
+            assert entry.drift_hash == compute_drift_hash(cfg.servers[name])
+            # 5. version pinned to module constant
+            assert entry.drift_hash_version == drift.HASH_VERSION
+            # 6. source_label exact match (claude-code at user scope)
+            assert entry.source_label == "Claude Code (user)"
+            # 7. timestamp within a CI-cold-start-tolerant window
+            ts = datetime.fromisoformat(entry.last_imported.replace("Z", "+00:00"))
+            assert before.replace(microsecond=0) <= ts
+            assert (ts - after).total_seconds() <= 300
+
+    def test_apply_preserves_existing_sidecar_entries(self, runner, sandbox):
+        """Adding new servers must not overwrite sidecar rows for servers
+        that were imported in a previous apply (dict-merge invariant)."""
+        # Seed sidecar with a pre-existing entry from some earlier import.
+        prior = state.ImportState(
+            entries={
+                "old": state.ImportStateEntry(
+                    drift_hash="sha256:dead0000beef0000",
+                    drift_hash_version=1,
+                    last_imported="2026-04-01T00:00:00Z",
+                    source_label="Cursor (user)",
+                )
+            }
+        )
+        state.save_import_state(prior)
+
+        _seed_claude_code(sandbox, {"newcomer": {"command": "echo"}})
+        res = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        assert res.exit_code == 0, res.output
+
+        loaded = state.load_import_state()
+        assert set(loaded.entries.keys()) == {"old", "newcomer"}
+        # `old` row preserved byte-equal — including its older timestamp.
+        assert loaded.entries["old"] == prior.entries["old"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_mms_import.py
+++ b/tests/cli/test_mms_import.py
@@ -316,6 +316,109 @@ class TestApply:
         assert res3.exit_code == 0, res3.output
         assert "Already up to date" in res3.output
 
+    def test_apply_writes_new_and_backfills_in_one_invocation(self, runner, sandbox):
+        """Mixed path: one ``--apply`` both writes a genuinely new entry
+        AND backfills a sidecar row for an entry already in the registry
+        but missing from the sidecar (pre-PR2 / crash-recovery shape).
+
+        Pins two contracts the empirical smoke test exercised but no unit
+        test had locked:
+        * Output contract — both ``Wrote N new entry`` and
+          ``Backfilled M sidecar row[s]`` lines are emitted in one run.
+        * Single-timestamp invariant holds *across* the new and backfill
+          paths (not just within either alone).
+
+        Note: ``source_label`` provenance under cross-host recovery
+        (original import from host A, recovery via host B) is its own
+        edge case — pinned in
+        ``test_backfill_source_label_uses_current_observing_host``.
+        """
+        # Step 1: first apply registers `existing` via the real scanner —
+        # this is the only reliable way to get a candidate shape that the
+        # subsequent apply will classify as idempotent. (Pre-seeding the
+        # registry directly via ``save_registry`` doesn't work: the host
+        # scanner derives ``prefix`` independently and the shapes diverge,
+        # producing a conflict instead of an idempotent classification.)
+        _seed_claude_code(sandbox, {"existing": {"command": "echo"}})
+        res1 = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        assert res1.exit_code == 0, res1.output
+        assert "existing" in state.load_import_state().entries
+
+        # Step 2: wipe sidecar — simulates crash mid-write or a pre-PR2
+        # registry. Registry intact, sidecar gone.
+        state.import_state_path().unlink()
+
+        # Step 3: host config grows — ``existing`` still there (idempotent
+        # against registry but missing from sidecar → backfill candidate)
+        # AND ``newcomer`` (genuinely new).
+        _seed_claude_code(
+            sandbox,
+            {
+                "existing": {"command": "echo"},
+                "newcomer": {"command": "ls"},
+            },
+        )
+        res2 = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        assert res2.exit_code == 0, res2.output
+
+        # Output contract — both lines present in the same run. Reviewers
+        # care that neither is silently swallowed; ordering is informational.
+        assert "Wrote 1 new entry" in res2.output
+        assert "Backfilled 1 sidecar row" in res2.output
+
+        # Sidecar carries both entries with hashes matching the canonical
+        # implementation.
+        loaded = state.load_import_state()
+        cfg = state.load_registry()
+        assert set(loaded.entries.keys()) == {"existing", "newcomer"}
+        assert set(cfg.servers.keys()) == {"existing", "newcomer"}
+        for name, entry in loaded.entries.items():
+            assert entry.drift_hash == compute_drift_hash(cfg.servers[name])
+            assert entry.drift_hash_version == drift.HASH_VERSION
+            assert entry.source_label == "Claude Code (user)"
+
+        # Single-timestamp invariant — holds across both code paths in one
+        # apply. Production captures ``now`` once at the action boundary;
+        # without this pin a refactor that re-captured for backfill would
+        # still pass the per-entry timestamp window check in #7.
+        assert len({e.last_imported for e in loaded.entries.values()}) == 1
+
+    def test_backfill_source_label_uses_current_observing_host(self, runner, sandbox):
+        """Edge: registry has ``foo`` from an original claude-code import,
+        sidecar is wiped, and by the time recovery runs the user has moved
+        ``foo`` to cursor (claude-code config no longer mentions it). The
+        backfill must stamp the row with **cursor**'s label, not the
+        registry-resident original — the host scanner only sees what's
+        there now, and "original import host" isn't recorded anywhere
+        recoverable. Documented in module docstring; pinned here.
+        """
+        # Step 1: original import via claude-code populates registry+sidecar.
+        _seed_claude_code(sandbox, {"foo": {"command": "echo"}})
+        runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        assert state.load_import_state().entries["foo"].source_label == "Claude Code (user)"
+
+        # Step 2: wipe sidecar AND remove ``foo`` from claude-code; user
+        # has moved the same MCP definition to cursor.
+        state.import_state_path().unlink()
+        (sandbox["home"] / ".claude.json").write_text(
+            json.dumps({"mcpServers": {}}), encoding="utf-8"
+        )
+        cursor_dir = sandbox["home"] / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"foo": {"command": "echo"}}}),
+            encoding="utf-8",
+        )
+
+        # Step 3: recovery via cursor — registry shape matches → idempotent
+        # → backfill. The candidate seen by ``--apply`` is from cursor.
+        res = runner.invoke(import_command, ["--from", "cursor", "--apply"])
+        assert res.exit_code == 0, res.output
+        assert "Backfilled 1 sidecar row" in res.output
+
+        # Source_label reflects the *current* observation, not the original.
+        assert state.load_import_state().entries["foo"].source_label == "Cursor (user)"
+
     def test_apply_preserves_existing_sidecar_entries(self, runner, sandbox):
         """Adding new servers must not overwrite sidecar rows for servers
         that were imported in a previous apply (dict-merge invariant)."""

--- a/tests/cli/test_mms_import.py
+++ b/tests/cli/test_mms_import.py
@@ -253,6 +253,69 @@ class TestApply:
             assert before.replace(microsecond=0) <= ts
             assert (ts - after).total_seconds() <= 300
 
+        # 8. single-timestamp invariant: every row in this --apply shares
+        # one ``last_imported`` value. The production code captures ``now``
+        # once at the action boundary; without this pin a future refactor
+        # moving the capture inside the loop would still pass (1)-(7) since
+        # all per-entry timestamps would still land in the 300s window.
+        # PR3 reads "rows with the same timestamp were observed in one
+        # apply" — break this invariant and that read is wrong.
+        all_timestamps = {entry.last_imported for entry in loaded.entries.values()}
+        assert len(all_timestamps) == 1, f"expected one shared timestamp, got {all_timestamps}"
+
+    def test_apply_backfills_sidecar_when_registry_populated_but_sidecar_missing(
+        self, runner, sandbox
+    ):
+        """Crash-recovery / pre-PR2 path: registry has entries but the
+        sidecar lacks rows for them. The next ``--apply`` with unchanged
+        host input must backfill the missing rows — this is what the
+        module docstring promises as idempotent recovery. Without
+        backfill, the sidecar stays empty forever (idempotent
+        classification short-circuits the write block) and PR3 drift
+        detection has no baseline to compare against.
+        """
+        _seed_claude_code(
+            sandbox,
+            {
+                "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+                "github": {"command": "npx"},
+            },
+        )
+        # First apply: both registry and sidecar populated normally.
+        res1 = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        assert res1.exit_code == 0, res1.output
+        assert set(state.load_import_state().entries.keys()) == {"filesystem", "github"}
+
+        # Simulate: crash mid-write, manual sidecar delete, OR a registry
+        # that was imported under a pre-PR2 mms (no sidecar wire existed).
+        state.import_state_path().unlink()
+        assert not state.import_state_path().exists()
+        assert set(state.load_registry().servers.keys()) == {"filesystem", "github"}
+
+        # Re-apply with unchanged host input — registry classifies both as
+        # idempotent, but the backfill pass restores the sidecar.
+        res2 = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        assert res2.exit_code == 0, res2.output
+        assert "Backfilled 2 sidecar rows" in res2.output
+        # Registry message must NOT appear — registry is byte-unchanged.
+        assert "Wrote" not in res2.output
+
+        # Sidecar fully restored, hashes match the canonical implementation.
+        cfg = state.load_registry()
+        loaded = state.load_import_state()
+        assert set(loaded.entries.keys()) == set(cfg.servers.keys())
+        for name, entry in loaded.entries.items():
+            assert entry.drift_hash == compute_drift_hash(cfg.servers[name])
+            assert entry.drift_hash_version == drift.HASH_VERSION
+            assert entry.source_label == "Claude Code (user)"
+        # Backfill rows share the recovery-moment timestamp.
+        assert len({e.last_imported for e in loaded.entries.values()}) == 1
+
+        # Third apply with sidecar now populated — pure no-op.
+        res3 = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+        assert res3.exit_code == 0, res3.output
+        assert "Already up to date" in res3.output
+
     def test_apply_preserves_existing_sidecar_entries(self, runner, sandbox):
         """Adding new servers must not overwrite sidecar rows for servers
         that were imported in a previous apply (dict-merge invariant)."""

--- a/tests/mms/test_state.py
+++ b/tests/mms/test_state.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from memtomem_stm.mms import state
+from memtomem_stm.mms.drift import canonical_form, compute_drift_hash
 
 
 @pytest.fixture
@@ -143,6 +144,28 @@ def test_utc_now_iso_format(sandbox_home):
 # ---------------------------------------------------------------------------
 
 
+def test_save_import_state_creates_directory_on_fresh_home(sandbox_home):
+    """``save_import_state`` must create ``~/.mms`` itself when no prior
+    ``save_registry`` has run. Pinned as the *first* test in this section
+    so a directory-creation regression localizes immediately rather than
+    cascading through every later sidecar test (one-glance diagnosis vs
+    bisect)."""
+    assert not state.mms_home().exists()  # precondition
+    s = state.ImportState(
+        entries={
+            "x": state.ImportStateEntry(
+                drift_hash="sha256:0123456789abcdef",
+                drift_hash_version=1,
+                last_imported="2026-05-01T13:24:03Z",
+                source_label="test",
+            )
+        }
+    )
+    state.save_import_state(s)
+    assert state.import_state_path().exists()
+    assert state.load_import_state() == s
+
+
 def test_load_import_state_returns_empty_when_missing(sandbox_home):
     s = state.load_import_state()
     assert s.entries == {}
@@ -169,6 +192,44 @@ def test_import_state_round_trip(sandbox_home):
     state.save_import_state(s)
     loaded = state.load_import_state()
     assert loaded == s
+
+
+@pytest.mark.parametrize(
+    "server",
+    [
+        state.RegistryServer(command="echo", prefix="x"),
+        state.RegistryServer(command="npx", args=["-y", "@mcp/fs"], prefix="fs"),
+        state.RegistryServer(command="npx", env={"TOKEN": "x"}, prefix="t"),
+        state.RegistryServer(command="npx", args=["a"], env={"A": "1", "B": "2"}, prefix="ax"),
+        state.RegistryServer(command="echo", env={"MSG": "héllo 🌍"}, prefix="u"),
+        state.RegistryServer(command="echo", args=[], env={}, prefix="e"),
+    ],
+    ids=["bare", "args", "env", "args+env", "unicode-env", "empty-explicit"],
+)
+def test_save_load_preserves_drift_hash(sandbox_home, server: state.RegistryServer):
+    """Round-trip pin: ``save_registry`` → ``load_registry`` must preserve
+    server identity along three independent axes — pydantic equality,
+    canonical bytes, and the derived drift hash. This test was punted from
+    PR1 review and lands as PR2's first commit *unconditional* (per the
+    22h-late-regression policy); it must be green against current main
+    *before* any wire-in, so the wire-in commit can only stay green by
+    keeping the contract intact.
+
+    The three oracles are deliberately on different layers — pydantic ``==``
+    today implies the other two, but a future ``model_validator`` (e.g.
+    one that strips trailing whitespace from ``command``) could break the
+    implication. Only a separate ``canonical_form`` oracle catches that.
+    The hash is derived from canonical_form, so if its truncation width
+    or algorithm ever swaps, the canonical_form oracle still pins what
+    we actually care about (byte-stable canonical bytes across save/load).
+    """
+    cfg = state.RegistryConfig(servers={"x": server})
+    state.save_registry(cfg)
+    loaded = state.load_registry()
+
+    assert loaded.servers["x"] == server
+    assert canonical_form(loaded.servers["x"]) == canonical_form(server)
+    assert compute_drift_hash(loaded.servers["x"]) == compute_drift_hash(server)
 
 
 def test_save_import_state_uses_0o600(sandbox_home):


### PR DESCRIPTION
## Summary

- Wires `compute_drift_hash` (PR1) into `mms import --apply`: every accepted candidate now gets its drift hash stamped into `~/.mms/import_state.toml` (mode 0o600) in the same invocation.
- First commit lands the unconditional regression test punted from PR1 review — `save_registry → load_registry → compute_drift_hash` byte-equal across save/load — pinned on **three independent layers** (pydantic equality, canonical bytes, derived hash) so a future regression localizes to the layer that broke it.
- Third commit (added after external review) closes the docstring promise: any registry entry whose sidecar row is missing gets backfilled on the next `--apply`, including pre-PR2 registries and crash-recovery scenarios.

## Why now

PR1 shipped the foundation but explicitly punted production wiring. Without a populated sidecar, PR3 (drift bucket + UX surface) has nothing to compare against — "changed at host" detection needs an anchor, and `mms import --apply` is the only natural place to set it.

The first-commit test was a *separate* punt from PR1 review (the 22h-late-regression policy: punt triggers are next-PR first commit unconditional, not "when signal appears"). It lands here regardless of any signal so the wire-in commit can only stay green by keeping the round-trip contract intact.

## Behavior change

`mms import --apply` now writes a second file: `~/.mms/import_state.toml` (mode 0o600). `--plan` is unchanged — the existing early-return keeps it side-effect-free (pinned by `test_plan_does_not_write_import_state`). Conflict handling and registry-write semantics are unchanged.

`--apply` now also **backfills missing sidecar rows** for entries that already match the registry — surfaced in the output as `Backfilled N sidecar row[s]`. A run that finds nothing to add and nothing to backfill prints "Already up to date" and writes nothing.

## Sidecar population & recovery (PR3 contract preview, locked here)

Every registry entry observed by an `--apply` run that is missing from the sidecar gets stamped during that run. New entries are stamped from their candidate; idempotent entries (registry already matches host) are *backfilled* from the same canonical hash. This makes sidecar population idempotent-recoverable across:

- a crash between the registry and sidecar writes within one apply,
- a sidecar deleted out-of-band,
- a registry imported under a pre-PR2 mms (no wire existed yet).

**Backfill timestamps reflect the recovery moment**, not the original import — that moment is the only one at which the canonical hash can be authoritatively recomputed. Backfill row hashes are byte-equal to what a fresh `--apply` would produce against the same `canonical_form`, so the recovery is semantically lossless even though the timestamp isn't the literal first-import wall-clock.

**No-op cases for PR3 to surface as "no drift"**:
- Reverted-to-original (host edited away from registry, then back) → `current_hash == sidecar.drift_hash` → no drift. Intended.
- Whitespace-only / non-canonical edits (different bytes in host config but identical `canonical_form`) → no drift. Intended.

Changing either case to *show* drift requires reopening this PR to change sidecar semantics.

## Atomicity

Registry write precedes sidecar write within a single apply; no transaction. A crash between leaves the sidecar stale for that run, but the next `--apply` of the same host input runs the backfill path and restores the missing rows. A `--force` option to re-stamp *existing* sidecar rows (resetting timestamps after a host edit you've acknowledged) lands in W3+.

## Wire-in counter test design

`test_apply_writes_import_state_sidecar` runs **8 ordered assertions**; the kill-switch is #4 (`entry.drift_hash == compute_drift_hash(cfg.servers[name])`). A stub sidecar passes (1)-(3) but fails the oracle. Cardinality + identity assertions both axes pinned (counter style). Assertion #8 pins the single-timestamp invariant — every row in one `--apply` shares one `last_imported`, so a future refactor moving the `now` capture inside the loop fails loudly instead of silently passing the per-entry window check.

`test_apply_first_import_wins_on_conflict` extended with `assert "foo" not in load_import_state().entries` — pins that conflict-rejected entries don't poison the sidecar. Without this, a future refactor building sidecar from `candidates` instead of `new` would let PR3 see "no drift" forever on a host that disagrees with the registry.

`test_apply_backfills_sidecar_when_registry_populated_but_sidecar_missing` reproduces the exact crash-recovery / pre-PR2 scenario and pins the docstring promise: registry intact + sidecar wiped → next `--apply` restores all rows + third `--apply` is a true no-op.

## Test plan

- [x] `uv run pytest -m "not ollama"` — full suite (1993 tests, all green locally)
- [x] `uv run ruff check src tests && uv run ruff format --check src` — lint + format
- [x] `uv run pytest tests/cli/test_mms_import.py tests/mms/test_state.py tests/mms/test_drift.py -v` — touched-area focus (78 tests)
- [x] End-to-end smoke against isolated `HOME`: `--plan` writes nothing; `--apply` writes both files at 0o600 with shared `last_imported`; `rm import_state.toml` then re-`--apply` prints "Backfilled 2 sidecar rows" and restores the file; third `--apply` is "Already up to date"

## Out of scope (W2 chain ordering)

- **Drift bucket detection** (`mms status` surfacing `changed at host` / `unchanged`) — PR3.
- **Secret classification metadata in sidecar** — deferred to PR3 or PR4 per chain ordering; not bundled here.
- **"Removed at host"** — PR4.
- **`--force` re-stamp of existing sidecar rows** (resetting timestamps after an acknowledged host edit) — W3+. Backfill of *missing* rows is in this PR; `--force` is for the *existing-rows* case.
- **Cross-host name collisions under `--from all`** (case-insensitive `GitHub` vs `github`) — today `_classify_against_registry` deduplicates via `seen_in_batch` so single-write is preserved; future case-insensitive policy is neither this PR nor PR3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)