### PR TITLE
feat(mms): W2 PR3 — `mms host status` (drift bucket + UX)

### DIFF
--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -129,8 +129,18 @@ def _classify(
     """
     cand_by_name = _select_candidate_by_name(candidates, import_state)
     rows: list[dict] = []
-    for name, server in registry.servers.items():
+    for name in registry.servers:
         baseline = import_state.entries.get(name)
+        cand = cand_by_name.get(name)
+        # ``current_hash`` is uniformly the host's view: the canonical
+        # hash of the matched candidate, or ``None`` if no host scanner
+        # finds the entry. This keeps the field's meaning the same
+        # across every bucket — downstream tooling that recomputes
+        # against the host config gets the same value back regardless
+        # of whether the row is unchanged / changed / removed / has no
+        # baseline.
+        current_hash = compute_drift_hash(cand.server) if cand is not None else None
+
         if baseline is None or baseline.drift_hash_version != HASH_VERSION:
             # ``no_baseline`` covers both the missing-row case and the
             # version-mismatch case — they both mean "the comparison
@@ -142,12 +152,11 @@ def _classify(
                     "state": "no_baseline",
                     "source_label": baseline.source_label if baseline else None,
                     "baseline_hash": baseline.drift_hash if baseline else None,
-                    "current_hash": compute_drift_hash(server),
+                    "current_hash": current_hash,
                     "last_imported": baseline.last_imported if baseline else None,
                 }
             )
             continue
-        cand = cand_by_name.get(name)
         if cand is None:
             rows.append(
                 {
@@ -160,7 +169,6 @@ def _classify(
                 }
             )
             continue
-        current_hash = compute_drift_hash(cand.server)
         rows.append(
             {
                 "name": name,
@@ -189,7 +197,10 @@ def _render_text(rows: list[dict]) -> None:
     comparison signal. Each is conditionally shown when its count > 0.
 
     Column widths follow ``mms project list`` (mms_project.py:285):
-    plain f-strings, no rich.
+    plain f-strings, no rich. Alignment is best-effort — names longer
+    than the NAME column overflow rather than truncate. Not a contract;
+    swap in textual/rich/whatever when MCP names regularly exceed 20
+    chars in practice.
     """
     main_rows = [r for r in rows if r["state"] in ("unchanged", "changed")]
     n_unchanged = sum(1 for r in main_rows if r["state"] == "unchanged")

--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -1,0 +1,275 @@
+"""``mms host`` Click subgroup — W2 host-sync surfaces (RFC §7.3).
+
+PR3 lands the read-only inspection command:
+
+* ``mms host status`` — classify every registry entry into one of four
+  drift buckets relative to the W2 sidecar baseline, and surface the
+  result either as a human table or ``--json``.
+
+The bucket vocabulary is the contract that PR4 (``removed_at_host``
+main-table promotion) and W3+ (``--force`` re-stamp) build on. PR3
+freezes the four state names; PR4 swaps a footer note for a main-table
+row but does not rename anything.
+
+The four buckets:
+
+* ``unchanged`` — host scan finds the entry and its canonical hash
+  matches the sidecar baseline.
+* ``changed`` — host scan finds the entry but the canonical hash
+  differs (host config was edited externally since last
+  ``mms import --apply``).
+* ``removed_at_host`` — registry has the entry, sidecar has the
+  baseline, but no host scanner finds it. PR3 surfaces this in the
+  footer as a count + neutral note; PR4 promotes it to the main table.
+* ``no_baseline`` — sidecar lacks a row for this entry, OR the
+  sidecar's ``drift_hash_version`` doesn't match the running mms's
+  :data:`HASH_VERSION`. Either way the comparison can't be made and
+  the user needs to re-stamp via ``mms import --apply``. This catches
+  three real paths that PR2's backfill alone doesn't cover:
+
+  1. Manual sidecar edits (RFC §3 says the user can hand-edit any of
+     these files; the sidecar isn't exempt).
+  2. Pre-PR2 installs that upgrade to the wired mms but call
+     ``mms host status`` before any ``mms import --apply``.
+  3. A future ``HASH_VERSION`` bump where v1 baselines coexist with a
+     v2 binary — comparing them silently would always read as
+     ``changed``, which is worse than asking for a re-stamp.
+
+When candidates with the same name appear in multiple host configs,
+the comparison candidate is chosen by ``baseline.source_label`` match
+first, falling back to first-seen across :data:`ALL_HOSTS`. This keeps
+``unchanged``/``changed`` stable when the user later mirrors an entry
+into a second host — the import-time host stays the comparison axis.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+
+import click
+
+from memtomem_stm.mms import state
+from memtomem_stm.mms.drift import HASH_VERSION, compute_drift_hash
+from memtomem_stm.mms.import_hosts import ImportCandidate, discover
+
+# ---------------------------------------------------------------------------
+# Pinned UX strings — kept as module constants so tests assert against the
+# *symbol* and any rewording is a single-place edit. Mirrors the convention
+# in ``mms_project.py`` (``_REGISTRY_EMPTY_MSG``).
+# ---------------------------------------------------------------------------
+
+_NO_REGISTRY_MSG = "No registered MCP entries. Run `mms import --apply` to import host configs.\n"
+
+_FOOTER_REMOVED_AT_HOST_TEMPLATE = "{n} entr{ies_or_y} in registry not present in any host scan"
+
+_FOOTER_NO_BASELINE_TEMPLATE = (
+    "{n} entr{ies_or_y} missing baseline hash — run `mms import --apply` to stamp"
+)
+
+
+def _ies_or_y(n: int) -> str:
+    return "y" if n == 1 else "ies"
+
+
+# ---------------------------------------------------------------------------
+# Group
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="host")
+def host_group() -> None:
+    """Host-config inspection and sync (RFC §7.3)."""
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _select_candidate_by_name(
+    candidates: list[ImportCandidate],
+    import_state: state.ImportState,
+) -> dict[str, ImportCandidate]:
+    """Return a name → candidate map with source_label-preferred matching.
+
+    Pass 1: for every sidecar entry, look for a candidate with the same
+    name *and* matching ``source_label``. This is the import-time host;
+    keeping it as the comparison axis avoids drift flicker when the
+    same entry name later appears in a second host.
+
+    Pass 2: any name not yet bound falls back to first-seen across
+    :data:`ALL_HOSTS` (the discover() iteration order). This covers
+    entries the user moved to a different host, plus entries whose
+    sidecar has no row yet (those will land in ``no_baseline`` anyway,
+    but the candidate is still useful for the JSON ``current_hash``).
+    """
+    by_name: dict[str, ImportCandidate] = {}
+    for name, baseline in import_state.entries.items():
+        for cand in candidates:
+            if cand.name == name and cand.source_label == baseline.source_label:
+                by_name[name] = cand
+                break
+    for cand in candidates:
+        by_name.setdefault(cand.name, cand)
+    return by_name
+
+
+def _classify(
+    registry: state.RegistryConfig,
+    import_state: state.ImportState,
+    candidates: list[ImportCandidate],
+) -> list[dict]:
+    """Bucket every registry entry into one of four states.
+
+    Returns a list of dicts (one per registry entry) with keys
+    ``name``, ``state``, ``source_label``, ``baseline_hash``,
+    ``current_hash``, ``last_imported``. Order matches
+    ``registry.servers`` insertion order (registry.toml file order).
+    """
+    cand_by_name = _select_candidate_by_name(candidates, import_state)
+    rows: list[dict] = []
+    for name, server in registry.servers.items():
+        baseline = import_state.entries.get(name)
+        if baseline is None or baseline.drift_hash_version != HASH_VERSION:
+            # ``no_baseline`` covers both the missing-row case and the
+            # version-mismatch case — they both mean "the comparison
+            # can't be trusted; re-stamp". Surfacing them as one bucket
+            # keeps the user-facing fix the same single command.
+            rows.append(
+                {
+                    "name": name,
+                    "state": "no_baseline",
+                    "source_label": baseline.source_label if baseline else None,
+                    "baseline_hash": baseline.drift_hash if baseline else None,
+                    "current_hash": compute_drift_hash(server),
+                    "last_imported": baseline.last_imported if baseline else None,
+                }
+            )
+            continue
+        cand = cand_by_name.get(name)
+        if cand is None:
+            rows.append(
+                {
+                    "name": name,
+                    "state": "removed_at_host",
+                    "source_label": baseline.source_label,
+                    "baseline_hash": baseline.drift_hash,
+                    "current_hash": None,
+                    "last_imported": baseline.last_imported,
+                }
+            )
+            continue
+        current_hash = compute_drift_hash(cand.server)
+        rows.append(
+            {
+                "name": name,
+                "state": "unchanged" if current_hash == baseline.drift_hash else "changed",
+                "source_label": baseline.source_label,
+                "baseline_hash": baseline.drift_hash,
+                "current_hash": current_hash,
+                "last_imported": baseline.last_imported,
+            }
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_text(rows: list[dict]) -> None:
+    """Default human-readable renderer.
+
+    Main table shows ``unchanged`` + ``changed`` rows (the comparable
+    states). ``removed_at_host`` and ``no_baseline`` are footer notes
+    only — they don't have a meaningful current-hash to put in the
+    SOURCE/STATE pair, so dumping them in the table would dilute the
+    comparison signal. Each is conditionally shown when its count > 0.
+
+    Column widths follow ``mms project list`` (mms_project.py:285):
+    plain f-strings, no rich.
+    """
+    main_rows = [r for r in rows if r["state"] in ("unchanged", "changed")]
+    n_unchanged = sum(1 for r in main_rows if r["state"] == "unchanged")
+    n_changed = sum(1 for r in main_rows if r["state"] == "changed")
+    n_removed = sum(1 for r in rows if r["state"] == "removed_at_host")
+    n_no_baseline = sum(1 for r in rows if r["state"] == "no_baseline")
+
+    if main_rows:
+        click.echo(f" {'NAME':<20} {'STATE':<10} SOURCE")
+        for row in main_rows:
+            source = row["source_label"] or ""
+            click.echo(f" {row['name']:<20} {row['state']:<10} {source}")
+        click.echo("")
+    click.echo(f" {n_unchanged} unchanged, {n_changed} changed at host")
+    if n_removed:
+        click.echo(
+            " "
+            + _FOOTER_REMOVED_AT_HOST_TEMPLATE.format(n=n_removed, ies_or_y=_ies_or_y(n_removed))
+        )
+    if n_no_baseline:
+        click.echo(
+            " "
+            + _FOOTER_NO_BASELINE_TEMPLATE.format(
+                n=n_no_baseline, ies_or_y=_ies_or_y(n_no_baseline)
+            )
+        )
+
+
+def _render_json(rows: list[dict]) -> None:
+    """JSON renderer. Includes every state; summary always carries 4 keys."""
+    summary = {
+        "unchanged": sum(1 for r in rows if r["state"] == "unchanged"),
+        "changed": sum(1 for r in rows if r["state"] == "changed"),
+        "removed_at_host": sum(1 for r in rows if r["state"] == "removed_at_host"),
+        "no_baseline": sum(1 for r in rows if r["state"] == "no_baseline"),
+    }
+    payload = {"entries": rows, "summary": summary}
+    click.echo(_json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+@host_group.command("status")
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def status_cmd(json_output: bool) -> None:
+    """Show drift state of every registry entry vs sidecar baseline.
+
+    Read-only: never writes to registry, sidecar, or anywhere else.
+    Exit code is always 0 — drift is a normal observation, not a CI
+    failure signal.
+    """
+    registry = state.load_registry()
+    import_state = state.load_import_state()
+
+    if not registry.servers:
+        if json_output:
+            click.echo(
+                _json.dumps(
+                    {
+                        "entries": [],
+                        "summary": {
+                            "unchanged": 0,
+                            "changed": 0,
+                            "removed_at_host": 0,
+                            "no_baseline": 0,
+                        },
+                    },
+                    indent=2,
+                )
+            )
+            return
+        click.echo(_NO_REGISTRY_MSG, nl=False)
+        return
+
+    candidates = discover("all", Path.cwd().resolve())
+    rows = _classify(registry, import_state, candidates)
+    if json_output:
+        _render_json(rows)
+    else:
+        _render_text(rows)

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import click
 
+from memtomem_stm.cli.mms_host import host_group as _mms_host_group
 from memtomem_stm.cli.mms_import import import_command as _mms_import_command
 from memtomem_stm.cli.mms_project import project_group as _mms_project_group
 from memtomem_stm.mms.import_hosts import (
@@ -2294,3 +2295,6 @@ cli.add_command(_mms_project_group)
 
 # `mms import ...` — RFC §7.2, lives in src/memtomem_stm/cli/mms_import.py.
 cli.add_command(_mms_import_command)
+
+# `mms host ...` — RFC §7.3, lives in src/memtomem_stm/cli/mms_host.py.
+cli.add_command(_mms_host_group)

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -1,0 +1,464 @@
+"""CliRunner tests for ``mms host status`` (RFC §7.3, W2 PR3).
+
+The four-state classifier (``unchanged`` / ``changed`` / ``removed_at_host``
+/ ``no_baseline``) is the contract that PR4 builds on, so every state
+gets explicit coverage here. ``no_baseline`` and the
+``drift_hash_version`` guard are reachable via real edit paths
+(manual sidecar edit, pre-PR2 install) — not just defensive code, so
+each gets a dedicated test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem_stm.cli.mms_host import host_group
+from memtomem_stm.cli.mms_import import import_command
+from memtomem_stm.mms import state
+from memtomem_stm.mms.drift import HASH_VERSION, compute_drift_hash
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """Pin HOME so ``~/.mms`` and ``~/.claude.json`` etc. land in tmp."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    return {"home": tmp_path, "cwd": cwd}
+
+
+def _seed_claude_code(sandbox, mcps: dict) -> None:
+    cfg = {"mcpServers": mcps}
+    (sandbox["home"] / ".claude.json").write_text(json.dumps(cfg), encoding="utf-8")
+
+
+def _seed_cursor_user(sandbox, mcps: dict) -> None:
+    cursor_dir = sandbox["home"] / ".cursor"
+    cursor_dir.mkdir(parents=True, exist_ok=True)
+    (cursor_dir / "mcp.json").write_text(json.dumps({"mcpServers": mcps}), encoding="utf-8")
+
+
+def _apply_claude_code(runner) -> None:
+    res = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+    assert res.exit_code == 0, res.output
+
+
+def _status(runner, *args: str):
+    return runner.invoke(host_group, ["status", *args])
+
+
+# ---------------------------------------------------------------------------
+# Core states
+# ---------------------------------------------------------------------------
+
+
+class TestStates:
+    def test_status_after_apply_all_unchanged(self, runner, sandbox):
+        _seed_claude_code(
+            sandbox,
+            {
+                "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+                "github": {"command": "npx"},
+            },
+        )
+        _apply_claude_code(runner)
+
+        res = _status(runner)
+        assert res.exit_code == 0, res.output
+        assert "filesystem" in res.output
+        assert "github" in res.output
+        # Footer count fragments — substring assertions, joining
+        # punctuation/order intentionally not pinned (PR4 may evolve
+        # the line shape).
+        assert "2 unchanged" in res.output
+        assert "0 changed at host" in res.output
+        # Nothing outside the comparable bucket → no extra footer notes.
+        assert "not present" not in res.output
+        assert "missing baseline" not in res.output
+
+    def test_status_changed_after_host_edit(self, runner, sandbox):
+        _seed_claude_code(
+            sandbox,
+            {
+                "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+                "github": {"command": "npx"},
+            },
+        )
+        _apply_claude_code(runner)
+
+        # Mutate one entry's args at the host config layer.
+        _seed_claude_code(
+            sandbox,
+            {
+                "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs2"]},
+                "github": {"command": "npx"},
+            },
+        )
+
+        res = _status(runner)
+        assert res.exit_code == 0, res.output
+        # filesystem is changed; github stays unchanged.
+        # Use the JSON shape for unambiguous state assertions.
+        json_res = _status(runner, "--json")
+        assert json_res.exit_code == 0, json_res.output
+        payload = json.loads(json_res.output)
+        states = {row["name"]: row["state"] for row in payload["entries"]}
+        assert states == {"filesystem": "changed", "github": "unchanged"}
+        assert "1 unchanged" in res.output
+        assert "1 changed at host" in res.output
+
+    def test_status_removed_at_host(self, runner, sandbox):
+        _seed_claude_code(
+            sandbox,
+            {
+                "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+                "github": {"command": "npx"},
+            },
+        )
+        _apply_claude_code(runner)
+
+        # Drop one entry at the host config — registry/sidecar still
+        # have it.
+        _seed_claude_code(sandbox, {"github": {"command": "npx"}})
+
+        res = _status(runner)
+        assert res.exit_code == 0, res.output
+        # Removed entry stays out of the main table.
+        main_table = res.output.split("0 changed" if "0 changed" in res.output else "1 changed")[0]
+        # filesystem absent from the main-table half, github present.
+        # (Footer note still mentions filesystem? No — neutral phrasing
+        # uses count only, not name. Verified below.)
+        assert "github" in main_table
+        # Footer count + neutral phrasing (no "PR4" / "removed" name leak).
+        assert "1 entry in registry not present in any host scan" in res.output
+
+        json_res = _status(runner, "--json")
+        payload = json.loads(json_res.output)
+        states = {row["name"]: row["state"] for row in payload["entries"]}
+        assert states == {"filesystem": "removed_at_host", "github": "unchanged"}
+        # current_hash is null for removed entries.
+        for row in payload["entries"]:
+            if row["name"] == "filesystem":
+                assert row["current_hash"] is None
+                assert row["baseline_hash"] is not None  # baseline preserved
+                assert row["source_label"] == "Claude Code (user)"
+
+    def test_status_no_baseline_missing_sidecar_entry(self, runner, sandbox):
+        """Manual sidecar deletion / pre-PR2 install / atomic-write race —
+        any path that leaves a registry entry without a sidecar row.
+        Read-only inspection must not crash; it must surface the row in
+        a recoverable bucket with an actionable hint.
+        """
+        _seed_claude_code(
+            sandbox,
+            {
+                "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+                "github": {"command": "npx"},
+            },
+        )
+        _apply_claude_code(runner)
+
+        # Manually delete one sidecar entry.
+        s = state.load_import_state()
+        new_entries = {k: v for k, v in s.entries.items() if k != "github"}
+        state.save_import_state(
+            state.ImportState(schema_version=s.schema_version, entries=new_entries)
+        )
+
+        res = _status(runner)
+        assert res.exit_code == 0, res.output
+        # filesystem is still unchanged; github falls into no_baseline.
+        assert "1 unchanged" in res.output
+        assert "0 changed at host" in res.output
+        assert "1 entry missing baseline hash" in res.output
+        assert "run `mms import --apply` to stamp" in res.output
+
+        json_res = _status(runner, "--json")
+        payload = json.loads(json_res.output)
+        states = {row["name"]: row["state"] for row in payload["entries"]}
+        assert states == {"filesystem": "unchanged", "github": "no_baseline"}
+        for row in payload["entries"]:
+            if row["name"] == "github":
+                assert row["baseline_hash"] is None
+                assert row["source_label"] is None
+                assert row["last_imported"] is None
+                # current_hash is computable from registry, so populated.
+                assert row["current_hash"] is not None
+
+    def test_status_no_baseline_drift_hash_version_mismatch(self, runner, sandbox):
+        """Future HASH_VERSION bump — v1 baselines vs v2 binary should
+        not silently miscompare as ``changed``. PR3 is the first
+        consumer; if it doesn't gate on version, no later consumer will.
+        """
+        _seed_claude_code(sandbox, {"filesystem": {"command": "npx"}})
+        _apply_claude_code(runner)
+
+        # Stamp the sidecar with a wildly different version — hash
+        # itself is real (we don't break the regex) but the version
+        # disagrees with the running mms's HASH_VERSION.
+        s = state.load_import_state()
+        entry = s.entries["filesystem"]
+        s.entries["filesystem"] = state.ImportStateEntry(
+            drift_hash=entry.drift_hash,
+            drift_hash_version=HASH_VERSION + 998,
+            last_imported=entry.last_imported,
+            source_label=entry.source_label,
+        )
+        state.save_import_state(s)
+
+        json_res = _status(runner, "--json")
+        assert json_res.exit_code == 0, json_res.output
+        payload = json.loads(json_res.output)
+        assert payload["entries"][0]["state"] == "no_baseline"
+
+
+# ---------------------------------------------------------------------------
+# source_label-preferred candidate matching
+# ---------------------------------------------------------------------------
+
+
+class TestSourceLabelMatching:
+    def test_status_source_label_match_preferred(self, runner, sandbox):
+        """Same-name entry exists in two hosts with different shapes;
+        comparison candidate must be the one whose source_label matches
+        the sidecar baseline (= the import-time host).
+        """
+        # Seed both claude-code and cursor with the same name, different args.
+        _seed_claude_code(
+            sandbox,
+            {"shared": {"command": "npx", "args": ["claude-args"]}},
+        )
+        _seed_cursor_user(
+            sandbox,
+            {"shared": {"command": "npx", "args": ["cursor-args"]}},
+        )
+
+        # Import only from cursor → registry + sidecar baseline carry
+        # source_label="Cursor (user)" and the cursor-args canonical hash.
+        res_apply = runner.invoke(import_command, ["--from", "cursor", "--apply"])
+        assert res_apply.exit_code == 0, res_apply.output
+        sidecar = state.load_import_state()
+        assert sidecar.entries["shared"].source_label == "Cursor (user)"
+
+        # Now mms host status discovers ALL hosts. ALL_HOSTS iterates
+        # claude-code first (different shape). Without source_label
+        # preference, the comparison would pick the claude-code
+        # candidate and report changed (false positive).
+        json_res = _status(runner, "--json")
+        payload = json.loads(json_res.output)
+        states = {row["name"]: row["state"] for row in payload["entries"]}
+        assert states == {"shared": "unchanged"}, payload
+
+    def test_status_source_label_fallback_to_first_match(self, runner, sandbox):
+        """Sidecar source_label points at a host that no longer has the
+        entry; fallback to first-seen ALL_HOSTS match. Behavior pin —
+        not necessarily ideal long-term but stable today.
+        """
+        _seed_cursor_user(sandbox, {"shared": {"command": "npx", "args": ["cursor-args"]}})
+        res_apply = runner.invoke(import_command, ["--from", "cursor", "--apply"])
+        assert res_apply.exit_code == 0, res_apply.output
+        # source_label baseline = "Cursor (user)"
+        assert state.load_import_state().entries["shared"].source_label == "Cursor (user)"
+
+        # Now move the entry to claude-code only (cursor config gone).
+        (sandbox["home"] / ".cursor" / "mcp.json").unlink()
+        _seed_claude_code(sandbox, {"shared": {"command": "npx", "args": ["cursor-args"]}})
+
+        # Same canonical args → fallback candidate (Claude Code (user))
+        # has matching hash, so state is unchanged.
+        json_res = _status(runner, "--json")
+        payload = json.loads(json_res.output)
+        states = {row["name"]: row["state"] for row in payload["entries"]}
+        assert states == {"shared": "unchanged"}
+
+    def test_status_source_column_shows_baseline_attribution(self, runner, sandbox):
+        """SOURCE column = baseline.source_label (import-time), NOT
+        current host. User imports from claude-code, then later mirrors
+        the same entry into cursor — SOURCE stays "Claude Code (user)".
+        """
+        _seed_claude_code(sandbox, {"shared": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Mirror to cursor with same shape (would be unchanged via fallback).
+        _seed_cursor_user(sandbox, {"shared": {"command": "npx"}})
+
+        json_res = _status(runner, "--json")
+        payload = json.loads(json_res.output)
+        assert len(payload["entries"]) == 1
+        assert payload["entries"][0]["source_label"] == "Claude Code (user)"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdges:
+    def test_status_empty_registry(self, runner, sandbox):
+        res = _status(runner)
+        assert res.exit_code == 0, res.output
+        assert (
+            "No registered MCP entries. Run `mms import --apply` to import host configs."
+            in res.output
+        )
+
+    def test_status_empty_registry_json(self, runner, sandbox):
+        res = _status(runner, "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload == {
+            "entries": [],
+            "summary": {
+                "unchanged": 0,
+                "changed": 0,
+                "removed_at_host": 0,
+                "no_baseline": 0,
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# JSON shape & invariants
+# ---------------------------------------------------------------------------
+
+
+class TestJsonShape:
+    def test_status_json_shape_includes_all_states(self, runner, sandbox):
+        """Seed one row per state; --json entries must include all four,
+        summary must always carry the four keys."""
+        # Two claude-code entries + one to be hand-edited into mismatch.
+        _seed_claude_code(
+            sandbox,
+            {
+                "fs_unchanged": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+                "gh_changed": {"command": "npx", "args": ["original"]},
+                "to_remove": {"command": "npx"},
+                "no_base_entry": {"command": "npx"},
+            },
+        )
+        _apply_claude_code(runner)
+
+        # Construct each state:
+        # - fs_unchanged: leave alone → unchanged
+        # - gh_changed: edit host args → changed
+        # - to_remove: drop from host config → removed_at_host
+        # - no_base_entry: delete sidecar row → no_baseline
+        _seed_claude_code(
+            sandbox,
+            {
+                "fs_unchanged": {"command": "npx", "args": ["-y", "@mcp/fs"]},
+                "gh_changed": {"command": "npx", "args": ["mutated"]},
+                "no_base_entry": {"command": "npx"},
+            },
+        )
+        s = state.load_import_state()
+        new_entries = {k: v for k, v in s.entries.items() if k != "no_base_entry"}
+        state.save_import_state(
+            state.ImportState(schema_version=s.schema_version, entries=new_entries)
+        )
+
+        res = _status(runner, "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+
+        # Summary always carries the four keys, all integers.
+        assert set(payload["summary"].keys()) == {
+            "unchanged",
+            "changed",
+            "removed_at_host",
+            "no_baseline",
+        }
+        assert payload["summary"] == {
+            "unchanged": 1,
+            "changed": 1,
+            "removed_at_host": 1,
+            "no_baseline": 1,
+        }
+
+        # entries[] includes all four states.
+        states_seen = {row["name"]: row["state"] for row in payload["entries"]}
+        assert states_seen == {
+            "fs_unchanged": "unchanged",
+            "gh_changed": "changed",
+            "to_remove": "removed_at_host",
+            "no_base_entry": "no_baseline",
+        }
+
+        # Required keys per row.
+        required = {
+            "name",
+            "state",
+            "source_label",
+            "baseline_hash",
+            "current_hash",
+            "last_imported",
+        }
+        for row in payload["entries"]:
+            assert set(row.keys()) == required, row
+
+    def test_status_exit_code_always_zero(self, runner, sandbox):
+        """Every state combination — drift / removed / no_baseline —
+        must exit 0. Read-only observation never signals failure.
+        """
+        _seed_claude_code(
+            sandbox,
+            {"a": {"command": "npx", "args": ["x"]}, "b": {"command": "npx"}},
+        )
+        _apply_claude_code(runner)
+        # Edit host (changed) + remove one (removed_at_host) + drop sidecar
+        # row for the remaining (no_baseline).
+        _seed_claude_code(sandbox, {"a": {"command": "npx", "args": ["edited"]}})
+        s = state.load_import_state()
+        s.entries.pop("a")  # baseline gone for the only host-present entry → no_baseline
+        state.save_import_state(s)
+
+        for args in ([], ["--json"]):
+            res = _status(runner, *args)
+            assert res.exit_code == 0, (args, res.output)
+
+
+# ---------------------------------------------------------------------------
+# Plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestPlumbing:
+    def test_baseline_hash_matches_canonical(self, runner, sandbox):
+        """The JSON ``baseline_hash`` is exactly what the canonical
+        compute_drift_hash() returns for the registry entry — so
+        downstream tooling can recompute and match without surprises.
+        """
+        _seed_claude_code(sandbox, {"x": {"command": "npx", "args": ["a", "b"]}})
+        _apply_claude_code(runner)
+
+        json_res = _status(runner, "--json")
+        payload = json.loads(json_res.output)
+        registry = state.load_registry()
+        assert payload["entries"][0]["baseline_hash"] == compute_drift_hash(registry.servers["x"])
+        assert payload["entries"][0]["current_hash"] == compute_drift_hash(registry.servers["x"])
+
+    def test_status_does_not_write_anything(self, runner, sandbox):
+        """Read-only invariant — running status N times must not
+        mutate registry or sidecar (mtimes / contents stable).
+        """
+        _seed_claude_code(sandbox, {"x": {"command": "npx"}})
+        _apply_claude_code(runner)
+
+        registry_before = Path(state.registry_path()).read_bytes()
+        sidecar_before = Path(state.import_state_path()).read_bytes()
+        for _ in range(3):
+            res = _status(runner)
+            assert res.exit_code == 0
+            res_json = _status(runner, "--json")
+            assert res_json.exit_code == 0
+        assert Path(state.registry_path()).read_bytes() == registry_before
+        assert Path(state.import_state_path()).read_bytes() == sidecar_before

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -133,14 +133,10 @@ class TestStates:
 
         res = _status(runner)
         assert res.exit_code == 0, res.output
-        # Removed entry stays out of the main table.
-        main_table = res.output.split("0 changed" if "0 changed" in res.output else "1 changed")[0]
-        # filesystem absent from the main-table half, github present.
-        # (Footer note still mentions filesystem? No — neutral phrasing
-        # uses count only, not name. Verified below.)
-        assert "github" in main_table
-        # Footer count + neutral phrasing (no "PR4" / "removed" name leak).
+        # Footer count + neutral phrasing (no PR-planning vocab leak).
         assert "1 entry in registry not present in any host scan" in res.output
+        # Main-table presence is asserted via the JSON shape below — the
+        # text split was brittle to footer rewording (PR4 may evolve it).
 
         json_res = _status(runner, "--json")
         payload = json.loads(json_res.output)
@@ -192,7 +188,9 @@ class TestStates:
                 assert row["baseline_hash"] is None
                 assert row["source_label"] is None
                 assert row["last_imported"] is None
-                # current_hash is computable from registry, so populated.
+                # current_hash reflects the host's view — github is
+                # still in the host config, so the host candidate's
+                # canonical hash is computable.
                 assert row["current_hash"] is not None
 
     def test_status_no_baseline_drift_hash_version_mismatch(self, runner, sandbox):
@@ -303,6 +301,23 @@ class TestSourceLabelMatching:
 
 
 class TestEdges:
+    def test_status_malformed_host_config_exit_0(self, runner, sandbox):
+        """Scanners catch parse errors at the import_hosts level
+        (import_hosts.py:_read_json_safely treats unreadable as "no
+        candidates"). PR3 must inherit that behavior — a malformed
+        host config is the same as missing host config, not a crash.
+        Pins the exit-0 contract against a future scanner refactor
+        that drops the catch.
+        """
+        _seed_claude_code(sandbox, {"x": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Now corrupt the host config — invalid JSON.
+        (sandbox["home"] / ".claude.json").write_text("{ this is not valid json", encoding="utf-8")
+
+        for args in ([], ["--json"]):
+            res = _status(runner, *args)
+            assert res.exit_code == 0, (args, res.output)
+
     def test_status_empty_registry(self, runner, sandbox):
         res = _status(runner)
         assert res.exit_code == 0, res.output
@@ -445,6 +460,66 @@ class TestPlumbing:
         registry = state.load_registry()
         assert payload["entries"][0]["baseline_hash"] == compute_drift_hash(registry.servers["x"])
         assert payload["entries"][0]["current_hash"] == compute_drift_hash(registry.servers["x"])
+
+    def test_current_hash_is_host_view_across_buckets(self, runner, sandbox):
+        """``current_hash`` means "the host's canonical hash, or null
+        if no host has the entry" in every bucket — including
+        ``no_baseline``. Without this, a script that recomputes
+        compute_drift_hash() against the live host config would match
+        for unchanged/changed but diverge for no_baseline whenever
+        registry and host differ (which is the most likely state when
+        the sidecar is stale).
+        """
+        # Apply with the canonical shape, then mutate the host to a
+        # different shape *and* drop the sidecar baseline. The registry
+        # still holds the original shape; the host now holds the new.
+        _seed_claude_code(sandbox, {"x": {"command": "npx", "args": ["original"]}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {"x": {"command": "npx", "args": ["edited"]}})
+        s = state.load_import_state()
+        s.entries.pop("x")
+        state.save_import_state(s)
+
+        json_res = _status(runner, "--json")
+        payload = json.loads(json_res.output)
+        row = payload["entries"][0]
+        assert row["state"] == "no_baseline"
+
+        # current_hash must reflect the *host's* current canonical form
+        # (the edited shape), not the registry entry. Recomputing
+        # against the host wire gives the same value back.
+        host_view = compute_drift_hash(
+            state.RegistryServer(
+                command="npx",
+                args=["edited"],
+                env={},
+                prefix="x",
+            )
+        )
+        registry_view = compute_drift_hash(state.load_registry().servers["x"])
+        assert row["current_hash"] == host_view
+        assert row["current_hash"] != registry_view  # the asymmetry the reviewer flagged
+
+    def test_current_hash_null_when_host_absent(self, runner, sandbox):
+        """When no host scanner finds the entry (``removed_at_host`` or
+        no_baseline-with-no-host), ``current_hash`` is null — the host
+        view is the empty set.
+        """
+        _seed_claude_code(sandbox, {"x": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Drop the entry from the host AND drop the sidecar row, so the
+        # row would be no_baseline (sidecar gate fires before host gate)
+        # but with no host candidate to compute current_hash against.
+        _seed_claude_code(sandbox, {})
+        s = state.load_import_state()
+        s.entries.pop("x")
+        state.save_import_state(s)
+
+        json_res = _status(runner, "--json")
+        payload = json.loads(json_res.output)
+        row = payload["entries"][0]
+        assert row["state"] == "no_baseline"
+        assert row["current_hash"] is None
 
     def test_status_does_not_write_anything(self, runner, sandbox):
         """Read-only invariant — running status N times must not


### PR DESCRIPTION
## Summary

- Adds `mms host status`, the read-only inspection surface for W2's host-sync work. Read-only, never mutates registry / sidecar / anywhere; exit code always 0 (drift is observation, not a CI failure signal).
- Classifies every registry entry into one of four buckets relative to the W2 sidecar baseline: `unchanged` / `changed` / `removed_at_host` / `no_baseline`. Lives in a new `host` click group reserved by RFC §7.3 for the upcoming `scan` and `sync` commands.
- `--json` output includes every state in `entries[]` and a four-key `summary` (zero counters explicit). Text output's main table only shows `unchanged` + `changed`; the other two are footer counts with neutral phrasing — PR4 promotes `removed_at_host` to the main table without renaming anything.

## Why four states (not two)

`import_state.entries[name]` can KeyError along three real paths that PR2's backfill alone doesn't close:

1. Manual sidecar edits (RFC §3 explicitly allows hand-editing these files; the sidecar isn't exempt).
2. Atomic-write race windows (`--apply` writes registry then sidecar; PR3 status called in between).
3. Pre-PR2 installs that upgrade to the wired mms but call `mms host status` before any `mms import --apply`.

Read-only inspection's first PR can't surface those as an unhandled traceback. `no_baseline` is the recovery bucket with an actionable hint (`run \`mms import --apply\` to stamp`). The same bucket also guards future `HASH_VERSION` bumps — PR3 is the first consumer of `drift_hash_version`, so without the gate here a v1 baseline vs v2 binary would silently miscompare as ""always changed"".

## source_label-preferred matching

When the same entry name appears in multiple host configs, the comparison candidate is chosen by `source_label` match against the sidecar baseline first, falling back to discover()'s `ALL_HOSTS` first-seen order. This keeps the comparison axis pinned to the import-time host — mirroring an entry into a second host doesn't flicker between `unchanged` and `changed` based on iteration order. Both arms (matched + fallback) are tested explicitly.

## What this is *not*

Each has an explicit reopen trigger documented either in the module docstring or in code comments:

- Per-key diff renderer (""which field changed""): wait-for-signal — user reports `"changed but I don't know what"` or one round of internal dogfooding.
- `changed` row actionable hints: PR3 is observation only; the `no_baseline` hint is invariant-violation recovery, a different category.
- `--strict` / exit-non-zero-on-drift flag: wait-for-signal.
- `mms host scan` / `mms host sync`: separate PRs in the same group.
- W3+ `--force` re-stamp existing sidecar rows.

## Test plan

- [x] `uv run pytest tests/cli/test_mms_host.py` — 14 passed, all four states explicitly covered.
- [x] `uv run pytest -m \"not ollama\"` — 2009 passed (full regression green).
- [x] `uv run ruff check src tests && uv run ruff format --check src/memtomem_stm/cli/mms_host.py tests/cli/test_mms_host.py src/memtomem_stm/cli/proxy.py` — clean.
- [x] `uv run mypy src/memtomem_stm/cli/mms_host.py` — clean (advisory; pre-existing `proxy/manager.py` errors unchanged).
- [x] Manual smoke: seed claude-code → `mms import --apply` → `mms host status` (all unchanged); edit host config → `mms host status` (one changed); delete entry from host → footer note + 0 changed at host; manually delete sidecar entry → footer note with actionable hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)