### PR TITLE
feat(mms): W2 PR4 — `removed_at_host` main-table promotion

### DIFF
--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -197,9 +197,12 @@ def _render_text(rows: list[dict]) -> None:
     Main table shows ``unchanged`` + ``changed`` + ``removed_at_host``
     rows — the three states that carry a baseline source attribution
     and benefit from name-level visibility. ``no_baseline`` stays
-    footer-only: re-stamping via ``mms import --apply`` is the only
-    meaningful response, and the row has no ``source_label`` /
-    ``baseline_hash`` to populate the SOURCE column.
+    footer-only: the only meaningful response is ``mms import --apply``
+    to re-stamp, and the footer's hint conveys that more directly than
+    a table row would. (The version-mismatch sub-case does carry a real
+    ``source_label`` and ``baseline_hash``; the missing-sidecar
+    sub-case doesn't — but the user-facing action is the same either
+    way.)
 
     ``removed_at_host`` rows render with ``current_hash=None`` (no
     host candidate to canonicalize) but the table only shows NAME +

--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -1,15 +1,17 @@
 """``mms host`` Click subgroup — W2 host-sync surfaces (RFC §7.3).
 
-PR3 lands the read-only inspection command:
+PR3 landed the read-only inspection command; PR4 promoted
+``removed_at_host`` from a footer-only count into a main-table row:
 
 * ``mms host status`` — classify every registry entry into one of four
   drift buckets relative to the W2 sidecar baseline, and surface the
   result either as a human table or ``--json``.
 
-The bucket vocabulary is the contract that PR4 (``removed_at_host``
-main-table promotion) and W3+ (``--force`` re-stamp) build on. PR3
-freezes the four state names; PR4 swaps a footer note for a main-table
-row but does not rename anything.
+The bucket vocabulary is the contract that W3+ (``--force`` re-stamp,
+``mms host scan``, ``mms host sync``) builds on. PR3 froze the four
+state names; PR4 changed *where* ``removed_at_host`` renders without
+renaming anything. JSON shape and footer text are backwards-compat
+anchors and stayed frozen across PR4.
 
 The four buckets:
 
@@ -19,8 +21,10 @@ The four buckets:
   differs (host config was edited externally since last
   ``mms import --apply``).
 * ``removed_at_host`` — registry has the entry, sidecar has the
-  baseline, but no host scanner finds it. PR3 surfaces this in the
-  footer as a count + neutral note; PR4 promotes it to the main table.
+  baseline, but no host scanner finds it. PR3 surfaced this as a
+  footer count + neutral note only; PR4 added a main-table row while
+  keeping the footer count as a backwards-compat anchor for downstream
+  tooling that grepped PR3's output.
 * ``no_baseline`` — sidecar lacks a row for this entry, OR the
   sidecar's ``drift_hash_version`` doesn't match the running mms's
   :data:`HASH_VERSION`. Either way the comparison can't be made and
@@ -190,29 +194,44 @@ def _classify(
 def _render_text(rows: list[dict]) -> None:
     """Default human-readable renderer.
 
-    Main table shows ``unchanged`` + ``changed`` rows (the comparable
-    states). ``removed_at_host`` and ``no_baseline`` are footer notes
-    only — they don't have a meaningful current-hash to put in the
-    SOURCE/STATE pair, so dumping them in the table would dilute the
-    comparison signal. Each is conditionally shown when its count > 0.
+    Main table shows ``unchanged`` + ``changed`` + ``removed_at_host``
+    rows — the three states that carry a baseline source attribution
+    and benefit from name-level visibility. ``no_baseline`` stays
+    footer-only: re-stamping via ``mms import --apply`` is the only
+    meaningful response, and the row has no ``source_label`` /
+    ``baseline_hash`` to populate the SOURCE column.
+
+    ``removed_at_host`` rows render with ``current_hash=None`` (no
+    host candidate to canonicalize) but the table only shows NAME +
+    STATE + SOURCE, all of which come from the preserved baseline. The
+    footer count + neutral note still appear after the summary line as
+    a backwards-compat anchor for downstream tooling that grepped
+    PR3's output — duplication with the table row is intentional.
+
+    Rows render in ``registry.servers`` insertion order (registry.toml
+    file order). Stable order > clever sort; if a user reports they
+    missed a single ``removed_at_host`` buried among many ``unchanged``
+    rows, swap in a state-priority sort here.
 
     Column widths follow ``mms project list`` (mms_project.py:285):
     plain f-strings, no rich. Alignment is best-effort — names longer
     than the NAME column overflow rather than truncate. Not a contract;
     swap in textual/rich/whatever when MCP names regularly exceed 20
-    chars in practice.
+    chars in practice. STATE is widened to 16 chars so
+    ``removed_at_host`` (15) fits with one char of padding past the
+    longest state name.
     """
-    main_rows = [r for r in rows if r["state"] in ("unchanged", "changed")]
+    main_rows = [r for r in rows if r["state"] in ("unchanged", "changed", "removed_at_host")]
     n_unchanged = sum(1 for r in main_rows if r["state"] == "unchanged")
     n_changed = sum(1 for r in main_rows if r["state"] == "changed")
     n_removed = sum(1 for r in rows if r["state"] == "removed_at_host")
     n_no_baseline = sum(1 for r in rows if r["state"] == "no_baseline")
 
     if main_rows:
-        click.echo(f" {'NAME':<20} {'STATE':<10} SOURCE")
+        click.echo(f" {'NAME':<20} {'STATE':<16} SOURCE")
         for row in main_rows:
             source = row["source_label"] or ""
-            click.echo(f" {row['name']:<20} {row['state']:<10} {source}")
+            click.echo(f" {row['name']:<20} {row['state']:<16} {source}")
         click.echo("")
     click.echo(f" {n_unchanged} unchanged, {n_changed} changed at host")
     if n_removed:

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -134,9 +134,17 @@ class TestStates:
         res = _status(runner)
         assert res.exit_code == 0, res.output
         # Footer count + neutral phrasing (no PR-planning vocab leak).
+        # Backwards-compat anchor — pinned across PR4's main-table promotion.
         assert "1 entry in registry not present in any host scan" in res.output
-        # Main-table presence is asserted via the JSON shape below — the
-        # text split was brittle to footer rewording (PR4 may evolve it).
+        # PR4: removed_at_host now renders as a main-table row, not only a
+        # footer count. Pin the row at line level so a future text-format
+        # refactor that splits NAME and STATE across lines (or drops SOURCE)
+        # fails this test loudly.
+        lines = res.output.splitlines()
+        removed_row = next((line for line in lines if "removed_at_host" in line), None)
+        assert removed_row is not None, res.output
+        assert "filesystem" in removed_row
+        assert "Claude Code (user)" in removed_row
 
         json_res = _status(runner, "--json")
         payload = json.loads(json_res.output)
@@ -148,6 +156,42 @@ class TestStates:
                 assert row["current_hash"] is None
                 assert row["baseline_hash"] is not None  # baseline preserved
                 assert row["source_label"] == "Claude Code (user)"
+
+    def test_status_only_removed_at_host_renders_table(self, runner, sandbox):
+        """PR4 reachable path: only ``removed_at_host`` rows, zero
+        ``unchanged`` / ``changed``. The table must still render
+        (header + each removed row); footer summary + removed-at-host
+        count still appear. Guards against a future refactor that
+        re-narrows the ``if main_rows:`` guard to comparable states
+        only — that would break PR4's promotion silently.
+        """
+        _seed_claude_code(
+            sandbox,
+            {"a": {"command": "npx"}, "b": {"command": "npx"}},
+        )
+        _apply_claude_code(runner)
+        # Drop both entries from the host config — registry/sidecar still have them.
+        _seed_claude_code(sandbox, {})
+
+        res = _status(runner)
+        assert res.exit_code == 0, res.output
+        # Header rendered (table not suppressed by the if-guard).
+        assert "NAME" in res.output
+        assert "STATE" in res.output
+        assert "SOURCE" in res.output
+        # Both rows present in the body, each on its own line.
+        lines = res.output.splitlines()
+        removed_lines = [line for line in lines if "removed_at_host" in line]
+        # 2 table rows + 1 footer note line that also contains the substring
+        # via the "removed_at_host" classifier name? No — the footer template
+        # ("...not present in any host scan") doesn't say removed_at_host, so
+        # only the 2 table rows match.
+        assert len(removed_lines) == 2, res.output
+        assert any(" a " in line for line in removed_lines)
+        assert any(" b " in line for line in removed_lines)
+        # Summary + footer still appear.
+        assert "0 unchanged, 0 changed at host" in res.output
+        assert "2 entries in registry not present in any host scan" in res.output
 
     def test_status_no_baseline_missing_sidecar_entry(self, runner, sandbox):
         """Manual sidecar deletion / pre-PR2 install / atomic-write race —

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -180,12 +180,10 @@ class TestStates:
         assert "STATE" in res.output
         assert "SOURCE" in res.output
         # Both rows present in the body, each on its own line.
+        # 2 table rows; the footer ("...not present in any host scan")
+        # doesn't contain "removed_at_host".
         lines = res.output.splitlines()
         removed_lines = [line for line in lines if "removed_at_host" in line]
-        # 2 table rows + 1 footer note line that also contains the substring
-        # via the "removed_at_host" classifier name? No — the footer template
-        # ("...not present in any host scan") doesn't say removed_at_host, so
-        # only the 2 table rows match.
         assert len(removed_lines) == 2, res.output
         assert any(" a " in line for line in removed_lines)
         assert any(" b " in line for line in removed_lines)


### PR DESCRIPTION
## Summary

PR3 (#282) shipped the 4-state classifier for `mms host status` but only rendered `unchanged` + `changed` rows in the main human-readable table. `removed_at_host` was surfaced as a footer count + neutral note only, which buries actionable rows for users with many registry entries.

This PR promotes `removed_at_host` into the main table while keeping PR3's footer text and JSON shape **frozen as backwards-compat anchors**. `no_baseline` stays footer-only — re-stamping via `mms import --apply` is the only meaningful response and there's no useful SOURCE/STATE pair to render for a missing baseline.

### What changed

- `src/memtomem_stm/cli/mms_host.py`
  - `_render_text()` filter now includes `removed_at_host` in `main_rows`.
  - STATE column width widened `:<10` → `:<16` so `removed_at_host` (15) fits with one char of padding past the longest state name.
  - `_render_text()` docstring rewritten — the previous "removed_at_host has no meaningful current-hash for SOURCE/STATE" rationale was tied to footer-only rendering and is now stale.
  - Module docstring flipped from future-tense intent ("PR4 promotes it") to past-tense fact, plus an explicit note that JSON shape and footer text are PR3 anchors that PR4 preserved.

- `tests/cli/test_mms_host.py`
  - `TestStates::test_status_removed_at_host` extended with a **line-level** row pin (NAME + STATE + SOURCE on one line). Substring-only matches don't guarantee co-located tokens — this echoes PR3's own forward-looking note about text-split brittleness.
  - New `TestStates::test_status_only_removed_at_host_renders_table` covers the new reachable path (`unchanged + changed == 0`, `removed_at_host > 0`). Without this, a future refactor that re-narrows the `if main_rows:` guard back to comparable-only states would break PR4 silently.

### What stayed frozen

- `_render_json()` — schema unchanged (entries[] + 4-key summary). Pinned by `TestJsonShape::test_status_json_shape_includes_all_states`.
- `_classify()` — bucket vocabulary + per-row dict shape unchanged.
- `_FOOTER_REMOVED_AT_HOST_TEMPLATE` and `_FOOTER_NO_BASELINE_TEMPLATE` — verbatim. Footer count + neutral note still appear after the summary line. Duplication with the new table row is intentional; downstream tooling that grepped PR3's footer doesn't break.
- Summary line `"N unchanged, M changed at host"` — verbatim.

### Sample output (after PR4)

```
 NAME                 STATE            SOURCE
 filesystem           removed_at_host  Claude Code (user)
 github               unchanged        Claude Code (user)

 1 unchanged, 0 changed at host
 1 entry in registry not present in any host scan
```

### Row ordering

Rows render in `registry.servers` insertion order (registry.toml file order) — **stable order > clever sort** for now. If a user reports a single `removed_at_host` row buried among many `unchanged` rows, the fix is a 1-line state-priority sort at the top of `_render_text()`. Documented in the docstring as a wait-for-signal reopen trigger.

## Test plan

- [x] `uv run pytest tests/cli/test_mms_host.py -v` — 18/18 passed (17 pre-PR + 1 net new + 1 extended in place)
- [x] `uv run pytest -m "not ollama"` — 2013 passed (full CI filter)
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run mypy src` — no new errors (2 pre-existing in `proxy/manager.py`, unrelated)

## Chain context

W2 host-sync chain progression:
- W2 PR1 (#280) — drift-hash foundation (canonical form + sidecar)
- W2 PR2 (#281) — wire drift-hash into `mms import --apply`
- W2 PR3 (#282) — `mms host status` 4-state classifier (footer-only `removed_at_host`)
- **W2 PR4 (this PR)** — `removed_at_host` main-table promotion
- Next: `mms host scan` → `mms host sync` → W3+ `--force` re-stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)
