### PR TITLE
feat(mms): W2 PR5 — `mms host scan` (host-side discovery surface)

### DIFF
--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -55,7 +55,7 @@ import click
 
 from memtomem_stm.mms import state
 from memtomem_stm.mms.drift import HASH_VERSION, compute_drift_hash
-from memtomem_stm.mms.import_hosts import ImportCandidate, discover
+from memtomem_stm.mms.import_hosts import ALL_HOSTS, ImportCandidate, discover
 
 # ---------------------------------------------------------------------------
 # Pinned UX strings — kept as module constants so tests assert against the
@@ -71,11 +71,13 @@ _FOOTER_NO_BASELINE_TEMPLATE = (
     "{n} entr{ies_or_y} missing baseline hash — run `mms import --apply` to stamp"
 )
 
-_NO_SCAN_RESULTS_MSG = "No MCP entries discovered across host configs.\n"
-
-# `mms host scan --from` choices. Subset of ALL_HOSTS plus the "all" sentinel
-# that ``import_hosts.discover()`` recognizes natively.
-_SCAN_HOST_CHOICES = click.Choice(["all", "claude-code", "cursor", "codex", "claude-desktop"])
+# `mms host scan --from` choices. Derived from canonical ``ALL_HOSTS`` plus
+# the "all" sentinel that ``import_hosts.discover()`` recognizes natively
+# — when a 5th host is added to ``ALL_HOSTS``, scan picks it up automatically
+# without a literal-list drift. ``case_sensitive=False`` matches ``mms
+# import --from``'s contract so users get symmetric UX (``mms host scan
+# --from CLAUDE-CODE`` works the same as ``mms import --from CLAUDE-CODE``).
+_SCAN_HOST_CHOICES = click.Choice([*ALL_HOSTS, "all"], case_sensitive=False)
 
 
 def _ies_or_y(n: int) -> str:
@@ -340,21 +342,31 @@ def _scan_rows(
     ]
 
 
-def _render_scan_text(rows: list[dict]) -> None:
+def _render_scan_text(rows: list[dict], from_host: str) -> None:
     """Default human-readable scan renderer.
 
-    Empty case: friendly one-liner. Non-empty: 3-column table (NAME /
-    HOST / IN_REGISTRY) followed by a summary line. ``Yes``/``No`` for
-    the boolean column — universal terminal encoding (no ✓/✗
-    glyphs that break on Windows cmd or restrictive SSH clients).
+    Empty case: scoped one-liner — ``across host configs`` when no
+    filter is in play, ``in <host>`` when ``--from <host>`` filters to
+    one scanner. Non-empty: 3-column table (NAME / HOST / IN_REGISTRY)
+    followed by a summary line. ``Yes``/``No`` for the boolean column —
+    universal terminal encoding (no ✓/✗ glyphs that break on Windows
+    cmd or restrictive SSH clients).
 
     Same-name multi-host rows are emitted in full — intentional
     divergence from ``mms host status``'s first-match-wins (scan is
     *collection*, status is *comparison*; they answer different
     questions and shouldn't share dedup logic).
+
+    Rows render in ``ALL_HOSTS`` × per-scanner-discovery order. When
+    the same name lives in two hosts that aren't iterated back-to-back,
+    its rows may not be visually adjacent. JSON consumers grouping by
+    name should sort their own pass. Reopen trigger for an
+    alphabetical or state-priority sort here = user reports buried
+    duplicates.
     """
     if not rows:
-        click.echo(_NO_SCAN_RESULTS_MSG, nl=False)
+        scope = "across host configs" if from_host == "all" else f"in {from_host}"
+        click.echo(f"No MCP entries discovered {scope}.\n", nl=False)
         return
     click.echo(f" {'NAME':<20} {'HOST':<22} IN_REGISTRY")
     for row in rows:
@@ -365,8 +377,10 @@ def _render_scan_text(rows: list[dict]) -> None:
     n_in_reg = sum(1 for r in rows if r["in_registry"])
     n_new = n_total - n_in_reg
     n_hosts = len({r["host"] for r in rows})
+    entries_word = f"entr{_ies_or_y(n_total)}"
+    hosts_word = "host" if n_hosts == 1 else "hosts"
     click.echo(
-        f" {n_total} entries across {n_hosts} host{'s' if n_hosts != 1 else ''} "
+        f" {n_total} {entries_word} across {n_hosts} {hosts_word} "
         f"({n_in_reg} in registry, {n_new} new at host)"
     )
 
@@ -423,4 +437,4 @@ def scan_cmd(from_host: str, json_output: bool) -> None:
     if json_output:
         _render_scan_json(rows)
     else:
-        _render_scan_text(rows)
+        _render_scan_text(rows, from_host)

--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -71,6 +71,12 @@ _FOOTER_NO_BASELINE_TEMPLATE = (
     "{n} entr{ies_or_y} missing baseline hash — run `mms import --apply` to stamp"
 )
 
+_NO_SCAN_RESULTS_MSG = "No MCP entries discovered across host configs.\n"
+
+# `mms host scan --from` choices. Subset of ALL_HOSTS plus the "all" sentinel
+# that ``import_hosts.discover()`` recognizes natively.
+_SCAN_HOST_CHOICES = click.Choice(["all", "claude-code", "cursor", "codex", "claude-desktop"])
+
 
 def _ies_or_y(n: int) -> str:
     return "y" if n == 1 else "ies"
@@ -306,3 +312,115 @@ def status_cmd(json_output: bool) -> None:
         _render_json(rows)
     else:
         _render_text(rows)
+
+
+# ---------------------------------------------------------------------------
+# scan — host-side discovery surface (W2 PR5)
+# ---------------------------------------------------------------------------
+
+
+def _scan_rows(
+    candidates: list[ImportCandidate],
+    registry: state.RegistryConfig,
+) -> list[dict]:
+    """Project each ImportCandidate into a scan row.
+
+    No deduplication: same name across hosts emits multiple rows — the
+    full host-side inventory is the value scan provides. ``in_registry``
+    is a name match only (``cand.name in registry.servers``); shape
+    comparison is delegated to ``mms host status``.
+    """
+    return [
+        {
+            "name": c.name,
+            "host": c.source_label,
+            "in_registry": c.name in registry.servers,
+        }
+        for c in candidates
+    ]
+
+
+def _render_scan_text(rows: list[dict]) -> None:
+    """Default human-readable scan renderer.
+
+    Empty case: friendly one-liner. Non-empty: 3-column table (NAME /
+    HOST / IN_REGISTRY) followed by a summary line. ``Yes``/``No`` for
+    the boolean column — universal terminal encoding (no ✓/✗
+    glyphs that break on Windows cmd or restrictive SSH clients).
+
+    Same-name multi-host rows are emitted in full — intentional
+    divergence from ``mms host status``'s first-match-wins (scan is
+    *collection*, status is *comparison*; they answer different
+    questions and shouldn't share dedup logic).
+    """
+    if not rows:
+        click.echo(_NO_SCAN_RESULTS_MSG, nl=False)
+        return
+    click.echo(f" {'NAME':<20} {'HOST':<22} IN_REGISTRY")
+    for row in rows:
+        flag = "Yes" if row["in_registry"] else "No"
+        click.echo(f" {row['name']:<20} {row['host']:<22} {flag}")
+    click.echo("")
+    n_total = len(rows)
+    n_in_reg = sum(1 for r in rows if r["in_registry"])
+    n_new = n_total - n_in_reg
+    n_hosts = len({r["host"] for r in rows})
+    click.echo(
+        f" {n_total} entries across {n_hosts} host{'s' if n_hosts != 1 else ''} "
+        f"({n_in_reg} in registry, {n_new} new at host)"
+    )
+
+
+def _render_scan_json(rows: list[dict]) -> None:
+    """JSON scan renderer. Always emits 3-key summary (zero counts explicit)."""
+    n_total = len(rows)
+    n_in_reg = sum(1 for r in rows if r["in_registry"])
+    payload = {
+        "entries": rows,
+        "summary": {
+            "total": n_total,
+            "in_registry": n_in_reg,
+            # ``new_at_host`` is the complementary symmetry to
+            # ``mms host status``'s ``removed_at_host`` (in registry,
+            # not at host vs at host, not in registry).
+            "new_at_host": n_total - n_in_reg,
+        },
+    }
+    click.echo(_json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+@host_group.command("scan")
+@click.option(
+    "--from",
+    "from_host",
+    type=_SCAN_HOST_CHOICES,
+    default="all",
+    show_default=True,
+    help="Limit scan to one host config.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+def scan_cmd(from_host: str, json_output: bool) -> None:
+    """List MCP entries discovered across host configs.
+
+    Read-only host-side inventory. Complements ``mms host status``:
+    scan is host-anchored (collection — every host occurrence shown),
+    status is registry-anchored (comparison — one row per registry
+    entry against sidecar baseline). When the same name appears in
+    multiple host configs, scan emits every occurrence; status's
+    first-match-wins is an axis difference, not an inconsistency.
+
+    The ``IN_REGISTRY`` column is a name match only
+    (``cand.name in registry.servers``). A registered entry whose host
+    shape differs still shows ``Yes`` here — shape comparison is
+    delegated to ``mms host status`` (it surfaces shape mismatches as
+    ``changed``).
+
+    Exit code is always 0; this is read-only inspection.
+    """
+    registry = state.load_registry()
+    candidates = discover(from_host, Path.cwd().resolve())
+    rows = _scan_rows(candidates, registry)
+    if json_output:
+        _render_scan_json(rows)
+    else:
+        _render_scan_text(rows)

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -57,6 +57,10 @@ def _status(runner, *args: str):
     return runner.invoke(host_group, ["status", *args])
 
 
+def _scan(runner, *args: str):
+    return runner.invoke(host_group, ["scan", *args])
+
+
 # ---------------------------------------------------------------------------
 # Core states
 # ---------------------------------------------------------------------------
@@ -577,5 +581,176 @@ class TestPlumbing:
             assert res.exit_code == 0
             res_json = _status(runner, "--json")
             assert res_json.exit_code == 0
+        assert Path(state.registry_path()).read_bytes() == registry_before
+        assert Path(state.import_state_path()).read_bytes() == sidecar_before
+
+
+# ---------------------------------------------------------------------------
+# scan — host-side discovery surface (W2 PR5)
+# ---------------------------------------------------------------------------
+
+
+class TestScan:
+    def test_scan_default_shows_all_hosts(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _seed_cursor_user(sandbox, {"b": {"command": "npx"}})
+
+        res = _scan(runner)
+        assert res.exit_code == 0, res.output
+        assert " a " in res.output
+        assert " b " in res.output
+        assert "Claude Code (user)" in res.output
+        assert "Cursor (user)" in res.output
+        assert "2 entries across 2 hosts" in res.output
+
+    def test_scan_in_registry_yes_after_apply(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"filesystem": {"command": "npx"}})
+        _apply_claude_code(runner)
+
+        res = _scan(runner)
+        assert res.exit_code == 0, res.output
+        # Find the row line; assert it ends with Yes (IN_REGISTRY column).
+        lines = res.output.splitlines()
+        row = next((line for line in lines if "filesystem" in line and "Claude Code" in line), None)
+        assert row is not None, res.output
+        assert row.rstrip().endswith("Yes"), row
+        assert "1 in registry, 0 new at host" in res.output
+
+        json_res = _scan(runner, "--json")
+        payload = json.loads(json_res.output)
+        assert payload["entries"][0]["in_registry"] is True
+        assert payload["summary"] == {"total": 1, "in_registry": 1, "new_at_host": 0}
+
+    def test_scan_in_registry_no_for_orphan(self, runner, sandbox):
+        # Cursor entry, never imported.
+        _seed_cursor_user(sandbox, {"shadcn": {"command": "npx"}})
+
+        res = _scan(runner)
+        assert res.exit_code == 0, res.output
+        lines = res.output.splitlines()
+        row = next((line for line in lines if "shadcn" in line), None)
+        assert row is not None, res.output
+        assert row.rstrip().endswith("No"), row
+        assert "0 in registry, 1 new at host" in res.output
+
+    def test_scan_same_name_multi_host_shows_both(self, runner, sandbox):
+        """Locked-in #1: full inventory. ``mms host status`` does
+        first-match-wins for its registry-comparison axis; ``scan`` has
+        no such axis and shows every host occurrence — intentional
+        divergence so users see real-world same-name mirroring.
+        """
+        _seed_claude_code(sandbox, {"filesystem": {"command": "npx", "args": ["-y", "@a/fs"]}})
+        _seed_cursor_user(sandbox, {"filesystem": {"command": "npx", "args": ["-y", "@b/fs"]}})
+
+        res = _scan(runner)
+        assert res.exit_code == 0, res.output
+        # Two text rows for the same name (one per host).
+        rows = [line for line in res.output.splitlines() if " filesystem " in line]
+        assert len(rows) == 2, res.output
+        assert any("Claude Code (user)" in line for line in rows)
+        assert any("Cursor (user)" in line for line in rows)
+
+        json_res = _scan(runner, "--json")
+        payload = json.loads(json_res.output)
+        fs_entries = [e for e in payload["entries"] if e["name"] == "filesystem"]
+        assert len(fs_entries) == 2, payload
+        assert payload["summary"]["total"] == 2
+
+    def test_scan_from_filter_single_host(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _seed_cursor_user(sandbox, {"b": {"command": "npx"}})
+
+        res = _scan(runner, "--from", "cursor")
+        assert res.exit_code == 0, res.output
+        assert " b " in res.output
+        assert " a " not in res.output  # claude-code excluded
+        assert "Claude Code (user)" not in res.output
+        assert "1 entries across 1 host" in res.output  # singular host phrasing
+
+    def test_scan_from_invalid_host_errors(self, runner, sandbox):
+        res = _scan(runner, "--from", "foo")
+        # click.Choice rejects with UsageError → exit code 2.
+        assert res.exit_code == 2, res.output
+        assert "foo" in res.output
+        assert "claude-code" in res.output  # choices listed in error
+
+    def test_scan_empty_no_host_configs(self, runner, sandbox):
+        res = _scan(runner)
+        assert res.exit_code == 0, res.output
+        assert "No MCP entries discovered across host configs." in res.output
+
+    def test_scan_empty_no_host_configs_json(self, runner, sandbox):
+        res = _scan(runner, "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        # Locked-in #4: 3-key always-emit summary, zero counts explicit.
+        assert payload == {
+            "entries": [],
+            "summary": {"total": 0, "in_registry": 0, "new_at_host": 0},
+        }
+
+    def test_scan_json_shape(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"registered": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_cursor_user(sandbox, {"orphan": {"command": "npx"}})
+
+        # Re-seed claude-code so it still has the registered entry after the
+        # cursor seed (the prior _apply_claude_code put it in registry, but
+        # the host scan reads ~/.claude.json on every invocation).
+        _seed_claude_code(sandbox, {"registered": {"command": "npx"}})
+
+        res = _scan(runner, "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+
+        # Per-entry required keys (locked-in shape).
+        required = {"name", "host", "in_registry"}
+        for entry in payload["entries"]:
+            assert set(entry.keys()) == required, entry
+
+        # Summary keys (locked-in #4).
+        assert set(payload["summary"].keys()) == {"total", "in_registry", "new_at_host"}
+
+        states = {e["name"]: e["in_registry"] for e in payload["entries"]}
+        assert states == {"registered": True, "orphan": False}
+        assert payload["summary"] == {"total": 2, "in_registry": 1, "new_at_host": 1}
+
+    def test_scan_in_registry_name_match_only_not_shape(self, runner, sandbox):
+        """Locked-in #2: ``IN_REGISTRY`` is a name match only. Shape
+        comparison is delegated to ``mms host status`` — registered
+        entry whose host shape differs still shows ``Yes`` here.
+        """
+        _seed_claude_code(sandbox, {"filesystem": {"command": "npx", "args": ["-y", "@a/fs"]}})
+        _apply_claude_code(runner)
+
+        # Mutate the host config — same name, different args → "changed"
+        # in status's vocab. scan should still report Yes.
+        _seed_claude_code(sandbox, {"filesystem": {"command": "npx", "args": ["-y", "@b/fs"]}})
+
+        res = _scan(runner, "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["entries"][0]["in_registry"] is True
+
+        # Cross-check: status would call this `changed`, demonstrating the
+        # contrast. scan's `IN_REGISTRY=Yes` and status's `changed` are
+        # both true at once — they're orthogonal axes, not a contradiction.
+        status_res = _status(runner, "--json")
+        status_payload = json.loads(status_res.output)
+        assert status_payload["entries"][0]["state"] == "changed"
+
+    def test_scan_does_not_write_anything(self, runner, sandbox):
+        """Read-only invariant. Mirrors ``test_status_does_not_write_anything``."""
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}, "b": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_cursor_user(sandbox, {"c": {"command": "npx"}})
+
+        registry_before = Path(state.registry_path()).read_bytes()
+        sidecar_before = Path(state.import_state_path()).read_bytes()
+
+        for args in ([], ["--json"], ["--from", "cursor"], ["--from", "claude-code", "--json"]):
+            res = _scan(runner, *args)
+            assert res.exit_code == 0, (args, res.output)
+
         assert Path(state.registry_path()).read_bytes() == registry_before
         assert Path(state.import_state_path()).read_bytes() == sidecar_before

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -665,7 +665,8 @@ class TestScan:
         assert " b " in res.output
         assert " a " not in res.output  # claude-code excluded
         assert "Claude Code (user)" not in res.output
-        assert "1 entries across 1 host" in res.output  # singular host phrasing
+        # Pin both singular forms — `entry`/`host` (not `entries`/`hosts`).
+        assert "1 entry across 1 host" in res.output
 
     def test_scan_from_invalid_host_errors(self, runner, sandbox):
         res = _scan(runner, "--from", "foo")
@@ -689,15 +690,44 @@ class TestScan:
             "summary": {"total": 0, "in_registry": 0, "new_at_host": 0},
         }
 
+    def test_scan_empty_filtered_host_message_scoped(self, runner, sandbox):
+        """``--from cursor`` with cursor empty (other hosts populated)
+        must say ``in cursor``, not the misleading ``across host
+        configs``. JSON shape unaffected (always 3-key summary).
+        """
+        _seed_claude_code(sandbox, {"only-claude-code-entry": {"command": "npx"}})
+
+        res = _scan(runner, "--from", "cursor")
+        assert res.exit_code == 0, res.output
+        assert "No MCP entries discovered in cursor." in res.output
+        assert "across host configs" not in res.output
+
+        json_res = _scan(runner, "--from", "cursor", "--json")
+        assert json_res.exit_code == 0, json_res.output
+        assert json.loads(json_res.output) == {
+            "entries": [],
+            "summary": {"total": 0, "in_registry": 0, "new_at_host": 0},
+        }
+
+    def test_scan_from_filter_case_insensitive(self, runner, sandbox):
+        """``--from CLAUDE-CODE`` works the same as ``--from
+        claude-code`` — symmetric with ``mms import --from`` UX. Pins
+        the ``case_sensitive=False`` derivation from ``ALL_HOSTS``.
+        """
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+
+        res = _scan(runner, "--from", "CLAUDE-CODE")
+        assert res.exit_code == 0, res.output
+        assert " a " in res.output
+        assert "Claude Code (user)" in res.output
+
     def test_scan_json_shape(self, runner, sandbox):
         _seed_claude_code(sandbox, {"registered": {"command": "npx"}})
         _apply_claude_code(runner)
+        # ``mms import --apply`` is read-only on host configs (project
+        # invariant) — the claude-code seed survives the cursor seed and
+        # the apply, so no re-seed needed.
         _seed_cursor_user(sandbox, {"orphan": {"command": "npx"}})
-
-        # Re-seed claude-code so it still has the registered entry after the
-        # cursor seed (the prior _apply_claude_code put it in registry, but
-        # the host scan reads ~/.claude.json on every invocation).
-        _seed_claude_code(sandbox, {"registered": {"command": "npx"}})
 
         res = _scan(runner, "--json")
         assert res.exit_code == 0, res.output


### PR DESCRIPTION
## Summary

Adds `mms host scan` — a **read-only host inventory** subcommand under the existing `host` Click group. Walks all 4 host configs (claude-code / cursor / codex / claude-desktop) via `import_hosts.discover()` and surfaces every discovered MCP entry with three columns: `NAME` / `HOST` / `IN_REGISTRY`.

`mms host scan` is **host-anchored** (collection — every host occurrence shown); `mms host status` is **registry-anchored** (comparison — one row per registry entry vs sidecar baseline). The two complement; neither subsumes the other.

User workflow:
- "Before importing, what's there?" → `mms host scan`
- "After importing, has anything drifted?" → `mms host status`

### Locked-in design choices (pinned in tests + docstring)

1. **Same-name multi-host = full inventory.** When the same entry name appears in multiple host configs, scan emits every occurrence. `mms host status`'s first-match-wins (`_select_candidate_by_name` Pass 1+2) is registry-comparison-axis logic; scan has no such axis. Intentional divergence — *scan = collection, status = comparison*. Pinned by `test_scan_same_name_multi_host_shows_both`.

2. **`IN_REGISTRY` = name match only** (`cand.name in registry.servers`). A registered entry whose host shape differs still shows `Yes` here. Shape comparison is delegated to `mms host status` (it surfaces shape mismatches as `changed`). Pinned by `test_scan_in_registry_name_match_only_not_shape` — which also asserts the cross-axis: scan reports `IN_REGISTRY=Yes` AND status reports `state=changed` for the same entry, demonstrating they're orthogonal axes, not a contradiction.

3. **Rendering = `Yes` / `No`** (text); native `boolean` (JSON). No `✓` / `✗` symbols — terminal-encoding portability matters (Windows cmd, restrictive SSH clients, CI log parsers).

4. **JSON summary keys = `total` / `in_registry` / `new_at_host`.** `new_at_host` is the complementary symmetry to `mms host status`'s `removed_at_host` (in registry, not at host vs at host, not in registry — same boundary, opposite direction). Always emit all 3 keys with zero counts explicit, parallel to status's 4-key always-emit invariant.

### Sample output

```
 NAME                 HOST                   IN_REGISTRY
 filesystem           Claude Code (user)     Yes
 filesystem           Cursor (user)          Yes
 shadcn-ui            Claude Code (user)     No
 github               Codex (user)           Yes

 4 entries across 3 hosts (3 in registry, 1 new at host)
```

```bash
$ mms host scan --from cursor --json
{
  "entries": [
    {"name": "filesystem", "host": "Cursor (user)", "in_registry": true}
  ],
  "summary": {"total": 1, "in_registry": 1, "new_at_host": 0}
}
```

## What this PR is NOT

- **Not a write surface.** Read-only invariant pinned by `test_scan_does_not_write_anything` (mirrors PR3's `test_status_does_not_write_anything`).
- **Not a drift detector.** `IN_REGISTRY` is a binary name match. Shape mismatches are `mms host status`'s `changed` bucket.
- **Not a duplicate of `mms import --plan`.** `import --plan` is registry-write-anchored (shows what *would be added* with secret redaction). `host scan` is host-discovery-anchored (shows what *exists*; for env see `mms import --plan --show-imported`).
- **Not part of the W2 sidecar story.** `mms host scan` doesn't read `~/.mms/import_state.toml` at all — sidecar/baseline comparison is exclusively `mms host status`'s axis.

## Test plan

- [x] `uv run pytest tests/cli/test_mms_host.py -v` — 29/29 passed (existing 18 + 11 new under `TestScan`)
- [x] `uv run pytest -m "not ollama"` — 2024 passed (full CI filter; +11 from PR4's 2013)
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] Locked-in choices each have a dedicated test pin (see #1–#4 above)

## Chain context

W2 host-sync chain progression:
- W2 PR1 (#280) — drift-hash foundation
- W2 PR2 (#281) — wire drift-hash into `mms import --apply` + backfill
- W2 PR3 (#282) — `mms host status` 4-state classifier
- W2 PR4 (#283) — `removed_at_host` main-table promotion
- **W2 PR5 (this PR)** — `mms host scan` host-side discovery surface
- Next: `mms host sync --plan/--apply` (the actual write surface) → W3+ `--force` re-stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)