### PR TITLE
feat(mms): W2 PR6 — `mms host sync --plan/--apply`

### DIFF
--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -49,10 +49,12 @@ into a second host — the import-time host stays the comparison axis.
 from __future__ import annotations
 
 import json as _json
+import sys
 from pathlib import Path
 
 import click
 
+from memtomem_stm.cli.mms_import import _classify_against_registry, _format_env_summary
 from memtomem_stm.mms import state
 from memtomem_stm.mms.drift import HASH_VERSION, compute_drift_hash
 from memtomem_stm.mms.import_hosts import ALL_HOSTS, ImportCandidate, discover
@@ -79,9 +81,61 @@ _FOOTER_NO_BASELINE_TEMPLATE = (
 # --from CLAUDE-CODE`` works the same as ``mms import --from CLAUDE-CODE``).
 _SCAN_HOST_CHOICES = click.Choice([*ALL_HOSTS, "all"], case_sensitive=False)
 
+# ---------------------------------------------------------------------------
+# sync UX strings — pinned templates so tests assert against the *symbol*.
+# When W3 ships ``mms host sync --force`` for the ``changed`` bucket, drop
+# the trailing " (W3+)" from ``_SYNC_CHANGED_FOOTER_TEMPLATE``.
+# ---------------------------------------------------------------------------
+
+_SYNC_NO_OP_MSG = "Already synchronized. No changes."
+
+_SYNC_CHANGED_FOOTER_TEMPLATE = (
+    "{n} entr{ies_or_y} differ in shape at host. Use `mms host sync --force` to acknowledge (W3+)."
+)
+
+_SYNC_ORPHAN_NO_BASELINE_FOOTER_TEMPLATE = (
+    "{n} entr{ies_or_y} in registry without baseline and not at any host scan."
+)
+
+_SYNC_REMOVE_PROMPT_HEADER_TEMPLATE = (
+    "The following {n} entr{ies_or_y} will be removed from registry:"
+)
+
+_SYNC_REMOVE_PROMPT_TAIL_TEMPLATE = (
+    "Also: {added} added, {backfilled} backfilled, "
+    "{cleanup} stale sidecar entr{cleanup_ies_or_y} cleaned."
+)
+
+_SYNC_NON_TTY_ABORT_TEMPLATE = (
+    "Refusing to remove {n} registry entr{ies_or_y} non-interactively. Pass --yes to confirm."
+)
+
+_SYNC_DECLINE_MSG = "Aborted. No changes."
+
+# Hint inserted under the ADD bucket (text mode) when any new candidate
+# carries secret env. ``mms host sync`` deliberately does not offer
+# ``--show-imported`` itself — escape hatch is ``mms import --plan
+# --show-imported``. Surface it visibly so users don't grep the docs.
+_SYNC_SHOW_IMPORTED_HINT = (
+    "    (Use `mms import --plan --show-imported` to inspect ADD env values before --apply.)"
+)
+
 
 def _ies_or_y(n: int) -> str:
     return "y" if n == 1 else "ies"
+
+
+def _is_interactive() -> bool:
+    """TTY check for ``sync --apply`` confirmation gating.
+
+    Wrapped as a module-level function so tests can flip the value
+    cleanly via ``monkeypatch.setattr(mms_host, "_is_interactive",
+    ...)``. ``CliRunner`` replaces ``sys.stdin`` with a non-TTY
+    stream, so calling ``sys.stdin.isatty()`` directly inside tests
+    would always read False — which would block the TTY-confirm test
+    paths.
+    """
+    return sys.stdin.isatty()
 
 
 # ---------------------------------------------------------------------------
@@ -438,3 +492,410 @@ def scan_cmd(from_host: str, json_output: bool) -> None:
         _render_scan_json(rows)
     else:
         _render_scan_text(rows, from_host)
+
+
+# ---------------------------------------------------------------------------
+# sync — write-back surface (W2 PR6)
+# ---------------------------------------------------------------------------
+
+
+def _empty_sync_payload() -> dict:
+    """Plan payload skeleton with all keys present + arrays empty.
+
+    Used when an ``--apply`` aborts (TTY decline or non-TTY no-`--yes`)
+    so the JSON shape stays uniform — downstream consumers don't have
+    to special-case missing keys on abort.
+    """
+    return {
+        "add": [],
+        "remove": [],
+        "backfill": [],
+        "cleanup": [],
+        "skipped_changed": [],
+        "conflicts": [],
+    }
+
+
+def _empty_sync_summary() -> dict:
+    return {
+        "added": 0,
+        "removed": 0,
+        "backfilled": 0,
+        "cleanup": 0,
+        "skipped_changed": 0,
+        "unchanged": 0,
+        "conflicts": 0,
+    }
+
+
+def _new_has_secret_env(new: list[ImportCandidate]) -> bool:
+    """True when any ADD candidate has at least one secret-classified env key."""
+    return any(cand.env_classification[k].is_secret for cand in new for k in cand.server.env)
+
+
+def _build_remove_prompt(removed_rows: list[dict], summary: dict) -> str:
+    """Compose the inline confirmation message for the REMOVE bucket.
+
+    Lists every entry by name + ``source_label`` + ``last_imported``
+    so the user gives informed consent without a separate ``--plan``
+    invocation. Tail summarizes the other (non-destructive) buckets so
+    decline cost is visible (``Also: A added, B backfilled, ...``).
+    """
+    n = len(removed_rows)
+    lines = [_SYNC_REMOVE_PROMPT_HEADER_TEMPLATE.format(n=n, ies_or_y=_ies_or_y(n))]
+    for row in removed_rows:
+        lines.append(
+            f"  - {row['name']} (last seen: {row['source_label']}, {row['last_imported']})"
+        )
+    lines.append("")
+    lines.append(
+        _SYNC_REMOVE_PROMPT_TAIL_TEMPLATE.format(
+            added=summary["added"],
+            backfilled=summary["backfilled"],
+            cleanup=summary["cleanup"],
+            cleanup_ies_or_y=_ies_or_y(summary["cleanup"]),
+        )
+    )
+    lines.append("")
+    lines.append("Proceed?")
+    return "\n".join(lines)
+
+
+def _render_sync_json(mode: str, plan_payload: dict, summary: dict, *, aborted: bool) -> None:
+    """Emit the locked JSON shape — all keys always present.
+
+    NOTE: ``summary.unchanged`` counts registry names (1 per registry
+    name); ``summary.conflicts`` counts candidate occurrences (1 per
+    candidate; multi-host name with shape divergence → multiple). The
+    two report on different units; downstream tooling that sums them
+    is buggy.
+    """
+    payload = {
+        "mode": mode,
+        "aborted": aborted,
+        "plan": plan_payload,
+        "summary": summary,
+    }
+    click.echo(_json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def _render_sync_text(
+    mode: str,
+    plan_payload: dict,
+    summary: dict,
+    *,
+    new: list[ImportCandidate],
+    apply_outcome: str | None = None,
+) -> None:
+    """Default human-readable sync renderer.
+
+    ``mode`` is "plan" or "apply"; ``apply_outcome`` is "no_op",
+    "mutated", or None (None = plan mode). The same bucket sections
+    render in every mode so users see consistent surface; only the
+    final footer changes.
+    """
+    add_rows = plan_payload["add"]
+    remove_rows = plan_payload["remove"]
+    backfill_rows = plan_payload["backfill"]
+    cleanup_rows = plan_payload["cleanup"]
+    conflict_rows = plan_payload["conflicts"]
+
+    def w(s: str) -> None:
+        click.echo(s)
+
+    w("Plan:" if mode == "plan" else "Apply:")
+    if add_rows:
+        n = len(add_rows)
+        w(f"  ADD       {n} entr{_ies_or_y(n)} (new at host)")
+        # Mirror import --plan's per-entry render shape, but always redact.
+        cand_by_name = {c.name: c for c in new}
+        for row in add_rows:
+            cand = cand_by_name[row["name"]]
+            env_summary = _format_env_summary(
+                cand.server, cand.env_classification, show_imported=False
+            )
+            w(
+                f"    - {cand.name} [{cand.source_label}]  "
+                f"command={cand.server.command}  {env_summary}"
+            )
+        if _new_has_secret_env(new):
+            w(_SYNC_SHOW_IMPORTED_HINT)
+    if remove_rows:
+        n = len(remove_rows)
+        w(f"  REMOVE    {n} entr{_ies_or_y(n)} (no longer at any host)")
+        for row in remove_rows:
+            w(f"    - {row['name']} (last seen: {row['source_label']}, {row['last_imported']})")
+    if backfill_rows:
+        n = len(backfill_rows)
+        w(f"  BACKFILL  {n} entr{_ies_or_y(n)} (re-stamp drift baseline)")
+        for row in backfill_rows:
+            w(f"    - {row['name']} [{row['host']}]")
+    if cleanup_rows:
+        n = len(cleanup_rows)
+        w(f"  CLEANUP   {n} stale sidecar entr{_ies_or_y(n)} (no registry entry)")
+        for row in cleanup_rows:
+            w(f"    - {row['name']} (last seen: {row['source_label']}, {row['last_imported']})")
+
+    w("")
+    w(f"  {summary['unchanged']} unchanged")
+
+    if conflict_rows:
+        w("")
+        n = len(conflict_rows)
+        w(f"  Conflicts: {n}  (skipped — first-import-wins)")
+        for row in conflict_rows:
+            w(f"    - {row['name']} from {row['host']}: {row['reason']}")
+
+    n_changed = summary["skipped_changed"]
+    if n_changed:
+        w("")
+        w("  " + _SYNC_CHANGED_FOOTER_TEMPLATE.format(n=n_changed, ies_or_y=_ies_or_y(n_changed)))
+
+    if mode == "plan":
+        w("")
+        w("Run `mms host sync --apply` to execute.")
+    elif apply_outcome == "no_op":
+        w("")
+        w(_SYNC_NO_OP_MSG)
+    elif apply_outcome == "mutated":
+        w("")
+        if summary["added"]:
+            w(
+                f"Wrote {summary['added']} new entr{_ies_or_y(summary['added'])} "
+                f"to {state.registry_path()}"
+            )
+        if summary["removed"]:
+            w(
+                f"Removed {summary['removed']} entr{_ies_or_y(summary['removed'])} "
+                f"from {state.registry_path()}"
+            )
+        if summary["backfilled"]:
+            w(
+                f"Backfilled {summary['backfilled']} sidecar "
+                f"row{'' if summary['backfilled'] == 1 else 's'} "
+                f"in {state.import_state_path()}"
+            )
+        if summary["cleanup"]:
+            w(
+                f"Removed {summary['cleanup']} stale sidecar "
+                f"entr{_ies_or_y(summary['cleanup'])} "
+                f"from {state.import_state_path()}"
+            )
+
+
+def _render_orphan_no_baseline_footer(n: int) -> None:
+    """Surface ``no_baseline`` rows that lack a matched candidate.
+
+    These are non-mutating skips (registry entry exists but neither
+    sidecar nor any host knows about it; sync can't safely act on
+    them). Footer-only — they don't go in the plan payload arrays.
+    """
+    if n:
+        click.echo(
+            "  " + _SYNC_ORPHAN_NO_BASELINE_FOOTER_TEMPLATE.format(n=n, ies_or_y=_ies_or_y(n))
+        )
+
+
+@host_group.command("sync")
+@click.option(
+    "--plan/--apply",
+    "is_plan",
+    default=True,
+    help="--plan (default) prints what would change; --apply writes registry + sidecar.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Bypass the confirmation prompt before removing registry entries.",
+)
+def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
+    """Reconcile registry + sidecar with the union of host scans.
+
+    vs ``mms import``:
+      ``mms import`` is the first-time entry point (host → empty/sparse
+      registry; additive only). ``mms host sync`` is the ongoing-
+      reconciliation entry point: it adds entries newly appearing at
+      hosts, removes entries no longer at any host, and stamps
+      baselines that PR2's import-time backfill couldn't cover. The
+      two have overlapping mutations but distinct intents; collapsing
+      them would mask the "first import" vs "drift reconciliation"
+      decision boundary.
+
+    Read-only buckets (see ``mms host status`` for definitions):
+      - ``unchanged``: silent no-op (most common case).
+      - ``changed``: NOT mutated by sync; user must acknowledge via
+        W3+ ``--force``. Surfaces as footer note + ``summary.skipped_changed``.
+
+    Mutating buckets:
+      - ``new`` (host candidate not in registry) → ADD.
+      - ``removed_at_host`` (registry entry absent from every host
+        scan) → REMOVE registry + sidecar entry.
+      - ``no_baseline`` with matched host candidate → BACKFILL sidecar.
+
+    Atomicity: registry write first, sidecar write second. The
+    sidecar is filtered to ``set(import_state.entries) ⊆
+    set(registry.servers)`` so a crash between writes self-heals on
+    the next run (orphan baselines drop; missing baselines BACKFILL).
+
+    See ``mms_import.py`` for the matching docstring at
+    ``import_command``.
+    """
+    cwd = Path.cwd().resolve()
+    candidates = discover("all", cwd)
+    registry = state.load_registry()
+    import_state = state.load_import_state()
+
+    # Two orthogonal classifiers (see Action-bucket matrix in the plan).
+    new, conflicts, _idempotent = _classify_against_registry(candidates, registry)
+    classified = _classify(registry, import_state, candidates)
+    cand_by_name = _select_candidate_by_name(candidates, import_state)
+
+    removed_at_host_rows = [r for r in classified if r["state"] == "removed_at_host"]
+    changed_rows_classified = [r for r in classified if r["state"] == "changed"]
+    no_baseline_rows = [r for r in classified if r["state"] == "no_baseline"]
+    n_unchanged = sum(1 for r in classified if r["state"] == "unchanged")
+
+    no_baseline_with_cand = [r for r in no_baseline_rows if cand_by_name.get(r["name"]) is not None]
+    n_orphan_no_baseline = sum(1 for r in no_baseline_rows if cand_by_name.get(r["name"]) is None)
+
+    # Pre-existing orphan sidecar entries: in sidecar but not in registry.
+    # ``_classify`` is registry-anchored and never emits these — detect
+    # separately.
+    cleanup_names = sorted(set(import_state.entries.keys()) - set(registry.servers.keys()))
+
+    plan_payload: dict = {
+        "add": [{"name": c.name, "host": c.source_label} for c in new],
+        "remove": [
+            {
+                "name": r["name"],
+                "baseline_hash": r["baseline_hash"],
+                "source_label": r["source_label"],
+                "last_imported": r["last_imported"],
+            }
+            for r in removed_at_host_rows
+        ],
+        "backfill": [
+            {"name": r["name"], "host": cand_by_name[r["name"]].source_label}
+            for r in no_baseline_with_cand
+        ],
+        "cleanup": [
+            {
+                "name": name,
+                "baseline_hash": import_state.entries[name].drift_hash,
+                "source_label": import_state.entries[name].source_label,
+                "last_imported": import_state.entries[name].last_imported,
+            }
+            for name in cleanup_names
+        ],
+        "skipped_changed": [{"name": r["name"]} for r in changed_rows_classified],
+        "conflicts": [
+            {"name": cand.name, "host": cand.source_label, "reason": reason}
+            for cand, reason in conflicts
+        ],
+    }
+    summary = {
+        "added": len(plan_payload["add"]),
+        "removed": len(plan_payload["remove"]),
+        "backfilled": len(plan_payload["backfill"]),
+        "cleanup": len(plan_payload["cleanup"]),
+        "skipped_changed": len(plan_payload["skipped_changed"]),
+        "unchanged": n_unchanged,
+        "conflicts": len(plan_payload["conflicts"]),
+    }
+
+    if is_plan:
+        if json_output:
+            _render_sync_json("plan", plan_payload, summary, aborted=False)
+        else:
+            _render_sync_text("plan", plan_payload, summary, new=new)
+            _render_orphan_no_baseline_footer(n_orphan_no_baseline)
+        return
+
+    # ----- --apply -----
+
+    # Confirmation gate (only when REMOVE bucket is non-empty).
+    if removed_at_host_rows and not yes:
+        if not _is_interactive():
+            n = len(removed_at_host_rows)
+            click.echo(
+                _SYNC_NON_TTY_ABORT_TEMPLATE.format(n=n, ies_or_y=_ies_or_y(n)),
+                err=True,
+            )
+            if json_output:
+                _render_sync_json(
+                    "apply", _empty_sync_payload(), _empty_sync_summary(), aborted=True
+                )
+            sys.exit(2)
+        if not click.confirm(_build_remove_prompt(removed_at_host_rows, summary), default=False):
+            click.echo(_SYNC_DECLINE_MSG, err=True)
+            if json_output:
+                _render_sync_json(
+                    "apply", _empty_sync_payload(), _empty_sync_summary(), aborted=True
+                )
+            sys.exit(2)
+
+    # No-op gate. ``cleanup_names`` non-empty counts as a mutation
+    # (orphan sidecar entries get filtered on the next save). Without
+    # this, orphans would never be cleaned up by a "boring" sync and
+    # the post-condition ``sidecar.keys() ⊆ registry.servers.keys()``
+    # would not self-heal.
+    no_mutations = not (new or removed_at_host_rows or no_baseline_with_cand)
+    no_orphans = not cleanup_names
+    if no_mutations and no_orphans:
+        if json_output:
+            _render_sync_json("apply", plan_payload, summary, aborted=False)
+        else:
+            _render_sync_text("apply", plan_payload, summary, new=new, apply_outcome="no_op")
+            _render_orphan_no_baseline_footer(n_orphan_no_baseline)
+        return
+
+    # Step 1: registry write (ADD inserts + REMOVE deletes).
+    registry_changed = bool(new) or bool(removed_at_host_rows)
+    if registry_changed:
+        new_servers = {**registry.servers}
+        for cand in new:
+            new_servers[cand.name] = cand.server
+        for row in removed_at_host_rows:
+            new_servers.pop(row["name"], None)
+        new_registry = state.RegistryConfig(
+            schema_version=registry.schema_version, servers=new_servers
+        )
+        state.save_registry(new_registry)
+    else:
+        new_servers = dict(registry.servers)
+
+    # Step 2: sidecar write. Filter to names surviving in new_servers
+    # (orphan cleanup), then add ADD baselines + BACKFILL stamps. The
+    # filter enforces the post-condition atomically with the rest of
+    # the write; PR2's "registry first, sidecar second" extends here.
+    now = state.utc_now_iso()
+    new_state_entries: dict[str, state.ImportStateEntry] = {}
+    for name, entry in import_state.entries.items():
+        if name in new_servers:
+            new_state_entries[name] = entry
+    for cand in new:
+        new_state_entries[cand.name] = state.ImportStateEntry(
+            drift_hash=compute_drift_hash(cand.server),
+            drift_hash_version=HASH_VERSION,
+            last_imported=now,
+            source_label=cand.source_label,
+        )
+    for row in no_baseline_with_cand:
+        cand_for_row = cand_by_name[row["name"]]
+        new_state_entries[row["name"]] = state.ImportStateEntry(
+            drift_hash=compute_drift_hash(cand_for_row.server),
+            drift_hash_version=HASH_VERSION,
+            last_imported=now,
+            source_label=cand_for_row.source_label,
+        )
+    new_import_state = state.ImportState(
+        schema_version=import_state.schema_version, entries=new_state_entries
+    )
+    state.save_import_state(new_import_state)
+
+    if json_output:
+        _render_sync_json("apply", plan_payload, summary, aborted=False)
+    else:
+        _render_sync_text("apply", plan_payload, summary, new=new, apply_outcome="mutated")
+        _render_orphan_no_baseline_footer(n_orphan_no_baseline)

--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -44,6 +44,12 @@ the comparison candidate is chosen by ``baseline.source_label`` match
 first, falling back to first-seen across :data:`ALL_HOSTS`. This keeps
 ``unchanged``/``changed`` stable when the user later mirrors an entry
 into a second host — the import-time host stays the comparison axis.
+
+PR6 added ``mms host sync`` as the write-back counterpart to status's
+read-only inspection. Sync's JSON shape (``mode``/``aborted``/``plan``
+/``summary``) is its own contract independent of status's locked-in
+4-key shape — bucket vocabulary is shared, but the surface that emits
+it is not.
 """
 
 from __future__ import annotations
@@ -512,6 +518,7 @@ def _empty_sync_payload() -> dict:
         "backfill": [],
         "cleanup": [],
         "skipped_changed": [],
+        "orphan_no_baseline": [],
         "conflicts": [],
     }
 
@@ -523,6 +530,7 @@ def _empty_sync_summary() -> dict:
         "backfilled": 0,
         "cleanup": 0,
         "skipped_changed": 0,
+        "orphan_no_baseline": 0,
         "unchanged": 0,
         "conflicts": 0,
     }
@@ -738,6 +746,12 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
     set(registry.servers)`` so a crash between writes self-heals on
     the next run (orphan baselines drop; missing baselines BACKFILL).
 
+    With ``--json``, the REMOVE bucket always requires ``--yes`` —
+    a TTY confirmation prompt cannot be answered programmatically by
+    a JSON consumer, and mixing prompt text with JSON output corrupts
+    machine parsing. Without ``--yes``, ``--json`` REMOVE aborts
+    (exit 2) with ``aborted: true`` in the payload.
+
     See ``mms_import.py`` for the matching docstring at
     ``import_command``.
     """
@@ -757,7 +771,7 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
     n_unchanged = sum(1 for r in classified if r["state"] == "unchanged")
 
     no_baseline_with_cand = [r for r in no_baseline_rows if cand_by_name.get(r["name"]) is not None]
-    n_orphan_no_baseline = sum(1 for r in no_baseline_rows if cand_by_name.get(r["name"]) is None)
+    no_baseline_orphans = [r for r in no_baseline_rows if cand_by_name.get(r["name"]) is None]
 
     # Pre-existing orphan sidecar entries: in sidecar but not in registry.
     # ``_classify`` is registry-anchored and never emits these — detect
@@ -789,6 +803,10 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
             for name in cleanup_names
         ],
         "skipped_changed": [{"name": r["name"]} for r in changed_rows_classified],
+        # ``orphan_no_baseline``: registry has the entry, sidecar has no
+        # baseline (or version mismatch), and no host scan finds it.
+        # Sync can't safely act — JSON parity with the text footer.
+        "orphan_no_baseline": [{"name": r["name"]} for r in no_baseline_orphans],
         "conflicts": [
             {"name": cand.name, "host": cand.source_label, "reason": reason}
             for cand, reason in conflicts
@@ -800,6 +818,7 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
         "backfilled": len(plan_payload["backfill"]),
         "cleanup": len(plan_payload["cleanup"]),
         "skipped_changed": len(plan_payload["skipped_changed"]),
+        "orphan_no_baseline": len(plan_payload["orphan_no_baseline"]),
         "unchanged": n_unchanged,
         "conflicts": len(plan_payload["conflicts"]),
     }
@@ -809,14 +828,19 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
             _render_sync_json("plan", plan_payload, summary, aborted=False)
         else:
             _render_sync_text("plan", plan_payload, summary, new=new)
-            _render_orphan_no_baseline_footer(n_orphan_no_baseline)
+            _render_orphan_no_baseline_footer(len(no_baseline_orphans))
         return
 
     # ----- --apply -----
 
     # Confirmation gate (only when REMOVE bucket is non-empty).
+    # ``--json`` + REMOVE forces ``--yes``: a TTY prompt cannot be
+    # answered by a JSON consumer, and mixing the prompt text with
+    # JSON output would corrupt machine parsing. So we fall through
+    # to the non-TTY abort path whenever ``--json`` is set, regardless
+    # of the actual TTY status.
     if removed_at_host_rows and not yes:
-        if not _is_interactive():
+        if not _is_interactive() or json_output:
             n = len(removed_at_host_rows)
             click.echo(
                 _SYNC_NON_TTY_ABORT_TEMPLATE.format(n=n, ies_or_y=_ies_or_y(n)),
@@ -829,10 +853,6 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
             sys.exit(2)
         if not click.confirm(_build_remove_prompt(removed_at_host_rows, summary), default=False):
             click.echo(_SYNC_DECLINE_MSG, err=True)
-            if json_output:
-                _render_sync_json(
-                    "apply", _empty_sync_payload(), _empty_sync_summary(), aborted=True
-                )
             sys.exit(2)
 
     # No-op gate. ``cleanup_names`` non-empty counts as a mutation
@@ -847,7 +867,7 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
             _render_sync_json("apply", plan_payload, summary, aborted=False)
         else:
             _render_sync_text("apply", plan_payload, summary, new=new, apply_outcome="no_op")
-            _render_orphan_no_baseline_footer(n_orphan_no_baseline)
+            _render_orphan_no_baseline_footer(len(no_baseline_orphans))
         return
 
     # Step 1: registry write (ADD inserts + REMOVE deletes).
@@ -898,4 +918,4 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
         _render_sync_json("apply", plan_payload, summary, aborted=False)
     else:
         _render_sync_text("apply", plan_payload, summary, new=new, apply_outcome="mutated")
-        _render_orphan_no_baseline_footer(n_orphan_no_baseline)
+        _render_orphan_no_baseline_footer(len(no_baseline_orphans))

--- a/src/memtomem_stm/cli/mms_import.py
+++ b/src/memtomem_stm/cli/mms_import.py
@@ -95,8 +95,13 @@ def _format_env_summary(
     return "env: " + ", ".join(parts)
 
 
-# Cross-imported by mms_host.sync_cmd as a second caller; promote
-# to mms/sync.py module if a third caller appears (W3+ --force).
+# Cross-imported by mms_host.sync_cmd (along with ``_format_env_summary``
+# above). Two helpers already share the cross-import; the promotion
+# trigger is now "next cross-imported helper joins" rather than "3rd
+# caller of this function" — at that point both should land in
+# ``mms/sync.py``. Signature drift is pinned by
+# ``test_classify_against_registry_signature_pinned`` /
+# ``test_format_env_summary_signature_pinned`` in tests/cli/test_mms_host.py.
 def _classify_against_registry(
     candidates: list[ImportCandidate], registry: state.RegistryConfig
 ) -> tuple[

--- a/src/memtomem_stm/cli/mms_import.py
+++ b/src/memtomem_stm/cli/mms_import.py
@@ -42,6 +42,15 @@ Registry write still precedes sidecar write within a single apply;
 no transaction. A ``--force`` option to re-stamp existing sidecar
 rows (resetting timestamps after a host edit you've already
 acknowledged) lands in W3+.
+
+vs ``mms host sync``:
+  ``mms import`` is the first-time entry point (host → empty
+  registry; additive only). For ongoing reconciliation — adding
+  entries newly appearing at hosts, removing entries no longer at
+  any host, and stamping baselines — see ``mms host sync``. The
+  two have overlapping mutations but distinct intents; collapsing
+  them would mask the "first import" vs "drift reconciliation"
+  decision boundary.
 """
 
 from __future__ import annotations
@@ -86,6 +95,8 @@ def _format_env_summary(
     return "env: " + ", ".join(parts)
 
 
+# Cross-imported by mms_host.sync_cmd as a second caller; promote
+# to mms/sync.py module if a third caller appears (W3+ --force).
 def _classify_against_registry(
     candidates: list[ImportCandidate], registry: state.RegistryConfig
 ) -> tuple[

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -784,3 +784,583 @@ class TestScan:
 
         assert Path(state.registry_path()).read_bytes() == registry_before
         assert Path(state.import_state_path()).read_bytes() == sidecar_before
+
+
+# ---------------------------------------------------------------------------
+# sync — write-back surface (W2 PR6)
+# ---------------------------------------------------------------------------
+
+
+def _sync(runner, *args: str, **kwargs):
+    return runner.invoke(host_group, ["sync", *args], **kwargs)
+
+
+def _force_tty(monkeypatch) -> None:
+    """Make ``_is_interactive()`` return True under CliRunner.
+
+    CliRunner replaces ``sys.stdin`` with a non-TTY stream, so without
+    this monkeypatch the TTY-confirm code path is unreachable from
+    tests.
+    """
+    from memtomem_stm.cli import mms_host
+
+    monkeypatch.setattr(mms_host, "_is_interactive", lambda: True)
+
+
+class TestSyncPlan:
+    def test_plan_no_op_when_in_sync(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+
+        res = _sync(runner, "--plan", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["mode"] == "plan"
+        assert payload["aborted"] is False
+        assert all(payload["plan"][k] == [] for k in payload["plan"])
+        assert payload["summary"] == {
+            "added": 0,
+            "removed": 0,
+            "backfilled": 0,
+            "cleanup": 0,
+            "skipped_changed": 0,
+            "unchanged": 1,
+            "conflicts": 0,
+        }
+
+    def test_plan_add_redacts_secrets_by_default(self, runner, sandbox):
+        # Seed an entry with a secret-classified env key (key contains "TOKEN").
+        _seed_claude_code(
+            sandbox,
+            {"svc": {"command": "npx", "env": {"GITHUB_TOKEN": "ghp_supersecret"}}},
+        )
+
+        res = _sync(runner, "--plan")
+        assert res.exit_code == 0, res.output
+        # The secret value should not appear verbatim.
+        assert "ghp_supersecret" not in res.output
+        # The hint pointing at `mms import --plan --show-imported` must
+        # be visible — sync deliberately omits its own --show-imported.
+        assert "mms import --plan --show-imported" in res.output
+
+    def test_plan_does_not_write(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_cursor_user(sandbox, {"b": {"command": "npx"}})
+
+        registry_before = Path(state.registry_path()).read_bytes()
+        sidecar_before = Path(state.import_state_path()).read_bytes()
+
+        for args in (["--plan"], ["--plan", "--json"]):
+            res = _sync(runner, *args)
+            assert res.exit_code == 0, (args, res.output)
+
+        assert Path(state.registry_path()).read_bytes() == registry_before
+        assert Path(state.import_state_path()).read_bytes() == sidecar_before
+
+    def test_plan_changed_footer_text(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx", "args": ["v1"]}})
+        _apply_claude_code(runner)
+        # Mutate host shape — entry surfaces as ``changed``.
+        _seed_claude_code(sandbox, {"a": {"command": "npx", "args": ["v2"]}})
+
+        res = _sync(runner, "--plan")
+        assert res.exit_code == 0, res.output
+        # The W3+ pointer footer fires when ``changed`` count > 0.
+        assert "differ in shape at host" in res.output
+        assert "mms host sync --force" in res.output
+        assert "(W3+)" in res.output
+
+    def test_plan_orphan_no_baseline_footer(self, runner, sandbox):
+        """no_baseline + no matched candidate → footer surfaces it.
+
+        Reachable path: host config drops the entry AND sidecar lacks
+        a baseline (e.g. import_state.toml hand-edited). Sync can't
+        safely act, but silence is the failure mode (Lock-down 3
+        siblings) — surface as a footer note.
+        """
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Delete the sidecar baseline AND drop the host entry.
+        s = state.load_import_state()
+        s.entries.pop("a")
+        state.save_import_state(s)
+        _seed_claude_code(sandbox, {})
+
+        res = _sync(runner, "--plan")
+        assert res.exit_code == 0, res.output
+        assert "in registry without baseline and not at any host scan" in res.output
+
+    def test_plan_aborted_field_always_false_in_plan_mode(self, runner, sandbox):
+        # Seed REMOVE-triggering state so the bucket would be visible
+        # in apply mode; --plan must still emit aborted=False.
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+
+        res = _sync(runner, "--plan", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["aborted"] is False
+        assert payload["mode"] == "plan"
+
+
+class TestSyncApply:
+    def test_apply_add_writes_registry_and_sidecar(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"alpha": {"command": "npx"}})
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+
+        registry = state.load_registry()
+        assert "alpha" in registry.servers
+
+        sidecar = state.load_import_state()
+        assert "alpha" in sidecar.entries
+        assert sidecar.entries["alpha"].drift_hash == compute_drift_hash(registry.servers["alpha"])
+
+    def test_apply_remove_drops_registry_and_sidecar(self, runner, sandbox):
+        """removed_at_host → REMOVE registry + sidecar entry (orphan cleanup
+        atomic with the registry write)."""
+        _seed_claude_code(sandbox, {"to_remove": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Drop entry from host.
+        _seed_claude_code(sandbox, {})
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+
+        registry = state.load_registry()
+        assert "to_remove" not in registry.servers
+        sidecar = state.load_import_state()
+        assert "to_remove" not in sidecar.entries
+
+    def test_apply_backfill_stamps_no_baseline_with_candidate(self, runner, sandbox):
+        """no_baseline + matched candidate → BACKFILL only the sidecar.
+        Registry stays as it was (no add, no remove)."""
+        _seed_claude_code(sandbox, {"x": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Manually delete the sidecar row but leave host + registry intact.
+        s = state.load_import_state()
+        s.entries.pop("x")
+        state.save_import_state(s)
+
+        registry_before = Path(state.registry_path()).read_bytes()
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+
+        # Registry bytes unchanged (BACKFILL never re-writes registry
+        # when there are no add/remove ops).
+        assert Path(state.registry_path()).read_bytes() == registry_before
+        sidecar = state.load_import_state()
+        assert "x" in sidecar.entries
+        assert sidecar.entries["x"].drift_hash_version == HASH_VERSION
+
+    def test_apply_changed_not_re_stamped(self, runner, sandbox):
+        """Lock-down 3: ``changed`` is NOT mutated by sync. The sidecar
+        baseline_hash stays at the original value; W3+ ``--force`` is
+        the only writer.
+        """
+        _seed_claude_code(sandbox, {"a": {"command": "npx", "args": ["v1"]}})
+        _apply_claude_code(runner)
+        original = state.load_import_state().entries["a"].drift_hash
+        _seed_claude_code(sandbox, {"a": {"command": "npx", "args": ["v2"]}})
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+
+        # baseline_hash unchanged after --apply.
+        assert state.load_import_state().entries["a"].drift_hash == original
+
+    def test_apply_orphan_no_baseline_left_alone(self, runner, sandbox):
+        """no_baseline with no matched candidate → SKIP. Sidecar +
+        registry both unchanged; sync can't safely fabricate a baseline.
+        """
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Drop sidecar baseline AND host entry — registry retains entry.
+        s = state.load_import_state()
+        s.entries.pop("a")
+        state.save_import_state(s)
+        _seed_claude_code(sandbox, {})
+
+        registry_before = Path(state.registry_path()).read_bytes()
+        sidecar_before = Path(state.import_state_path()).read_bytes()
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+
+        # Both unchanged: orphan no_baseline is non-mutating.
+        assert Path(state.registry_path()).read_bytes() == registry_before
+        assert Path(state.import_state_path()).read_bytes() == sidecar_before
+
+    def test_apply_atomicity_registry_first(self, runner, sandbox, monkeypatch):
+        """Crash between registry write and sidecar write → second sync
+        recovers via BACKFILL (no_baseline + matched candidate)."""
+        _seed_claude_code(sandbox, {"alpha": {"command": "npx"}})
+
+        # Patch save_import_state to raise, only for the first call.
+        from memtomem_stm.mms import state as state_mod
+
+        original_save = state_mod.save_import_state
+        calls = {"n": 0}
+
+        def flaky_save(s):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("simulated sidecar write failure")
+            return original_save(s)
+
+        monkeypatch.setattr(state_mod, "save_import_state", flaky_save)
+
+        res = _sync(runner, "--apply", "--yes")
+        # Registry was written; sidecar raised → exit non-zero.
+        assert res.exit_code != 0, res.output
+        registry = state.load_registry()
+        assert "alpha" in registry.servers
+        # Sidecar still empty (write failed before any state was saved).
+        assert "alpha" not in state.load_import_state().entries
+
+        # Second sync recovers: alpha now appears as no_baseline +
+        # matched candidate → BACKFILL.
+        res2 = _sync(runner, "--apply", "--yes")
+        assert res2.exit_code == 0, res2.output
+        assert "alpha" in state.load_import_state().entries
+
+    def test_apply_no_sidecar_write_when_registry_fails(self, runner, sandbox, monkeypatch):
+        """Atomicity invariant reverse: if save_registry raises, the
+        sidecar must be untouched (registry-first means sidecar never
+        gets a chance to write)."""
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}, "b": {"command": "npx"}})
+
+        sidecar_before = Path(state.import_state_path()).read_bytes()
+
+        from memtomem_stm.mms import state as state_mod
+
+        def boom(_):
+            raise OSError("simulated registry write failure")
+
+        monkeypatch.setattr(state_mod, "save_registry", boom)
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code != 0, res.output
+        assert Path(state.import_state_path()).read_bytes() == sidecar_before
+
+    def test_apply_orphan_cleanup_executes_when_only_orphans_present(self, runner, sandbox):
+        """Orphan-only state (sidecar has row for name not in registry,
+        nothing else pending) must trigger a sidecar write — orphan
+        cleanup is a mutation, not a no-op.
+        """
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Inject an orphan: sidecar has a row for "ghost" with no
+        # corresponding registry entry.
+        s = state.load_import_state()
+        s.entries["ghost"] = state.ImportStateEntry(
+            drift_hash="sha256:" + "f" * 16,
+            drift_hash_version=HASH_VERSION,
+            last_imported="2026-01-01T00:00:00Z",
+            source_label="Claude Code (user)",
+        )
+        state.save_import_state(s)
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+        # Orphan got filtered out.
+        assert "ghost" not in state.load_import_state().entries
+        # NOT the no-op message — orphan cleanup counts as work done.
+        assert "Already synchronized" not in res.output
+        assert "stale sidecar" in res.output
+
+    def test_apply_orphan_cleanup_alongside_other_mutations(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # Add orphan + add a new host entry (ADD bucket).
+        s = state.load_import_state()
+        s.entries["ghost"] = state.ImportStateEntry(
+            drift_hash="sha256:" + "f" * 16,
+            drift_hash_version=HASH_VERSION,
+            last_imported="2026-01-01T00:00:00Z",
+            source_label="Claude Code (user)",
+        )
+        state.save_import_state(s)
+        _seed_cursor_user(sandbox, {"b": {"command": "npx"}})
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+        assert "b" in state.load_registry().servers
+        assert "ghost" not in state.load_import_state().entries
+
+    def test_apply_already_synchronized_message(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+
+        registry_before = Path(state.registry_path()).read_bytes()
+        sidecar_before = Path(state.import_state_path()).read_bytes()
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+        assert "Already synchronized. No changes." in res.output
+
+        # No writes (mtime / contents stable).
+        assert Path(state.registry_path()).read_bytes() == registry_before
+        assert Path(state.import_state_path()).read_bytes() == sidecar_before
+
+    def test_apply_first_import_wins_for_new_in_multiple_hosts(self, runner, sandbox):
+        """Same `new` name in two hosts with different shapes:
+        first-import-wins on the ADD path → only one written; the
+        second is a conflict.
+        """
+        _seed_claude_code(sandbox, {"shared": {"command": "claude-cmd"}})
+        _seed_cursor_user(sandbox, {"shared": {"command": "cursor-cmd"}})
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+
+        # Claude Code is iterated first in ALL_HOSTS, so it wins.
+        registry = state.load_registry()
+        assert registry.servers["shared"].command == "claude-cmd"
+
+        # Conflict surfaced in plan output.
+        assert "Conflicts" in res.output
+
+    def test_cross_host_shape_relocation_does_not_replace(self, runner, sandbox):
+        """Load-bearing contract (BLOCKER fix): X baselined to host A,
+        then A drops X and a different host B picks up X with a new
+        shape. ``_classify`` Pass 2 fallback finds B's X → state =
+        ``changed`` (NOT ``removed_at_host``). Sync MUST NOT replace
+        the registry shape; user acknowledges via W3+ ``--force``.
+        """
+        # Step 1: import shared from claude-code (becomes baseline).
+        _seed_claude_code(sandbox, {"shared": {"command": "npx", "args": ["claude-args"]}})
+        _apply_claude_code(runner)
+        original_shape = state.load_registry().servers["shared"]
+        original_hash = state.load_import_state().entries["shared"].drift_hash
+
+        # Step 2: drop from claude-code, add to cursor with a DIFFERENT shape.
+        _seed_claude_code(sandbox, {})
+        _seed_cursor_user(sandbox, {"shared": {"command": "npx", "args": ["cursor-args"]}})
+
+        # Plan: assert X surfaces as `changed` (skipped) — not REMOVE,
+        # not ADD.
+        plan_res = _sync(runner, "--plan", "--json")
+        assert plan_res.exit_code == 0, plan_res.output
+        plan_payload = json.loads(plan_res.output)
+        assert plan_payload["summary"]["skipped_changed"] == 1
+        assert plan_payload["summary"]["removed"] == 0
+        assert plan_payload["summary"]["added"] == 0
+
+        # Apply: registry shape MUST be unchanged.
+        apply_res = _sync(runner, "--apply", "--yes")
+        assert apply_res.exit_code == 0, apply_res.output
+        assert state.load_registry().servers["shared"] == original_shape
+        assert state.load_import_state().entries["shared"].drift_hash == original_hash
+
+
+class TestSyncConfirmation:
+    def test_apply_remove_prompts_in_tty_declines_no_writes(self, runner, sandbox, monkeypatch):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})  # triggers REMOVE
+
+        _force_tty(monkeypatch)
+        registry_before = Path(state.registry_path()).read_bytes()
+        sidecar_before = Path(state.import_state_path()).read_bytes()
+
+        res = _sync(runner, "--apply", input="n\n")
+        assert res.exit_code == 2, res.output
+        assert "Aborted. No changes." in res.output
+        # No writes.
+        assert Path(state.registry_path()).read_bytes() == registry_before
+        assert Path(state.import_state_path()).read_bytes() == sidecar_before
+
+    def test_apply_remove_prompts_in_tty_accepts_executes(self, runner, sandbox, monkeypatch):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+
+        _force_tty(monkeypatch)
+
+        res = _sync(runner, "--apply", input="y\n")
+        assert res.exit_code == 0, res.output
+        assert "a" not in state.load_registry().servers
+
+    def test_apply_remove_aborts_in_non_tty_without_yes(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+
+        registry_before = Path(state.registry_path()).read_bytes()
+
+        res = _sync(runner, "--apply")
+        # Non-TTY without --yes → exit 2 + clear error.
+        assert res.exit_code == 2, res.output
+        # CliRunner mixes stdout+stderr; the abort message lands in
+        # res.output regardless.
+        assert "--yes" in res.output
+        # No writes.
+        assert Path(state.registry_path()).read_bytes() == registry_before
+
+    def test_apply_yes_bypasses_prompt_in_non_tty(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+        assert "a" not in state.load_registry().servers
+
+    def test_apply_no_remove_no_prompt(self, runner, sandbox):
+        """Only ADD bucket — no REMOVE, no prompt regardless of TTY/--yes."""
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        # No --yes; should still succeed because no removal needs confirmation.
+        res = _sync(runner, "--apply")
+        assert res.exit_code == 0, res.output
+        assert "a" in state.load_registry().servers
+        assert "Aborted" not in res.output
+        assert "--yes" not in res.output
+
+    def test_apply_remove_prompt_lists_each_entry(self, runner, sandbox, monkeypatch):
+        """Confirmation message must list every removed entry by name +
+        source_label + last_imported, plus the tail with other-bucket
+        counts. Pins the inline-disambiguation contract.
+        """
+        _seed_claude_code(sandbox, {"first": {"command": "npx"}, "second": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})  # both → REMOVE
+
+        captured = {"prompt": ""}
+        # Intercept click.confirm to capture the prompt text.
+        import click as _click_mod
+
+        original_confirm = _click_mod.confirm
+
+        def spy_confirm(text, *args, **kwargs):
+            captured["prompt"] = text
+            return False  # decline → no writes
+
+        monkeypatch.setattr(_click_mod, "confirm", spy_confirm)
+        _force_tty(monkeypatch)
+
+        res = _sync(runner, "--apply")
+        assert res.exit_code == 2, res.output
+        prompt = captured["prompt"]
+        assert "first" in prompt
+        assert "second" in prompt
+        assert "Claude Code (user)" in prompt
+        # Tail summary present.
+        assert "Also:" in prompt
+        # Avoid lint-warning for unused alias.
+        del original_confirm
+
+
+class TestSyncJsonShape:
+    _PLAN_PAYLOAD_KEYS = {
+        "add",
+        "remove",
+        "backfill",
+        "cleanup",
+        "skipped_changed",
+        "conflicts",
+    }
+    _SUMMARY_KEYS = {
+        "added",
+        "removed",
+        "backfilled",
+        "cleanup",
+        "skipped_changed",
+        "unchanged",
+        "conflicts",
+    }
+
+    def test_json_shape_plan_mode_all_keys_present(self, runner, sandbox):
+        # Empty registry → still emits full shape with zeros.
+        res = _sync(runner, "--plan", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert set(payload.keys()) == {"mode", "aborted", "plan", "summary"}
+        assert payload["mode"] == "plan"
+        assert payload["aborted"] is False
+        assert set(payload["plan"].keys()) == self._PLAN_PAYLOAD_KEYS
+        assert set(payload["summary"].keys()) == self._SUMMARY_KEYS
+
+    def test_json_shape_apply_mode_same_shape(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        res = _sync(runner, "--apply", "--yes", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["mode"] == "apply"
+        assert payload["aborted"] is False
+        assert set(payload["plan"].keys()) == self._PLAN_PAYLOAD_KEYS
+        assert set(payload["summary"].keys()) == self._SUMMARY_KEYS
+
+    def test_json_aborted_true_on_tty_decline(self, runner, sandbox, monkeypatch):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+
+        _force_tty(monkeypatch)
+
+        res = _sync(runner, "--apply", "--json", input="n\n")
+        assert res.exit_code == 2, res.output
+        # JSON is in res.output; the prompt may also be mixed in but
+        # JSON is on its own line. Find it by parsing each candidate
+        # block.
+        # Click writes the JSON via click.echo after the confirm
+        # decision; locate the JSON object.
+        text = res.output
+        start = text.find("{")
+        # Final JSON object — find the *last* well-formed one.
+        end = text.rfind("}")
+        payload = json.loads(text[start : end + 1])
+        assert payload["aborted"] is True
+        assert payload["mode"] == "apply"
+        assert all(payload["plan"][k] == [] for k in payload["plan"])
+        assert all(payload["summary"][k] == 0 for k in payload["summary"])
+
+    def test_json_aborted_true_on_non_tty_abort_with_json_flag(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+
+        res = _sync(runner, "--apply", "--json")
+        assert res.exit_code == 2, res.output
+        text = res.output
+        start = text.find("{")
+        end = text.rfind("}")
+        payload = json.loads(text[start : end + 1])
+        assert payload["aborted"] is True
+        assert payload["mode"] == "apply"
+
+
+class TestSyncContractPin:
+    def test_classify_against_registry_signature_pinned(self):
+        """Cross-CLI import is brittle by convention; signature change
+        in mms_import.py would silently break sync_cmd. This is the
+        tripwire."""
+        from inspect import signature
+
+        from memtomem_stm.cli.mms_import import _classify_against_registry
+
+        sig = signature(_classify_against_registry)
+        assert list(sig.parameters) == ["candidates", "registry"]
+
+    def test_sync_docstring_mentions_first_time_vs_ongoing(self):
+        """Lock-down 1 anchor: sync's docstring carries the
+        intent-distinction phrase. Future docstring rewrites must
+        preserve it or this test fires."""
+        from memtomem_stm.cli.mms_host import sync_cmd
+
+        # ``sync_cmd.__doc__`` returns Click's command docstring.
+        doc = sync_cmd.__doc__ or ""
+        assert "ongoing-" in doc and "reconciliation" in doc, doc
+
+    def test_import_docstring_mentions_sync_cross_link(self):
+        """Lock-down 1 mirror anchor: mms_import.py module docstring
+        cross-links sync."""
+        from memtomem_stm.cli import mms_import
+
+        assert "mms host sync" in (mms_import.__doc__ or "")

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -824,6 +824,7 @@ class TestSyncPlan:
             "backfilled": 0,
             "cleanup": 0,
             "skipped_changed": 0,
+            "orphan_no_baseline": 0,
             "unchanged": 1,
             "conflicts": 0,
         }
@@ -890,6 +891,24 @@ class TestSyncPlan:
         res = _sync(runner, "--plan")
         assert res.exit_code == 0, res.output
         assert "in registry without baseline and not at any host scan" in res.output
+
+    def test_plan_orphan_no_baseline_in_json_summary(self, runner, sandbox):
+        """JSON parity with the text footer: ``orphan_no_baseline``
+        surfaces in both ``summary`` (count) and ``plan`` (per-entry
+        list). Without this, JSON consumers miss what text users see.
+        """
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        s = state.load_import_state()
+        s.entries.pop("a")
+        state.save_import_state(s)
+        _seed_claude_code(sandbox, {})
+
+        res = _sync(runner, "--plan", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["summary"]["orphan_no_baseline"] == 1
+        assert payload["plan"]["orphan_no_baseline"] == [{"name": "a"}]
 
     def test_plan_aborted_field_always_false_in_plan_mode(self, runner, sandbox):
         # Seed REMOVE-triggering state so the bucket would be visible
@@ -1233,14 +1252,14 @@ class TestSyncConfirmation:
         _seed_claude_code(sandbox, {})  # both → REMOVE
 
         captured = {"prompt": ""}
-        # Intercept click.confirm to capture the prompt text.
+        # Intercept click.confirm to capture the prompt text. The
+        # spy declines so no writes happen; the test asserts on the
+        # captured text rather than dispatching to the real confirm.
         import click as _click_mod
-
-        original_confirm = _click_mod.confirm
 
         def spy_confirm(text, *args, **kwargs):
             captured["prompt"] = text
-            return False  # decline → no writes
+            return False
 
         monkeypatch.setattr(_click_mod, "confirm", spy_confirm)
         _force_tty(monkeypatch)
@@ -1253,8 +1272,6 @@ class TestSyncConfirmation:
         assert "Claude Code (user)" in prompt
         # Tail summary present.
         assert "Also:" in prompt
-        # Avoid lint-warning for unused alias.
-        del original_confirm
 
 
 class TestSyncJsonShape:
@@ -1264,6 +1281,7 @@ class TestSyncJsonShape:
         "backfill",
         "cleanup",
         "skipped_changed",
+        "orphan_no_baseline",
         "conflicts",
     }
     _SUMMARY_KEYS = {
@@ -1272,6 +1290,7 @@ class TestSyncJsonShape:
         "backfilled",
         "cleanup",
         "skipped_changed",
+        "orphan_no_baseline",
         "unchanged",
         "conflicts",
     }
@@ -1297,23 +1316,29 @@ class TestSyncJsonShape:
         assert set(payload["plan"].keys()) == self._PLAN_PAYLOAD_KEYS
         assert set(payload["summary"].keys()) == self._SUMMARY_KEYS
 
-    def test_json_aborted_true_on_tty_decline(self, runner, sandbox, monkeypatch):
+    def test_json_apply_with_remove_requires_yes_even_in_tty(self, runner, sandbox, monkeypatch):
+        """``--json`` + REMOVE forces ``--yes`` regardless of TTY.
+
+        A TTY confirmation prompt cannot be answered programmatically
+        by a JSON consumer, and mixing prompt text with JSON output
+        would corrupt machine parsing — so even with a real TTY we
+        bypass the prompt path and abort like the non-TTY case.
+        """
         _seed_claude_code(sandbox, {"a": {"command": "npx"}})
         _apply_claude_code(runner)
         _seed_claude_code(sandbox, {})
 
         _force_tty(monkeypatch)
 
-        res = _sync(runner, "--apply", "--json", input="n\n")
+        res = _sync(runner, "--apply", "--json")
         assert res.exit_code == 2, res.output
-        # JSON is in res.output; the prompt may also be mixed in but
-        # JSON is on its own line. Find it by parsing each candidate
-        # block.
-        # Click writes the JSON via click.echo after the confirm
-        # decision; locate the JSON object.
+        # No prompt was shown — output is just the stderr abort
+        # message followed by JSON. Pin both halves: prompt absent +
+        # JSON parses cleanly when stripped of the stderr message.
+        assert "Proceed?" not in res.output
+        # Locate the JSON payload (after the stderr abort message).
         text = res.output
         start = text.find("{")
-        # Final JSON object — find the *last* well-formed one.
         end = text.rfind("}")
         payload = json.loads(text[start : end + 1])
         assert payload["aborted"] is True
@@ -1321,7 +1346,10 @@ class TestSyncJsonShape:
         assert all(payload["plan"][k] == [] for k in payload["plan"])
         assert all(payload["summary"][k] == 0 for k in payload["summary"])
 
-    def test_json_aborted_true_on_non_tty_abort_with_json_flag(self, runner, sandbox):
+    def test_json_aborted_true_on_non_tty_abort(self, runner, sandbox):
+        """Non-TTY + REMOVE + no ``--yes`` + ``--json`` → exit 2 with
+        ``aborted: true`` JSON. Symmetric path with the TTY+--json
+        case (see test above)."""
         _seed_claude_code(sandbox, {"a": {"command": "npx"}})
         _apply_claude_code(runner)
         _seed_claude_code(sandbox, {})
@@ -1337,16 +1365,45 @@ class TestSyncJsonShape:
 
 
 class TestSyncContractPin:
-    def test_classify_against_registry_signature_pinned(self):
-        """Cross-CLI import is brittle by convention; signature change
-        in mms_import.py would silently break sync_cmd. This is the
-        tripwire."""
+    def test_classify_against_registry_signature_and_return_shape_pinned(self):
+        """Cross-CLI import is brittle by convention; signature OR
+        return-shape change in mms_import.py would silently break
+        sync_cmd. Pin both — the param-name list AND the runtime
+        contract (3-tuple of lists).
+        """
         from inspect import signature
 
         from memtomem_stm.cli.mms_import import _classify_against_registry
 
         sig = signature(_classify_against_registry)
         assert list(sig.parameters) == ["candidates", "registry"]
+
+        # Smoke: empty inputs → 3-tuple of lists. sync_cmd unpacks
+        # ``new, conflicts, _idempotent = _classify_against_registry(...)``;
+        # if the return type ever changes to a dict / 2-tuple / NamedTuple,
+        # this test fires before the unpack does at runtime.
+        result = _classify_against_registry([], state.RegistryConfig())
+        assert isinstance(result, tuple) and len(result) == 3
+        assert all(isinstance(x, list) for x in result)
+
+    def test_format_env_summary_signature_and_return_shape_pinned(self):
+        """Second cross-imported helper. ``_render_sync_text`` calls
+        ``_format_env_summary(cand.server, cand.env_classification,
+        show_imported=False)``; a kwarg rename or type change would
+        silently break sync's ADD bucket text rendering.
+        """
+        from inspect import signature
+
+        from memtomem_stm.cli.mms_import import _format_env_summary
+        from memtomem_stm.mms.secrets import classify_env
+
+        sig = signature(_format_env_summary)
+        assert list(sig.parameters) == ["server", "env_classification", "show_imported"]
+
+        # Smoke: empty env → returns a string ("no env" path).
+        server = state.RegistryServer(command="npx", args=[], env={}, prefix="x")
+        result = _format_env_summary(server, classify_env({}), show_imported=False)
+        assert isinstance(result, str)
 
     def test_sync_docstring_mentions_first_time_vs_ongoing(self):
         """Lock-down 1 anchor: sync's docstring carries the


### PR DESCRIPTION
## Summary

Adds the write-back surface that closes the host-side loop opened by PR3/PR4/PR5. `mms host sync --apply` reconciles `~/.mms/registry.toml` + `~/.mms/import_state.toml` against the union of host scans:

- **ADD**: host candidates not in registry
- **REMOVE**: registry entries absent from every host scan (new vs PR2 — only path that *deletes* from the registry)
- **BACKFILL**: `no_baseline` rows that have a matching host candidate
- **CLEANUP**: pre-existing orphan sidecar entries (sidecar row, no registry row)
- **SKIP `changed`**: surfaced via footer + `summary.skipped_changed`; re-stamp is deferred to W3+ `--force`
- **SKIP `orphan_no_baseline`**: registry entry with no baseline AND not in any host scan; surfaced via footer + `summary.orphan_no_baseline` (no safe action)

`mms import` and `mms host sync` overlap in their additive paths, so the intent split is locked in cross-linked docstrings (Lock-down 1):

- `mms import --apply` — first-time entry point (host → empty/sparse registry).
- `mms host sync --apply` — ongoing reconciliation (host ↔ registry both mutate over time).

## Atomicity (extends PR2's invariant to the deletion path)

1. Registry write first: covers ADD inserts + REMOVE deletes in a single `save_registry()`.
2. Sidecar write second: filtered to `set(import_state.entries) ⊆ set(registry.servers)` atomically, then ADD baselines + BACKFILL stamps applied.

A crash between (1) and (2) self-heals on the next sync: orphan baselines drop, missing baselines BACKFILL. Pinned in both directions:

- `test_apply_atomicity_registry_first` (sidecar fails after registry succeeds → recovery via BACKFILL)
- `test_apply_no_sidecar_write_when_registry_fails` (registry fails → sidecar untouched)

## UX

- `--yes` + TTY-aware confirmation gates *only* the REMOVE bucket. Non-TTY without `--yes` aborts (exit 2). TTY without `--yes` shows an inline list of every removed entry (name + `source_label` + `last_imported`) plus a tail summary of the other buckets — informed consent without a separate `--plan` invocation.
- **`--json` + REMOVE always requires `--yes`** regardless of TTY status: a `click.confirm` prompt cannot be answered programmatically by a JSON consumer, and mixing prompt text with JSON output corrupts machine parsing. Without `--yes`, exit 2 with `aborted: true` payload (matches the non-TTY abort path).
- `--json` shape is locked: `mode` + `aborted` + `plan` (seven always-emit arrays) + `summary` (eight always-emit counts). `--plan` and `--apply` share the shape; `aborted: true` only on TTY decline / non-TTY abort / `--json` + REMOVE without `--yes`.
- Cross-host shape-relocation contract: when entry X is baselined to host A, then A drops X and host B picks it up with a different shape, sync surfaces X as `changed` (NOT REMOVE+ADD). Registry shape is *never silently reshaped* across hosts. Pinned by `test_cross_host_shape_relocation_does_not_replace`.

## Files

- `src/memtomem_stm/cli/mms_host.py` — `sync_cmd` + helpers + 8 pinned UX strings.
- `src/memtomem_stm/cli/mms_import.py` — module docstring cross-link to sync; cross-import contract comment naming both helpers (`_classify_against_registry` + `_format_env_summary`). **No code change.**
- `tests/cli/test_mms_host.py` — 31 new tests across `TestSyncPlan` / `TestSyncApply` / `TestSyncConfirmation` / `TestSyncJsonShape` / `TestSyncContractPin`. Both cross-imported helpers have signature + return-shape tripwires.

## Out of scope

- W3+ `--force` re-stamp for `changed`. **Wait-for-signal cleanup**: drop the trailing ` (W3+)` from `_SYNC_CHANGED_FOOTER_TEMPLATE` once W3 ships.
- RFC §7.3.1 interactive 3-option model — separate follow-up RFC.
- `--from <host>` scoping for sync — wait-for-signal.
- `--show-imported` parity with import — sync ships a hint line pointing at `mms import --plan --show-imported` instead. Wait-for-signal for full parity.
- Retroactive TTY+`--yes` pattern adoption in `mms import` — the pattern is introduced here; backfill is a separate decision.
- Promotion of cross-imported helpers to a shared `mms/sync.py` module — trigger is "next cross-imported helper joins" (two already share the trip-wire).
- `skipped_changed` JSON entries currently carry only `name`. If users report confusion when changed entries have moved hosts, surface `baseline_source` vs `current_source`.

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src` — clean (only modified files; pre-existing reformatable test files unchanged)
- [x] `uv run pytest -m "not ollama"` — 2059 passed
- [x] Cross-host shape-relocation scenario verified by `test_cross_host_shape_relocation_does_not_replace`
- [x] Atomicity invariant verified in both directions (registry-first preserved on sidecar failure; sidecar untouched on registry failure)
- [x] `--json` + REMOVE forces `--yes` verified by `test_json_apply_with_remove_requires_yes_even_in_tty` (no prompt mixing in JSON output)
- [x] No-op semantics preserved: `Already synchronized. No changes.` only fires when `set(sidecar) ⊆ set(registry)` AND no mutations pending; orphan-only state correctly counts as work and emits `Removed N stale sidecar entries` instead

## Review feedback addressed (2nd pass)

Two-pass review on this PR; second-pass medium + low issues all folded into commit `fa7a95a`:

- **Medium**: `summary.orphan_no_baseline` JSON parity with existing text footer.
- **Medium**: `--json` + REMOVE forces `--yes` (prevents prompt/JSON output mixing).
- **Low**: Both cross-imported helpers (`_classify_against_registry` + `_format_env_summary`) now have signature + return-shape pin tests.
- **Low**: Cross-import comment in `mms_import.py` updated to mention both helpers; promotion trigger shifted to "next cross-imported helper joins".
- **Low**: Removed `del original_confirm` smell in `test_apply_remove_prompt_lists_each_entry`.
- **Low**: Module docstring updated with PR6 paragraph noting sync's JSON shape contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)