### PR TITLE
feat(mms): W3 — `mms host sync --force` re-stamp

### DIFF
--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -97,14 +97,20 @@ _SYNC_CHANGED_FOOTER_TEMPLATE = (
     "{n} entr{ies_or_y} differ in shape at host. Use `mms host sync --force` to acknowledge."
 )
 
-# Sub-line under ``_SYNC_CHANGED_FOOTER_TEMPLATE`` when any of those
-# changed entries are shape-relocated to a non-baseline host (Lock-down
-# 6). ``--force`` deliberately skips these because adopting a Pass-2
-# fallback candidate would silently relocate the entry's host-of-record
-# — exactly the failure the W2 PR6 "no silent reshape" contract guards.
+# Cross-host drift footer (Lock-down 6). Used in two contexts:
+#   - Sub-line under ``_SYNC_CHANGED_FOOTER_TEMPLATE`` when ``--force``
+#     is *not* set and some changed entries are cross-host (so users
+#     know ``--force`` won't help these).
+#   - Standalone footer when ``--force`` *is* set and only cross-host
+#     entries remain in ``skipped_changed`` (the eligible subset got
+#     re-stamped, so the original "use --force" footer would be wrong).
+# ``--force`` deliberately skips cross-host entries because adopting a
+# Pass-2 fallback candidate would silently relocate the entry's
+# host-of-record — exactly the failure the W2 PR6 "no silent reshape"
+# contract guards.
 _SYNC_CROSS_HOST_FOOTER_TEMPLATE = (
-    "{n} of those entr{ies_or_y} appear at a different host than baseline source — "
-    "`--force` will skip these (manual review via `mms host status`)."
+    "{n} entr{ies_or_y} shape-relocated to a different host than baseline source — "
+    "`--force` will not adopt these (manual review via `mms host status`)."
 )
 
 _SYNC_ORPHAN_NO_BASELINE_FOOTER_TEMPLATE = (
@@ -687,6 +693,7 @@ def _render_sync_text(
     new: list[ImportCandidate],
     restamp_rows: list[dict] | None = None,
     cross_host_count: int = 0,
+    force_active: bool = False,
     apply_outcome: str | None = None,
 ) -> None:
     """Default human-readable sync renderer.
@@ -698,9 +705,11 @@ def _render_sync_text(
 
     ``restamp_rows`` (W3 ``--force``) renders as a RESTAMP section
     with an old/new diff per entry. Empty list (or default ``None``)
-    skips the section. ``cross_host_count`` extends the CHANGED footer
-    with a sub-line when the Lock-down 6 partition flagged any
-    shape-relocated entries.
+    skips the section. ``cross_host_count`` is the size of the
+    Lock-down 6 cross-host partition; ``force_active`` flips the
+    changed-bucket footer wording — without ``--force`` we point at
+    ``--force`` as the remedy, with ``--force`` we point at manual
+    review (``--force`` deliberately doesn't help cross-host).
     """
     add_rows = plan_payload["add"]
     remove_rows = plan_payload["remove"]
@@ -761,17 +770,36 @@ def _render_sync_text(
         for row in conflict_rows:
             w(f"    - {row['name']} from {row['host']}: {row['reason']}")
 
-    n_changed = summary["skipped_changed"]
-    if n_changed:
+    n_skipped = summary["skipped_changed"]
+    if n_skipped:
         w("")
-        w("  " + _SYNC_CHANGED_FOOTER_TEMPLATE.format(n=n_changed, ies_or_y=_ies_or_y(n_changed)))
-        if cross_host_count:
+        if force_active:
+            # ``--force`` was set; the only entries left in
+            # skipped_changed are the cross-host slice (eligible got
+            # re-stamped). Use the cross-host footer as the primary
+            # message — the standard "use --force" pointer would be
+            # wrong here since --force already declined to adopt these.
             w(
                 "  "
                 + _SYNC_CROSS_HOST_FOOTER_TEMPLATE.format(
-                    n=cross_host_count, ies_or_y=_ies_or_y(cross_host_count)
+                    n=n_skipped, ies_or_y=_ies_or_y(n_skipped)
                 )
             )
+        else:
+            # No --force. Standard "use --force" pointer + optional
+            # cross-host sub-line so users know --force won't help
+            # those.
+            w(
+                "  "
+                + _SYNC_CHANGED_FOOTER_TEMPLATE.format(n=n_skipped, ies_or_y=_ies_or_y(n_skipped))
+            )
+            if cross_host_count:
+                w(
+                    "  "
+                    + _SYNC_CROSS_HOST_FOOTER_TEMPLATE.format(
+                        n=cross_host_count, ies_or_y=_ies_or_y(cross_host_count)
+                    )
+                )
 
     if mode == "plan":
         w("")
@@ -967,13 +995,19 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
             }
             for name in cleanup_names
         ],
-        # ``skipped_changed`` is registry-anchored and gains 5 fields
-        # in W3 (was minimal ``{"name": ...}`` in PR6). Existing
-        # downstream parsers reading ``[i]["name"]`` keep working —
-        # this is an *additive* change at the entry-field level, not a
+        # ``skipped_changed`` lists changed entries that this run does
+        # *not* re-stamp. Without ``--force``, that's every changed
+        # entry (the bucket stays non-mutating per W2 PR6). With
+        # ``--force``, only the cross-host slice remains skipped — the
+        # eligible subset moves to RESTAMP. Counting both would
+        # double-report and make the "use ``--force`` to acknowledge"
+        # footer fire even after we just re-stamped them.
+        #
+        # Gains 5 fields in W3 (was minimal ``{"name": ...}`` in PR6).
+        # Existing downstream parsers reading ``[i]["name"]`` keep
+        # working — additive change at the entry-field level, not a
         # new top-level key. ``host_relocation`` flags the Lock-down 6
-        # cross-host partition: ``True`` when the only host candidate
-        # is at a non-baseline source (``--force`` will skip these).
+        # cross-host partition.
         "skipped_changed": [
             {
                 "name": r["name"],
@@ -983,7 +1017,7 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
                 "last_imported": r["last_imported"],
                 "host_relocation": (cand_by_name[r["name"]].source_label != r["source_label"]),
             }
-            for r in changed_rows_classified
+            for r in (cross_host_changed_rows if force else changed_rows_classified)
         ],
         # ``orphan_no_baseline``: registry has the entry, sidecar has no
         # baseline (or version mismatch), and no host scan finds it.
@@ -1030,6 +1064,7 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
                 new=new,
                 restamp_rows=restamp_eligible_rows if force else [],
                 cross_host_count=len(cross_host_changed_rows),
+                force_active=force,
             )
             _render_orphan_no_baseline_footer(len(no_baseline_orphans))
         return
@@ -1085,6 +1120,7 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
                 new=new,
                 restamp_rows=restamp_rows,
                 cross_host_count=len(cross_host_changed_rows),
+                force_active=force,
                 apply_outcome="no_op",
             )
             _render_orphan_no_baseline_footer(len(no_baseline_orphans))
@@ -1163,6 +1199,7 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
             new=new,
             restamp_rows=restamp_rows,
             cross_host_count=len(cross_host_changed_rows),
+            force_active=force,
             apply_outcome="mutated",
         )
         _render_orphan_no_baseline_footer(len(no_baseline_orphans))

--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -99,6 +99,16 @@ _SYNC_CHANGED_FOOTER_TEMPLATE = (
     "{n} entr{ies_or_y} differ in shape at host. Use `mms host sync --force` to acknowledge (W3+)."
 )
 
+# Sub-line under ``_SYNC_CHANGED_FOOTER_TEMPLATE`` when any of those
+# changed entries are shape-relocated to a non-baseline host (Lock-down
+# 6). ``--force`` deliberately skips these because adopting a Pass-2
+# fallback candidate would silently relocate the entry's host-of-record
+# — exactly the failure the W2 PR6 "no silent reshape" contract guards.
+_SYNC_CROSS_HOST_FOOTER_TEMPLATE = (
+    "{n} of those entr{ies_or_y} appear at a different host than baseline source — "
+    "`--force` will skip these (manual review via `mms host status`)."
+)
+
 _SYNC_ORPHAN_NO_BASELINE_FOOTER_TEMPLATE = (
     "{n} entr{ies_or_y} in registry without baseline and not at any host scan."
 )
@@ -107,13 +117,17 @@ _SYNC_REMOVE_PROMPT_HEADER_TEMPLATE = (
     "The following {n} entr{ies_or_y} will be removed from registry:"
 )
 
+_SYNC_RESTAMP_PROMPT_HEADER_TEMPLATE = (
+    "The following {n} entr{ies_or_y} will be re-stamped (registry shape updated to current host):"
+)
+
 _SYNC_REMOVE_PROMPT_TAIL_TEMPLATE = (
     "Also: {added} added, {backfilled} backfilled, "
     "{cleanup} stale sidecar entr{cleanup_ies_or_y} cleaned."
 )
 
 _SYNC_NON_TTY_ABORT_TEMPLATE = (
-    "Refusing to remove {n} registry entr{ies_or_y} non-interactively. Pass --yes to confirm."
+    "Refusing to apply {n} registry mutation{s_suffix} non-interactively. Pass --yes to confirm."
 )
 
 _SYNC_DECLINE_MSG = "Aborted. No changes."
@@ -129,6 +143,11 @@ _SYNC_SHOW_IMPORTED_HINT = (
 
 def _ies_or_y(n: int) -> str:
     return "y" if n == 1 else "ies"
+
+
+def _s_suffix(n: int) -> str:
+    """Plural helper for words like ``mutation`` (no -y/-ies vowel shift)."""
+    return "" if n == 1 else "s"
 
 
 def _is_interactive() -> bool:
@@ -531,6 +550,7 @@ def _empty_sync_summary() -> dict:
         "cleanup": 0,
         "skipped_changed": 0,
         "orphan_no_baseline": 0,
+        "restamped": 0,
         "unchanged": 0,
         "conflicts": 0,
     }
@@ -541,21 +561,95 @@ def _new_has_secret_env(new: list[ImportCandidate]) -> bool:
     return any(cand.env_classification[k].is_secret for cand in new for k in cand.server.env)
 
 
-def _build_remove_prompt(removed_rows: list[dict], summary: dict) -> str:
-    """Compose the inline confirmation message for the REMOVE bucket.
+def _format_env_keys_redacted(server: state.RegistryServer) -> str:
+    """Render env as ``{key1, key2, ...}`` with keys sorted (diff-stable).
+
+    Values redacted; ``mms host sync --force`` confirmation must show
+    *what changed* without leaking secrets. Sorted ordering ensures
+    two semantically-identical env dicts don't appear "different" just
+    because their insertion order differs across host scanners.
+    """
+    if not server.env:
+        return "{}"
+    return "{" + ", ".join(sorted(server.env.keys())) + "}"
+
+
+def _format_server_diff_lines(row: dict) -> list[str]:
+    """Render Old/New shape for one re-stamp entry.
+
+    Identical fields collapse to a single line so the prompt stays
+    readable. Env values are redacted (key set only); ``command`` and
+    ``args`` render verbatim. ``row`` carries the in-process keys
+    ``_old_server`` and ``_new_server`` (excluded from the JSON
+    payload — see ``sync_cmd``).
+    """
+    old: state.RegistryServer = row["_old_server"]
+    new: state.RegistryServer = row["_new_server"]
+    new_source = row["_new_source_label"]
+    lines = [f"  - {row['name']}"]
+    same_command = old.command == new.command
+    same_args = list(old.args or []) == list(new.args or [])
+    same_env = sorted(old.env.keys()) == sorted(new.env.keys())
+    if same_command and same_args and same_env:
+        # Edge case: hash differs but every observable surface matches.
+        # Fall through to a single-line "unchanged surface" note —
+        # users can still re-stamp (e.g. drift_hash_version bump).
+        lines.append(
+            f"    command={new.command}  args={list(new.args or [])}  "
+            f"env={_format_env_keys_redacted(new)}"
+        )
+    else:
+        lines.append(
+            f"    Old: command={old.command}  args={list(old.args or [])}  "
+            f"env={_format_env_keys_redacted(old)}"
+        )
+        lines.append(
+            f"    New: command={new.command}  args={list(new.args or [])}  "
+            f"env={_format_env_keys_redacted(new)}"
+        )
+    lines.append(f"    Source: {new_source}")
+    return lines
+
+
+def _build_apply_prompt(
+    removed_rows: list[dict],
+    restamp_rows: list[dict],
+    summary: dict,
+) -> str:
+    """Compose the inline confirmation message for ``--apply`` mutations.
 
     Lists every entry by name + ``source_label`` + ``last_imported``
     so the user gives informed consent without a separate ``--plan``
     invocation. Tail summarizes the other (non-destructive) buckets so
     decline cost is visible (``Also: A added, B backfilled, ...``).
+
+    Section order is intentional: REMOVE first (most destructive — entry
+    disappears from registry), RESTAMP second (entry shape changes but
+    name persists), summary tail last (additive buckets). Destructive-
+    first lets users review the most reversibility-critical changes
+    before fatigue. PRs that want to reorder must justify against this.
+
+    ``restamp_rows`` is empty when ``--force`` is absent; the RE-STAMP
+    section is skipped entirely. The W3 ``--force`` apply path fills it
+    after the Lock-down 6 cross-host partition drops shape-relocated
+    entries (re-stamping a candidate from a non-baseline host would
+    silently relocate the entry's host-of-record).
     """
-    n = len(removed_rows)
-    lines = [_SYNC_REMOVE_PROMPT_HEADER_TEMPLATE.format(n=n, ies_or_y=_ies_or_y(n))]
-    for row in removed_rows:
-        lines.append(
-            f"  - {row['name']} (last seen: {row['source_label']}, {row['last_imported']})"
-        )
-    lines.append("")
+    lines: list[str] = []
+    if removed_rows:
+        n = len(removed_rows)
+        lines.append(_SYNC_REMOVE_PROMPT_HEADER_TEMPLATE.format(n=n, ies_or_y=_ies_or_y(n)))
+        for row in removed_rows:
+            lines.append(
+                f"  - {row['name']} (last seen: {row['source_label']}, {row['last_imported']})"
+            )
+        lines.append("")
+    if restamp_rows:
+        n = len(restamp_rows)
+        lines.append(_SYNC_RESTAMP_PROMPT_HEADER_TEMPLATE.format(n=n, ies_or_y=_ies_or_y(n)))
+        for row in restamp_rows:
+            lines.extend(_format_server_diff_lines(row))
+        lines.append("")
     lines.append(
         _SYNC_REMOVE_PROMPT_TAIL_TEMPLATE.format(
             added=summary["added"],
@@ -593,6 +687,8 @@ def _render_sync_text(
     summary: dict,
     *,
     new: list[ImportCandidate],
+    restamp_rows: list[dict] | None = None,
+    cross_host_count: int = 0,
     apply_outcome: str | None = None,
 ) -> None:
     """Default human-readable sync renderer.
@@ -601,12 +697,19 @@ def _render_sync_text(
     "mutated", or None (None = plan mode). The same bucket sections
     render in every mode so users see consistent surface; only the
     final footer changes.
+
+    ``restamp_rows`` (W3 ``--force``) renders as a RESTAMP section
+    with an old/new diff per entry. Empty list (or default ``None``)
+    skips the section. ``cross_host_count`` extends the CHANGED footer
+    with a sub-line when the Lock-down 6 partition flagged any
+    shape-relocated entries.
     """
     add_rows = plan_payload["add"]
     remove_rows = plan_payload["remove"]
     backfill_rows = plan_payload["backfill"]
     cleanup_rows = plan_payload["cleanup"]
     conflict_rows = plan_payload["conflicts"]
+    restamp_rows = restamp_rows or []
 
     def w(s: str) -> None:
         click.echo(s)
@@ -643,6 +746,12 @@ def _render_sync_text(
         w(f"  CLEANUP   {n} stale sidecar entr{_ies_or_y(n)} (no registry entry)")
         for row in cleanup_rows:
             w(f"    - {row['name']} (last seen: {row['source_label']}, {row['last_imported']})")
+    if restamp_rows:
+        n = len(restamp_rows)
+        w(f"  RESTAMP   {n} entr{_ies_or_y(n)} (registry shape updated to current host)")
+        for row in restamp_rows:
+            for line in _format_server_diff_lines(row):
+                w(line)
 
     w("")
     w(f"  {summary['unchanged']} unchanged")
@@ -658,6 +767,13 @@ def _render_sync_text(
     if n_changed:
         w("")
         w("  " + _SYNC_CHANGED_FOOTER_TEMPLATE.format(n=n_changed, ies_or_y=_ies_or_y(n_changed)))
+        if cross_host_count:
+            w(
+                "  "
+                + _SYNC_CROSS_HOST_FOOTER_TEMPLATE.format(
+                    n=cross_host_count, ies_or_y=_ies_or_y(cross_host_count)
+                )
+            )
 
     if mode == "plan":
         w("")
@@ -689,6 +805,11 @@ def _render_sync_text(
                 f"entr{_ies_or_y(summary['cleanup'])} "
                 f"from {state.import_state_path()}"
             )
+        if summary["restamped"]:
+            w(
+                f"Re-stamped {summary['restamped']} entr{_ies_or_y(summary['restamped'])} "
+                f"(registry + sidecar) — {state.registry_path()}, {state.import_state_path()}"
+            )
 
 
 def _render_orphan_no_baseline_footer(n: int) -> None:
@@ -715,9 +836,19 @@ def _render_orphan_no_baseline_footer(n: int) -> None:
 @click.option(
     "--yes",
     is_flag=True,
-    help="Bypass the confirmation prompt before removing registry entries.",
+    help="Bypass the confirmation prompt before applying mutations.",
 )
-def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
+@click.option(
+    "--force",
+    is_flag=True,
+    help=(
+        "Adopt host shape for entries flagged 'changed' (registry + sidecar). "
+        "Skips entries that have shape-relocated to a different host than the "
+        "baseline source. Orthogonal to --yes (which bypasses the confirmation "
+        "prompt)."
+    ),
+)
+def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
     """Reconcile registry + sidecar with the union of host scans.
 
     vs ``mms import``:
@@ -732,25 +863,42 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
 
     Read-only buckets (see ``mms host status`` for definitions):
       - ``unchanged``: silent no-op (most common case).
-      - ``changed``: NOT mutated by sync; user must acknowledge via
-        W3+ ``--force``. Surfaces as footer note + ``summary.skipped_changed``.
+      - ``changed``: non-mutating without ``--force``; user must
+        acknowledge via ``mms host sync --force`` to adopt the host
+        shape. Surfaces as footer note + ``summary.skipped_changed``.
 
     Mutating buckets:
       - ``new`` (host candidate not in registry) → ADD.
       - ``removed_at_host`` (registry entry absent from every host
         scan) → REMOVE registry + sidecar entry.
       - ``no_baseline`` with matched host candidate → BACKFILL sidecar.
+      - ``changed`` (with ``--force``) → RESTAMP registry + sidecar
+        with current host shape. Lock-down 6: re-stamp candidate must
+        come from the baseline source host. Cross-host (Pass-2)
+        candidates are excluded — re-stamping from a non-baseline host
+        would silently relocate the entry's host-of-record. Excluded
+        entries surface in the extended CHANGED footer for manual
+        review (``mms host status``).
+
+    ``--force`` and ``--yes`` are orthogonal:
+      - ``--force`` activates the ``changed`` bucket as a mutator
+        (without it, ``changed`` stays non-mutating).
+      - ``--yes`` bypasses the interactive confirmation prompt.
+      ``--force`` alone still prompts; ``--force --yes`` is the
+      non-interactive combination. ``--force --json`` without
+      ``--yes`` aborts (exit 2, ``aborted: true``) — same gate REMOVE
+      uses, since mixing prompt text with JSON corrupts parsing.
 
     Atomicity: registry write first, sidecar write second. The
     sidecar is filtered to ``set(import_state.entries) ⊆
     set(registry.servers)`` so a crash between writes self-heals on
     the next run (orphan baselines drop; missing baselines BACKFILL).
 
-    With ``--json``, the REMOVE bucket always requires ``--yes`` —
-    a TTY confirmation prompt cannot be answered programmatically by
-    a JSON consumer, and mixing prompt text with JSON output corrupts
-    machine parsing. Without ``--yes``, ``--json`` REMOVE aborts
-    (exit 2) with ``aborted: true`` in the payload.
+    With ``--json``, REMOVE and RESTAMP both require ``--yes`` — a TTY
+    confirmation prompt cannot be answered programmatically by a JSON
+    consumer, and mixing prompt text with JSON output corrupts machine
+    parsing. Without ``--yes``, ``--json`` aborts (exit 2) with
+    ``aborted: true`` in the payload.
 
     See ``mms_import.py`` for the matching docstring at
     ``import_command``.
@@ -772,6 +920,25 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
 
     no_baseline_with_cand = [r for r in no_baseline_rows if cand_by_name.get(r["name"]) is not None]
     no_baseline_orphans = [r for r in no_baseline_rows if cand_by_name.get(r["name"]) is None]
+
+    # Lock-down 6: partition ``changed`` by candidate host. Only entries
+    # whose Pass-1 candidate matches the baseline source are valid
+    # ``--force`` re-stamp targets; Pass-2 fallbacks to a different host
+    # would silently relocate the entry's host-of-record (see
+    # ``_select_candidate_by_name`` doc + W3 plan §Lock-down 6). The
+    # cross-host slice surfaces as a sub-line in the CHANGED footer so
+    # users can review via ``mms host status`` instead of having
+    # ``--force`` adopt a non-baseline shape.
+    restamp_eligible_rows = [
+        r
+        for r in changed_rows_classified
+        if cand_by_name[r["name"]].source_label == r["source_label"]
+    ]
+    cross_host_changed_rows = [
+        r
+        for r in changed_rows_classified
+        if cand_by_name[r["name"]].source_label != r["source_label"]
+    ]
 
     # Pre-existing orphan sidecar entries: in sidecar but not in registry.
     # ``_classify`` is registry-anchored and never emits these — detect
@@ -802,7 +969,24 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
             }
             for name in cleanup_names
         ],
-        "skipped_changed": [{"name": r["name"]} for r in changed_rows_classified],
+        # ``skipped_changed`` is registry-anchored and gains 5 fields
+        # in W3 (was minimal ``{"name": ...}`` in PR6). Existing
+        # downstream parsers reading ``[i]["name"]`` keep working —
+        # this is an *additive* change at the entry-field level, not a
+        # new top-level key. ``host_relocation`` flags the Lock-down 6
+        # cross-host partition: ``True`` when the only host candidate
+        # is at a non-baseline source (``--force`` will skip these).
+        "skipped_changed": [
+            {
+                "name": r["name"],
+                "source_label": r["source_label"],
+                "baseline_hash": r["baseline_hash"],
+                "current_hash": r["current_hash"],
+                "last_imported": r["last_imported"],
+                "host_relocation": (cand_by_name[r["name"]].source_label != r["source_label"]),
+            }
+            for r in changed_rows_classified
+        ],
         # ``orphan_no_baseline``: registry has the entry, sidecar has no
         # baseline (or version mismatch), and no host scan finds it.
         # Sync can't safely act — JSON parity with the text footer.
@@ -812,6 +996,8 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
             for cand, reason in conflicts
         ],
     }
+    # ``restamped`` always present (default 0); incremented only on
+    # ``--apply --force`` over baseline-source-matched entries.
     summary = {
         "added": len(plan_payload["add"]),
         "removed": len(plan_payload["remove"]),
@@ -819,31 +1005,56 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
         "cleanup": len(plan_payload["cleanup"]),
         "skipped_changed": len(plan_payload["skipped_changed"]),
         "orphan_no_baseline": len(plan_payload["orphan_no_baseline"]),
+        "restamped": len(restamp_eligible_rows) if force else 0,
         "unchanged": n_unchanged,
         "conflicts": len(plan_payload["conflicts"]),
     }
+
+    # In-process row enrichment for the diff renderer (Lock-down 2).
+    # ``_old_server`` / ``_new_server`` / ``_new_source_label`` carry
+    # the live ``RegistryServer`` references the prompt + plan-mode
+    # RESTAMP section need — kept off the JSON payload (underscore-
+    # prefixed keys are an in-process convention for "render-only").
+    for row in restamp_eligible_rows:
+        cand = cand_by_name[row["name"]]
+        row["_old_server"] = registry.servers[row["name"]]
+        row["_new_server"] = cand.server
+        row["_new_source_label"] = cand.source_label
 
     if is_plan:
         if json_output:
             _render_sync_json("plan", plan_payload, summary, aborted=False)
         else:
-            _render_sync_text("plan", plan_payload, summary, new=new)
+            _render_sync_text(
+                "plan",
+                plan_payload,
+                summary,
+                new=new,
+                restamp_rows=restamp_eligible_rows if force else [],
+                cross_host_count=len(cross_host_changed_rows),
+            )
             _render_orphan_no_baseline_footer(len(no_baseline_orphans))
         return
 
     # ----- --apply -----
 
-    # Confirmation gate (only when REMOVE bucket is non-empty).
-    # ``--json`` + REMOVE forces ``--yes``: a TTY prompt cannot be
-    # answered by a JSON consumer, and mixing the prompt text with
-    # JSON output would corrupt machine parsing. So we fall through
-    # to the non-TTY abort path whenever ``--json`` is set, regardless
-    # of the actual TTY status.
-    if removed_at_host_rows and not yes:
+    # ``--force`` activates the ``changed`` bucket as a mutator
+    # (Lock-down 3). The cross-host slice (Lock-down 6) is excluded —
+    # surfaced in the CHANGED footer for manual review only.
+    restamp_rows = restamp_eligible_rows if force else []
+
+    # Confirmation gate (REMOVE or RESTAMP non-empty).
+    # ``--json`` + any destructive bucket forces ``--yes``: a TTY prompt
+    # cannot be answered by a JSON consumer, and mixing prompt text with
+    # JSON output would corrupt machine parsing. So we fall through to
+    # the non-TTY abort path whenever ``--json`` is set, regardless of
+    # the actual TTY status.
+    needs_confirmation = bool(removed_at_host_rows) or bool(restamp_rows)
+    if needs_confirmation and not yes:
         if not _is_interactive() or json_output:
-            n = len(removed_at_host_rows)
+            n_total = len(removed_at_host_rows) + len(restamp_rows)
             click.echo(
-                _SYNC_NON_TTY_ABORT_TEMPLATE.format(n=n, ies_or_y=_ies_or_y(n)),
+                _SYNC_NON_TTY_ABORT_TEMPLATE.format(n=n_total, s_suffix=_s_suffix(n_total)),
                 err=True,
             )
             if json_output:
@@ -851,7 +1062,10 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
                     "apply", _empty_sync_payload(), _empty_sync_summary(), aborted=True
                 )
             sys.exit(2)
-        if not click.confirm(_build_remove_prompt(removed_at_host_rows, summary), default=False):
+        if not click.confirm(
+            _build_apply_prompt(removed_at_host_rows, restamp_rows, summary),
+            default=False,
+        ):
             click.echo(_SYNC_DECLINE_MSG, err=True)
             sys.exit(2)
 
@@ -860,24 +1074,42 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
     # this, orphans would never be cleaned up by a "boring" sync and
     # the post-condition ``sidecar.keys() ⊆ registry.servers.keys()``
     # would not self-heal.
-    no_mutations = not (new or removed_at_host_rows or no_baseline_with_cand)
+    no_mutations = not (new or removed_at_host_rows or no_baseline_with_cand or restamp_rows)
     no_orphans = not cleanup_names
     if no_mutations and no_orphans:
         if json_output:
             _render_sync_json("apply", plan_payload, summary, aborted=False)
         else:
-            _render_sync_text("apply", plan_payload, summary, new=new, apply_outcome="no_op")
+            _render_sync_text(
+                "apply",
+                plan_payload,
+                summary,
+                new=new,
+                restamp_rows=restamp_rows,
+                cross_host_count=len(cross_host_changed_rows),
+                apply_outcome="no_op",
+            )
             _render_orphan_no_baseline_footer(len(no_baseline_orphans))
         return
 
-    # Step 1: registry write (ADD inserts + REMOVE deletes).
-    registry_changed = bool(new) or bool(removed_at_host_rows)
+    # Step 1: registry write (ADD inserts + REMOVE deletes + RESTAMP
+    # replacements). Sequential passes, single ``save_registry`` —
+    # cross-bucket name collision is impossible by construction (RESTAMP
+    # rows require registry membership AND a host candidate; REMOVE
+    # requires no candidate; ADD requires no registry membership).
+    registry_changed = bool(new) or bool(removed_at_host_rows) or bool(restamp_rows)
     if registry_changed:
         new_servers = {**registry.servers}
         for cand in new:
             new_servers[cand.name] = cand.server
         for row in removed_at_host_rows:
             new_servers.pop(row["name"], None)
+        # RESTAMP: replace the existing registry entry with the candidate's
+        # server. Lock-down 1 (full reconciliation): registry shape adopts
+        # the host's shape. Lock-down 6 has already filtered cross-host
+        # candidates out of ``restamp_rows`` upstream.
+        for row in restamp_rows:
+            new_servers[row["name"]] = cand_by_name[row["name"]].server
         new_registry = state.RegistryConfig(
             schema_version=registry.schema_version, servers=new_servers
         )
@@ -886,9 +1118,10 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
         new_servers = dict(registry.servers)
 
     # Step 2: sidecar write. Filter to names surviving in new_servers
-    # (orphan cleanup), then add ADD baselines + BACKFILL stamps. The
-    # filter enforces the post-condition atomically with the rest of
-    # the write; PR2's "registry first, sidecar second" extends here.
+    # (orphan cleanup), then add ADD baselines + BACKFILL stamps + RESTAMP
+    # refreshes. The filter enforces the post-condition atomically with
+    # the rest of the write; PR2's "registry first, sidecar second"
+    # extends here.
     now = state.utc_now_iso()
     new_state_entries: dict[str, state.ImportStateEntry] = {}
     for name, entry in import_state.entries.items():
@@ -909,6 +1142,14 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
             last_imported=now,
             source_label=cand_for_row.source_label,
         )
+    for row in restamp_rows:
+        cand_for_row = cand_by_name[row["name"]]
+        new_state_entries[row["name"]] = state.ImportStateEntry(
+            drift_hash=compute_drift_hash(cand_for_row.server),
+            drift_hash_version=HASH_VERSION,
+            last_imported=now,
+            source_label=cand_for_row.source_label,
+        )
     new_import_state = state.ImportState(
         schema_version=import_state.schema_version, entries=new_state_entries
     )
@@ -917,5 +1158,13 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool) -> None:
     if json_output:
         _render_sync_json("apply", plan_payload, summary, aborted=False)
     else:
-        _render_sync_text("apply", plan_payload, summary, new=new, apply_outcome="mutated")
+        _render_sync_text(
+            "apply",
+            plan_payload,
+            summary,
+            new=new,
+            restamp_rows=restamp_rows,
+            cross_host_count=len(cross_host_changed_rows),
+            apply_outcome="mutated",
+        )
         _render_orphan_no_baseline_footer(len(no_baseline_orphans))

--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -7,8 +7,8 @@ PR3 landed the read-only inspection command; PR4 promoted
   drift buckets relative to the W2 sidecar baseline, and surface the
   result either as a human table or ``--json``.
 
-The bucket vocabulary is the contract that W3+ (``--force`` re-stamp,
-``mms host scan``, ``mms host sync``) builds on. PR3 froze the four
+The bucket vocabulary is the contract that ``mms host scan``,
+``mms host sync``, and ``mms host sync --force`` build on. PR3 froze the four
 state names; PR4 changed *where* ``removed_at_host`` renders without
 renaming anything. JSON shape and footer text are backwards-compat
 anchors and stayed frozen across PR4.
@@ -89,14 +89,12 @@ _SCAN_HOST_CHOICES = click.Choice([*ALL_HOSTS, "all"], case_sensitive=False)
 
 # ---------------------------------------------------------------------------
 # sync UX strings — pinned templates so tests assert against the *symbol*.
-# When W3 ships ``mms host sync --force`` for the ``changed`` bucket, drop
-# the trailing " (W3+)" from ``_SYNC_CHANGED_FOOTER_TEMPLATE``.
 # ---------------------------------------------------------------------------
 
 _SYNC_NO_OP_MSG = "Already synchronized. No changes."
 
 _SYNC_CHANGED_FOOTER_TEMPLATE = (
-    "{n} entr{ies_or_y} differ in shape at host. Use `mms host sync --force` to acknowledge (W3+)."
+    "{n} entr{ies_or_y} differ in shape at host. Use `mms host sync --force` to acknowledge."
 )
 
 # Sub-line under ``_SYNC_CHANGED_FOOTER_TEMPLATE`` when any of those
@@ -864,8 +862,8 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
     Read-only buckets (see ``mms host status`` for definitions):
       - ``unchanged``: silent no-op (most common case).
       - ``changed``: non-mutating without ``--force``; user must
-        acknowledge via ``mms host sync --force`` to adopt the host
-        shape. Surfaces as footer note + ``summary.skipped_changed``.
+        acknowledge via ``--force`` to adopt the host shape. Surfaces
+        as footer note + ``summary.skipped_changed``.
 
     Mutating buckets:
       - ``new`` (host candidate not in registry) → ADD.

--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -593,8 +593,12 @@ def _format_server_diff_lines(row: dict) -> list[str]:
     lines = [f"  - {row['name']}"]
     same_command = old.command == new.command
     same_args = list(old.args or []) == list(new.args or [])
-    same_env = sorted(old.env.keys()) == sorted(new.env.keys())
-    if same_command and same_args and same_env:
+    same_env_keys = sorted(old.env.keys()) == sorted(new.env.keys())
+    # Env values may differ even when keys match (e.g. token rotation).
+    # Treat that as a *visible* drift signal even though the values
+    # themselves stay redacted, so users see *why* re-stamp is firing.
+    same_env_values = old.env == new.env
+    if same_command and same_args and same_env_keys and same_env_values:
         # Edge case: hash differs but every observable surface matches.
         # Fall through to a single-line "unchanged surface" note —
         # users can still re-stamp (e.g. drift_hash_version bump).
@@ -602,6 +606,18 @@ def _format_server_diff_lines(row: dict) -> list[str]:
             f"    command={new.command}  args={list(new.args or [])}  "
             f"env={_format_env_keys_redacted(new)}"
         )
+    elif same_command and same_args and same_env_keys:
+        # Surface looks identical but env values changed (redacted).
+        # Without this branch the "Old:" / "New:" lines would render
+        # twice with the same string — confusing — so collapse to one
+        # line + an explicit "(env values redacted; values changed)"
+        # note. User has informed consent that *something* changed,
+        # without leaking secrets.
+        lines.append(
+            f"    command={new.command}  args={list(new.args or [])}  "
+            f"env={_format_env_keys_redacted(new)}"
+        )
+        lines.append("    (env values redacted; values changed)")
     else:
         lines.append(
             f"    Old: command={old.command}  args={list(old.args or [])}  "
@@ -773,12 +789,15 @@ def _render_sync_text(
     n_skipped = summary["skipped_changed"]
     if n_skipped:
         w("")
-        if force_active:
-            # ``--force`` was set; the only entries left in
-            # skipped_changed are the cross-host slice (eligible got
-            # re-stamped). Use the cross-host footer as the primary
-            # message — the standard "use --force" pointer would be
-            # wrong here since --force already declined to adopt these.
+        # Cross-host primary footer fires when (a) ``--force`` was set
+        # so eligible got re-stamped — the slice left is only cross-
+        # host, OR (b) every changed row is cross-host so the standard
+        # "use --force" pointer is wrong (--force won't help them
+        # anyway). A user reading only the first line should walk away
+        # with the right action — don't lead with "use --force" when
+        # --force won't help.
+        all_skipped_are_cross_host = n_skipped == cross_host_count
+        if force_active or all_skipped_are_cross_host:
             w(
                 "  "
                 + _SYNC_CROSS_HOST_FOOTER_TEMPLATE.format(
@@ -786,9 +805,9 @@ def _render_sync_text(
                 )
             )
         else:
-            # No --force. Standard "use --force" pointer + optional
-            # cross-host sub-line so users know --force won't help
-            # those.
+            # Mixed (some in-place that --force could help). Standard
+            # "use --force" pointer + cross-host sub-line so users
+            # know --force won't help that subset.
             w(
                 "  "
                 + _SYNC_CHANGED_FOOTER_TEMPLATE.format(n=n_skipped, ies_or_y=_ies_or_y(n_skipped))
@@ -1047,11 +1066,14 @@ def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
     # the live ``RegistryServer`` references the prompt + plan-mode
     # RESTAMP section need — kept off the JSON payload (underscore-
     # prefixed keys are an in-process convention for "render-only").
-    for row in restamp_eligible_rows:
-        cand = cand_by_name[row["name"]]
-        row["_old_server"] = registry.servers[row["name"]]
-        row["_new_server"] = cand.server
-        row["_new_source_label"] = cand.source_label
+    # Guarded by ``force`` so non-force runs don't quietly mutate
+    # ``changed_rows_classified`` dicts that the renderer never reads.
+    if force:
+        for row in restamp_eligible_rows:
+            cand = cand_by_name[row["name"]]
+            row["_old_server"] = registry.servers[row["name"]]
+            row["_new_server"] = cand.server
+            row["_new_source_label"] = cand.source_label
 
     if is_plan:
         if json_output:

--- a/src/memtomem_stm/cli/mms_import.py
+++ b/src/memtomem_stm/cli/mms_import.py
@@ -39,9 +39,9 @@ sees what's there now, and "original import host" isn't recorded
 anywhere we can recover from.
 
 Registry write still precedes sidecar write within a single apply;
-no transaction. A ``--force`` option to re-stamp existing sidecar
-rows (resetting timestamps after a host edit you've already
-acknowledged) lands in W3+.
+no transaction. To re-stamp existing sidecar rows (after a host edit
+you've already acknowledged), use ``mms host sync --force`` — the
+ongoing-reconciliation entry point, not ``mms import``.
 
 vs ``mms host sync``:
   ``mms import`` is the first-time entry point (host → empty

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -1731,7 +1731,9 @@ class TestSyncForceCrossHostLockdown6:
     def test_apply_force_only_eligible_when_mixed(self, runner, sandbox):
         """Mixed bucket: one in-place drift (eligible) + one cross-host
         drift (ineligible). ``--force`` re-stamps only the eligible one;
-        cross-host stays in skipped_changed."""
+        cross-host stays in skipped_changed; in-place is removed from
+        skipped_changed (it was just re-stamped, no longer 'skipped').
+        """
         _seed_claude_code(
             sandbox,
             {
@@ -1759,11 +1761,16 @@ class TestSyncForceCrossHostLockdown6:
         # Cross-host untouched, still in skipped_changed.
         assert state.load_registry().servers["moves"] == original_moves_shape
         skipped_names = {row["name"] for row in payload["plan"]["skipped_changed"]}
-        assert "moves" in skipped_names
+        assert skipped_names == {"moves"}, skipped_names
+        # Smoke-discovered fix: in-place must NOT be reported as
+        # 'skipped' once --force has re-stamped it. Counting both in
+        # skipped_changed would make the "use --force to acknowledge"
+        # footer fire after we just re-stamped them.
+        assert payload["summary"]["skipped_changed"] == 1
 
     def test_cross_host_footer_renders_in_text_mode(self, runner, sandbox):
-        """Text-mode CHANGED footer extends with a sub-line when any
-        cross-host shape-relocations exist."""
+        """Without ``--force``, text-mode CHANGED footer extends with a
+        cross-host sub-line when any shape-relocations exist."""
         _seed_claude_code(sandbox, {"x": {"command": "npx", "args": ["v1"]}})
         _apply_claude_code(runner)
         _seed_claude_code(sandbox, {})
@@ -1774,4 +1781,46 @@ class TestSyncForceCrossHostLockdown6:
         # Top-line CHANGED footer present.
         assert "differ in shape at host" in res.output
         # Cross-host sub-line present.
-        assert "different host than baseline source" in res.output
+        assert "shape-relocated to a different host than baseline source" in res.output
+
+    def test_apply_force_does_not_print_changed_footer_for_restamped(
+        self, runner, sandbox
+    ):
+        """Smoke-discovered fix: after ``--force --apply`` re-stamps an
+        entry, the "differ in shape at host. Use --force to acknowledge."
+        footer must NOT fire for it. The footer's ``--force`` pointer
+        would be misleading — the entry is already re-stamped.
+        """
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        res = _sync(runner, "--apply", "--force", "--yes")
+        assert res.exit_code == 0, res.output
+        # The standard "differ" pointer footer must NOT fire — the
+        # only entry in changed bucket got re-stamped.
+        assert "differ in shape at host" not in res.output
+        assert "use `mms host sync --force` to acknowledge" not in res.output.lower()
+
+    def test_apply_force_prints_cross_host_only_footer_when_only_cross_host_left(
+        self, runner, sandbox
+    ):
+        """When ``--force --apply`` only had cross-host entries to deal
+        with (no eligible re-stamps), the changed-bucket footer renders
+        as the cross-host manual-review message — not the standard
+        ``--force`` pointer (which is wrong for cross-host)."""
+        _seed_claude_code(sandbox, {"x": {"command": "npx", "args": ["v1"]}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+        _seed_cursor_user(sandbox, {"x": {"command": "npx", "args": ["v2"]}})
+
+        res = _sync(runner, "--apply", "--force", "--yes")
+        assert res.exit_code == 0, res.output
+        # Standard pointer suppressed — --force already declined to
+        # adopt cross-host candidates.
+        assert "differ in shape at host" not in res.output
+        # Cross-host manual-review footer fires instead.
+        assert "shape-relocated to a different host than baseline source" in res.output
+        assert "manual review" in res.output

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -868,10 +868,13 @@ class TestSyncPlan:
 
         res = _sync(runner, "--plan")
         assert res.exit_code == 0, res.output
-        # The W3+ pointer footer fires when ``changed`` count > 0.
+        # The pointer footer fires when ``changed`` count > 0 and now
+        # references a real flag (W3 shipped ``--force``).
         assert "differ in shape at host" in res.output
         assert "mms host sync --force" in res.output
-        assert "(W3+)" in res.output
+        # The ``(W3+)`` qualifier is gone — `--force` is now a real
+        # working flag, not a future promise.
+        assert "(W3+)" not in res.output
 
     def test_plan_orphan_no_baseline_footer(self, runner, sandbox):
         """no_baseline + no matched candidate → footer surfaces it.
@@ -978,9 +981,10 @@ class TestSyncApply:
         assert sidecar.entries["x"].drift_hash_version == HASH_VERSION
 
     def test_apply_changed_not_re_stamped(self, runner, sandbox):
-        """Lock-down 3: ``changed`` is NOT mutated by sync. The sidecar
-        baseline_hash stays at the original value; W3+ ``--force`` is
-        the only writer.
+        """Lock-down 3: without ``--force``, ``changed`` is NOT mutated
+        by sync. The sidecar baseline_hash stays at the original value;
+        ``--force`` is the only writer (pinned by
+        ``TestSyncForceApply.test_apply_force_yes_re_stamps_registry_and_sidecar``).
         """
         _seed_claude_code(sandbox, {"a": {"command": "npx", "args": ["v1"]}})
         _apply_claude_code(runner)
@@ -1152,7 +1156,10 @@ class TestSyncApply:
         then A drops X and a different host B picks up X with a new
         shape. ``_classify`` Pass 2 fallback finds B's X → state =
         ``changed`` (NOT ``removed_at_host``). Sync MUST NOT replace
-        the registry shape; user acknowledges via W3+ ``--force``.
+        the registry shape; user can acknowledge via ``--force`` only
+        when the candidate matches the baseline source — see W3
+        Lock-down 6 + ``TestSyncForceCrossHostLockdown6`` for the
+        ``--force`` behavior on cross-host drift.
         """
         # Step 1: import shared from claude-code (becomes baseline).
         _seed_claude_code(sandbox, {"shared": {"command": "npx", "args": ["claude-args"]}})

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -825,6 +825,7 @@ class TestSyncPlan:
             "cleanup": 0,
             "skipped_changed": 0,
             "orphan_no_baseline": 0,
+            "restamped": 0,
             "unchanged": 1,
             "conflicts": 0,
         }
@@ -1291,6 +1292,7 @@ class TestSyncJsonShape:
         "cleanup",
         "skipped_changed",
         "orphan_no_baseline",
+        "restamped",
         "unchanged",
         "conflicts",
     }
@@ -1421,3 +1423,348 @@ class TestSyncContractPin:
         from memtomem_stm.cli import mms_import
 
         assert "mms host sync" in (mms_import.__doc__ or "")
+
+
+# ---------------------------------------------------------------------------
+# sync --force — re-stamp surface (W3)
+# ---------------------------------------------------------------------------
+
+
+def _drift_changed(sandbox, runner, *, original: dict, drifted: dict, name: str = "x") -> None:
+    """Helper: import ``original`` from claude-code, then mutate host
+    config to ``drifted`` so the entry surfaces as ``changed`` on the
+    next sync.
+    """
+    _seed_claude_code(sandbox, {name: original})
+    _apply_claude_code(runner)
+    _seed_claude_code(sandbox, {name: drifted})
+
+
+class TestSyncForcePlan:
+    def test_plan_force_renders_restamp_section_with_diff(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        res = _sync(runner, "--plan", "--force")
+        assert res.exit_code == 0, res.output
+        # RESTAMP section header.
+        assert "RESTAMP" in res.output
+        # Diff renderer shows old/new args.
+        assert "v1" in res.output
+        assert "v2" in res.output
+        assert "Old:" in res.output
+        assert "New:" in res.output
+
+    def test_plan_force_no_changed_renders_no_restamp_section(self, runner, sandbox):
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+        # No drift — `changed` bucket empty, RESTAMP must NOT render
+        # even with --force.
+        res = _sync(runner, "--plan", "--force")
+        assert res.exit_code == 0, res.output
+        assert "RESTAMP" not in res.output
+
+    def test_plan_force_diff_redacts_secret_env_values(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "env": {"GITHUB_TOKEN": "ghp_old"}},
+            drifted={"command": "npx", "env": {"GITHUB_TOKEN": "ghp_new"}},
+        )
+        res = _sync(runner, "--plan", "--force")
+        assert res.exit_code == 0, res.output
+        # Secret values must NOT leak in either Old or New.
+        assert "ghp_old" not in res.output
+        assert "ghp_new" not in res.output
+        # The key should still appear.
+        assert "GITHUB_TOKEN" in res.output
+
+
+class TestSyncForceApply:
+    def test_apply_force_yes_re_stamps_registry_and_sidecar(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        original_baseline = state.load_import_state().entries["x"].drift_hash
+
+        res = _sync(runner, "--apply", "--force", "--yes")
+        assert res.exit_code == 0, res.output
+
+        # Registry adopted host shape (Lock-down 1).
+        assert list(state.load_registry().servers["x"].args) == ["v2"]
+        # Sidecar baseline refreshed.
+        new_baseline = state.load_import_state().entries["x"].drift_hash
+        assert new_baseline != original_baseline
+        # And matches current canonical hash.
+        from memtomem_stm.mms.drift import compute_drift_hash
+
+        assert new_baseline == compute_drift_hash(state.load_registry().servers["x"])
+
+    def test_apply_no_force_does_not_mutate_changed(self, runner, sandbox):
+        """Lock-down 3 sibling: without ``--force``, ``changed`` stays
+        non-mutating even on ``--apply``."""
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        original_baseline = state.load_import_state().entries["x"].drift_hash
+        original_shape = state.load_registry().servers["x"]
+
+        res = _sync(runner, "--apply", "--yes")
+        assert res.exit_code == 0, res.output
+        # Both registry and sidecar untouched.
+        assert state.load_registry().servers["x"] == original_shape
+        assert state.load_import_state().entries["x"].drift_hash == original_baseline
+
+    def test_apply_force_no_changed_is_no_op(self, runner, sandbox):
+        """``--apply --force`` with empty ``changed`` and no other
+        mutations → no-op message, exit 0."""
+        _seed_claude_code(sandbox, {"a": {"command": "npx"}})
+        _apply_claude_code(runner)
+
+        res = _sync(runner, "--apply", "--force", "--yes")
+        assert res.exit_code == 0, res.output
+        assert "Already synchronized" in res.output
+
+    def test_apply_force_summary_emits_restamped_count(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        res = _sync(runner, "--apply", "--force", "--yes", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["summary"]["restamped"] == 1
+        # Default-0 invariant for non-force runs is pinned by
+        # ``TestSyncJsonShape._SUMMARY_KEYS`` + the no-op test in
+        # TestSyncPlan.
+
+    def test_apply_force_no_force_keeps_restamped_zero(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        # Without --force, restamped stays 0 even when changed > 0.
+        res = _sync(runner, "--plan", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["summary"]["restamped"] == 0
+        assert payload["summary"]["skipped_changed"] == 1
+
+
+class TestSyncForceConfirmation:
+    def test_apply_force_prompts_in_tty_and_declines(self, runner, sandbox, monkeypatch):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        original_shape = state.load_registry().servers["x"]
+        _force_tty(monkeypatch)
+
+        res = _sync(runner, "--apply", "--force", input="n\n")
+        assert res.exit_code == 2, res.output
+        assert "Aborted" in res.output
+        # No mutation on decline.
+        assert state.load_registry().servers["x"] == original_shape
+
+    def test_apply_force_non_tty_aborts_without_yes(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        original_shape = state.load_registry().servers["x"]
+
+        res = _sync(runner, "--apply", "--force")
+        assert res.exit_code == 2, res.output
+        assert "--yes" in res.output
+        assert state.load_registry().servers["x"] == original_shape
+
+    def test_apply_force_json_without_yes_aborts_with_payload(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        res = _sync(runner, "--apply", "--force", "--json")
+        assert res.exit_code == 2, res.output
+        # Output is stderr abort message + JSON payload (CliRunner
+        # mixes streams). Locate the JSON payload bounds — same
+        # pattern as the REMOVE-only abort tests.
+        text = res.output
+        start = text.find("{")
+        end = text.rfind("}")
+        payload = json.loads(text[start : end + 1])
+        assert payload["aborted"] is True
+        assert payload["mode"] == "apply"
+
+    def test_apply_force_yes_bypasses_prompt(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        # --yes alongside --force skips confirmation entirely.
+        res = _sync(runner, "--apply", "--force", "--yes")
+        assert res.exit_code == 0, res.output
+        assert list(state.load_registry().servers["x"].args) == ["v2"]
+
+    def test_apply_force_combined_remove_and_restamp_single_prompt(
+        self, runner, sandbox, monkeypatch
+    ):
+        """REMOVE + RESTAMP both pending → one combined prompt with
+        REMOVE section before RESTAMP section (Lock-down 2 / MEDIUM 3
+        section order)."""
+        _seed_claude_code(
+            sandbox,
+            {
+                "to_remove": {"command": "npx"},
+                "to_restamp": {"command": "npx", "args": ["v1"]},
+            },
+        )
+        _apply_claude_code(runner)
+        # Drop ``to_remove`` (REMOVE) and mutate ``to_restamp`` (RESTAMP).
+        _seed_claude_code(sandbox, {"to_restamp": {"command": "npx", "args": ["v2"]}})
+
+        captured = {"prompt": ""}
+        import click as _click_mod
+
+        def spy_confirm(text, *args, **kwargs):
+            captured["prompt"] = text
+            return False
+
+        monkeypatch.setattr(_click_mod, "confirm", spy_confirm)
+        _force_tty(monkeypatch)
+
+        res = _sync(runner, "--apply", "--force")
+        assert res.exit_code == 2, res.output
+        prompt = captured["prompt"]
+        # Both sections present.
+        assert "removed from registry" in prompt
+        assert "re-stamped" in prompt
+        # Section order: REMOVE first (most destructive), RESTAMP second.
+        # Pin the relative order so future PRs that flip them must
+        # justify against the Lock-down 2 anchor.
+        assert prompt.index("removed from registry") < prompt.index("re-stamped"), prompt
+
+
+class TestSyncForceCrossHostLockdown6:
+    def test_apply_force_does_not_re_stamp_cross_host_drift(
+        self, runner, sandbox
+    ):
+        """Lock-down 6 BLOCKER: baseline source = claude-code; only
+        cursor has the entry now; ``--force`` MUST NOT adopt cursor's
+        shape. The entry stays in the changed bucket; registry +
+        sidecar unchanged.
+        """
+        # Step 1: import shared from claude-code (baseline).
+        _seed_claude_code(sandbox, {"shared": {"command": "npx", "args": ["claude-args"]}})
+        _apply_claude_code(runner)
+        original_shape = state.load_registry().servers["shared"]
+        original_hash = state.load_import_state().entries["shared"].drift_hash
+
+        # Step 2: drop from claude-code, add to cursor with a different shape.
+        _seed_claude_code(sandbox, {})
+        _seed_cursor_user(sandbox, {"shared": {"command": "npx", "args": ["cursor-args"]}})
+
+        # --apply --force --yes: still must NOT replace registry shape.
+        res = _sync(runner, "--apply", "--force", "--yes")
+        assert res.exit_code == 0, res.output
+        assert state.load_registry().servers["shared"] == original_shape
+        assert state.load_import_state().entries["shared"].drift_hash == original_hash
+
+    def test_skipped_changed_payload_marks_host_relocation(self, runner, sandbox):
+        """Lock-down 6 JSON shape: cross-host drift → ``host_relocation:
+        true``; in-place drift → ``host_relocation: false``."""
+        # Cross-host drift case.
+        _seed_claude_code(sandbox, {"x": {"command": "npx", "args": ["v1"]}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+        _seed_cursor_user(sandbox, {"x": {"command": "npx", "args": ["v2"]}})
+
+        res = _sync(runner, "--plan", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        skipped = payload["plan"]["skipped_changed"]
+        assert len(skipped) == 1
+        assert skipped[0]["name"] == "x"
+        assert skipped[0]["host_relocation"] is True
+
+    def test_skipped_changed_in_place_drift_host_relocation_false(self, runner, sandbox):
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"]},
+            drifted={"command": "npx", "args": ["v2"]},
+        )
+        res = _sync(runner, "--plan", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        skipped = payload["plan"]["skipped_changed"]
+        assert len(skipped) == 1
+        assert skipped[0]["host_relocation"] is False
+
+    def test_apply_force_only_eligible_when_mixed(self, runner, sandbox):
+        """Mixed bucket: one in-place drift (eligible) + one cross-host
+        drift (ineligible). ``--force`` re-stamps only the eligible one;
+        cross-host stays in skipped_changed."""
+        _seed_claude_code(
+            sandbox,
+            {
+                "in_place": {"command": "npx", "args": ["v1"]},
+                "moves": {"command": "npx", "args": ["origA"]},
+            },
+        )
+        _apply_claude_code(runner)
+
+        # in_place drifts at claude-code; moves disappears from claude-
+        # code and re-appears at cursor with a different shape.
+        _seed_claude_code(sandbox, {"in_place": {"command": "npx", "args": ["v2"]}})
+        _seed_cursor_user(sandbox, {"moves": {"command": "npx", "args": ["cursorB"]}})
+
+        original_moves_shape = state.load_registry().servers["moves"]
+
+        res = _sync(runner, "--apply", "--force", "--yes", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+
+        # Eligible re-stamped.
+        assert payload["summary"]["restamped"] == 1
+        assert list(state.load_registry().servers["in_place"].args) == ["v2"]
+
+        # Cross-host untouched, still in skipped_changed.
+        assert state.load_registry().servers["moves"] == original_moves_shape
+        skipped_names = {row["name"] for row in payload["plan"]["skipped_changed"]}
+        assert "moves" in skipped_names
+
+    def test_cross_host_footer_renders_in_text_mode(self, runner, sandbox):
+        """Text-mode CHANGED footer extends with a sub-line when any
+        cross-host shape-relocations exist."""
+        _seed_claude_code(sandbox, {"x": {"command": "npx", "args": ["v1"]}})
+        _apply_claude_code(runner)
+        _seed_claude_code(sandbox, {})
+        _seed_cursor_user(sandbox, {"x": {"command": "npx", "args": ["v2"]}})
+
+        res = _sync(runner, "--plan")
+        assert res.exit_code == 0, res.output
+        # Top-line CHANGED footer present.
+        assert "differ in shape at host" in res.output
+        # Cross-host sub-line present.
+        assert "different host than baseline source" in res.output

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -1489,6 +1489,29 @@ class TestSyncForcePlan:
         # The key should still appear.
         assert "GITHUB_TOKEN" in res.output
 
+    def test_plan_force_env_value_only_drift_renders_changed_note(self, runner, sandbox):
+        """Edge case: command + args + env keys all match; only env
+        values changed (e.g. token rotation). The diff renderer
+        collapses to a single observable-shape line + an explicit
+        "(env values redacted; values changed)" note so the user knows
+        *something* changed without the values leaking.
+        """
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "env": {"API_KEY": "k1"}},
+            drifted={"command": "npx", "env": {"API_KEY": "k2"}},
+        )
+        res = _sync(runner, "--plan", "--force")
+        assert res.exit_code == 0, res.output
+        # Both values redacted, key visible.
+        assert "k1" not in res.output
+        assert "k2" not in res.output
+        assert "API_KEY" in res.output
+        # The clarifying note fires — user sees *why* re-stamp will run
+        # even though Old/New rows would have looked identical.
+        assert "(env values redacted; values changed)" in res.output
+
 
 class TestSyncForceApply:
     def test_apply_force_yes_re_stamps_registry_and_sidecar(self, runner, sandbox):
@@ -1728,6 +1751,51 @@ class TestSyncForceCrossHostLockdown6:
         assert len(skipped) == 1
         assert skipped[0]["host_relocation"] is False
 
+    def test_json_skipped_changed_does_not_leak_render_only_keys(self, runner, sandbox):
+        """The diff renderer enriches ``changed_rows_classified`` rows
+        in-place with underscore-prefixed keys (``_old_server``,
+        ``_new_server``, ``_new_source_label``). These are
+        render-only — a future refactor that accidentally builds
+        ``plan_payload["skipped_changed"]`` from the enriched rows
+        would silently leak ``RegistryServer`` objects into JSON
+        (TypeError at serialization, or worse, a custom serializer
+        that succeeds and exposes secret env values).
+
+        Pin the invariant explicitly: no key in the JSON
+        ``skipped_changed`` entries starts with ``_``.
+        """
+        # --plan --force triggers the enrichment loop; --json reads
+        # the JSON payload after enrichment ran.
+        _drift_changed(
+            sandbox,
+            runner,
+            original={"command": "npx", "args": ["v1"], "env": {"API_KEY": "secret"}},
+            drifted={"command": "npx", "args": ["v2"], "env": {"API_KEY": "secret"}},
+        )
+        res = _sync(runner, "--plan", "--force", "--json")
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        # Force surfaced the entry into RESTAMP, so skipped_changed is
+        # empty in --force mode. Make the leak check robust by also
+        # exercising the no-force path where skipped_changed has rows.
+        for row in payload["plan"]["skipped_changed"]:
+            for key in row:
+                assert not key.startswith("_"), (
+                    f"render-only key {key!r} leaked into JSON: {row}"
+                )
+
+        res2 = _sync(runner, "--plan", "--json")
+        payload2 = json.loads(res2.output)
+        assert len(payload2["plan"]["skipped_changed"]) == 1
+        for row in payload2["plan"]["skipped_changed"]:
+            for key in row:
+                assert not key.startswith("_"), (
+                    f"render-only key {key!r} leaked into JSON: {row}"
+                )
+        # Also assert the secret value didn't leak via any route.
+        assert "secret" not in res.output
+        assert "secret" not in res2.output
+
     def test_apply_force_only_eligible_when_mixed(self, runner, sandbox):
         """Mixed bucket: one in-place drift (eligible) + one cross-host
         drift (ineligible). ``--force`` re-stamps only the eligible one;
@@ -1768,9 +1836,14 @@ class TestSyncForceCrossHostLockdown6:
         # footer fire after we just re-stamped them.
         assert payload["summary"]["skipped_changed"] == 1
 
-    def test_cross_host_footer_renders_in_text_mode(self, runner, sandbox):
-        """Without ``--force``, text-mode CHANGED footer extends with a
-        cross-host sub-line when any shape-relocations exist."""
+    def test_all_cross_host_suppresses_standard_pointer(self, runner, sandbox):
+        """When *every* changed entry is cross-host, the standard
+        "use --force to acknowledge" pointer is wrong — --force won't
+        adopt any of them. Suppress it; render only the cross-host
+        manual-review footer as the primary message. A user reading
+        only the first footer line should walk away with the right
+        action.
+        """
         _seed_claude_code(sandbox, {"x": {"command": "npx", "args": ["v1"]}})
         _apply_claude_code(runner)
         _seed_claude_code(sandbox, {})
@@ -1778,10 +1851,37 @@ class TestSyncForceCrossHostLockdown6:
 
         res = _sync(runner, "--plan")
         assert res.exit_code == 0, res.output
-        # Top-line CHANGED footer present.
-        assert "differ in shape at host" in res.output
-        # Cross-host sub-line present.
+        # Standard pointer suppressed.
+        assert "differ in shape at host" not in res.output
+        # Cross-host manual-review footer fires as primary.
         assert "shape-relocated to a different host than baseline source" in res.output
+        assert "manual review" in res.output
+
+    def test_mixed_cross_host_renders_both_pointer_and_subline(self, runner, sandbox):
+        """When changed entries are a *mix* of in-place + cross-host,
+        the standard pointer fires (it helps the in-place subset) and
+        the cross-host sub-line clarifies that --force will skip the
+        relocated subset.
+        """
+        _seed_claude_code(
+            sandbox,
+            {
+                "in_place": {"command": "npx", "args": ["v1"]},
+                "moves": {"command": "npx", "args": ["origA"]},
+            },
+        )
+        _apply_claude_code(runner)
+        # in_place drifts at claude-code; moves shape-relocates to cursor.
+        _seed_claude_code(sandbox, {"in_place": {"command": "npx", "args": ["v2"]}})
+        _seed_cursor_user(sandbox, {"moves": {"command": "npx", "args": ["cursorB"]}})
+
+        res = _sync(runner, "--plan")
+        assert res.exit_code == 0, res.output
+        # Both lines fire.
+        assert "differ in shape at host" in res.output
+        assert "shape-relocated to a different host than baseline source" in res.output
+        # Pointer first (helps the in_place subset), sub-line after.
+        assert res.output.index("differ in shape") < res.output.index("shape-relocated"), res.output
 
     def test_apply_force_does_not_print_changed_footer_for_restamped(
         self, runner, sandbox


### PR DESCRIPTION
## Summary

Adds `--force` to `mms host sync --apply` so users can adopt the host's
current shape for entries flagged `changed` (registry + sidecar updated
together — full reconciliation, not sidecar-only). Without `--force`,
the `changed` bucket stays non-mutating exactly as PR6 ships.

## Lock-downs (anchored in code + tests + docstrings)

1. **Re-stamp = registry + sidecar.** Sidecar-only would silently retain
   a stale `RegistryServer` while marking drift "acknowledged"; every
   downstream consumer (`mms import`, agent runtime) would still see
   the old shape. Atomicity invariant from PR4 (registry first, sidecar
   second) extends to the new RESTAMP pass.
2. **Confirmation prompt with old/new diff.** Re-stamp is destructive
   but visually subtle (the entry name doesn't disappear). The prompt's
   RESTAMP section shows command/args/env-key diff so users give
   informed consent. Env values redacted; env keys sorted for diff
   stability.
3. **`--force` and `--yes` are orthogonal.** `--force` activates the
   `changed` bucket as a mutator; `--yes` bypasses the interactive
   prompt. `--force --json` without `--yes` aborts with `aborted: true`
   (same gate REMOVE uses).
4. **`(W3+)` markers dropped** as a consequent fix. Footer template,
   docstrings, and W2 PR6's literal pin (`assert "(W3+)" in res.output`
   → flipped to `not in`).
5. **Selective filter (`--name` / `--from`) deferred** to wait-for-
   signal: user reports needing to re-stamp specific entries while
   accepting drift on others.
6. **(BLOCKER from review.)** RESTAMP candidate must come from the
   baseline source host. `_select_candidate_by_name`'s Pass-2 fallback
   binds the first candidate seen across `ALL_HOSTS`, which `_classify`
   then routes to `changed` if hashes differ. Re-stamping from a
   Pass-2 candidate would silently relocate the entry's host-of-record
   — exactly the cross-host failure mode PR6's "no silent reshape"
   contract guards. Sync partitions changed rows into
   `restamp_eligible_rows` (baseline-source-matched) and
   `cross_host_changed_rows`; `--force` only operates on the former.
   Cross-host count surfaces in the extended CHANGED footer + JSON
   `skipped_changed[i].host_relocation: bool`. Cross-host policy
   (auto-route to REMOVE? new bucket?) is wait-for-signal.

## JSON shape additions

Additive at the entry-field level — existing parsers reading
`skipped_changed[i]["name"]` keep working.

- `summary.restamped: int` (always present, default 0)
- `plan.skipped_changed[i]` gains `source_label`, `baseline_hash`,
  `current_hash`, `last_imported`, `host_relocation`
- `plan.skipped_changed` post-`--force` lists only entries that were
  *not* re-stamped this run (cross-host slice). Without `--force`,
  every changed entry is listed (the bucket stays non-mutating).

## Behavior change

- `mms host sync --apply --force --yes` re-stamps in-place drift
  (registry + sidecar).
- `mms host sync --apply --force --json` without `--yes` exits 2 with
  `aborted: true` (same gate as REMOVE-only abort).
- TTY prompt with both REMOVE and RESTAMP rows fires a single combined
  prompt with REMOVE section before RESTAMP section.
- The W2 PR6 changed-bucket footer dropped the `(W3+)` qualifier and
  the cross-host slice now extends it as a sub-line (or replaces it
  as the primary message under `--force`).

## Commits

1. `feat(mms): W3 — mms host sync --force re-stamp` — full
   implementation (option + apply path + diff renderer + cross-host
   partition + tests).
2. `docs(mms): drop W3+ markers now that mms host sync --force
   shipped` — consequent fix per `feedback_consequent_vs_driveby.md`.
3. `fix(mms): post-force skipped_changed reflects only what was
   skipped` — smoke-discovered correction so the
   "use `--force` to acknowledge" footer doesn't fire after
   re-stamping.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 2079 passed
- [x] `uv run ruff check src tests && uv run ruff format --check src`
- [x] `rg -F 'W3+' src/ tests/` returns only the regression test that
      asserts the literal is absent
- [x] Manual smoke (HOME-isolated): import baseline → mutate host
      shape → `sync --plan --force` shows RESTAMP section with old/new
      diff → `sync --apply --force --yes` re-stamps registry + sidecar
      → `host status` reports `unchanged`
- [x] Cross-host smoke: baseline source = claude-code, drop from
      claude-code, add to cursor with different shape → `--apply
      --force --yes` does NOT replace registry shape; cross-host footer
      fires; `summary.restamped == 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)