### PR TITLE
fix(cli): pin UTF-8 on `_run_claude_mcp` subprocess (Refs #302 P0)

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -139,7 +139,16 @@ def _save(config_path: Path, data: dict[str, Any]) -> None:
 
 def _run_claude_mcp(cmd: list[str], timeout: int = 5) -> subprocess.CompletedProcess[str]:
     """Invoke the ``claude`` CLI — isolated so tests replace a single seam."""
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    # ``encoding="utf-8"`` is explicit so non-ASCII bytes from the child don't
+    # hit the platform default codec (cp1252/cp949 on Windows). See #302 P0.
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+    )
 
 
 # PEP 508 dependency specifier: the distribution name is the leading identifier

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -1741,6 +1741,38 @@ class TestInitImportFlow:
 # ── MCP client registration (3-way prompt) ──────────────────────────────
 
 
+class TestRunClaudeMcp:
+    """The single shell-out seam ``_run_claude_mcp`` must pin
+    ``encoding="utf-8"`` so non-ASCII output from the ``claude`` CLI
+    (em-dash, localized error strings, box drawing) doesn't crash on
+    Windows consoles whose default codec is cp1252/cp949. Regression
+    for memtomem-stm#302 P0."""
+
+    def test_passes_explicit_utf8_encoding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        captured: dict[str, object] = {}
+
+        def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(
+                args=list(args[0]) if args else [], returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr(proxy_mod.subprocess, "run", fake_run)
+        proxy_mod._run_claude_mcp(["claude", "mcp", "list"])
+
+        kwargs = captured["kwargs"]
+        assert isinstance(kwargs, dict)
+        assert kwargs.get("encoding") == "utf-8"
+        assert kwargs.get("errors") == "replace"
+        assert kwargs.get("text") is True
+        assert kwargs.get("capture_output") is True
+
+
 class _FakeClaudeResult:
     """Lightweight stand-in for ``subprocess.CompletedProcess[str]``. Using
     a plain object avoids pinning the test to a specific stdlib version's


### PR DESCRIPTION
## Summary

- `subprocess.run(..., text=True)` in `_run_claude_mcp` was decoding the child's stdout/stderr with the platform default codec (cp1252 on Windows-EN, cp949 on Windows-KR), so any non-ASCII byte from the `claude` CLI raised `UnicodeDecodeError` or returned `stdout=None` and silently broke every caller of this seam.
- Pin `encoding="utf-8", errors="replace"` so STM behaves identically across locales. `errors="replace"` is intentional — the seam is read-only diagnostic output, not data we round-trip back, so swallowing a malformed byte is preferable to crashing the proxy.
- Adds a regression test in `TestRunClaudeMcp` that asserts the kwargs are forwarded to `subprocess.run`. There is only one shell-out seam in the CLI (per the `_run_claude_mcp` docstring), so pinning its contract here is sufficient.

This is the first follow-up PR off the Windows-support triage in #302 (P0 row). Subsequent PRs (P1a CI matrix, P1b `set_home` helper, P2 console reconfigure, P3 AST guard) will land separately.

## Test plan

- [x] `uv run ruff check src tests/cli/test_proxy_cli.py` — clean
- [x] `uv run ruff format --check src` — clean (58 files already formatted)
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean
- [x] `uv run pytest tests/cli/test_proxy_cli.py` — 194 passed (was 193, includes the new regression)
- [ ] CI green on `ubuntu-latest` (GitHub Actions)

Refs #302