### PR TITLE
ci(workflows): add `windows-latest` informational matrix (Refs #302 P1a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,18 @@ on:
     branches: [main]
 
 jobs:
+  # Windows runs on lint/typecheck/test are informational only while the
+  # Windows-support triage in #302 is in flight. Ubuntu remains the gating
+  # required check; the Windows leg is a `continue-on-error` signal so
+  # P1b/P2/P3 fixes can be observed without blocking merges. Flip to
+  # required once the matrix is consistently green.
   lint:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -19,7 +29,12 @@ jobs:
       - run: uv run ruff format --check src
 
   typecheck:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -31,7 +46,12 @@ jobs:
         continue-on-error: true
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## Summary

- Adds `windows-latest` as a matrix axis to the `lint`, `typecheck`, and `test` jobs with `continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}` and `fail-fast: false`. Ubuntu stays the gating required check on every job; the Windows leg is informational.
- This makes Windows-side regressions visible in PR checks now (so subsequent triage PRs — P1b `set_home` helper sweep, P2 console UTF-8 reconfigure, P3 AST guard — can be observed against real Windows runs) without blocking merges before the codebase is actually green on Windows.
- `notebooks` and `bench_qa` stay ubuntu-only: notebook execution on Windows is fragile for reasons unrelated to STM, and `bench_qa` is already informational under its own `continue-on-error: true`.
- Mirrors the pattern memtomem core used in #634/#638 to bootstrap their cross-platform CI.

Once P1b/P2 land and the Windows column is consistently green, drop `continue-on-error` to promote `windows-latest` to a required check.

## Test plan

- [x] YAML well-formed (`yaml.safe_load` → OK)
- [x] Diff scope: only the three intended jobs gain a matrix; ubuntu legs preserve identical behavior to pre-change
- [ ] On this PR: ubuntu legs all SUCCESS, windows legs visible (PASS or FAIL) and not blocking merge
- [ ] After merge: same matrix appears on subsequent PR checks

Refs #302 (P1a).