### PR TITLE
test(windows): set_home helper + 10-site HOME-patch sweep (#302 P1b)

### DIFF
--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -20,6 +20,7 @@ from memtomem_stm.cli.mms_host import host_group
 from memtomem_stm.cli.mms_import import import_command
 from memtomem_stm.mms import state
 from memtomem_stm.mms.drift import HASH_VERSION, compute_drift_hash
+from helpers import set_home
 
 
 @pytest.fixture
@@ -30,7 +31,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def sandbox(tmp_path, monkeypatch):
     """Pin HOME so ``~/.mms`` and ``~/.claude.json`` etc. land in tmp."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     cwd = tmp_path / "proj"
     cwd.mkdir()
     monkeypatch.chdir(cwd)

--- a/tests/cli/test_mms_import.py
+++ b/tests/cli/test_mms_import.py
@@ -14,6 +14,7 @@ from memtomem_stm.cli.mms_import import import_command
 from memtomem_stm.mms import drift, state
 from memtomem_stm.mms.drift import compute_drift_hash
 from memtomem_stm.mms.secrets import REDACTED_DISPLAY
+from helpers import set_home
 
 
 @pytest.fixture
@@ -24,7 +25,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def sandbox(tmp_path, monkeypatch):
     """Pin HOME so ``~/.mms`` and ``~/.claude.json`` etc. land in tmp."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     cwd = tmp_path / "proj"
     cwd.mkdir()
     monkeypatch.chdir(cwd)

--- a/tests/cli/test_mms_project.py
+++ b/tests/cli/test_mms_project.py
@@ -15,6 +15,7 @@ from memtomem_stm.cli.mms_project import (
     project_group,
 )
 from memtomem_stm.mms import state
+from helpers import set_home
 
 
 @pytest.fixture
@@ -29,7 +30,7 @@ def sandbox(tmp_path, monkeypatch):
     Returns a dict with the sandbox HOME and the cwd directory so tests
     can do path assertions.
     """
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     proj_dir = tmp_path / "proj"
     proj_dir.mkdir()
     monkeypatch.chdir(proj_dir)

--- a/tests/cli/test_mms_w1_acceptance.py
+++ b/tests/cli/test_mms_w1_acceptance.py
@@ -15,8 +15,9 @@ path:
 6. `mms project show` from proj-a — enabled list correct, source = marker.
 7. Re-run `mms import --apply` — idempotent, "Already up to date."
 
-Sandboxed via `monkeypatch.setenv("HOME", tmp_path)`. The registry,
-projects index, and per-project markers all land in tmp.
+Sandboxed via `set_home(monkeypatch, tmp_path)` — patches HOME and
+USERPROFILE so `Path.home()` is hermetic on every platform. The
+registry, projects index, and per-project markers all land in tmp.
 """
 
 from __future__ import annotations
@@ -30,6 +31,7 @@ from click.testing import CliRunner
 from memtomem_stm.cli.mms_import import import_command
 from memtomem_stm.cli.mms_project import project_group
 from memtomem_stm.mms import state
+from helpers import set_home
 
 
 @pytest.fixture
@@ -40,7 +42,7 @@ def runner() -> CliRunner:
 def test_w1_acceptance_path_b_and_common_path(runner, tmp_path, monkeypatch):
     """Full §12 walk-through. Tagged via the test name; runs in CI default."""
     # ── Step 0: sandbox HOME, chdir into a clean dir, seed fake claude-code ────
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     # The import scanner's claude-code path also reads <cwd>/.mcp.json; make sure
     # we're not standing in the actual repo (which has no .mcp.json today, but
     # any future commit that adds one would silently inflate this test's count).
@@ -139,7 +141,7 @@ def test_w1_acceptance_path_b_and_common_path(runner, tmp_path, monkeypatch):
 
 def test_w1_acceptance_marker_walk_up_from_subdirectory(runner, tmp_path, monkeypatch):
     """RFC §6 — `mms project show` from a subdirectory finds the parent marker."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
 
     project_root = tmp_path / "monorepo"
     project_root.mkdir()
@@ -161,7 +163,7 @@ def test_w1_acceptance_marker_walk_up_from_subdirectory(runner, tmp_path, monkey
 def test_w1_acceptance_empty_registry_friendly_error(runner, tmp_path, monkeypatch):
     """PR1's graceful contract surfaces in the W1 acceptance test —
     a user who runs enable before importing gets a friendly hint."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
 
     proj = tmp_path / "proj"
     proj.mkdir()

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -23,6 +23,7 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem_stm.cli.proxy import cli
+from helpers import set_home
 
 _FAKE_SERVER = Path(__file__).resolve().parents[1] / "_fake_memtomem_server.py"
 
@@ -1237,7 +1238,7 @@ class TestInitDiscoverySources:
         home.mkdir()
         cwd = tmp_path / "cwd"
         cwd.mkdir()
-        monkeypatch.setenv("HOME", str(home))
+        set_home(monkeypatch, home)
         # Redirect the macOS-specific Desktop path into our sandbox too.
         desktop = home / "Library/Application Support/Claude"
         desktop.mkdir(parents=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,23 @@
+"""Shared cross-platform test helpers.
+
+Kept deliberately small — fixtures live in ``conftest.py``; this module
+holds plain functions that are easier to grep for and call inline.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def set_home(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    """Pin the user's home directory to ``path`` on every platform.
+
+    ``Path.home()`` and ``os.path.expanduser("~")`` consult ``USERPROFILE``
+    before ``HOME`` on Windows. Tests that monkeypatch only ``HOME`` therefore
+    leak the developer's real profile into temp-dir fixtures on Windows
+    runners. Patching both keeps the sandbox hermetic.
+    """
+    monkeypatch.setenv("HOME", str(path))
+    monkeypatch.setenv("USERPROFILE", str(path))

--- a/tests/mms/test_import_hosts.py
+++ b/tests/mms/test_import_hosts.py
@@ -10,6 +10,7 @@ import pytest
 from memtomem_stm.mms import import_hosts as ih
 from memtomem_stm.mms.secrets import Kind
 from memtomem_stm.mms.state import RegistryServer
+from helpers import set_home
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +161,7 @@ class TestDerivePrefix:
 
 @pytest.fixture
 def sandbox_home(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     return tmp_path
 
 

--- a/tests/mms/test_state.py
+++ b/tests/mms/test_state.py
@@ -10,12 +10,13 @@ import pytest
 
 from memtomem_stm.mms import state
 from memtomem_stm.mms.drift import canonical_form, compute_drift_hash
+from helpers import set_home
 
 
 @pytest.fixture
 def sandbox_home(tmp_path, monkeypatch):
     """Repoint ``~/.mms`` at a sandbox dir; yield it."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     return tmp_path
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,41 @@
+"""Regression tests for ``tests.helpers`` — small but load-bearing.
+
+The 10 monkeypatch sites that previously set only ``HOME`` were migrated to
+``set_home`` for memtomem-stm#302 P1b. If ``set_home`` ever stops patching
+``USERPROFILE`` the Windows leg of the CI matrix silently regresses, so
+keep a direct contract test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from helpers import set_home
+
+
+def test_set_home_patches_home_and_userprofile(tmp_path: Path, monkeypatch):
+    set_home(monkeypatch, tmp_path)
+    assert os.environ["HOME"] == str(tmp_path)
+    assert os.environ["USERPROFILE"] == str(tmp_path)
+
+
+def test_set_home_path_home_resolves_to_sandbox(tmp_path: Path, monkeypatch):
+    """``Path.home()`` reads HOME on POSIX and USERPROFILE on Windows; setting
+    both means the assertion holds on every platform without a ``sys.platform``
+    branch in the test."""
+    set_home(monkeypatch, tmp_path)
+    assert Path.home() == tmp_path
+
+
+def test_set_home_is_undone_after_test(tmp_path: Path, monkeypatch):
+    """monkeypatch must restore both env vars when the test exits — otherwise
+    the next test in the same session inherits the sandbox HOME."""
+    original_home = os.environ.get("HOME")
+    original_userprofile = os.environ.get("USERPROFILE")
+
+    set_home(monkeypatch, tmp_path)
+    monkeypatch.undo()
+
+    assert os.environ.get("HOME") == original_home
+    assert os.environ.get("USERPROFILE") == original_userprofile

--- a/tests/test_progressive_reads.py
+++ b/tests/test_progressive_reads.py
@@ -13,6 +13,7 @@ import pytest
 
 from memtomem_stm.proxy.progressive_reads import ProgressiveReadsTracker
 from memtomem_stm.proxy.progressive_reads_store import ProgressiveReadsStore
+from helpers import set_home
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +239,7 @@ class TestProgressiveReadsTracker:
 
     def test_path_expansion(self, tmp_path: Path, monkeypatch):
         """``~`` in db_path should be expanded to ``$HOME``."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         tracker = ProgressiveReadsTracker(Path("~/pr_expand.db"))
         try:
             assert (tmp_path / "pr_expand.db").exists()


### PR DESCRIPTION
## Summary

- Adds `tests/helpers.py::set_home(monkeypatch, path)` patching both `HOME` and `USERPROFILE` (memtomem #714 idiom). On Windows, `Path.home()` and `os.path.expanduser("~")` consult `USERPROFILE` first, so fixtures that monkeypatched only `HOME` leaked the developer's real profile into temp-dir-based tests on the new `windows-latest` CI leg.
- Migrates the 10 sites enumerated in the [#302 P1b inventory](https://github.com/memtomem/memtomem-stm/issues/302) — `tests/cli/test_mms_w1_acceptance.py` (×3), `tests/cli/test_mms_host.py`, `tests/cli/test_mms_project.py`, `tests/cli/test_mms_import.py`, `tests/cli/test_proxy_cli.py`, `tests/mms/test_state.py`, `tests/mms/test_import_hosts.py`, `tests/test_progressive_reads.py`. No behavior change on POSIX; removes the leak on Windows.
- Adds `tests/test_helpers.py` with a direct contract test so a future regression that drops the `USERPROFILE` patch fails here rather than via a flaky Windows job.

Refs #302 (P1b in the suggested PR sequence).

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src` — clean (CI-required scope)
- [x] `uv run pytest -m "not ollama"` — 2079 passed, 7 skipped, locally on macOS
- [ ] Watch the `windows-latest` matrix leg on this PR (continue-on-error from #304) — expect a meaningful drop in HOME-leak failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)