### PR TITLE
test(windows): skipif NTFS mode-bit assertions (#302 P1c)

### DIFF
--- a/tests/cli/test_mms_import.py
+++ b/tests/cli/test_mms_import.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import stat
 from datetime import datetime, timezone
@@ -230,8 +231,10 @@ class TestApply:
 
         # 1. file + permissions
         assert state.import_state_path().exists()
-        mode = stat.S_IMODE(state.import_state_path().stat().st_mode)
-        assert mode == 0o600
+        if os.name != "nt":
+            # NTFS doesn't expose POSIX mode bits; ACL is the right primitive.
+            mode = stat.S_IMODE(state.import_state_path().stat().st_mode)
+            assert mode == 0o600
 
         # 2. counter assertion: cardinality AND identity, both axes
         cfg = state.load_registry()

--- a/tests/mms/test_state.py
+++ b/tests/mms/test_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 import tomllib
 from pathlib import Path
@@ -67,6 +68,9 @@ def test_registry_round_trip(sandbox_home):
     assert loaded == cfg
 
 
+@pytest.mark.skipif(
+    os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+)
 def test_save_registry_uses_0o600(sandbox_home):
     cfg = state.RegistryConfig(servers={"foo": state.RegistryServer(command="echo", prefix="f")})
     state.save_registry(cfg)
@@ -232,6 +236,9 @@ def test_save_load_preserves_drift_hash(sandbox_home, server: state.RegistryServ
     assert compute_drift_hash(loaded.servers["x"]) == compute_drift_hash(server)
 
 
+@pytest.mark.skipif(
+    os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+)
 def test_save_import_state_uses_0o600(sandbox_home):
     s = state.ImportState(
         entries={

--- a/tests/test_utils_fileio.py
+++ b/tests/test_utils_fileio.py
@@ -8,6 +8,7 @@ proper cleanup of the temp file on failure.
 
 from __future__ import annotations
 
+import os
 import threading
 from pathlib import Path
 
@@ -34,12 +35,18 @@ class TestAtomicWriteText:
         atomic_write_text(target, payload)
         assert target.read_text(encoding="utf-8") == payload
 
+    @pytest.mark.skipif(
+        os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+    )
     def test_mode_applied(self, tmp_path: Path):
         target = tmp_path / "secret.json"
         atomic_write_text(target, "{}", mode=0o600)
         # Bottom 9 bits = permission bits.
         assert (target.stat().st_mode & 0o777) == 0o600
 
+    @pytest.mark.skipif(
+        os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+    )
     def test_no_mode_inherits_mkstemp_default(self, tmp_path: Path):
         """When ``mode`` is None we don't ``chmod`` — the file keeps the
         mode ``tempfile.mkstemp`` assigned, which is ``0o600`` on POSIX.
@@ -133,7 +140,9 @@ class TestSaveProxyConfigStillAtomic:
         target = tmp_path / "stm_proxy.json"
         _save(target, {"enabled": True, "upstream_servers": {"x": {"prefix": "x"}}})
 
-        assert (target.stat().st_mode & 0o777) == 0o600
+        if os.name != "nt":
+            # NTFS doesn't expose POSIX mode bits; ACL is the right primitive.
+            assert (target.stat().st_mode & 0o777) == 0o600
         assert "upstream_servers" in target.read_text(encoding="utf-8")
         # No leftover tempfile.
         assert list(target.parent.glob("stm_proxy.json.*.tmp")) == []


### PR DESCRIPTION
## Summary

Six tests assert POSIX `0o600` mode bits and fail on `windows-latest` with `assert 438 == 384` because NTFS doesn't expose POSIX mode bits — the read/write bit gets mapped to the read-only attribute, and `stat().st_mode` reports `0o666`. The security guarantee `0o600` represents is a POSIX concept; on Windows the right primitive is the ACL (which stm doesn't manipulate because it's not the threat model — these tests pin a write-time defense for tmpfs callers, not a multi-user filesystem).

Mirrors memtomem #732/#733. Of the 12 remaining failures after [#305 (P1b)](https://github.com/memtomem/memtomem-stm/pull/305), this PR addresses 6.

### Two patterns, picked per call-site

**Whole-test skip** (4 sites — the mode assertion is the only behavior under test):

- `tests/mms/test_state.py::test_save_registry_uses_0o600`
- `tests/mms/test_state.py::test_save_import_state_uses_0o600`
- `tests/test_utils_fileio.py::TestAtomicWriteText::test_mode_applied`
- `tests/test_utils_fileio.py::TestAtomicWriteText::test_no_mode_inherits_mkstemp_default`

**Inline guard** (2 sites — the mode assertion is bundled with cross-platform invariants we want to keep running on Windows):

- `tests/cli/test_mms_import.py::TestApply::test_apply_writes_import_state_sidecar` — preserves the drift-hash counter assertion
- `tests/test_utils_fileio.py::TestSaveProxyConfigStillAtomic::test_save_writes_json_at_mode_0o600` — preserves the JSON-body and tempfile-cleanup assertions

Refs #302 (P1c). After this lands, expect `windows-latest` failures to drop from 12 → 6 (the remaining 6 are 2 console UTF-8 → P2, 1 `os.rename` → P1d, 1 subprocess argv → P2-adjacent, 2 untriaged).

## Test plan

- [x] `uv run ruff check tests` — clean
- [x] `uv run ruff format tests/mms/test_state.py tests/test_utils_fileio.py` — applied (line-length 100 forced multi-line `skipif`)
- [x] `uv run pytest -m "not ollama"` — 2076 passed, 7 skipped on macOS (skipif inactive on POSIX as expected)
- [ ] `windows-latest` matrix on this PR — confirm 4 skips + 6 → 6 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)