### PR TITLE
fix(utils/fileio): retry os.replace on Windows transient WinError 5 (#302 P1d)

### DIFF
--- a/src/memtomem_stm/utils/fileio.py
+++ b/src/memtomem_stm/utils/fileio.py
@@ -13,6 +13,14 @@ import tempfile
 import time
 from pathlib import Path
 
+# Windows ``MoveFileEx`` retry budget. The wall-clock ceiling is approximate —
+# Windows' default timer resolution is ~15.6 ms, so each ``time.sleep(0.005)``
+# typically rounds up to one tick. Real worst case is closer to 150 ms than
+# 50 ms; treat the budget as "low enough to not stall a hot-path write" rather
+# than a hard SLA.
+_WIN_REPLACE_ATTEMPTS = 10
+_WIN_REPLACE_BACKOFF_S = 0.005
+
 
 def atomic_write_text(
     path: Path,
@@ -82,17 +90,20 @@ def _replace_with_windows_retry(src: Path, dst: Path) -> None:
     re-reading the same file ``atomic_write_text`` is replacing) holds a
     sub-millisecond handle that briefly blocks the rename. The rename
     itself stays NTFS-atomic; we just ride out the transient conflict.
-    50 ms ceiling — ten attempts, 5 ms apart — keeps a hot-path write
-    from stalling if ``dst`` is genuinely locked by another process.
+
+    Scope intentionally narrow: only ``PermissionError`` (``WinError 5``)
+    is retried. ``WinError 32`` (sharing violation under AV scans, etc.)
+    has a similar transient pattern but isn't observed in CI today; widen
+    the catch only when a concrete failure appears.
     """
     if sys.platform != "win32":
         os.replace(src, dst)
         return
-    for attempt in range(10):
+    for attempt in range(_WIN_REPLACE_ATTEMPTS):
         try:
             os.replace(src, dst)
             return
         except PermissionError:
-            if attempt == 9:
+            if attempt == _WIN_REPLACE_ATTEMPTS - 1:
                 raise
-            time.sleep(0.005)
+            time.sleep(_WIN_REPLACE_BACKOFF_S)

--- a/src/memtomem_stm/utils/fileio.py
+++ b/src/memtomem_stm/utils/fileio.py
@@ -8,7 +8,9 @@ pattern keeps the third re-implementation of it from showing up.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
+import time
 from pathlib import Path
 
 
@@ -64,7 +66,33 @@ def atomic_write_text(
                 tmp.chmod(mode)
             except OSError:
                 pass
-        os.replace(tmp, resolved)
+        _replace_with_windows_retry(tmp, resolved)
     except Exception:
         tmp.unlink(missing_ok=True)
         raise
+
+
+def _replace_with_windows_retry(src: Path, dst: Path) -> None:
+    """``os.replace`` with a brief retry loop on Windows.
+
+    On Windows, ``MoveFileEx`` (the syscall behind ``os.replace``) raises
+    ``PermissionError`` (``WinError 5``) when another process has ``dst``
+    open without ``FILE_SHARE_DELETE`` — and Python's ``open()`` does not
+    pass that flag. A concurrent reader (e.g. the auto-index watcher
+    re-reading the same file ``atomic_write_text`` is replacing) holds a
+    sub-millisecond handle that briefly blocks the rename. The rename
+    itself stays NTFS-atomic; we just ride out the transient conflict.
+    50 ms ceiling — ten attempts, 5 ms apart — keeps a hot-path write
+    from stalling if ``dst`` is genuinely locked by another process.
+    """
+    if sys.platform != "win32":
+        os.replace(src, dst)
+        return
+    for attempt in range(10):
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError:
+            if attempt == 9:
+                raise
+            time.sleep(0.005)

--- a/tests/test_utils_fileio.py
+++ b/tests/test_utils_fileio.py
@@ -8,6 +8,7 @@ proper cleanup of the temp file on failure.
 
 from __future__ import annotations
 
+import os
 import threading
 from pathlib import Path
 
@@ -118,6 +119,59 @@ class TestAtomicWriteText:
         # Every observation must be one of the two complete payloads.
         bad = [s for s in seen if s not in (small, big)]
         assert not bad, f"observed {len(bad)} partial reads, e.g. len={len(bad[0])}"
+
+    def test_windows_retries_transient_permission_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """On Windows, ``MoveFileEx`` raises ``PermissionError`` (``WinError 5``)
+        when a concurrent reader holds a transient handle on the destination.
+        The retry loop must ride out a short burst of failures and succeed
+        without surfacing the error to the caller. Pinned cross-platform by
+        forcing ``sys.platform == "win32"`` so the POSIX CI leg also exercises
+        the retry path."""
+        monkeypatch.setattr("memtomem_stm.utils.fileio.sys.platform", "win32")
+
+        real_replace = os.replace
+        calls = {"n": 0}
+
+        def flaky(src, dst):
+            calls["n"] += 1
+            if calls["n"] <= 3:
+                raise PermissionError(5, "Access is denied", str(dst))
+            real_replace(src, dst)
+
+        monkeypatch.setattr("memtomem_stm.utils.fileio.os.replace", flaky)
+
+        target = tmp_path / "out.txt"
+        atomic_write_text(target, "payload")
+
+        assert target.read_text(encoding="utf-8") == "payload"
+        assert calls["n"] == 4, f"expected 3 retries + 1 success, got {calls['n']} calls"
+
+    def test_windows_retry_gives_up_after_ten_attempts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Bound on the retry loop — if ``os.replace`` keeps failing with
+        ``PermissionError``, surface it to the caller rather than stalling
+        forever. 50 ms ceiling (10 × 5 ms) is short enough to not visibly
+        slow a test run."""
+        monkeypatch.setattr("memtomem_stm.utils.fileio.sys.platform", "win32")
+
+        calls = {"n": 0}
+
+        def always_locked(src, dst):
+            calls["n"] += 1
+            raise PermissionError(5, "Access is denied", str(dst))
+
+        monkeypatch.setattr("memtomem_stm.utils.fileio.os.replace", always_locked)
+
+        target = tmp_path / "out.txt"
+        with pytest.raises(PermissionError):
+            atomic_write_text(target, "payload")
+
+        assert calls["n"] == 10, f"expected 10 attempts, got {calls['n']}"
+        # Temp must still be cleaned up despite the exhaustion path.
+        assert list(tmp_path.glob(target.name + ".*.tmp")) == []
 
 
 class TestSaveProxyConfigStillAtomic:

--- a/tests/test_utils_fileio.py
+++ b/tests/test_utils_fileio.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from memtomem_stm.utils.fileio import atomic_write_text
+from memtomem_stm.utils.fileio import _WIN_REPLACE_ATTEMPTS, atomic_write_text
 
 
 class TestAtomicWriteText:
@@ -148,13 +148,14 @@ class TestAtomicWriteText:
         assert target.read_text(encoding="utf-8") == "payload"
         assert calls["n"] == 4, f"expected 3 retries + 1 success, got {calls['n']} calls"
 
-    def test_windows_retry_gives_up_after_ten_attempts(
+    def test_windows_retry_gives_up_after_bounded_attempts(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         """Bound on the retry loop — if ``os.replace`` keeps failing with
         ``PermissionError``, surface it to the caller rather than stalling
-        forever. 50 ms ceiling (10 × 5 ms) is short enough to not visibly
-        slow a test run."""
+        forever. The exact attempt count is sourced from
+        ``_WIN_REPLACE_ATTEMPTS`` so a future tuning of the budget keeps
+        this test honest."""
         monkeypatch.setattr("memtomem_stm.utils.fileio.sys.platform", "win32")
 
         calls = {"n": 0}
@@ -169,7 +170,9 @@ class TestAtomicWriteText:
         with pytest.raises(PermissionError):
             atomic_write_text(target, "payload")
 
-        assert calls["n"] == 10, f"expected 10 attempts, got {calls['n']}"
+        assert calls["n"] == _WIN_REPLACE_ATTEMPTS, (
+            f"expected {_WIN_REPLACE_ATTEMPTS} attempts, got {calls['n']}"
+        )
         # Temp must still be cleaned up despite the exhaustion path.
         assert list(tmp_path.glob(target.name + ".*.tmp")) == []
 


### PR DESCRIPTION
## Summary

Original P1d hypothesis was wrong — `atomic_write_text` already uses `os.replace` (PR #115). The actual cause of `tests/test_utils_fileio.py::TestAtomicWriteText::test_concurrent_reader_never_sees_partial` failing on `windows-latest` with `PermissionError: [WinError 5]` is a Windows file-sharing issue: `MoveFileEx` (the syscall behind `os.replace`) raises when another process has the destination open without `FILE_SHARE_DELETE`, and Python's `open()` does not pass that flag. The reader thread's sub-millisecond `read_text` handle is enough to transiently block the writer's atomic-replace.

Wraps `os.replace` in a small Windows-only retry loop (10 attempts × 5 ms = 50 ms ceiling) inside `_replace_with_windows_retry`. The rename itself stays NTFS-atomic; we just ride out the transient sharing conflict. Behavior is unchanged on POSIX (early return before the loop).

## Why a retry instead of skipping the test

The property `test_concurrent_reader_never_sees_partial` exercises (concurrent readers never observe partial writes) is the actual contract callers depend on — `auto_index_response`, `extract_and_store`, and the hot-reload watcher all assume it. Skipping the test on Windows would silently leave Windows users open to `WinError 5` whenever any indexer co-runs with a writer. The retry is the minimum production change that preserves the contract on Windows.

50 ms ceiling is short enough not to stall a hot-path write if the destination is genuinely locked by another process — at the 10th attempt the original `PermissionError` propagates with the temp file cleaned up.

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src` — clean
- [x] `uv run pytest -m "not ollama"` — 2078 passed, 7 skipped on macOS (the two new tests pin the retry/exhaustion paths by monkey-patching `sys.platform`, so the POSIX leg exercises them without needing the matrix)
- [ ] `windows-latest` matrix on this PR — expect `test_concurrent_reader_never_sees_partial` to flip from FAIL → PASS, dropping the count from 6 → 5 (assuming P1c lands first; otherwise from 12 → 11)

Refs #302 (P1d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)