### PR TITLE
chore(tests): unify on sys.platform == "win32" platform-detection idiom

### DIFF
--- a/tests/cli/test_mms_import.py
+++ b/tests/cli/test_mms_import.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import stat
+import sys
 from datetime import datetime, timezone
 
 import pytest
@@ -231,7 +231,7 @@ class TestApply:
 
         # 1. file + permissions
         assert state.import_state_path().exists()
-        if os.name != "nt":
+        if sys.platform != "win32":
             # NTFS doesn't expose POSIX mode bits; ACL is the right primitive.
             mode = stat.S_IMODE(state.import_state_path().stat().st_mode)
             assert mode == 0o600

--- a/tests/mms/test_state.py
+++ b/tests/mms/test_state.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import os
 import stat
+import sys
 import tomllib
 from pathlib import Path
 
@@ -69,7 +69,8 @@ def test_registry_round_trip(sandbox_home):
 
 
 @pytest.mark.skipif(
-    os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+    sys.platform == "win32",
+    reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",
 )
 def test_save_registry_uses_0o600(sandbox_home):
     cfg = state.RegistryConfig(servers={"foo": state.RegistryServer(command="echo", prefix="f")})
@@ -237,7 +238,8 @@ def test_save_load_preserves_drift_hash(sandbox_home, server: state.RegistryServ
 
 
 @pytest.mark.skipif(
-    os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+    sys.platform == "win32",
+    reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",
 )
 def test_save_import_state_uses_0o600(sandbox_home):
     s = state.ImportState(

--- a/tests/test_utils_fileio.py
+++ b/tests/test_utils_fileio.py
@@ -8,7 +8,7 @@ proper cleanup of the temp file on failure.
 
 from __future__ import annotations
 
-import os
+import sys
 import threading
 from pathlib import Path
 
@@ -36,7 +36,8 @@ class TestAtomicWriteText:
         assert target.read_text(encoding="utf-8") == payload
 
     @pytest.mark.skipif(
-        os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+        sys.platform == "win32",
+        reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",
     )
     def test_mode_applied(self, tmp_path: Path):
         target = tmp_path / "secret.json"
@@ -45,7 +46,8 @@ class TestAtomicWriteText:
         assert (target.stat().st_mode & 0o777) == 0o600
 
     @pytest.mark.skipif(
-        os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+        sys.platform == "win32",
+        reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",
     )
     def test_no_mode_inherits_mkstemp_default(self, tmp_path: Path):
         """When ``mode`` is None we don't ``chmod`` — the file keeps the
@@ -140,7 +142,7 @@ class TestSaveProxyConfigStillAtomic:
         target = tmp_path / "stm_proxy.json"
         _save(target, {"enabled": True, "upstream_servers": {"x": {"prefix": "x"}}})
 
-        if os.name != "nt":
+        if sys.platform != "win32":
             # NTFS doesn't expose POSIX mode bits; ACL is the right primitive.
             assert (target.stat().st_mode & 0o777) == 0o600
         assert "upstream_servers" in target.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Stacked on #306 — addresses the convention split flagged in #306/#307 reviews. Today the codebase uses two equivalent idioms for "is this Windows":

- The broader ``sys.platform`` idiom (established convention). Sites today on ``main``: ``src/memtomem_stm/cli/proxy.py:316`` (``== "darwin"``), ``:318`` (``== "win32"``), ``src/memtomem_stm/mms/import_hosts.py:306`` (``!= "darwin"``), ``tests/cli/test_proxy_cli.py:2247-2264`` (``monkeypatch.setattr("sys.platform", ...)`` setups), ``tests/mms/test_import_hosts.py:312`` (``!= "darwin"``); plus #307 (P1d) production code (``!= "win32"``).
- ``os.name == "nt"`` — newly introduced by #306 (P1c) at 6 sites; zero occurrences elsewhere on ``main``.

This PR rewrites the 6 P1c sites onto ``sys.platform == "win32"`` (or ``!= "win32"`` for the two inline guards), removes the now-unused ``import os`` from the three affected test modules, and adds ``import sys``. No behavior change — both idioms are equivalent on every supported platform; this is purely about not carrying two ways to say the same thing.

The chore could equally have aligned everything on ``os.name``, but only one site on ``main`` matches that idiom (zero, in fact — every existing platform check is on ``sys.platform``), and ``sys.platform`` matches the upstream memtomem core's ``skipif(sys.platform=="win32")`` pattern referenced in #302's CI/Tests row.

Stacked PR: base is ``windows-p1c-ntfs-mode-skipif`` (PR #306) so the diff shown here is just the rename, not P1c's content. Auto-rebases to ``main`` once #306 merges.

## Test plan

- [x] ``uv run ruff check src tests`` — clean
- [x] ``uv run ruff format --check src`` — clean
- [x] ``uv run pytest tests/mms/test_state.py tests/cli/test_mms_import.py tests/test_utils_fileio.py`` — 73 passed locally on macOS (skipif inactive on POSIX as expected)
- [x] ``grep -rn 'os\.name\s*[!=]=\s*"nt"' src tests`` — zero matches after this PR
- [ ] After #306 merges → auto-rebase to ``main`` → ``windows-latest`` informational matrix run for the actual ``win32`` skipif evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)