### PR TITLE
test(helpers): tighten set_home undo contract for absent originals (recovery for #308)

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -30,12 +30,25 @@ def test_set_home_path_home_resolves_to_sandbox(tmp_path: Path, monkeypatch):
 
 def test_set_home_is_undone_after_test(tmp_path: Path, monkeypatch):
     """monkeypatch must restore both env vars when the test exits — otherwise
-    the next test in the same session inherits the sandbox HOME."""
-    original_home = os.environ.get("HOME")
-    original_userprofile = os.environ.get("USERPROFILE")
+    the next test in the same session inherits the sandbox HOME.
+
+    Note that ``os.environ.get("VAR") == None`` would silently pass even if
+    monkeypatch had failed to *delete* a previously-absent key (since both
+    cases ``get`` returns ``None``). When the original is absent, assert
+    the key is not in ``os.environ`` so a regression that left a None-string
+    behind would still trip — important for bare CI shells where ``HOME``
+    or ``USERPROFILE`` may not be pre-populated.
+    """
+    snapshots = {
+        var: ("HAS" if var in os.environ else "ABSENT", os.environ.get(var))
+        for var in ("HOME", "USERPROFILE")
+    }
 
     set_home(monkeypatch, tmp_path)
     monkeypatch.undo()
 
-    assert os.environ.get("HOME") == original_home
-    assert os.environ.get("USERPROFILE") == original_userprofile
+    for var, (state, original) in snapshots.items():
+        if state == "HAS":
+            assert os.environ.get(var) == original, f"{var} not restored"
+        else:
+            assert var not in os.environ, f"{var} key not deleted"


### PR DESCRIPTION
## Summary

Recovery of [#308](https://github.com/memtomem/memtomem-stm/pull/308). #308 was squash-merged into its stacked-PR base (``windows-p1b-set-home-helper``) instead of ``main`` — the base wasn't auto-rebased to ``main`` after #305 squash-merged. Result: PR shown as MERGED, but the diff never reached ``main``.

This PR cherry-picks the same squash commit onto ``main`` so the contract tightening lands.

The change itself is unchanged from #308: ``test_set_home_is_undone_after_test`` previously used ``os.environ.get(var) == original``, which silently passes even when monkeypatch fails to *delete* a previously-absent key (since both "absent" and "set to None" return ``None`` from ``get``). On a bare CI shell where ``HOME`` or ``USERPROFILE`` isn't pre-populated, a regression that left the variable behind as a stub would slip through.

Snapshot whether each var is present *before* ``set_home``, then assert the right shape per state — present-original round-trips to the same string; absent-original results in the key truly missing. Both branches exercise on every run since macOS has ``HOME`` set but ``USERPROFILE`` absent, and Windows has both set.

Refs #302, #305, #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)