### PR TITLE
fix(cli/proxy): backslash-safe `--args` tokenization on Windows (#302 P1e)

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -30,12 +30,25 @@ def test_set_home_path_home_resolves_to_sandbox(tmp_path: Path, monkeypatch):
 
 def test_set_home_is_undone_after_test(tmp_path: Path, monkeypatch):
     """monkeypatch must restore both env vars when the test exits — otherwise
-    the next test in the same session inherits the sandbox HOME."""
-    original_home = os.environ.get("HOME")
-    original_userprofile = os.environ.get("USERPROFILE")
+    the next test in the same session inherits the sandbox HOME.
+
+    Note that ``os.environ.get("VAR") == None`` would silently pass even if
+    monkeypatch had failed to *delete* a previously-absent key (since both
+    cases ``get`` returns ``None``). When the original is absent, assert
+    the key is not in ``os.environ`` so a regression that left a None-string
+    behind would still trip — important for bare CI shells where ``HOME``
+    or ``USERPROFILE`` may not be pre-populated.
+    """
+    snapshots = {
+        var: ("HAS" if var in os.environ else "ABSENT", os.environ.get(var))
+        for var in ("HOME", "USERPROFILE")
+    }
 
     set_home(monkeypatch, tmp_path)
     monkeypatch.undo()
 
-    assert os.environ.get("HOME") == original_home
-    assert os.environ.get("USERPROFILE") == original_userprofile
+    for var, (state, original) in snapshots.items():
+        if state == "HAS":
+            assert os.environ.get(var) == original, f"{var} not restored"
+        else:
+            assert var not in os.environ, f"{var} key not deleted"


### PR DESCRIPTION
## Summary

- `entry["args"] = shlex.split(args_str)` in `add` / `init` ran POSIX shlex on the raw argument string, which on Windows ate `\a`, `\t`, `\_` etc. as escapes. A path like `D:\a\repo\repo\tests\_fake_memtomem_server.py` came out as `D:arepotests_fake_memtomem_server.py`, was persisted into the JSON config, and was then handed to `asyncio.create_subprocess_exec` as a relative script path — surfacing as `[Errno 2] No such file` in `tests/cli/test_proxy_cli.py::TestAddValidate::test_validate_success_writes_entry_with_tool_count` on the windows-latest leg added in #304.
- Adds `_split_args` in `src/memtomem_stm/cli/proxy.py`. POSIX still calls plain `shlex.split` (no behavior change). On Windows we drive a `shlex.shlex` instance with `posix=True` + `escape=""` so quoting (`"hello world"` → `hello world`) keeps working but backslashes are preserved verbatim. `ValueError` on unclosed quotes is preserved so the existing `except ValueError` branches in `add` / `init` still catch malformed input. Both call sites (`proxy.py:802`, `proxy.py:1808`) are migrated.
- Adds `tests/cli/test_proxy_cli.py::TestSplitArgs` covering the POSIX branch, the literal CI repro path, quoted-whitespace tokens on Windows, the `ValueError` contract, and an end-to-end `mms add --args <win path>` that asserts the saved JSON config keeps the path intact. `sys.platform` is monkeypatched so the Windows branch runs on POSIX too; the live windows-latest leg covers the real interpreter on top.

This is a production bug exposed (not introduced) by the windows-latest matrix in #304 — the affected test is `TestAddValidate::test_validate_success_writes_entry_with_tool_count`, which was untouched in #305 (P1b) and unrelated to the NTFS mode-bit assertions in #306 (P1c).

Refs #302 (suggested as P1e in the sequence).

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src` — clean (CI-required scope)
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean
- [x] `uv run pytest tests/cli/test_proxy_cli.py -m "not ollama"` — 199 passed
- [x] `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"` — 2083 passed locally on macOS
- [ ] Watch `windows-latest` matrix (continue-on-error from #304): `TestAddValidate::test_validate_success_writes_entry_with_tool_count` should turn green; the new `TestSplitArgs` class should be all-pass on the real interpreter.

Generated with Claude Code.