### PR TITLE
chore(tests): unify on sys.platform == "win32" platform-detection idiom (recovery for #309)

### DIFF
--- a/tests/cli/test_mms_import.py
+++ b/tests/cli/test_mms_import.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import stat
+import sys
 from datetime import datetime, timezone
 
 import pytest
@@ -232,7 +232,7 @@ class TestApply:
 
         # 1. file + permissions
         assert state.import_state_path().exists()
-        if os.name != "nt":
+        if sys.platform != "win32":
             # NTFS doesn't expose POSIX mode bits; ACL is the right primitive.
             mode = stat.S_IMODE(state.import_state_path().stat().st_mode)
             assert mode == 0o600

--- a/tests/mms/test_state.py
+++ b/tests/mms/test_state.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import os
 import stat
+import sys
 import tomllib
 from pathlib import Path
 
@@ -70,7 +70,8 @@ def test_registry_round_trip(sandbox_home):
 
 
 @pytest.mark.skipif(
-    os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+    sys.platform == "win32",
+    reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",
 )
 def test_save_registry_uses_0o600(sandbox_home):
     cfg = state.RegistryConfig(servers={"foo": state.RegistryServer(command="echo", prefix="f")})
@@ -238,7 +239,8 @@ def test_save_load_preserves_drift_hash(sandbox_home, server: state.RegistryServ
 
 
 @pytest.mark.skipif(
-    os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+    sys.platform == "win32",
+    reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",
 )
 def test_save_import_state_uses_0o600(sandbox_home):
     s = state.ImportState(

--- a/tests/test_utils_fileio.py
+++ b/tests/test_utils_fileio.py
@@ -8,7 +8,7 @@ proper cleanup of the temp file on failure.
 
 from __future__ import annotations
 
-import os
+import sys
 import threading
 from pathlib import Path
 
@@ -36,7 +36,8 @@ class TestAtomicWriteText:
         assert target.read_text(encoding="utf-8") == payload
 
     @pytest.mark.skipif(
-        os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+        sys.platform == "win32",
+        reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",
     )
     def test_mode_applied(self, tmp_path: Path):
         target = tmp_path / "secret.json"
@@ -45,7 +46,8 @@ class TestAtomicWriteText:
         assert (target.stat().st_mode & 0o777) == 0o600
 
     @pytest.mark.skipif(
-        os.name == "nt", reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive"
+        sys.platform == "win32",
+        reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",
     )
     def test_no_mode_inherits_mkstemp_default(self, tmp_path: Path):
         """When ``mode`` is None we don't ``chmod`` — the file keeps the
@@ -196,7 +198,7 @@ class TestSaveProxyConfigStillAtomic:
         target = tmp_path / "stm_proxy.json"
         _save(target, {"enabled": True, "upstream_servers": {"x": {"prefix": "x"}}})
 
-        if os.name != "nt":
+        if sys.platform != "win32":
             # NTFS doesn't expose POSIX mode bits; ACL is the right primitive.
             assert (target.stat().st_mode & 0o777) == 0o600
         assert "upstream_servers" in target.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Recovery of [#309](https://github.com/memtomem/memtomem-stm/pull/309). #309 was squash-merged into its stacked-PR base (``windows-p1c-ntfs-mode-skipif``) instead of ``main`` — the base wasn't auto-rebased to ``main`` after #306 squash-merged. Result: PR shown as MERGED, but the diff never reached ``main``.

This PR cherry-picks the same squash commit onto ``main`` so the convention unification lands.

Content unchanged from #309: rewrites the 6 ``os.name == "nt"`` sites introduced by #306 onto ``sys.platform == "win32"`` (or ``!= "win32"`` for the inline guards), drops the now-unused ``import os`` from the three affected test modules, adds ``import sys``. After this lands, ``grep -rn 'os\.name\s*[!=]=\s*"nt"' src tests`` returns zero matches.

Refs #302, #306, #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)