### PR TITLE
fix(tests): restore import os after #309/#312 convention sweep

### DIFF
--- a/tests/test_utils_fileio.py
+++ b/tests/test_utils_fileio.py
@@ -8,6 +8,7 @@ proper cleanup of the temp file on failure.
 
 from __future__ import annotations
 
+import os
 import sys
 import threading
 from pathlib import Path


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced when #312 (recovery of #309) merged after #307 (P1d). The convention chore removed ``import os`` from ``tests/test_utils_fileio.py`` along with the ``os.name == "nt"`` sites it was unifying, but P1d's retry-contract test (``test_windows_retries_transient_permission_error``) added a ``real_replace = os.replace`` line that the chore's grep didn't account for — at #309 review time, #307 was on a different unmerged branch, so the new ``os.replace`` use site wasn't visible to the "no other ``os.*`` references" check.

Result on ``main`` after both landed: ``NameError: name 'os' is not defined`` on every CI run of the retry test.

One-line fix: re-add ``import os``.

```
$ uv run pytest tests/test_utils_fileio.py -q
...............                                                          [100%]
15 passed in 0.18s
```

Refs #302, #307, #309, #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)