### PR TITLE
fix(cli/proxy): backslash-safe `--args` tokenization on Windows (#302 P1e)

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -77,6 +77,25 @@ def _hdr(s: str) -> str:
     return click.style(s, bold=True) if _color_on() else s
 
 
+def _split_args(args_str: str) -> list[str]:
+    """Tokenize a stdio-server ``--args`` / prompt-args string.
+
+    POSIX: plain ``shlex.split``. Windows: same POSIX-style quoting, but with
+    backslash-escape disabled so ``D:\\a\\repo\\tests\\_x.py`` round-trips —
+    default ``shlex.split`` would chew ``\\a``, ``\\t``, ``\\_`` as escapes
+    and emit ``D:arepotests_x.py``, which would later be passed to the child
+    interpreter as a (mangled, relative) path. Raises ``ValueError`` on
+    unclosed quotes, matching ``shlex.split``'s contract.
+    """
+    if sys.platform == "win32":
+        lex = shlex.shlex(args_str, posix=True)
+        lex.whitespace_split = True
+        lex.commenters = ""
+        lex.escape = ""
+        return list(lex)
+    return shlex.split(args_str)
+
+
 def _load(config_path: Path) -> dict[str, Any]:
     resolved = config_path.expanduser().resolve()
     if not resolved.exists():
@@ -799,7 +818,7 @@ def add(
         entry["command"] = command
         if args_str:
             try:
-                entry["args"] = shlex.split(args_str)
+                entry["args"] = _split_args(args_str)
             except ValueError as exc:
                 click.echo(f"{_err('Error:')} malformed --args: {exc}", err=True)
                 sys.exit(1)
@@ -1805,7 +1824,7 @@ def init(
             )
             if args_str.strip():
                 try:
-                    entry["args"] = shlex.split(args_str)
+                    entry["args"] = _split_args(args_str)
                 except ValueError as exc:
                     click.echo(f"{_err('Error:')} malformed arguments: {exc}", err=True)
                     sys.exit(1)

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -86,6 +86,11 @@ def _split_args(args_str: str) -> list[str]:
     and emit ``D:arepotests_x.py``, which would later be passed to the child
     interpreter as a (mangled, relative) path. Raises ``ValueError`` on
     unclosed quotes, matching ``shlex.split``'s contract.
+
+    Trade-off: with ``escape=""`` an embedded quote-escape (``\\"`` inside a
+    double-quoted token) is no longer recognized on Windows. Acceptable
+    because Windows-native ``cmd.exe`` quoting uses ``^`` rather than ``\\``,
+    and backslash-as-path-separator is the dominant case in this surface.
     """
     if sys.platform == "win32":
         lex = shlex.shlex(args_str, posix=True)

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -230,6 +230,18 @@ class TestSplitArgs:
             "hello world",
         ]
 
+    def test_windows_honors_single_quoted_whitespace(self, monkeypatch):
+        """POSIX-style single quoting is preserved on Windows too — only
+        the backslash-escape (``\\X``) is suppressed by ``escape=""``."""
+        from memtomem_stm.cli.proxy import _split_args
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert _split_args(r"C:\bin\x.py --msg 'hello world'") == [
+            r"C:\bin\x.py",
+            "--msg",
+            "hello world",
+        ]
+
     def test_windows_unclosed_quote_raises_valueerror(self, monkeypatch):
         """Match ``shlex.split``'s contract so the existing
         ``except ValueError`` blocks in ``add`` / ``init`` keep working."""

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -181,6 +181,88 @@ class TestStyleHelpers:
             assert fn("X") == "X"
 
 
+# ── _split_args tokenization (Windows backslash-safe) ───────────────────
+
+
+class TestSplitArgs:
+    """``_split_args`` must round-trip Windows paths supplied via ``--args``
+    and the interactive prompt. POSIX-mode ``shlex.split`` (the previous
+    implementation) consumed ``\\a``, ``\\t``, ``\\_`` etc. as escape
+    sequences and emitted ``D:arepotests_x.py`` for
+    ``D:\\a\\repo\\tests\\_x.py`` — the mangled string was then handed to
+    ``asyncio.create_subprocess_exec`` as a (relative) script path,
+    surfacing as ``[Errno 2] No such file`` on the windows-latest CI
+    matrix added in #304.
+
+    Tested against monkeypatched ``sys.platform`` so the Windows branch
+    runs on POSIX runners too; the live Windows leg covers the real
+    interpreter on top.
+    """
+
+    def test_posix_uses_shlex_split(self, monkeypatch):
+        from memtomem_stm.cli.proxy import _split_args
+
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert _split_args("/usr/bin/python script.py --flag x") == [
+            "/usr/bin/python",
+            "script.py",
+            "--flag",
+            "x",
+        ]
+
+    def test_windows_preserves_backslash_paths(self, monkeypatch):
+        """The exact CI repro: a GitHub-Actions Windows-runner path under
+        ``D:\\a\\<repo>\\<repo>\\tests\\_fake_memtomem_server.py`` must
+        survive tokenization unmodified."""
+        from memtomem_stm.cli.proxy import _split_args
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        path = r"D:\a\memtomem-stm\memtomem-stm\tests\_fake_memtomem_server.py"
+        assert _split_args(path) == [path]
+
+    def test_windows_still_honors_quoted_whitespace(self, monkeypatch):
+        from memtomem_stm.cli.proxy import _split_args
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert _split_args(r'C:\bin\x.py --msg "hello world"') == [
+            r"C:\bin\x.py",
+            "--msg",
+            "hello world",
+        ]
+
+    def test_windows_unclosed_quote_raises_valueerror(self, monkeypatch):
+        """Match ``shlex.split``'s contract so the existing
+        ``except ValueError`` blocks in ``add`` / ``init`` keep working."""
+        from memtomem_stm.cli.proxy import _split_args
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        with pytest.raises(ValueError):
+            _split_args(r'C:\bin\x.py "open ended')
+
+    def test_add_persists_unmangled_args_on_windows(self, runner, config, monkeypatch):
+        """End-to-end: ``mms add --args <win path>`` must round-trip into
+        the saved JSON config without backslash-escape damage."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        win_path = r"D:\a\memtomem-stm\memtomem-stm\tests\_fake_memtomem_server.py"
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "fake",
+                "--prefix",
+                "fk",
+                "--command",
+                sys.executable,
+                "--args",
+                win_path,
+                *_cfg_args(config),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert data["upstream_servers"]["fake"]["args"] == [win_path]
+
+
 # ── _load / config-corruption paths ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `entry["args"] = shlex.split(args_str)` in `add` / `init` ran POSIX shlex on the raw argument string, which on Windows ate `\a`, `\t`, `\_` etc. as escapes. A path like `D:\a\repo\repo\tests\_fake_memtomem_server.py` came out as `D:arepotests_fake_memtomem_server.py`, was persisted into the JSON config, and was then handed to `asyncio.create_subprocess_exec` as a relative script path — surfacing as `[Errno 2] No such file` in `tests/cli/test_proxy_cli.py::TestAddValidate::test_validate_success_writes_entry_with_tool_count` on the windows-latest leg added in #304.
- Adds `_split_args` in `src/memtomem_stm/cli/proxy.py`. POSIX still calls plain `shlex.split` (no behavior change). On Windows we drive a `shlex.shlex` instance with `posix=True` + `escape=""` so quoting (`"hello world"` → `hello world`) keeps working but backslashes are preserved verbatim. `ValueError` on unclosed quotes is preserved so the existing `except ValueError` branches in `add` / `init` still catch malformed input. Both call sites (`proxy.py:802`, `proxy.py:1808`) are migrated.
- Adds `tests/cli/test_proxy_cli.py::TestSplitArgs` covering the POSIX branch, the literal CI repro path, quoted-whitespace tokens on Windows, the `ValueError` contract, and an end-to-end `mms add --args <win path>` that asserts the saved JSON config keeps the path intact. `sys.platform` is monkeypatched so the Windows branch runs on POSIX too; the live windows-latest leg covers the real interpreter on top.

This is a production bug exposed (not introduced) by the windows-latest matrix in #304 — the affected test was untouched by P1b (#305) and unrelated to the NTFS mode-bit assertions in P1c (#306). Replaces the closed #311 (which had the wrong head branch attached); branch was rebased onto current main (post #310/#312/#313) so the diff is exactly the two intended files.

Refs #302 (suggested as P1e in the sequence).

## Test plan

- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src` — clean (CI-required scope)
- [x] `uv run mypy src/memtomem_stm/cli/proxy.py` — clean
- [x] `uv run pytest tests/cli/test_proxy_cli.py::TestSplitArgs -q` — 5 passed
- [x] `uv run pytest tests/cli/test_proxy_cli.py -m "not ollama" -q` — 199 passed (pre-rebase)
- [x] `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"` — 2083 passed locally on macOS (pre-rebase)
- [ ] Watch `windows-latest` matrix (continue-on-error from #304): `TestAddValidate::test_validate_success_writes_entry_with_tool_count` should turn green; new `TestSplitArgs` class should be all-pass on the real interpreter.

Generated with Claude Code.