### PR TITLE
fix(tests): utf-8 encoding for read_text in test_qa_round3 (#302 P2)

### DIFF
--- a/tests/test_qa_round3.py
+++ b/tests/test_qa_round3.py
@@ -164,7 +164,7 @@ class TestParseResultsRegex:
 class TestDocsToolCount:
     def test_cli_md_has_11_tools(self):
         cli_md = Path(__file__).parent.parent / "docs" / "cli.md"
-        content = cli_md.read_text()
+        content = cli_md.read_text(encoding="utf-8")
         assert "11 + proxied" in content
         assert "stm_proxy_health" in content
         assert "stm_compression_feedback" in content
@@ -173,7 +173,7 @@ class TestDocsToolCount:
 
     def test_readme_has_11_tools(self):
         readme = Path(__file__).parent.parent / "README.md"
-        content = readme.read_text()
+        content = readme.read_text(encoding="utf-8")
         assert "11 MCP tools" in content
 
 
@@ -428,7 +428,7 @@ class TestCacheStatsLock:
 class TestCompressionDocsFlowchart:
     def test_selective_not_in_auto_flowchart(self):
         doc = Path(__file__).parent.parent / "docs" / "compression.md"
-        content = doc.read_text()
+        content = doc.read_text(encoding="utf-8")
         # The flowchart should not show selective as an auto-selection target
         lines = content.split("\n")
         in_flowchart = False
@@ -442,7 +442,7 @@ class TestCompressionDocsFlowchart:
 
     def test_note_mentions_selective_opt_in(self):
         doc = Path(__file__).parent.parent / "docs" / "compression.md"
-        content = doc.read_text()
+        content = doc.read_text(encoding="utf-8")
         assert "selective" in content.lower()
         assert "opt-in" in content.lower() or "never" in content.lower()
 
@@ -456,7 +456,7 @@ class TestFeedbackTrackerPosition:
     def test_feedback_not_created_when_adapter_fails(self):
         """feedback_tracker should only be created when mcp_adapter succeeds."""
         server_py = Path(__file__).parent.parent / "src" / "memtomem_stm" / "server.py"
-        source = server_py.read_text()
+        source = server_py.read_text(encoding="utf-8")
 
         # Simple text check: "if mcp_adapter is not None:" should appear
         # before the surfacing FeedbackTracker constructor in the code.


### PR DESCRIPTION
## Summary

- Pin `encoding="utf-8"` on all five `Path.read_text()` calls in `tests/test_qa_round3.py`. On Windows the default codec is `cp1252` (en-US runners), which raises `UnicodeDecodeError` when reading `docs/cli.md` and `README.md` because they contain non-ASCII characters.
- Two of the five reads are currently failing on `windows-latest` (`test_cli_md_has_11_tools`, `test_readme_has_11_tools`); the other three target ASCII-only files today and are pinned defensively to keep the file consistent and prevent regression when non-ASCII content is added later.
- This is the **P2** row in the #302 Windows triage ladder. After P1e (#314, #316), P1e #5 (#317), and P1f (#318) land as well, `windows-latest` reduces from 5 untriaged failures to 1 (the resurfaced `test_select_expired_key` flake — separate follow-up).

## Scope note

A repo-wide grep for `read_text()` with no `encoding=` only surfaces the five sites in `tests/test_qa_round3.py` (fixed here). One additional hit at `tests/bench/datasets_expanded.py:613` is a **false positive** — the matched text lives inside the `_MD_TUTORIAL = """..."""` string literal as Python pseudocode in a markdown fence, not an actual executed call — so no fix is needed there. After this PR `src/` and `tests/` have zero real un-encoded `read_text()` call sites; that's the right place to draw a line for #302's UTF-8 cleanup.

## Test plan

- [x] `uv run pytest tests/test_qa_round3.py -q` — 34 passed locally (macOS).
- [x] `uv run ruff check tests/test_qa_round3.py` — clean.
- [x] CI `windows-latest`: `test_cli_md_has_11_tools` and `test_readme_has_11_tools` flipped from failed → passed (verified on run [25439089840](https://github.com/memtomem/memtomem-stm/actions/runs/25439089840/job/74625033942)). Remaining failures on that job are pre-existing and tracked separately by sibling PRs in the #302 ladder.
- [x] CI `ubuntu-latest`: no regression (test job green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)