### PR TITLE
fix(surfacing/feedback): deterministic recent order on tied created_at (#302 P1e)

### DIFF
--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -291,7 +291,7 @@ class FeedbackStore:
             recent_rows = self._db.execute(
                 f"SELECT created_at, tool, query, memory_ids, scores "
                 f"FROM surfacing_events{where_sql} "
-                "ORDER BY created_at DESC LIMIT ?",
+                "ORDER BY created_at DESC, rowid DESC LIMIT ?",
                 [*event_params, limit],
             ).fetchall()
             for ts, tool_name, query, memory_ids_json, scores_json in recent_rows:

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -143,9 +143,25 @@ class TestFeedbackStore:
         assert row_s1["query_preview"].endswith("...")
         assert len(row_s1["query_preview"]) == 80
 
-    def test_get_stats_tool_filter_excludes_other_ratings(
+    def test_get_stats_recent_tied_created_at_breaks_by_insert_order(
         self, feedback_store: FeedbackStore
     ):
+        for i in range(1, 6):
+            feedback_store.record_surfacing(f"s{i}", "srv", "t", f"q{i}", ["m"], [0.5])
+        # Force a tie on created_at — Windows time.time() resolution can collapse
+        # rapid inserts onto identical timestamps; without a secondary sort key,
+        # SQLite's tie-break is unspecified and "recent" becomes nondeterministic.
+        feedback_store._db.executemany(  # type: ignore[union-attr]
+            "UPDATE surfacing_events SET created_at = ? WHERE id = ?",
+            [(1000.0, f"s{i}") for i in range(1, 6)],
+        )
+        feedback_store._db.commit()  # type: ignore[union-attr]
+
+        stats = feedback_store.get_stats(limit=3)
+        previews = [r["query_preview"] for r in stats["recent"]]
+        assert previews == ["q5", "q4", "q3"]
+
+    def test_get_stats_tool_filter_excludes_other_ratings(self, feedback_store: FeedbackStore):
         feedback_store.record_surfacing("s_a", "srv", "tool_a", "q", ["m1"], [0.9])
         feedback_store.record_surfacing("s_b", "srv", "tool_b", "q", ["m2"], [0.9])
         feedback_store.record_feedback("s_a", "helpful")
@@ -211,9 +227,7 @@ class TestFeedbackTracker:
 
 
 class TestAutoTuner:
-    def _make_tuner(
-        self, feedback_store: FeedbackStore, min_score: float = 0.02
-    ) -> AutoTuner:
+    def _make_tuner(self, feedback_store: FeedbackStore, min_score: float = 0.02) -> AutoTuner:
         cfg = SurfacingConfig(
             auto_tune_enabled=True,
             auto_tune_min_samples=5,
@@ -222,9 +236,7 @@ class TestAutoTuner:
         )
         return AutoTuner(cfg, feedback_store)
 
-    def _seed_feedback(
-        self, store: FeedbackStore, tool: str, not_relevant: int, helpful: int
-    ):
+    def _seed_feedback(self, store: FeedbackStore, tool: str, not_relevant: int, helpful: int):
         store.record_surfacing("s1", "sv", tool, "q", ["m1"], [0.5])
         for _ in range(not_relevant):
             store.record_feedback("s1", "not_relevant")


### PR DESCRIPTION
## Summary

Fixes the last lingering Windows-CI failure from the #302 P1e batch:
`tests/test_feedback.py::TestFeedbackStore::test_get_stats_recent_limit_and_preview`
on `windows-latest`.

`FeedbackStore.get_stats(limit=N)` returned the most recent events with
`ORDER BY created_at DESC LIMIT ?`. On Windows, `time.time()` resolution
is coarse enough that several `record_surfacing()` calls in rapid succession
land on identical timestamps. SQLite's tie-break for `ORDER BY` is
unspecified, so the user-visible "recent" list became nondeterministic.

The CI assertion `all(p.startswith("q") for p in previews)` flaked because
`s1` (the long "x..." query inserted first) sometimes leaked back into the
limit=3 tail when its `created_at` tied with later inserts.

## Fix

`ORDER BY created_at DESC, rowid DESC` — `surfacing_events.id` is `TEXT
PRIMARY KEY` so the table keeps an implicit auto-incrementing rowid;
DESC-ordering it as a secondary key makes insert order the tiebreaker.
Net effect: same ordering on platforms where timestamps are already
distinct, deterministic ordering when they tie.

This is a real production correctness improvement, not just a test fix —
the "recent" list shown to users (via `stm_surfacing_stats`) was
nondeterministic on Windows.

## Test plan

- [x] `uv run pytest tests/test_feedback.py -q` (23 passed locally on macOS)
- [x] `uv run ruff check src && uv run ruff format --check src`
- [x] Full suite: `uv run pytest -m "not ollama" -q` (2088 passed)
- [x] Added a regression test (`test_get_stats_recent_tied_created_at_breaks_by_insert_order`)
      that forces `created_at` ties via `UPDATE` so the tiebreak is exercised
      on every platform — not just whichever ones happen to have coarse
      clock resolution.
- [ ] windows-latest CI: previously red on the targeted test, expected green.

## Out of scope (follow-up candidates)

The same `ORDER BY created_at DESC` pattern exists in `metrics_store.py`:
- `get_history()` (line 277)
- `lookup_recent_trace_id()` (line 317)

Both have the same tie-break ambiguity. No failing test points at them
today, so leaving them for a follow-up rather than expanding this PR's
scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)