### PR TITLE
test(pending_store): sleep above Windows monotonic tick in touch test (#302 P1e)

### DIFF
--- a/tests/test_pending_store.py
+++ b/tests/test_pending_store.py
@@ -37,7 +37,10 @@ class TestInMemoryPendingStore:
         sel = _make_selection()
         original_time = sel.created_at
         store.put("k1", sel)
-        time.sleep(0.01)
+        # Windows time.monotonic() falls back to GetTickCount64 with ~15.6 ms
+        # resolution; sleep at least one tick + headroom so the second sample
+        # is guaranteed to advance.
+        time.sleep(0.05)
         store.touch("k1")
         assert store.get("k1").created_at > original_time
 


### PR DESCRIPTION
## Summary

- `tests/test_pending_store.py::TestInMemoryPendingStore::test_touch_updates_created_at` slept 10 ms between two `time.monotonic()` samples and asserted strict `>` on the result. On Windows, `time.monotonic()` falls back to `GetTickCount64` with **~15.6 ms** resolution; if the sleep landed inside a single tick, the second sample equaled the first and the assertion flaked on `windows-latest` (intermittent — earlier #302 status reports flagged this as the new "5th remaining" failure with `time.time() / monotonic` resolution as the working hypothesis, now confirmed against the Windows clock-info docs).
- Bump the sleep to 50 ms (~3 ticks) so the second sample is guaranteed to advance, and add an inline comment so the next maintainer doesn't optimistically shrink it back to 10 ms without re-checking the Windows tick.
- Production code is not at fault here. `InMemoryPendingStore.touch()` correctly uses `time.monotonic()` for lifetime tracking (`time.perf_counter()` would have higher resolution on Windows but loses no semantics that matter to a single-process pending store, so we don't switch — the test assumed clock resolution the platform doesn't provide, that's the actual bug).

This is **#5 in the P1e ladder** under #302. Together with #314 (P1e #1) and #316 (P1e #4) this should drop `windows-latest` to 0 untriaged Python-side failures, leaving only the reader-thread `PermissionError` warning and the resurfaced `test_select_expired_key` (both tracked separately in the #302 epilogue).

## Test plan

- [x] `uv run pytest tests/test_pending_store.py -q` — 18 passed locally (macOS).
- [x] `uv run ruff check tests/test_pending_store.py` — clean.
- [ ] CI `windows-latest`: `test_touch_updates_created_at` no longer flakes; full job becomes deterministic on this test (cannot be observed in a single run because the failure was intermittent — watch over a few runs).
- [ ] CI `ubuntu-latest` / typecheck / lint / notebooks / bench_qa: no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)