### PR TITLE
test(compression): sleep above Windows monotonic tick in expired-key test (#302 P1g)

### DIFF
--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -143,7 +143,13 @@ class TestSelectiveCompressor:
 
         import time
 
-        time.sleep(0.01)
+        # `evict_expired` uses ``(now - created_at) > ttl`` with ttl=0.0, so
+        # any non-zero monotonic delta marks the entry expired. Windows
+        # ``time.monotonic()`` falls back to ``GetTickCount64`` with ~15.6 ms
+        # resolution; sleeping 10 ms could land inside a single tick, leave
+        # ``now == created_at``, and skip eviction. Sleep ≥ 1 tick + headroom
+        # so the delta is guaranteed positive.
+        time.sleep(0.05)
         result = c.select(key, ["a"])
         assert "not found or expired" in result
 


### PR DESCRIPTION
## Summary

- `tests/test_compression.py::TestSelectiveCompressor::test_select_expired_key` slept 10 ms between `SelectiveCompressor.compress()` (which stamps `created_at = time.monotonic()`) and `.select()` (which calls `evict_expired(ttl=0.0)`, i.e. `(now - created_at) > 0.0`). On Windows, `time.monotonic()` falls back to `GetTickCount64` with **~15.6 ms** resolution; when the sleep landed inside a single tick the two samples were equal, the delta was `0.0`, the strict `>` check was `False`, the entry was *not* evicted, and `.select()` returned the real content. Symptom on windows-latest CI: `assert 'not found or expired' in '"xxxxx..."'`.
- Bump the sleep to 50 ms (≈3 ticks) so the second sample is guaranteed to advance. Production code is correct — `evict_expired` compares monotonic timestamps as intended; only the test assumed clock resolution finer than the Windows runner provides. Inline comment cross-references the `GetTickCount64` fact so a future maintainer doesn't optimistically shrink the sleep back to 10 ms.
- This is the **last untriaged Windows failure** under #302. Once #314, #315, #316, #317, #318, and this PR all merge, `windows-latest` is deterministically green (worst case 0 failures, best case identical) and the matrix axis is ready for `continue-on-error: false` + required-status-check enrollment per the "CI matrix → branch protection" workflow.

Same root-cause family as **PR #317** (P1e #5, `test_touch_updates_created_at`) and same idiom: 10 ms → 50 ms with a comment pinning the reason.

## Test plan

- [x] `uv run pytest tests/test_compression.py::TestSelectiveCompressor::test_select_expired_key -q` — passes locally (macOS).
- [x] `uv run ruff check tests/test_compression.py` — clean.
- [ ] CI `windows-latest`: `test_select_expired_key` no longer flakes; full job becomes deterministic on this test (the failure was intermittent, so verification is over multiple runs once merged).
- [ ] CI `ubuntu-latest` / typecheck / lint / notebooks / bench_qa: no regression.

## Follow-up after merge

After this PR + the 5 sibling #302 PRs land, the recommended sequence is:
1. Watch a few `main` runs to confirm windows-latest stays green.
2. Open the **continue-on-error flip** PR — drop `continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}` from the test matrix in `.github/workflows/ci.yml` and add the new windows-latest check names to required-status-checks per the "CI matrix renames branch-protection checks" runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)