### PR TITLE
chore(ci): require windows-latest matrix axis after #302 closes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,19 @@ on:
     branches: [main]
 
 jobs:
-  # Windows runs on lint/typecheck/test are informational only while the
-  # Windows-support triage in #302 is in flight. Ubuntu remains the gating
-  # required check; the Windows leg is a `continue-on-error` signal so
-  # P1b/P2/P3 fixes can be observed without blocking merges. Flip to
-  # required once the matrix is consistently green.
+  # Windows runs on lint/typecheck/test are gating required checks alongside
+  # ubuntu-latest. The matrix was introduced in #304 (P1a) with a
+  # `continue-on-error` escape hatch while the #302 Windows-support triage
+  # was in flight; with #314–#319 merged the matrix is consistently green
+  # so the escape hatch is gone. The mypy *step* keeps its own
+  # `continue-on-error: true` because typecheck is still advisory project-wide
+  # (CLAUDE.md), independent of the OS matrix.
   lint:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -34,7 +35,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -51,7 +51,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## Summary

The `lint` / `typecheck` / `test` jobs were introduced as a Windows-inclusive matrix in #304 (P1a) with `continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}` as an explicit escape hatch — the #302 Windows-support triage was in flight (P1b → P1g) and real failures needed to be visible on PRs without blocking merges to `main`. With **#314 / #315 / #316 / #317 / #318 / #319** all merged, the Windows leg is consistently green and the escape hatch is no longer earning its keep.

This PR:

- Removes the per-job `continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}` from `lint`, `typecheck`, and `test`. A real Windows-side regression on any of those now blocks merge instead of being a silent yellow signal.
- Rewrites the leading comment to record the post-triage state (matrix is gating, escape hatch removed) and explicitly notes that the `mypy` *step* keeps its own `continue-on-error: true` — typecheck is advisory project-wide per `CLAUDE.md`, independent of the OS matrix, so the `typecheck (<axis>)` jobs continue to report green regardless of mypy's exit code.

## Paired branch-protection action (post-merge)

Per the "CI matrix renames branch-protection checks" runbook (memtomem-stm memory): adding or removing matrix axes on a required job needs a paired `gh api -X PATCH` to keep `required_status_checks` exactly matching the live check names.

After this PR squash-merges, run:

```bash
gh api -X PATCH /repos/memtomem/memtomem-stm/branches/main/protection/required_status_checks \
  -f 'contexts[]=notebooks' \
  -f 'contexts[]=lint (ubuntu-latest)' \
  -f 'contexts[]=lint (windows-latest)' \
  -f 'contexts[]=test (ubuntu-latest)' \
  -f 'contexts[]=test (windows-latest)'
```

That promotes `lint (windows-latest)` and `test (windows-latest)` to required, alongside the existing three (`notebooks`, `lint (ubuntu-latest)`, `test (ubuntu-latest)`). The two `typecheck (<axis>)` jobs stay advisory — same posture as before this PR, since `typecheck (ubuntu-latest)` was never in `required_status_checks` either, and the mypy step's `continue-on-error: true` still drives that decision.

`bench_qa` keeps its own `continue-on-error: true` (advisory while per-scenario thresholds settle — different rationale, separate decision).

## Pre-flip evidence

Three consecutive `main` runs post-#302-ladder are green on windows-latest:

| run | sha | ladder coverage | windows-latest result |
|-----|-----|-----------------|-----------------------|
| `25440626677` | `f622e78` | through #317 | ✅ success |
| `25440628986` | `4c256ff` | through #318 | ✅ success |
| `25441260244` | `4075965` | through #319 (full ladder) | ✅ success (8/8 jobs) |

Notably, the first two were green even *before* the P1g sleep bump landed — `test_select_expired_key` did not flake. P1g is still the right belt-and-suspenders fix (the underlying Windows monotonic tick reality doesn't go away), but it confirms the post-flip pipeline is not riding on luck.

## Test plan

- [x] `git diff` is exactly 7 inserts / 8 deletes in `.github/workflows/ci.yml` — the comment and three `continue-on-error` lines, nothing else.
- [ ] CI on this PR: ubuntu-latest + windows-latest both pass for `lint` / `typecheck` / `test`. (Without the escape hatch, a stray Windows-side issue would surface here as a real check failure rather than a yellow informational signal.)
- [ ] Post-merge: run the `gh api -X PATCH` above and verify with `gh api .../required_status_checks` that the live `contexts` list contains exactly the 5 expected names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)