### PR TITLE
docs(compression): mode-aware surfacing on progressive (F6 follow-up)

### DIFF
--- a/docs/compression.md
+++ b/docs/compression.md
@@ -178,7 +178,7 @@ Each call to `stm_proxy_read_more` resets the TTL. The `ttl` field is omitted on
 
 Progressive is **opt-in only** — `auto` strategy never selects it because it changes the agent interaction pattern (requires calling `stm_proxy_read_more`). When configured, the proxied tool description includes a convention suffix (`| Chunked: use stm_proxy_read_more for more`) so the agent knows to expect chunked delivery.
 
-> **Note**: Memory surfacing (Stage 3) is **skipped** for progressive delivery responses. Injecting memories into the first chunk would shift character offsets for subsequent `stm_proxy_read_more` calls.
+> **Note**: Memory surfacing (Stage 3) on progressive delivery is **mode-aware**. It runs on the first chunk when `injection_mode` is `append` or `section` — both modes preserve the `PROGRESSIVE_FOOTER_TOKEN` concat invariant that `stm_proxy_read_more` relies on. It is **skipped only for `prepend`**, which would shift character offsets for subsequent `stm_proxy_read_more` calls.
 
 ## Progressive Fallback Ladder
 
@@ -192,7 +192,7 @@ flowchart TD
     S -->|no| Size{"content ><br/>chunk_size?"}
     Size -->|yes| T1["Tier 1: progressive<br/>(zero-loss, best-effort)"]
     Size -->|no| H{"≥ 3 headings?"}
-    T1 -->|success| Done["progressive_fallback<br/>+ skip surfacing"]
+    T1 -->|success| Done["progressive_fallback<br/>+ mode-aware surfacing"]
     T1 -->|failure| H
     H -->|yes| T2["Tier 2: hybrid<br/>(structure-preserving)"]
     H -->|no| T3["Tier 3: truncate<br/>(guaranteed floor)"]


### PR DESCRIPTION
## Summary

- Updates the `docs/compression.md` Stage 3 note and the progressive-fallback mermaid label from "skipped" to "mode-aware", matching the F6 behavior shipped in #161.
- Surfacing on progressive runs for `injection_mode` `append`/`section` and is skipped only for `prepend` (the only mode that breaks the `PROGRESSIVE_FOOTER_TOKEN` concat invariant `stm_proxy_read_more` relies on).
- Doc-only change. No code, test, or config changes.

## Why this PR (and not the original direct push)

The original docs commit (`ce1f618`) was pushed directly to `main`, bypassing the "Changes must be made through a pull request" branch-protection rule. To restore the audit trail, that commit was reverted on `main` (`def5ee8`) and this PR re-applies the same diff through the normal review path.

## Verification against the implementation

- `src/memtomem_stm/proxy/manager.py:690` — `_apply_surfacing_on_progressive` helper.
- `src/memtomem_stm/proxy/manager.py:718-723` — `prepend` returns early with a one-time WARNING.
- `src/memtomem_stm/proxy/manager.py:1425` — inline comment: "F6: surface on progressive when `injection_mode` is append/section."
- `src/memtomem_stm/proxy/manager.py:1613-1627` — `progressive_fallback` branch routes through the same mode-aware helper, so the mermaid `Done` node label correctly applies to the fallback path too.
- `src/memtomem_stm/proxy/progressive.py:26` — `PROGRESSIVE_FOOTER_TOKEN` is the canonical split token referenced in the new doc note.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src` — clean.
- [x] `uv run pytest tests/test_proxy_manager_pipeline.py tests/test_progressive.py -m "not ollama"` — 84 passed in 0.39s.
- [ ] Full `uv run pytest -m "not ollama"` will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)