### PR TITLE
feat(surfacing): thread _context_query through SurfacingEngine (F1)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -666,6 +666,7 @@ class ProxyManager:
         text: str,
         *,
         trace_id: str | None = None,
+        context_query: str | None = None,
     ) -> str:
         """Apply proactive memory surfacing if eligible."""
         if self._surfacing_engine is None:
@@ -677,6 +678,7 @@ class ProxyManager:
                 arguments=arguments,
                 response_text=text,
                 trace_id=trace_id,
+                context_query=context_query,
             )
         except Exception:
             logger.warning(
@@ -695,6 +697,7 @@ class ProxyManager:
         text: str,
         *,
         trace_id: str | None = None,
+        context_query: str | None = None,
     ) -> tuple[str, bool | None, str | None]:
         """Surface on a progressive first-chunk when the formatter mode keeps
         the ``PROGRESSIVE_FOOTER_TOKEN`` concat invariant intact.
@@ -731,6 +734,7 @@ class ProxyManager:
                 arguments=arguments,
                 response_text=text,
                 trace_id=trace_id,
+                context_query=context_query,
             )
             return surfaced, True, None
         except Exception as exc:
@@ -986,8 +990,16 @@ class ProxyManager:
         through the same hit pipeline as a single call would.
         """
         self.tracker.record_cache_hit()
+        context_query = arguments.get("_context_query") if arguments else None
         with traced("proxy_call_cache_hit", metadata={"server": server, "tool": tool}):
-            return await self._apply_surfacing(server, tool, arguments, cached, trace_id=trace_id)
+            return await self._apply_surfacing(
+                server,
+                tool,
+                arguments,
+                cached,
+                trace_id=trace_id,
+                context_query=context_query if isinstance(context_query, str) else None,
+            )
 
     async def call_tool(
         self,
@@ -1431,7 +1443,12 @@ class ProxyManager:
                 surfacing_on_progressive_ok,
                 surface_error,
             ) = await self._apply_surfacing_on_progressive(
-                server, tool, upstream_args, compressed, trace_id=trace_id
+                server,
+                tool,
+                upstream_args,
+                compressed,
+                trace_id=trace_id,
+                context_query=context_query,
             )
             _surface_ms = (_time.monotonic() - _t0) * 1000
         else:
@@ -1625,7 +1642,12 @@ class ProxyManager:
                         surfacing_on_progressive_ok,
                         surface_error,
                     ) = await self._apply_surfacing_on_progressive(
-                        server, tool, upstream_args, compressed, trace_id=trace_id
+                        server,
+                        tool,
+                        upstream_args,
+                        compressed,
+                        trace_id=trace_id,
+                        context_query=context_query,
                     )
                     _surface_ms = (_time.monotonic() - _t0) * 1000
             else:
@@ -1635,7 +1657,12 @@ class ProxyManager:
                 ):
                     _t0 = _time.monotonic()
                     surfaced = await self._apply_surfacing(
-                        server, tool, upstream_args, compressed, trace_id=trace_id
+                        server,
+                        tool,
+                        upstream_args,
+                        compressed,
+                        trace_id=trace_id,
+                        context_query=context_query,
                     )
                     _surface_ms = (_time.monotonic() - _t0) * 1000
 

--- a/src/memtomem_stm/surfacing/context_extractor.py
+++ b/src/memtomem_stm/surfacing/context_extractor.py
@@ -23,13 +23,22 @@ class ContextExtractor:
         tool: str,
         arguments: dict[str, Any],
         config: SurfacingConfig,
+        *,
+        context_query: str | None = None,
     ) -> str | None:
         # 1. Per-tool template
         tool_cfg = config.context_tools.get(tool)
         if tool_cfg and tool_cfg.query_template:
             return self._apply_template(tool_cfg.query_template, server, tool, arguments)
 
-        # 2. Agent-provided context
+        # 2. Explicit context_query parameter (preferred path from the proxy,
+        # which extracts ``_context_query`` from upstream args and forwards it
+        # via this kwarg without re-inserting it into ``arguments``).
+        if isinstance(context_query, str) and context_query.strip():
+            return context_query.strip()
+
+        # 3. Agent-provided context (legacy: kept for direct engine callers
+        # and tests that still pass ``_context_query`` inside ``arguments``).
         if "_context_query" in arguments:
             cq = arguments["_context_query"]
             if isinstance(cq, str) and cq.strip():

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -141,6 +141,7 @@ class SurfacingEngine:
         response_text: str,
         *,
         trace_id: str | None = None,
+        context_query: str | None = None,
     ) -> str:
         """Surface relevant memories and inject into response_text.
 
@@ -165,7 +166,9 @@ class SurfacingEngine:
             logger.debug("Surfacing skipped: circuit breaker open for %s/%s", server, tool)
             return response_text
 
-        query = self._extractor.extract_query(server, tool, arguments, self._config)
+        query = self._extractor.extract_query(
+            server, tool, arguments, self._config, context_query=context_query
+        )
         if query is None:
             self._observability.record_skip(tool, "no_query")
             logger.debug("Surfacing skipped: no query extracted for %s/%s", server, tool)

--- a/tests/bench/test_bench_qa_scenarios.py
+++ b/tests/bench/test_bench_qa_scenarios.py
@@ -286,14 +286,14 @@ _SURFACING_ID_RE = re.compile(r"Surfacing ID:\s*([a-f0-9]{16})")
 async def test_s10_surfacing_recall_at_k(tmp_path, bench_qa_report):
     """Fake LTM serves 3 fixture-declared seeds; top-2 match the expected ranks.
 
-    The ``path`` argument (not ``_context_query``) drives ``ContextExtractor``
-    because ``ProxyManager.call_tool`` strips ``_context_query`` from
-    ``upstream_args`` before invoking surfacing (see ``manager.py:973``);
-    ``_context_query`` is today a compression hint, not a surfacing hint.
-    ``path`` tokenizes to ``"src auth jwt rotation py"`` which clears
-    ``min_query_tokens=3``. The fake LTM ignores the query and returns
-    fixture seeds verbatim, so query content does not affect recall —
-    the test exercises the pipeline wiring, not query semantics.
+    Post-F1: ``_context_query`` drives ``ContextExtractor`` via the explicit
+    ``context_query`` kwarg threaded through ``SurfacingEngine.surface()``.
+    The proxy still strips ``_context_query`` from ``upstream_args`` to keep
+    the control signal out of the upstream tool's argument bag, but the
+    extractor receives it via the kwarg at priority 2 (above the legacy
+    in-arguments branch). The fake LTM ignores the query and returns fixture
+    seeds verbatim, so query content does not affect recall — the test
+    exercises the pipeline wiring, not query semantics.
 
     The fake server's per-call UUID suffix exists only in default mode
     to defeat ``sha256(content)`` dedup — bench_qa ``--seeds`` mode omits
@@ -332,10 +332,7 @@ async def test_s10_surfacing_recall_at_k(tmp_path, bench_qa_report):
         result = await mgr.call_tool(
             "fake",
             "tool_s10",
-            {
-                "path": "src/auth/jwt_rotation.py",
-                "_context_query": fixture["surfacing_eval"]["query"],
-            },
+            {"_context_query": fixture["surfacing_eval"]["query"]},
             trace_id=expected_trace_id,
         )
 

--- a/tests/test_context_extractor.py
+++ b/tests/test_context_extractor.py
@@ -9,19 +9,19 @@ from memtomem_stm.surfacing.context_extractor import ContextExtractor
 def _extract(
     tool: str = "read_file",
     arguments: dict | None = None,
+    *,
+    context_query: str | None = None,
     **config_kwargs,
 ) -> str | None:
     ext = ContextExtractor()
     cfg = SurfacingConfig(**config_kwargs)
-    return ext.extract_query("server", tool, arguments or {}, cfg)
+    return ext.extract_query("server", tool, arguments or {}, cfg, context_query=context_query)
 
 
 class TestQueryTemplate:
     def test_template_substitution(self):
         cfg_kwargs = {
-            "context_tools": {
-                "read_file": ToolSurfacingConfig(query_template="file {arg.path}")
-            }
+            "context_tools": {"read_file": ToolSurfacingConfig(query_template="file {arg.path}")}
         }
         result = _extract("read_file", {"path": "/src/main.py"}, **cfg_kwargs)
         assert result == "file /src/main.py"
@@ -47,6 +47,76 @@ class TestContextQuery:
         assert "/src/main.py" in result
 
 
+class TestExplicitContextQueryKwarg:
+    """Priority-2 branch: explicit ``context_query`` kwarg from the proxy.
+
+    The proxy strips ``_context_query`` out of ``arguments`` before invoking
+    surfacing and forwards it via this kwarg. The legacy in-arguments branch
+    stays as a fallback for direct engine callers and tests.
+    """
+
+    def test_explicit_kwarg_wins(self):
+        result = _extract(
+            "any_tool",
+            {"path": "/unrelated.py"},
+            context_query="find authentication code",
+        )
+        assert result == "find authentication code"
+
+    def test_explicit_kwarg_wins_over_legacy_in_arguments(self):
+        result = _extract(
+            "any_tool",
+            {"_context_query": "loser", "path": "/unrelated.py"},
+            context_query="winner",
+        )
+        assert result == "winner"
+
+    def test_empty_explicit_kwarg_falls_through_to_legacy(self):
+        result = _extract(
+            "any_tool",
+            {"_context_query": "from arguments", "path": "/x.py"},
+            context_query="",
+        )
+        assert result == "from arguments"
+
+    def test_whitespace_explicit_kwarg_falls_through_to_legacy(self):
+        result = _extract(
+            "any_tool",
+            {"_context_query": "from arguments", "path": "/x.py"},
+            context_query="   \n\t  ",
+        )
+        assert result == "from arguments"
+
+    def test_none_explicit_kwarg_falls_through_to_heuristic(self):
+        result = _extract(
+            "any_tool",
+            {"path": "/src/main.py is a test file"},
+            context_query=None,
+        )
+        assert result is not None
+        assert "main.py" in result
+
+    def test_template_still_wins_over_explicit_kwarg(self):
+        cfg_kwargs = {
+            "context_tools": {"read_file": ToolSurfacingConfig(query_template="file {arg.path}")}
+        }
+        result = _extract(
+            "read_file",
+            {"path": "/src/main.py"},
+            context_query="ignored because template wins",
+            **cfg_kwargs,
+        )
+        assert result == "file /src/main.py"
+
+    def test_explicit_kwarg_is_stripped(self):
+        result = _extract(
+            "any_tool",
+            {"path": "/unrelated.py"},
+            context_query="  padded query  ",
+        )
+        assert result == "padded query"
+
+
 class TestHeuristicExtraction:
     def test_semantic_string_args(self):
         result = _extract("tool", {"path": "/src/main.py", "query": "search term"})
@@ -63,10 +133,13 @@ class TestHeuristicExtraction:
             assert "main" in result
 
     def test_skips_identifiers(self):
-        result = _extract("tool", {
-            "id": "550e8400-e29b-41d4-a716-446655440000",
-            "name": "actual content with enough words",
-        })
+        result = _extract(
+            "tool",
+            {
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "name": "actual content with enough words",
+            },
+        )
         assert "550e8400" not in (result or "")
         assert "actual content" in result
 

--- a/tests/test_proxy_manager_pipeline.py
+++ b/tests/test_proxy_manager_pipeline.py
@@ -189,9 +189,7 @@ class TestLLMCompressorLifecycle:
         cfg = LLMCompressorConfig(provider=LLMProvider.OPENAI, api_key="k")
         instance = _make_llm_instance_mock()
 
-        with patch(
-            "memtomem_stm.proxy.manager.LLMCompressor", return_value=instance
-        ) as mock_cls:
+        with patch("memtomem_stm.proxy.manager.LLMCompressor", return_value=instance) as mock_cls:
             for _ in range(3):
                 await mgr._apply_compression(
                     "x" * 500,
@@ -392,8 +390,12 @@ class TestApplySurfacing:
 
         assert result == "surfaced text"
         mock_engine.surface.assert_awaited_once_with(
-            server="srv", tool="t", arguments={"q": "x"}, response_text="original",
+            server="srv",
+            tool="t",
+            arguments={"q": "x"},
+            response_text="original",
             trace_id=None,
+            context_query=None,
         )
 
     async def test_engine_failure_returns_original(self, tmp_path, caplog):
@@ -493,6 +495,79 @@ class TestApplySurfacingOnProgressive:
         assert "Surfacing failed" in caplog.text
 
 
+# ── F1: context_query plumbing through proxy helpers ───────────────────
+
+
+class TestContextQueryPlumbing:
+    """F1 — proxy strips ``_context_query`` from ``upstream_args`` and forwards
+    it via the explicit ``context_query`` kwarg on both surfacing helpers
+    and the cache-hit path."""
+
+    async def test_apply_surfacing_forwards_context_query(self, tmp_path):
+        mgr = _make_manager(tmp_path=tmp_path)
+        mock_engine = AsyncMock()
+        mock_engine.surface.return_value = "surfaced"
+        mgr._surfacing_engine = mock_engine
+
+        await mgr._apply_surfacing("srv", "t", {"q": "x"}, "text", context_query="find auth")
+
+        mock_engine.surface.assert_awaited_once_with(
+            server="srv",
+            tool="t",
+            arguments={"q": "x"},
+            response_text="text",
+            trace_id=None,
+            context_query="find auth",
+        )
+
+    async def test_apply_surfacing_on_progressive_forwards_context_query(self, tmp_path):
+        mgr = _make_manager(tmp_path=tmp_path)
+        engine = _mock_engine_with_mode("append", surface_return="with memories")
+        mgr._surfacing_engine = engine
+
+        await mgr._apply_surfacing_on_progressive(
+            "srv", "t", {"q": "x"}, "chunk", context_query="find auth"
+        )
+
+        kwargs = engine.surface.await_args.kwargs
+        assert kwargs["context_query"] == "find auth"
+
+    async def test_on_cache_hit_extracts_and_forwards_context_query(self, tmp_path):
+        """``_on_cache_hit`` pulls ``_context_query`` from ``arguments`` and
+        passes it explicitly to ``_apply_surfacing`` without mutating args."""
+        mgr = _make_manager(tmp_path=tmp_path)
+        mock_engine = AsyncMock()
+        mock_engine.surface.return_value = "cached + surfaced"
+        mgr._surfacing_engine = mock_engine
+
+        args = {"path": "/x.py", "_context_query": "find auth"}
+        await mgr._on_cache_hit("cached body", "srv", "t", args, trace_id="abc")
+
+        # The cache-hit path forwards ``arguments`` as-is (without stripping)
+        # so the legacy in-args branch keeps working for direct callers; the
+        # explicit kwarg wins via priority-2.
+        mock_engine.surface.assert_awaited_once_with(
+            server="srv",
+            tool="t",
+            arguments=args,
+            response_text="cached body",
+            trace_id="abc",
+            context_query="find auth",
+        )
+        # arguments dict was not mutated by ``_on_cache_hit``.
+        assert args == {"path": "/x.py", "_context_query": "find auth"}
+
+    async def test_on_cache_hit_no_context_query_passes_none(self, tmp_path):
+        mgr = _make_manager(tmp_path=tmp_path)
+        mock_engine = AsyncMock()
+        mock_engine.surface.return_value = "ok"
+        mgr._surfacing_engine = mock_engine
+
+        await mgr._on_cache_hit("body", "srv", "t", {"q": "x"}, trace_id="abc")
+
+        assert mock_engine.surface.await_args.kwargs["context_query"] is None
+
+
 # ── select_chunks ────────────────────────────────────────────────────────
 
 
@@ -572,9 +647,7 @@ class TestSelectiveHotReload:
     """Selective compressor must be recreated when config changes via hot-reload."""
 
     async def test_selective_recreated_on_config_change(self, tmp_path):
-        mgr = _make_manager(
-            tmp_path=tmp_path, compression=CompressionStrategy.SELECTIVE
-        )
+        mgr = _make_manager(tmp_path=tmp_path, compression=CompressionStrategy.SELECTIVE)
         _inject_connection(mgr, "section1\n---\nsection2\n---\nsection3")
 
         sel_cfg_a = SelectiveConfig(json_depth=1)
@@ -595,9 +668,7 @@ class TestSelectiveHotReload:
         assert mgr._selective_compressor_cfg == sel_cfg_b
 
     async def test_selective_not_recreated_when_config_same(self, tmp_path):
-        mgr = _make_manager(
-            tmp_path=tmp_path, compression=CompressionStrategy.SELECTIVE
-        )
+        mgr = _make_manager(tmp_path=tmp_path, compression=CompressionStrategy.SELECTIVE)
         sel_cfg = SelectiveConfig(json_depth=2)
 
         async with mgr._selective_lock:
@@ -722,7 +793,9 @@ class TestAutoIndex:
         _inject_connection(mgr, text=response_text)
 
         with patch.object(
-            mgr, "_auto_index_response", new_callable=AsyncMock,
+            mgr,
+            "_auto_index_response",
+            new_callable=AsyncMock,
             side_effect=OSError("disk full"),
         ):
             result = await mgr.call_tool("srv", "some_tool", {})

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -109,6 +109,60 @@ class TestSurfacingBasic:
         assert output == LONG_RESPONSE
 
 
+class TestExplicitContextQueryKwarg:
+    """``surface(context_query=...)`` threads through to the LTM query.
+
+    Behavioral pin — the proxy forwards the agent-provided ``_context_query``
+    via this kwarg instead of leaving it in ``arguments``. The query reaching
+    ``adapter.search`` must be the explicit value, not the heuristic.
+    """
+
+    async def test_explicit_kwarg_drives_adapter_search_query(self):
+        adapter = _make_mcp_adapter([FakeSearchResult(FakeChunk(content="hit"), 0.5)])
+        engine = SurfacingEngine(config=_make_config(), mcp_adapter=adapter)
+        await engine.surface(
+            "gh",
+            "read_file",
+            {"path": "/unrelated/path.py"},
+            LONG_RESPONSE,
+            context_query="find authentication code",
+        )
+        assert adapter.search.await_args is not None
+        kwargs = adapter.search.await_args.kwargs
+        assert kwargs["query"] == "find authentication code"
+
+    async def test_explicit_kwarg_wins_over_legacy_in_arguments(self):
+        adapter = _make_mcp_adapter([FakeSearchResult(FakeChunk(content="hit"), 0.5)])
+        engine = SurfacingEngine(config=_make_config(), mcp_adapter=adapter)
+        await engine.surface(
+            "gh",
+            "read_file",
+            {"path": "/x.py", "_context_query": "loser"},
+            LONG_RESPONSE,
+            context_query="winner",
+        )
+        assert adapter.search.await_args.kwargs["query"] == "winner"
+
+    async def test_per_tool_template_still_wins_over_kwarg(self):
+        from memtomem_stm.surfacing.config import ToolSurfacingConfig
+
+        adapter = _make_mcp_adapter([FakeSearchResult(FakeChunk(content="hit"), 0.5)])
+        engine = SurfacingEngine(
+            config=_make_config(
+                context_tools={"read_file": ToolSurfacingConfig(query_template="file {arg.path}")}
+            ),
+            mcp_adapter=adapter,
+        )
+        await engine.surface(
+            "gh",
+            "read_file",
+            {"path": "/src/main.py"},
+            LONG_RESPONSE,
+            context_query="ignored because template wins",
+        )
+        assert adapter.search.await_args.kwargs["query"] == "file /src/main.py"
+
+
 class TestSurfacingGating:
     async def test_short_response_skipped(self):
         engine = SurfacingEngine(


### PR DESCRIPTION
## Summary

`ProxyManager._call_tool_inner` extracted `_context_query` from upstream args for the compression path but **stripped it from the args dict passed to surfacing** (`src/memtomem_stm/proxy/manager.py:1146-1150`). `ContextExtractor.extract_query()` had a legacy branch that prefers `arguments["_context_query"]`, but in the proxy path that key was already gone — so surfacing fell back to heuristics (path tokenization, semantic keys, tool name) and searched LTM with thin queries instead of the agent's actual intent.

This PR threads the agent-provided context query to surfacing via an explicit `context_query` keyword, without re-coupling to `upstream_args`.

## Approach

Added optional `context_query: str | None = None` keyword parameter to:

- `ContextExtractor.extract_query()` — **new priority-2 branch**, between the per-tool template (priority 1) and the legacy in-arguments branch (now priority 3).
- `SurfacingEngine.surface()` — forwards to `extract_query`.
- `ProxyManager._apply_surfacing()` / `_apply_surfacing_on_progressive()` — forward to `surface()`.

Wired all four proxy call sites:

| Path | File:Line | How it gets `context_query` |
|---|---|---|
| Cache hit | `manager.py:_on_cache_hit` | Extracts from incoming `arguments` locally; does not mutate the args dict |
| Primary progressive | `manager.py:_call_tool_inner` | Already-extracted local |
| Progressive fallback | `manager.py:_call_tool_inner` | Already-extracted local |
| Non-progressive | `manager.py:_call_tool_inner` | Already-extracted local |

`upstream_args` is **not** modified — the new kwarg is the only delivery path. The control signal stays out of the args bag so it never leaks downstream to the proxied tool.

### Extractor priority (final order)

1. Per-tool `query_template` — unchanged top precedence.
2. **NEW** — explicit `context_query` kwarg, when non-empty after strip.
3. Legacy `arguments["_context_query"]` — kept as fallback for direct engine callers and tests.
4. Heuristic extraction.
5. Tool name fallback.

Backwards-compatible: the legacy branch stays so existing tests in `test_context_extractor.py` and `test_query_aware.py` pass unchanged.

## Bench cleanup

`tests/bench/test_bench_qa_scenarios.py::test_s10_surfacing_recall_at_k` previously passed both `path` (workaround to clear `min_query_tokens`) and `_context_query` (stripped before reaching extractor). After F1 the `_context_query` reaches the extractor directly, so the `path` workaround is dropped. Docstring updated to reflect the new wiring.

## Out of scope (deferred)

- **F2** — `min_score` default change (experiment-driven, separate PR).
- **F3** — truncation knobs (`result_content_max_chars`, `preview_max_chars`); shares files but a separate concern.
- **F4** — docs/compression.md fix; already shipped in #323 (`eaa5d30`).

## Test plan

- [x] `uv run pytest -m "not ollama" tests/test_context_extractor.py tests/test_surfacing_engine.py tests/test_query_aware.py tests/test_proxy_manager_pipeline.py` — 167 passed (new tests: 11).
- [x] `uv run pytest -m "not ollama" tests/bench/test_bench_qa_scenarios.py::test_s10_surfacing_recall_at_k` — 1 passed with `path` workaround removed.
- [x] `uv run pytest -m "not ollama"` — 2102 passed, 7 skipped.
- [x] `uv run ruff check src tests && uv run ruff format --check src` — clean.
- [x] `uv run mypy src` — 2 pre-existing errors (`manager.py:459, :862`, tracked in #164); no new errors from F1.

New tests:

- `TestExplicitContextQueryKwarg` in `test_context_extractor.py` — 7 priority-order assertions (explicit wins over legacy; empty/whitespace falls through; template still wins; whitespace stripped).
- `TestExplicitContextQueryKwarg` in `test_surfacing_engine.py` — 3 behavioral assertions on `adapter.search` receiving the explicit query.
- `TestContextQueryPlumbing` in `test_proxy_manager_pipeline.py` — 4 assertions covering both helpers + cache-hit extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)