### PR TITLE
feat(surfacing): expose result_content_max_chars + preview_max_chars (F3)

### DIFF
--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -85,6 +85,8 @@ The injection mode is configurable: `prepend` (default), `append`, or `section`.
 | `include_session_context` | `true` | Include working memory (scratch) items |
 | `dedup_ttl_seconds` | `604800` (7d) | Cross-session dedup window; `0` to disable |
 | `context_window_size` | `0` | Expand ±N adjacent chunks around search hits; `0` to disable |
+| `result_content_max_chars` | `500` | Max chars retained per LTM result before the formatter sees it |
+| `preview_max_chars` | `300` | Max chars per result preview in the injected memory block |
 | `consumer_model` | `""` | Model name for auto-scaling `max_results` and `max_injection_chars` |
 | `feedback_db_path` | `~/.memtomem/stm_feedback.db` | SQLite store for events, feedback, and cross-session dedup |
 | `cache_ttl_seconds` | `60.0` | Internal surfacing result cache TTL |

--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -70,6 +70,11 @@ class SurfacingConfig(BaseModel):
     max_injection_chars: int = Field(default=3000, gt=0)
     context_window_size: int = Field(default=0, ge=0)
     """0=disabled; >0 expands ±N adjacent chunks."""
+    result_content_max_chars: int = Field(default=500, gt=0)
+    """Max chars retained per LTM result by the parser. Trims long content
+    before it reaches the formatter."""
+    preview_max_chars: int = Field(default=300, gt=0)
+    """Max chars rendered per result preview in the injected memory block."""
     dedup_ttl_seconds: float = Field(default=604800.0, ge=0.0)
     """7 days default; 0 disables cross-session dedup."""
     consumer_model: str = ""

--- a/src/memtomem_stm/surfacing/formatter.py
+++ b/src/memtomem_stm/surfacing/formatter.py
@@ -41,16 +41,17 @@ class SurfacingFormatter:
             source = str(meta.source_file.name) if meta.source_file else ""
 
             ctx = getattr(r, "context", None)
+            preview_cap = self._config.preview_max_chars
             if ctx and (ctx.window_before or ctx.window_after):
                 parts = []
                 if ctx.window_before:
                     parts.append("..." + ctx.window_before[-1].content[-150:].replace("\n", " "))
-                parts.append(chunk.content[:300].replace("\n", " "))
+                parts.append(chunk.content[:preview_cap].replace("\n", " "))
                 if ctx.window_after:
                     parts.append(ctx.window_after[0].content[:150].replace("\n", " ") + "...")
                 preview = " | ".join(parts)
             else:
-                preview = chunk.content[:300].replace("\n", " ")
+                preview = chunk.content[:preview_cap].replace("\n", " ")
 
             lines.append(f"- **{source}**{ns_badge} (score={r.score:.2f}): {preview}")
 

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -51,7 +51,12 @@ class ResultParser:
     renamed or removed, so callers must tolerate an empty list silently.
     """
 
-    def parse(self, text: str) -> tuple[list[RemoteSearchResult], list[str]]:
+    def parse(
+        self,
+        text: str,
+        *,
+        max_content_chars: int = 500,
+    ) -> tuple[list[RemoteSearchResult], list[str]]:
         raise NotImplementedError
 
 
@@ -69,7 +74,12 @@ class CompactResultParser(ResultParser):
     always an empty list.
     """
 
-    def parse(self, text: str) -> tuple[list[RemoteSearchResult], list[str]]:
+    def parse(
+        self,
+        text: str,
+        *,
+        max_content_chars: int = 500,
+    ) -> tuple[list[RemoteSearchResult], list[str]]:
         results: list[RemoteSearchResult] = []
         if not text or not text.strip():
             return results, []
@@ -104,15 +114,16 @@ class CompactResultParser(ResultParser):
 
             content = rest.strip() if rest else ""
             if content:
-                if len(content) > 500:
+                if len(content) > max_content_chars:
                     logger.debug(
-                        "Truncating search result content from %d to 500 chars (source=%s)",
+                        "Truncating search result content from %d to %d chars (source=%s)",
                         len(content),
+                        max_content_chars,
                         source,
                     )
                 results.append(
                     RemoteSearchResult(
-                        content=content[:500],
+                        content=content[:max_content_chars],
                         score=score,
                         source=source,
                         namespace=namespace,
@@ -133,7 +144,12 @@ class StructuredResultParser(ResultParser):
     asserted on and its absence degrades silently to an empty list.
     """
 
-    def parse(self, text: str) -> tuple[list[RemoteSearchResult], list[str]]:
+    def parse(
+        self,
+        text: str,
+        *,
+        max_content_chars: int = 500,
+    ) -> tuple[list[RemoteSearchResult], list[str]]:
         if not text or not text.strip():
             return [], []
 
@@ -154,14 +170,15 @@ class StructuredResultParser(ResultParser):
             content = item.get("content", "")
             if not content:
                 continue
-            if len(content) > 500:
+            if len(content) > max_content_chars:
                 logger.debug(
-                    "Truncating search result content from %d to 500 chars (source=%s)",
+                    "Truncating search result content from %d to %d chars (source=%s)",
                     len(content),
+                    max_content_chars,
                     item.get("source", "unknown"),
                 )
             result = RemoteSearchResult(
-                content=content[:500],
+                content=content[:max_content_chars],
                 score=safe_float(item.get("score", 0.0), 0.0),
                 source=item.get("source", "unknown"),
                 namespace=item.get("namespace", "default"),
@@ -366,7 +383,7 @@ class McpClientSearchAdapter:
             return [], []
 
         text = "\n".join(text_parts)
-        return self._parser.parse(text)
+        return self._parser.parse(text, max_content_chars=self._config.result_content_max_chars)
 
     async def increment_access(self, chunk_ids: list[str], *, trace_id: str | None = None) -> None:
         """Boost the access_count of the given chunks via mem_do(increment_access).

--- a/tests/test_core_format_contract.py
+++ b/tests/test_core_format_contract.py
@@ -280,6 +280,72 @@ class TestParserStrategy:
         assert isinstance(adapter._parser, CompactResultParser)
 
 
+class TestParserMaxContentChars:
+    """F3 — ``parse(max_content_chars=N)`` caps per-result content at N.
+
+    Default (500) preserves prior behavior so existing callers and the
+    module-level ``_compact_parser`` singleton keep working unchanged.
+    """
+
+    def test_compact_parser_honors_max_content_chars(self):
+        from memtomem_stm.surfacing.mcp_client import CompactResultParser
+
+        long_line = "x" * 800
+        text = f"[1] 0.50 | doc.md\n{long_line}\n"
+        results, _ = CompactResultParser().parse(text, max_content_chars=100)
+        assert len(results) == 1
+        assert len(results[0].chunk.content) == 100
+
+    def test_compact_parser_default_caps_at_500(self):
+        """Regression guard: kwarg default must stay at 500 so the
+        module-level singleton and any unaware callers keep current behavior."""
+        from memtomem_stm.surfacing.mcp_client import CompactResultParser
+
+        long_line = "x" * 800
+        text = f"[1] 0.50 | doc.md\n{long_line}\n"
+        results, _ = CompactResultParser().parse(text)
+        assert len(results) == 1
+        assert len(results[0].chunk.content) == 500
+
+    def test_structured_parser_honors_max_content_chars(self):
+        from memtomem_stm.surfacing.mcp_client import StructuredResultParser
+
+        long_content = "y" * 800
+        text = (
+            '{"results": ['
+            '  {"rank": 1, "score": 0.5, "source": "doc.md", "hierarchy": "X",'
+            '   "namespace": "default", "chunk_id": "abc",'
+            f'   "content": "{long_content}"}}'
+            "]}"
+        )
+        results, _ = StructuredResultParser().parse(text, max_content_chars=200)
+        assert len(results) == 1
+        assert len(results[0].chunk.content) == 200
+
+    def test_structured_parser_default_caps_at_500(self):
+        from memtomem_stm.surfacing.mcp_client import StructuredResultParser
+
+        long_content = "y" * 800
+        text = (
+            '{"results": ['
+            '  {"rank": 1, "score": 0.5, "source": "doc.md", "hierarchy": "X",'
+            '   "namespace": "default", "chunk_id": "abc",'
+            f'   "content": "{long_content}"}}'
+            "]}"
+        )
+        results, _ = StructuredResultParser().parse(text)
+        assert len(results) == 1
+        assert len(results[0].chunk.content) == 500
+
+    def test_short_content_unaffected_by_max_content_chars(self):
+        """Sanity: content shorter than the cap stays intact regardless."""
+        from memtomem_stm.surfacing.mcp_client import CompactResultParser
+
+        text = "[1] 0.50 | doc.md\nshort\n"
+        results, _ = CompactResultParser().parse(text, max_content_chars=100)
+        assert results[0].chunk.content == "short"
+
+
 # ── Phase 2 structured format snapshots ──────────────────────────────────
 
 STRUCTURED_TWO_RESULTS = (

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -105,3 +105,47 @@ class TestFormatterInjection:
         results = [FakeResult(FakeChunk(), 0.5)]
         output = fmt.inject("response", results, "query")
         assert "## 관련 기억" in output
+
+
+class TestPreviewMaxCharsKnob:
+    """F3 — ``preview_max_chars`` controls the per-result preview slice.
+
+    Default (300) preserves prior behavior; operators can shorten or
+    lengthen the preview per deployment.
+    """
+
+    def test_default_preview_caps_at_300(self):
+        """Regression guard: existing 300-cap behavior must survive when
+        ``preview_max_chars`` is not overridden."""
+        fmt = SurfacingFormatter(SurfacingConfig())
+        long_content = "a" * 800
+        results = [FakeResult(FakeChunk(content=long_content), 0.5)]
+        output = fmt.inject("response", results, "query")
+        # The preview is the slice that follows the "score=X.XX): " marker
+        marker = "score=0.50): "
+        idx = output.index(marker) + len(marker)
+        preview_line = output[idx:].split("\n", 1)[0]
+        assert len(preview_line) <= 300
+        assert "a" * 250 in preview_line  # well within the cap
+
+    def test_lower_preview_max_chars_truncates(self):
+        fmt = SurfacingFormatter(SurfacingConfig(preview_max_chars=50))
+        results = [FakeResult(FakeChunk(content="b" * 800), 0.5)]
+        output = fmt.inject("response", results, "query")
+        marker = "score=0.50): "
+        idx = output.index(marker) + len(marker)
+        preview_line = output[idx:].split("\n", 1)[0]
+        assert len(preview_line) <= 50
+        # Tighter check: exactly 50 'b's then nothing more on that line
+        assert preview_line.startswith("b" * 50)
+        assert "b" * 51 not in preview_line
+
+    def test_higher_preview_max_chars_allows_longer_preview(self):
+        fmt = SurfacingFormatter(SurfacingConfig(preview_max_chars=600, max_injection_chars=10000))
+        results = [FakeResult(FakeChunk(content="c" * 800), 0.5)]
+        output = fmt.inject("response", results, "query")
+        marker = "score=0.50): "
+        idx = output.index(marker) + len(marker)
+        preview_line = output[idx:].split("\n", 1)[0]
+        assert len(preview_line) >= 600
+        assert "c" * 600 in preview_line


### PR DESCRIPTION
## Summary

Two truncation limits silently capped how much LTM content reached the agent's context, with no operator knob:

- **Parser** (`mcp_client.py:107, 115` Compact; `:157, 164` Structured): each LTM result content capped at 500 chars before reaching the formatter.
- **Formatter** (`formatter.py:48, 53`): rendered preview capped at 300 chars before reaching the agent.

This PR exposes both as `SurfacingConfig` fields, defaults unchanged:

```python
result_content_max_chars: int = Field(default=500, gt=0)
preview_max_chars:        int = Field(default=300, gt=0)
```

Out-of-the-box behavior is **identical** to before — F3 is purely additive.

## Parse-time, not constructor-time

The parser is created once in `McpClientSearchAdapter.__init__` AND replaced with a bare `CompactResultParser()` during version-negotiation fallback. A constructor-stored limit would either become startup-only (breaking hot-reload) or get lost across the fallback path. F3 threads the limit through the call signature instead:

```python
def parse(
    self,
    text: str,
    *,
    max_content_chars: int = 500,
) -> tuple[list[RemoteSearchResult], list[str]]:
```

The adapter passes `self._config.result_content_max_chars` at parse time, so hot-reloads propagate automatically via the existing live-config pattern. The module-level `_compact_parser` singleton (used by a backwards-compat static helper) keeps working unchanged — it doesn't pass the kwarg, so it falls back to the 500 default.

For the formatter side, `SurfacingFormatter` already holds `self._config`, so the change is a one-line slice: `chunk.content[:300]` → `chunk.content[: self._config.preview_max_chars]`. The 150-char window slices (`window_before` / `window_after`) are intentionally left alone — they're context, not the primary preview, and were not flagged.

## Docs

Added two rows to the Surfacing Controls table in `docs/surfacing.md`, alongside `context_window_size`.

## Test plan

- [x] `uv run pytest -m "not ollama" tests/test_formatter.py tests/test_core_format_contract.py tests/test_surfacing_engine.py tests/test_remote_ltm_integration.py` — 136 passed (8 new in F3).
- [x] `uv run pytest -m "not ollama"` — 2117 passed, 7 skipped.
- [x] `uv run ruff check src tests && uv run ruff format --check src` — clean.

New tests:

- `TestPreviewMaxCharsKnob` in `test_formatter.py` — 3 tests: default 300-cap preserved, lower truncates, higher allows longer.
- `TestParserMaxContentChars` in `test_core_format_contract.py` — 5 tests: both parsers honor the kwarg, both default to 500 (regression guard against silent drift), short content unaffected.

## Out of scope

- **F2** (`min_score` default change) — deferred to an experiment-driven follow-up PR per the original adaptive-waffle plan.
- The 150-char window snippet slices in `formatter.py:47, 50`.

## Status of the surfacing roadmap

| Item | Status |
|---|---|
| F1 — `_context_query` plumbing | ✅ #324 |
| F2 — `min_score` default | deferred (experiment-driven) |
| **F3 — truncation knobs** | **this PR** |
| F4 — compression.md docs | ✅ #323 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)