### PR TITLE
fix(proxy/privacy): scan full payload instead of first 10K chars

### DIFF
--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -39,13 +39,9 @@ def _compile_patterns(patterns: tuple[str, ...]) -> list[re.Pattern[str]]:
 
 
 def contains_sensitive_content(text: str, patterns: list[str] | None = None) -> bool:
-    """Check if text contains any sensitive patterns.
-
-    Scans only the first 10K chars for performance.
-    """
+    """Check if text contains any sensitive patterns."""
     effective = patterns if patterns else DEFAULT_PATTERNS
     if not effective:
         return False
-    sample = text[:10_000]
     compiled = _compile_patterns(tuple(effective))
-    return any(p.search(sample) for p in compiled)
+    return any(p.search(text) for p in compiled)

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -275,6 +275,19 @@ class TestLLMCompressorFallback:
         assert len(result) < len(text)
 
     @pytest.mark.asyncio
+    async def test_privacy_fallback_scans_full_payload_before_provider_call(self):
+        comp = _make_llm_compressor()
+        text = ("safe content " * 900) + "password: hunter2"
+        assert len(text) > 10_000
+
+        with patch.object(comp, "_call_api", new_callable=AsyncMock) as call_api:
+            result = await comp.compress(text, max_chars=100, privacy_patterns=[r"password\s*:"])
+
+        call_api.assert_not_called()
+        assert comp.last_fallback == "privacy"
+        assert len(result) < len(text)
+
+    @pytest.mark.asyncio
     async def test_circuit_breaker_fallback(self):
         comp = _make_llm_compressor()
         # Trip the circuit breaker

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -180,3 +180,8 @@ class TestDefaultPatternCoverage:
     )
     def test_default_patterns_do_not_match_benign_strings(self, sample: str) -> None:
         assert privacy.contains_sensitive_content(sample) is False
+
+    def test_scans_beyond_ten_kilobytes(self) -> None:
+        text = ("safe content " * 900) + "password: hunter2"
+        assert len(text) > 10_000
+        assert privacy.contains_sensitive_content(text) is True


### PR DESCRIPTION
## Summary

`contains_sensitive_content()` (used by `LLMCompressor`'s privacy guard before sending payloads to the external LLM provider) was sampling only the first 10K chars. Any sensitive token past that offset — JWT, AWS key, private key, password assignment — slipped past the scan and got forwarded to the provider.

Drops the truncation and scans the full text. The privacy scan runs **before** the LLM call, so the alternative trade-off is "send N KB of potentially-sensitive content to a third party for a small CPU savings" — not worth it.

## Behavior change

- Privacy scan now flags sensitive content anywhere in the payload, not just the first 10K chars.
- No new config knob — this is a correctness fix on an existing default-on guard (#289).
- Pattern compilation is unchanged; the regex set is bounded (≤ ~10 patterns per call site), so full-text scan over a few hundred KB is dominated by Python regex engine cost, which is linear and remains fast in practice.

## Test plan

- [x] `uv run pytest tests/test_privacy.py tests/test_compression.py -q` — 85 passed
- [x] `uv run pytest -m "not ollama" -q` — 2126 passed (+2 new tests for the past-10K case)
- [x] `uv run ruff check src && uv run ruff format --check src` — clean

New tests pin both layers:
- `test_privacy.py`: unit test asserting `contains_sensitive_content` detects a sensitive token past the 10K mark
- `test_compression.py`: `LLMCompressor` fallback test asserting `_call_api` is never reached when the sensitive token sits past 10K

🤖 Generated with [Claude Code](https://claude.com/claude-code)