### PR TITLE
feat(bench_qa): add s11 min_score sweep harness (F2 prep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           version: "latest"
       - run: uv sync --frozen
-      - run: uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge" --tb=short -q
+      - run: uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep" --tb=short -q
 
   notebooks:
     runs-on: ubuntu-latest
@@ -88,7 +88,7 @@ jobs:
       - name: Run bench_qa suite
         env:
           BENCH_QA_REPORT_DIR: ${{ github.workspace }}/bench-qa-report
-        run: uv run pytest -m bench_qa --tb=short -q
+        run: uv run pytest -m "bench_qa and not bench_qa_sweep" --tb=short -q
       - name: Upload bench_qa report
         if: always()
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ cd memtomem-stm
 uv sync
 
 # Run tests (same filter CI uses)
-uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"
+uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep"
 
 # Lint and format
 uv run ruff check src
@@ -43,7 +43,7 @@ The LTM core lives in a separate repository: [memtomem/memtomem](https://github.
 2. Keep changes focused — one feature or fix per PR
 3. Add tests for new functionality
 4. Ensure `uv run ruff check src` and `uv run ruff format --check src` pass
-5. Ensure `uv run pytest -m "not ollama"` passes
+5. Ensure `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep"` passes
 6. `uv run mypy src` is advisory but aim to not introduce new errors
 7. Write a clear commit message describing the "why"
 8. Sign the CLA on your first pull request (see below)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ A second tier of management lets you decide *which MCP servers a given project s
 
 ```bash
 uv sync                                                    # install dev deps
-uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"   # tests (CI filter)
+uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep"   # tests (CI filter)
 uv run ruff check src && uv run ruff format --check src    # lint (required)
 uv run mypy src                                            # typecheck (advisory)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
     "bench_qa: end-to-end compression/surfacing regression gate (fake upstream, deterministic)",
     "bench_qa_meta: self-test probes for bench_qa — intentional failures, NOT CI-safe",
     "bench_qa_llm_judge: LLM-as-judge advisory scoring — requires OPENAI_API_KEY or ANTHROPIC_API_KEY, off in default CI",
+    "bench_qa_sweep: measurement runs that emit curve artifacts; off in default and advisory CI, invoked manually",
 ]
 
 [tool.mypy]

--- a/tests/bench/bench_qa/report.py
+++ b/tests/bench/bench_qa/report.py
@@ -106,9 +106,25 @@ class BenchReportCollector:
 
     def __init__(self) -> None:
         self._rows: list[ScenarioReport] = []
+        # Sidecar curves keyed by sweep name. Emitted as ``sweep_{name}.json``
+        # next to ``report.json`` so a measurement run lands in the same
+        # ``$BENCH_QA_REPORT_DIR`` artifact as a scenario run, without
+        # forcing a ``BenchReport`` schema bump for every scenario row.
+        self._sweeps: dict[str, list[dict[str, Any]]] = {}
 
     def has_data(self) -> bool:
-        return bool(self._rows)
+        return bool(self._rows) or bool(self._sweeps)
+
+    def record_sweep(self, name: str, rows: list[dict[str, Any]]) -> None:
+        """Attach a sidecar curve flushed alongside ``report.json``.
+
+        Sweep tests (e.g. F2 min_score curve) aren't regression gates and
+        don't fit the per-scenario ``record_scenario`` shape. Each call
+        produces one ``sweep_{name}.json`` in the output dir at session
+        end; later calls with the same ``name`` overwrite earlier ones
+        within the session.
+        """
+        self._sweeps[name] = rows
 
     def record_scenario(
         self,
@@ -204,15 +220,27 @@ class BenchReportCollector:
         """Write ``report.json`` and ``summary.md`` under *out_dir*.
 
         Creates the directory if missing. Returns the output directory so
-        callers can log it for CI artifact upload.
+        callers can log it for CI artifact upload. Sweep sidecars
+        recorded via :meth:`record_sweep` are flushed as
+        ``sweep_{name}.json`` in the same dir.
         """
         out_dir.mkdir(parents=True, exist_ok=True)
-        report = self.build_report(run_seed=run_seed)
-        (out_dir / "report.json").write_text(
-            json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+        if self._rows:
+            report = self.build_report(run_seed=run_seed)
+            (out_dir / "report.json").write_text(
+                json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+            )
+            (out_dir / "summary.md").write_text(_format_summary_md(report), encoding="utf-8")
+        for name, rows in self._sweeps.items():
+            (out_dir / f"sweep_{name}.json").write_text(
+                json.dumps(rows, indent=2, sort_keys=True), encoding="utf-8"
+            )
+        logger.info(
+            "bench_qa report written to %s (%d scenarios, %d sweeps)",
+            out_dir,
+            len(self._rows),
+            len(self._sweeps),
         )
-        (out_dir / "summary.md").write_text(_format_summary_md(report), encoding="utf-8")
-        logger.info("bench_qa report written to %s (%d scenarios)", out_dir, len(self._rows))
         return out_dir
 
 

--- a/tests/bench/bench_qa/runner.py
+++ b/tests/bench/bench_qa/runner.py
@@ -131,6 +131,8 @@ def make_surfacing_proxy_manager(
     min_retention: float = 0.65,
     server_name: str = "fake",
     tool_prefix: str = "fake",
+    min_score: float | None = None,
+    max_results: int | None = None,
 ) -> tuple[
     ProxyManager,
     MetricsStore,
@@ -168,6 +170,15 @@ def make_surfacing_proxy_manager(
     store = MetricsStore(tmp_path / "proxy_metrics.db")
     store.initialize()
 
+    # min_score / max_results stay at SurfacingConfig defaults unless the
+    # caller pins them — the F2 sweep harness (s11) overrides both so the
+    # threshold becomes the sole gate; production-shape callers like s10
+    # leave them None to exercise the live defaults.
+    surfacing_kwargs: dict[str, object] = {}
+    if min_score is not None:
+        surfacing_kwargs["min_score"] = min_score
+    if max_results is not None:
+        surfacing_kwargs["max_results"] = max_results
     surfacing_cfg = SurfacingConfig(
         enabled=True,
         min_response_chars=10,
@@ -181,6 +192,7 @@ def make_surfacing_proxy_manager(
         feedback_db_path=tmp_path / "stm_feedback.db",
         ltm_mcp_command=sys.executable,
         ltm_mcp_args=[str(_FAKE_LTM_SERVER), "--seeds", str(seeds_path)],
+        **surfacing_kwargs,
     )
     adapter = McpClientSearchAdapter(surfacing_cfg)
     tracker = FeedbackTracker(surfacing_cfg)

--- a/tests/bench/fixtures/s11.json
+++ b/tests/bench/fixtures/s11.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "scenario_id": "s11",
+  "description": "F2 min_score sweep harness — 8 labeled seeds (4 positives / 4 negatives) with scores distributed across the AutoTuner clamp band (0.003..0.065). The sweep test (bench_qa_sweep marker) sets min_score per iteration and emits a recall/precision/F1 curve. The fixture is mostly signal-aligned with one noise inversion (one positive sits below one negative) so the F1 curve has a non-trivial peak — informs the F2 follow-up PR's choice of default.",
+  "content_type": "text",
+  "expected_compressor": "none",
+  "force_tier": null,
+  "max_result_chars": 50000,
+  "qa_gate_min": 0.0,
+  "qa_probes": [],
+  "surfacing_seeds": [
+    {
+      "rank": 1,
+      "score": 0.065,
+      "source": "auth-jwt-rotation-policy.md",
+      "content": "JWT rotation policy overview: HS256 signing keys rotate every 24 hours on a staggered per-region schedule; the rotation coordinator broadcasts a signed event when each kid is retired."
+    },
+    {
+      "rank": 2,
+      "score": 0.048,
+      "source": "auth-jwt-kid-rotation.md",
+      "content": "Key identifier (kid) rotation: each rotation produces a fresh kid embedded in the JOSE header; verifiers track the last two active kid values to keep the rotation seam invisible to clients."
+    },
+    {
+      "rank": 3,
+      "score": 0.035,
+      "source": "auth-jwt-signing-secrets.md",
+      "content": "Signing secret cadence: HS256 secrets live in the HSM and are exported to regional auth services on a 24h cadence aligned to the rotation policy; cache TTL is bounded at 15 minutes."
+    },
+    {
+      "rank": 4,
+      "score": 0.025,
+      "source": "ratelimit-headers.md",
+      "content": "Rate limit headers: clients should respect X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset; per-minute windows align to the calendar minute."
+    },
+    {
+      "rank": 5,
+      "score": 0.018,
+      "source": "auth-jwt-grace-window.md",
+      "content": "Grace window: the previous kid stays valid for a 90-minute grace period after rotation; tokens signed with the older kid verify successfully during this window and are not re-issued."
+    },
+    {
+      "rank": 6,
+      "score": 0.012,
+      "source": "session-refresh-tokens.md",
+      "content": "Refresh tokens: long-lived credentials used to obtain new access tokens without re-authenticating; refresh tokens live in a separate key space not subject to the standard 24h rotation."
+    },
+    {
+      "rank": 7,
+      "score": 0.008,
+      "source": "cache-invalidation.md",
+      "content": "Cache invalidation strategies: prefer signed-broadcast invalidation over TTL-only expiry when cache freshness matters more than tail latency; document the invalidation path in the runbook."
+    },
+    {
+      "rank": 8,
+      "score": 0.003,
+      "source": "audit-log-format.md",
+      "content": "Audit log line format: structured JSON with timestamp (RFC3339), actor, action, resource, outcome, and trace_id; rotated daily and retained for 90 days."
+    }
+  ],
+  "surfacing_eval": {
+    "query": "JWT authentication rotation policy",
+    "k": 4,
+    "expected_ids": [
+      "auth-jwt-rotation-policy.md",
+      "auth-jwt-kid-rotation.md",
+      "auth-jwt-signing-secrets.md",
+      "auth-jwt-grace-window.md"
+    ]
+  },
+  "payload": "F2 sweep harness payload — content is intentionally short. The bench loops mgr.call_tool() once per threshold; the fake LTM returns surfacing_seeds verbatim and min_score is the only gate. The proxy emits a compressed result but the sweep test does not assert on compression or QA probes."
+}

--- a/tests/bench/test_bench_qa_scenarios.py
+++ b/tests/bench/test_bench_qa_scenarios.py
@@ -397,3 +397,123 @@ async def test_s10_surfacing_recall_at_k(tmp_path, bench_qa_report):
         await adapter.stop()
         tracker.close()
         store.close()
+
+
+# F2 prep — min_score sweep harness. Measurement only, off in default and
+# advisory CI (bench_qa_sweep marker). One fresh proxy per threshold; the
+# curve is emitted as ``sweep_s11_min_score.json`` in ``$BENCH_QA_REPORT_DIR``.
+_S11_THRESHOLDS: list[float] = [0.005, 0.010, 0.020, 0.030, 0.050, 0.070]
+
+
+def _f1(precision: float, recall: float) -> float:
+    if precision + recall == 0.0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+@pytest.mark.bench_qa
+@pytest.mark.bench_qa_sweep
+@pytest.mark.asyncio
+async def test_s11_min_score_sweep(tmp_path, bench_qa_report):
+    """Sweep ``min_score`` across ``_S11_THRESHOLDS`` and emit a curve.
+
+    The fixture (s11) declares 8 labeled seeds spanning 0.003..0.065. The
+    helper sets ``max_results=len(seeds)`` so the threshold is the sole
+    gate — the curve measures pure ``min_score`` sensitivity, not
+    production top-K truncation behavior. The top threshold (0.070) is
+    above every seed score, so no ``<surfaced-memories>`` block is
+    emitted and no surfacing_id is recorded — the test treats that as
+    ``returned_ids = []`` rather than a failure, validating the
+    upper-bound shape of the curve.
+
+    Assertions are deliberately minimal: this is a measurement run for
+    the F2 follow-up PR, not a regression gate.
+    """
+    fixture = load_fixture("s11")
+    seeds = fixture["surfacing_seeds"]
+    seed_count = len(seeds)
+    assert seed_count >= 4, "s11: sweep needs at least 4 labeled seeds"
+
+    source_to_chunk_id = {
+        seed["source"]: hashlib.sha256(seed["content"].encode()).hexdigest()[:16] for seed in seeds
+    }
+    chunk_id_to_source = {chunk_id: src for src, chunk_id in source_to_chunk_id.items()}
+    positives = set(fixture["surfacing_eval"]["expected_ids"])
+    positive_count = len(positives)
+    assert 0 < positive_count < seed_count, (
+        "s11: fixture must declare a strict subset of seeds as positives — "
+        "otherwise precision/recall degenerate"
+    )
+
+    seeds_path = tmp_path / "s11_seeds.json"
+    seeds_path.write_text(json.dumps(seeds), encoding="utf-8")
+
+    curve: list[dict] = []
+    for threshold in _S11_THRESHOLDS:
+        sub_dir = tmp_path / f"th_{threshold:.3f}"
+        sub_dir.mkdir()
+        mgr, store, session, adapter, engine, tracker = make_surfacing_proxy_manager(
+            sub_dir,
+            seeds_path=seeds_path,
+            compression=fixture["expected_compressor"],
+            max_result_chars=fixture["max_result_chars"],
+            min_score=threshold,
+            max_results=seed_count,
+        )
+        session.call_tool.return_value = make_tool_result(fixture["payload"])
+        await adapter.start()
+        try:
+            result = await mgr.call_tool(
+                "fake",
+                "tool_s11",
+                {"_context_query": fixture["surfacing_eval"]["query"]},
+                trace_id=deterministic_trace_id(f"s11:{threshold:.3f}"),
+            )
+            id_match = _SURFACING_ID_RE.search(result)
+            if id_match:
+                returned_chunk_ids = tracker.store.get_memory_ids_for_surfacing(id_match.group(1))
+            else:
+                # Threshold above every seed score: no surfaced block,
+                # engine writes ``no_results_score`` and emits no
+                # surfacing_id. Treat as an empty result list.
+                returned_chunk_ids = []
+
+            returned_sources = [
+                chunk_id_to_source[cid] for cid in returned_chunk_ids if cid in chunk_id_to_source
+            ]
+            tp = sum(1 for src in returned_sources if src in positives)
+            fp = len(returned_sources) - tp
+            fn = positive_count - tp
+            precision = tp / (tp + fp) if (tp + fp) else 0.0
+            recall = tp / (tp + fn) if (tp + fn) else 0.0
+            curve.append(
+                {
+                    "threshold": threshold,
+                    "tp": tp,
+                    "fp": fp,
+                    "fn": fn,
+                    "precision": round(precision, 4),
+                    "recall": round(recall, 4),
+                    "f1": round(_f1(precision, recall), 4),
+                    "returned": len(returned_sources),
+                }
+            )
+        finally:
+            await adapter.stop()
+            tracker.close()
+            store.close()
+
+    assert len(curve) == len(_S11_THRESHOLDS), (
+        f"s11 sweep: expected {len(_S11_THRESHOLDS)} curve rows, got {len(curve)}"
+    )
+    recalls = [row["recall"] for row in curve]
+    assert recalls == sorted(recalls, reverse=True), (
+        f"s11 sweep: recall must be non-increasing as threshold rises — "
+        f"got {recalls}. Harness likely failed to apply min_score."
+    )
+    assert any(row["f1"] > 0.0 for row in curve), (
+        f"s11 sweep: no threshold produced F1 > 0 — fixture has no surfaced "
+        f"positives. Curve: {curve}"
+    )
+
+    bench_qa_report.record_sweep("s11_min_score", curve)


### PR DESCRIPTION
## Summary

- F2 of the surfacing roadmap (raise / auto-tune the default `min_score`) was deferred from #324/#325/#326 pending **benchmark + feedback-distribution data**. The local `~/.memtomem/stm_feedback.db` has no `surfacing_events` / `surfacing_feedback` tables yet, so this PR builds the deterministic synthetic path instead: a sweep test that emits a recall/precision/F1 curve as a durable artifact under `$BENCH_QA_REPORT_DIR`. The follow-up F2 PR will read the curve and decide whether to bump `SurfacingConfig.min_score` or tighten AutoTuner clamps. **AutoTuner code and the production default are untouched here.**
- New `bench_qa_sweep` pytest marker registered in `pyproject.toml`; off in both the required CI `test` job and the advisory `bench_qa` job — sweeps take ~6× the wall time of s10 (fresh proxy per threshold) and are measurement runs, not regression gates.
- `make_surfacing_proxy_manager` gains optional `min_score` / `max_results` kwargs (default `None` preserves the s10 contract); the sweep sets `max_results=len(seeds)` so the threshold is the sole gate. `BenchReportCollector` gains a `record_sweep()` sidecar method — `write()` emits `sweep_{name}.json` next to `report.json` without a `BenchReport` schema bump.
- New fixture `tests/bench/fixtures/s11.json`: 8 seeds scoring 0.003..0.065, mostly signal-aligned with one noise inversion so the F1 curve has a non-trivial peak. Sample curve from this branch peaks at **F1=0.857 at threshold 0.030** (R=0.75, P=1.0); 0.070 correctly produces empty results (above max seed score).
- CONTRIBUTING.md (two spots) and README.md kept in sync with the new canonical filter — required by `tests/test_docs_sync.py::test_contributing_pytest_command_matches_ci`.

## Test plan

- [x] `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep"` (the required-job filter after the ci.yml edit) — 2123 passed, sweep deselected, docs-sync test green.
- [x] `uv run pytest -m "bench_qa and not bench_qa_sweep"` (advisory job filter) — 13 passed, sweep deselected.
- [x] `BENCH_QA_REPORT_DIR=/tmp/s11-sweep uv run pytest -m bench_qa_sweep` — 1 passed; `sweep_s11_min_score.json` written; recall non-increasing across thresholds; 0.070 row is all-zero as expected.
- [x] `uv run ruff check src tests && uv run ruff format --check src tests/bench/` — clean.
- [x] `uv run mypy src` — advisory; no new errors from this PR (pre-existing errors in `mcp_client.py` / `proxy/manager.py` are unrelated).

## Out of scope

- No change to `SurfacingConfig.min_score` default — that's the F2 follow-up PR, informed by this curve.
- No AutoTuner code change.
- No real-DB analysis script (no rows to analyze today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)