### PR TITLE
feat(surfacing): per-tool feedback + auto-tune readiness in stm_surfacing_stats

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -700,11 +700,17 @@ async def stm_surfacing_stats(
                 if tool_name in overrides:
                     detail_parts.append(f"pinned {overrides[tool_name]:.3f}")
                 elif auto_tune_active and min_samples_required > 0:
-                    if fb >= min_samples_required:
-                        if tool_name in adjusted_scores:
-                            detail_parts.append("auto-tuned")
-                        else:
-                            detail_parts.append("auto-tune ready")
+                    # Check ``adjusted_scores`` first: AutoTuner has a documented
+                    # cold-start fallback (feedback.py::maybe_adjust) that tunes a
+                    # tool from the global feedback pool even when the tool's own
+                    # feedback count is below ``min_samples``. So an "auto-tuned"
+                    # row can have fb < min_samples — gating on fb first would
+                    # contradict both the per-tool adjustment block and the
+                    # effective threshold the engine actually used.
+                    if tool_name in adjusted_scores:
+                        detail_parts.append("auto-tuned")
+                    elif fb >= min_samples_required:
+                        detail_parts.append("auto-tune ready")
                     else:
                         detail_parts.append(f"need {min_samples_required - fb} more for auto-tune")
                 lines.append(f"  {tool_name}: {', '.join(detail_parts)}")

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -649,13 +649,51 @@ async def stm_surfacing_stats(
             last_iso = datetime.fromtimestamp(dr["last"]).isoformat(timespec="seconds")
             lines.append(f"Date range:      {first_iso} — {last_iso}")
 
+        # Min score block — show the default, whether auto-tune is on, and any
+        # per-tool adjustments AutoTuner has made this process. Surfaced before
+        # the per-tool breakdown so the reader can interpret the breakdown's
+        # "feedback N (negative R%)" against the auto-tune readiness threshold.
+        min_samples_required = 0
+        adjusted_scores: dict[str, float] = {}
+        if app.surfacing_engine is not None:
+            snap = app.surfacing_engine.get_min_score_snapshot()
+            adjusted_scores = snap["adjusted"]
+            min_samples_required = snap["auto_tune_min_samples"]
+            auto_state = "on" if snap["auto_tune_enabled"] else "off"
+            lines.append(
+                f"\nMin score:       {snap['default']:.3f} "
+                f"(auto-tune {auto_state}, min {min_samples_required} samples)"
+            )
+            if adjusted_scores:
+                lines.append("  Per-tool adjustments:")
+                for t, s in sorted(adjusted_scores.items()):
+                    lines.append(f"    {t}: {s:.3f}")
+
         if stats["per_tool_breakdown"]:
             lines.append("\nBy tool:")
             for row in stats["per_tool_breakdown"]:
-                lines.append(
-                    f"  {row['tool']}: {row['events']} events, "
-                    f"avg {row['avg_memory_count']} memories"
-                )
+                fb = row.get("feedback_count", 0)
+                neg = row.get("not_relevant_count", 0)
+                # negative ratio only meaningful with feedback; readiness signal
+                # compares feedback count to AutoTuner min_samples.
+                detail_parts = [
+                    f"{row['events']} events",
+                    f"avg {row['avg_memory_count']} memories",
+                ]
+                if fb > 0:
+                    ratio_pct = round(neg / fb * 100, 1)
+                    detail_parts.append(f"feedback {fb} (negative {ratio_pct}%)")
+                else:
+                    detail_parts.append("feedback 0")
+                if min_samples_required > 0:
+                    if fb >= min_samples_required:
+                        if row["tool"] in adjusted_scores:
+                            detail_parts.append("auto-tuned")
+                        else:
+                            detail_parts.append("auto-tune ready")
+                    else:
+                        detail_parts.append(f"need {min_samples_required - fb} more for auto-tune")
+                lines.append(f"  {row['tool']}: {', '.join(detail_parts)}")
 
         if stats["rating_distribution"]:
             lines.append("\nRating distribution:")

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -655,11 +655,13 @@ async def stm_surfacing_stats(
         # "feedback N (negative R%)" against the auto-tune readiness threshold.
         min_samples_required = 0
         adjusted_scores: dict[str, float] = {}
+        auto_tune_active = False
         if app.surfacing_engine is not None:
             snap = app.surfacing_engine.get_min_score_snapshot()
             adjusted_scores = snap["adjusted"]
             min_samples_required = snap["auto_tune_min_samples"]
-            auto_state = "on" if snap["auto_tune_enabled"] else "off"
+            auto_tune_active = snap["auto_tune_enabled"]
+            auto_state = "on" if auto_tune_active else "off"
             lines.append(
                 f"\nMin score:       {snap['default']:.3f} "
                 f"(auto-tune {auto_state}, min {min_samples_required} samples)"
@@ -674,8 +676,10 @@ async def stm_surfacing_stats(
             for row in stats["per_tool_breakdown"]:
                 fb = row.get("feedback_count", 0)
                 neg = row.get("not_relevant_count", 0)
-                # negative ratio only meaningful with feedback; readiness signal
-                # compares feedback count to AutoTuner min_samples.
+                # Readiness annotations only render when auto-tune is actually
+                # active; otherwise they'd contradict the "auto-tune off" header
+                # (operators with auto_tune_enabled=False would see "ready" /
+                # "need N more" labels for a tuner that will never fire).
                 detail_parts = [
                     f"{row['events']} events",
                     f"avg {row['avg_memory_count']} memories",
@@ -685,7 +689,7 @@ async def stm_surfacing_stats(
                     detail_parts.append(f"feedback {fb} (negative {ratio_pct}%)")
                 else:
                     detail_parts.append("feedback 0")
-                if min_samples_required > 0:
+                if auto_tune_active and min_samples_required > 0:
                     if fb >= min_samples_required:
                         if row["tool"] in adjusted_scores:
                             detail_parts.append("auto-tuned")

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -665,12 +665,17 @@ async def stm_surfacing_stats(
         # eligibility for a tool with enough historical samples but only a
         # handful of recent events. Falls back to the row's filtered fb only
         # when the unfiltered counts aren't available (e.g. tracker missing).
+        # ``readiness_total_fb`` mirrors the global pool AutoTuner consults
+        # via the documented cold-start fallback: a tool with too few of
+        # its own samples still becomes eligible once total feedback across
+        # all tools reaches ``min_samples`` (feedback.py::maybe_adjust).
         readiness_counts: dict[str, int] = {}
         if app.feedback_tracker is not None:
             try:
                 readiness_counts = app.feedback_tracker.store.get_per_tool_feedback_counts()
             except Exception:
                 readiness_counts = {}
+        readiness_total_fb = sum(readiness_counts.values())
         if app.surfacing_engine is not None:
             snap = app.surfacing_engine.get_min_score_snapshot()
             adjusted_scores = snap["adjusted"]
@@ -732,15 +737,27 @@ async def stm_surfacing_stats(
                     if tool_name in adjusted_scores:
                         detail_parts.append("auto-tuned")
                     else:
-                        # Use unfiltered count for readiness — see ``readiness_counts``
-                        # comment above. Falls back to the windowed fb when the
-                        # store didn't supply a count for this tool (closed/missing).
+                        # AutoTuner is eligible when either the tool's own
+                        # feedback or the global pool has hit ``min_samples``
+                        # (cold-start fallback). Reporting only the per-tool
+                        # gate would label a tool "need N more" even when the
+                        # very next surfacing would tune it from the global
+                        # pool with ratio outside the [0.2, 0.6] no-op band.
+                        # Falls back to the windowed fb when the store didn't
+                        # supply a count for this tool (closed/missing).
                         eligible_fb = readiness_counts.get(tool_name, fb)
-                        if eligible_fb >= min_samples_required:
+                        if (
+                            eligible_fb >= min_samples_required
+                            or readiness_total_fb >= min_samples_required
+                        ):
                             detail_parts.append("auto-tune ready")
                         else:
+                            # Cold-start gap is the smaller of the two — once
+                            # the global pool reaches min_samples, any tool
+                            # becomes eligible regardless of its own count.
                             detail_parts.append(
-                                f"need {min_samples_required - eligible_fb} more for auto-tune"
+                                f"need {min_samples_required - readiness_total_fb} "
+                                "more for auto-tune"
                             )
                 lines.append(f"  {tool_name}: {', '.join(detail_parts)}")
 

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -655,10 +655,12 @@ async def stm_surfacing_stats(
         # "feedback N (negative R%)" against the auto-tune readiness threshold.
         min_samples_required = 0
         adjusted_scores: dict[str, float] = {}
+        overrides: dict[str, float] = {}
         auto_tune_active = False
         if app.surfacing_engine is not None:
             snap = app.surfacing_engine.get_min_score_snapshot()
             adjusted_scores = snap["adjusted"]
+            overrides = snap.get("overrides", {})
             min_samples_required = snap["auto_tune_min_samples"]
             auto_tune_active = snap["auto_tune_enabled"]
             auto_state = "on" if auto_tune_active else "off"
@@ -670,6 +672,10 @@ async def stm_surfacing_stats(
                 lines.append("  Per-tool adjustments:")
                 for t, s in sorted(adjusted_scores.items()):
                     lines.append(f"    {t}: {s:.3f}")
+            if overrides:
+                lines.append("  Per-tool pinned (bypass auto-tune):")
+                for t, s in sorted(overrides.items()):
+                    lines.append(f"    {t}: {s:.3f}")
 
         if stats["per_tool_breakdown"]:
             lines.append("\nBy tool:")
@@ -677,9 +683,10 @@ async def stm_surfacing_stats(
                 fb = row.get("feedback_count", 0)
                 neg = row.get("not_relevant_count", 0)
                 # Readiness annotations only render when auto-tune is actually
-                # active; otherwise they'd contradict the "auto-tune off" header
-                # (operators with auto_tune_enabled=False would see "ready" /
-                # "need N more" labels for a tuner that will never fire).
+                # active and the tool isn't pinned via context_tools.<tool>.min_score.
+                # A pinned override bypasses the tuner entirely (engine.py:458-460),
+                # so any "ready" / "need N more" label would imply the tuner could
+                # change a threshold the operator has explicitly fixed.
                 detail_parts = [
                     f"{row['events']} events",
                     f"avg {row['avg_memory_count']} memories",
@@ -689,15 +696,18 @@ async def stm_surfacing_stats(
                     detail_parts.append(f"feedback {fb} (negative {ratio_pct}%)")
                 else:
                     detail_parts.append("feedback 0")
-                if auto_tune_active and min_samples_required > 0:
+                tool_name = row["tool"]
+                if tool_name in overrides:
+                    detail_parts.append(f"pinned {overrides[tool_name]:.3f}")
+                elif auto_tune_active and min_samples_required > 0:
                     if fb >= min_samples_required:
-                        if row["tool"] in adjusted_scores:
+                        if tool_name in adjusted_scores:
                             detail_parts.append("auto-tuned")
                         else:
                             detail_parts.append("auto-tune ready")
                     else:
                         detail_parts.append(f"need {min_samples_required - fb} more for auto-tune")
-                lines.append(f"  {row['tool']}: {', '.join(detail_parts)}")
+                lines.append(f"  {tool_name}: {', '.join(detail_parts)}")
 
         if stats["rating_distribution"]:
             lines.append("\nRating distribution:")

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -653,10 +653,24 @@ async def stm_surfacing_stats(
         # per-tool adjustments AutoTuner has made this process. Surfaced before
         # the per-tool breakdown so the reader can interpret the breakdown's
         # "feedback N (negative R%)" against the auto-tune readiness threshold.
+        # When ``tool=`` is set we restrict the per-tool sublists to that tool
+        # only — otherwise the lists would contradict the trailing
+        # "(filtered by tool: ...)" marker by leaking unrelated thresholds.
         min_samples_required = 0
         adjusted_scores: dict[str, float] = {}
         overrides: dict[str, float] = {}
         auto_tune_active = False
+        # Readiness must be computed against the same unfiltered sample set
+        # AutoTuner sees — a ``since=`` window would otherwise under-report
+        # eligibility for a tool with enough historical samples but only a
+        # handful of recent events. Falls back to the row's filtered fb only
+        # when the unfiltered counts aren't available (e.g. tracker missing).
+        readiness_counts: dict[str, int] = {}
+        if app.feedback_tracker is not None:
+            try:
+                readiness_counts = app.feedback_tracker.store.get_per_tool_feedback_counts()
+            except Exception:
+                readiness_counts = {}
         if app.surfacing_engine is not None:
             snap = app.surfacing_engine.get_min_score_snapshot()
             adjusted_scores = snap["adjusted"]
@@ -668,13 +682,21 @@ async def stm_surfacing_stats(
                 f"\nMin score:       {snap['default']:.3f} "
                 f"(auto-tune {auto_state}, min {min_samples_required} samples)"
             )
-            if adjusted_scores:
+            visible_adjusted = (
+                {t: s for t, s in adjusted_scores.items() if t == tool}
+                if tool is not None
+                else adjusted_scores
+            )
+            visible_overrides = (
+                {t: s for t, s in overrides.items() if t == tool} if tool is not None else overrides
+            )
+            if visible_adjusted:
                 lines.append("  Per-tool adjustments:")
-                for t, s in sorted(adjusted_scores.items()):
+                for t, s in sorted(visible_adjusted.items()):
                     lines.append(f"    {t}: {s:.3f}")
-            if overrides:
+            if visible_overrides:
                 lines.append("  Per-tool pinned (bypass auto-tune):")
-                for t, s in sorted(overrides.items()):
+                for t, s in sorted(visible_overrides.items()):
                     lines.append(f"    {t}: {s:.3f}")
 
         if stats["per_tool_breakdown"]:
@@ -709,10 +731,17 @@ async def stm_surfacing_stats(
                     # effective threshold the engine actually used.
                     if tool_name in adjusted_scores:
                         detail_parts.append("auto-tuned")
-                    elif fb >= min_samples_required:
-                        detail_parts.append("auto-tune ready")
                     else:
-                        detail_parts.append(f"need {min_samples_required - fb} more for auto-tune")
+                        # Use unfiltered count for readiness — see ``readiness_counts``
+                        # comment above. Falls back to the windowed fb when the
+                        # store didn't supply a count for this tool (closed/missing).
+                        eligible_fb = readiness_counts.get(tool_name, fb)
+                        if eligible_fb >= min_samples_required:
+                            detail_parts.append("auto-tune ready")
+                        else:
+                            detail_parts.append(
+                                f"need {min_samples_required - eligible_fb} more for auto-tune"
+                            )
                 lines.append(f"  {tool_name}: {', '.join(detail_parts)}")
 
         if stats["rating_distribution"]:

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -133,6 +133,27 @@ class SurfacingEngine:
         """
         return self._config.injection_mode
 
+    def get_min_score_snapshot(self) -> dict:
+        """Return the current min_score state for observability.
+
+        Read by ``server.py::stm_surfacing_stats`` to render which tools
+        have been auto-tuned away from the default and which are still
+        accumulating samples. ``adjusted`` only contains tools whose
+        ``AutoTuner.maybe_adjust`` has fired this process; an empty dict
+        with ``enabled=True`` means auto-tuning is on but no tool has
+        moved off the default yet (either insufficient samples or ratio
+        inside the [0.2, 0.6] no-op band).
+        """
+        adjusted: dict[str, float] = (
+            self._auto_tuner.adjustments if self._auto_tuner is not None else {}
+        )
+        return {
+            "default": self._config.min_score,
+            "auto_tune_enabled": self._config.auto_tune_enabled and self._auto_tuner is not None,
+            "auto_tune_min_samples": self._config.auto_tune_min_samples,
+            "adjusted": adjusted,
+        }
+
     async def surface(
         self,
         server: str,

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -143,15 +143,28 @@ class SurfacingEngine:
         with ``enabled=True`` means auto-tuning is on but no tool has
         moved off the default yet (either insufficient samples or ratio
         inside the [0.2, 0.6] no-op band).
+
+        ``overrides`` maps tool name → pinned ``min_score`` from
+        ``context_tools.<tool>.min_score``. These tools bypass the
+        auto-tuner entirely (see ``_do_surface`` — tool_cfg override
+        takes precedence over ``maybe_adjust``), so the formatter must
+        suppress readiness labels for them or it implies the tuner
+        could change a threshold the operator has explicitly pinned.
         """
         adjusted: dict[str, float] = (
             self._auto_tuner.adjustments if self._auto_tuner is not None else {}
         )
+        overrides: dict[str, float] = {
+            tool: tcfg.min_score
+            for tool, tcfg in self._config.context_tools.items()
+            if tcfg.min_score is not None
+        }
         return {
             "default": self._config.min_score,
             "auto_tune_enabled": self._config.auto_tune_enabled and self._auto_tuner is not None,
             "auto_tune_min_samples": self._config.auto_tune_min_samples,
             "adjusted": adjusted,
+            "overrides": overrides,
         }
 
     async def surface(

--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -143,3 +143,13 @@ class AutoTuner:
     def get_effective_min_score(self, tool: str) -> float:
         """Return the auto-tuned min_score for a tool, or the default."""
         return self._adjustments.get(tool, self._config.min_score)
+
+    @property
+    def adjustments(self) -> dict[str, float]:
+        """Per-tool min_score adjustments applied this process.
+
+        Returned as a snapshot copy so callers (e.g. the engine's
+        ``get_min_score_snapshot`` and ``stm_surfacing_stats``) cannot
+        mutate the tuner's internal state.
+        """
+        return dict(self._adjustments)

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -418,3 +418,24 @@ class FeedbackStore:
                 "SELECT COUNT(*) FROM surfacing_feedback WHERE rating = 'not_relevant'"
             ).fetchone()[0]
         return not_relevant / total if total > 0 else 0.0
+
+    def get_per_tool_feedback_counts(self) -> dict[str, int]:
+        """Return total feedback rows per tool, ignoring any time window.
+
+        Mirrors what ``AutoTuner.maybe_adjust`` actually sees — the tuner
+        decides readiness from the full feedback history, not from any
+        ``since`` window an operator passes to ``stm_surfacing_stats``.
+        Used by the server formatter to compute "auto-tune ready" /
+        "need N more" labels that don't contradict the tuner just because
+        the stats query is windowed.
+
+        Returns ``{}`` when the store is closed.
+        """
+        if self._db is None:
+            return {}
+        rows = self._db.execute(
+            "SELECT e.tool, COUNT(*) FROM surfacing_feedback f "
+            "JOIN surfacing_events e ON f.surfacing_id = e.id "
+            "GROUP BY e.tool"
+        ).fetchall()
+        return {tool: count for tool, count in rows}

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -263,6 +263,28 @@ class FeedbackStore:
             bucket = per_tool.setdefault(tool_name, {"events": 0, "sum_memory_count": 0})
             bucket["events"] += 1
             bucket["sum_memory_count"] += n
+
+        # Per-tool feedback counts (total + not_relevant) within the same
+        # event filter. Powers the AutoTuner readiness signal: with these
+        # the formatter can render "feedback N (negative R%)" and decide
+        # whether the tool has hit auto_tune_min_samples.
+        per_tool_feedback_filter = " AND ".join(f"e.{f}" for f in event_filters)
+        per_tool_feedback_where = (
+            (" WHERE " + per_tool_feedback_filter) if per_tool_feedback_filter else ""
+        )
+        feedback_rows = self._db.execute(
+            "SELECT e.tool, f.rating, COUNT(*) FROM surfacing_feedback f "
+            "JOIN surfacing_events e ON f.surfacing_id = e.id"
+            f"{per_tool_feedback_where} GROUP BY e.tool, f.rating",
+            event_params,
+        ).fetchall()
+        per_tool_feedback: dict[str, dict[str, int]] = {}
+        for tool_name, rating, count in feedback_rows:
+            bucket_fb = per_tool_feedback.setdefault(tool_name, {"total": 0, "not_relevant": 0})
+            bucket_fb["total"] += count
+            if rating == "not_relevant":
+                bucket_fb["not_relevant"] += count
+
         per_tool_breakdown: list[dict] = [
             {
                 "tool": t,
@@ -270,6 +292,8 @@ class FeedbackStore:
                 "avg_memory_count": round(b["sum_memory_count"] / b["events"], 2)
                 if b["events"]
                 else 0.0,
+                "feedback_count": per_tool_feedback.get(t, {}).get("total", 0),
+                "not_relevant_count": per_tool_feedback.get(t, {}).get("not_relevant", 0),
             }
             for t, b in sorted(per_tool.items(), key=lambda kv: kv[1]["events"], reverse=True)
         ]

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
+from memtomem_stm.proxy.compression_feedback_store import CompressionFeedbackStore
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.feedback import AutoTuner, FeedbackTracker
 from memtomem_stm.surfacing.feedback_store import FeedbackStore
@@ -90,11 +91,15 @@ class TestFeedbackStore:
             "tool": "tool_a",
             "events": 2,
             "avg_memory_count": 2.5,
+            "feedback_count": 2,
+            "not_relevant_count": 1,
         }
         assert stats["per_tool_breakdown"][1] == {
             "tool": "tool_b",
             "events": 1,
             "avg_memory_count": 1.0,
+            "feedback_count": 1,
+            "not_relevant_count": 0,
         }
         assert stats["rating_distribution"] == {
             "helpful": 1,
@@ -180,6 +185,107 @@ class TestFeedbackStore:
         ratio = feedback_store.get_tool_not_relevant_ratio("t", min_samples=20)
         assert ratio is not None
         assert abs(ratio - 0.6) < 0.01
+
+    def test_per_tool_breakdown_includes_feedback_counts(self, feedback_store: FeedbackStore):
+        """Per-tool breakdown exposes feedback_count + not_relevant_count."""
+        feedback_store.record_surfacing("s_a1", "sv", "tool_a", "q", ["m1"], [0.9])
+        feedback_store.record_surfacing("s_a2", "sv", "tool_a", "q", ["m2"], [0.9])
+        feedback_store.record_surfacing("s_b", "sv", "tool_b", "q", ["m3"], [0.9])
+        feedback_store.record_feedback("s_a1", "helpful")
+        feedback_store.record_feedback("s_a2", "not_relevant")
+        feedback_store.record_feedback("s_a2", "not_relevant")
+        # tool_b has no feedback yet.
+
+        stats = feedback_store.get_stats()
+        by_tool = {row["tool"]: row for row in stats["per_tool_breakdown"]}
+        assert by_tool["tool_a"]["feedback_count"] == 3
+        assert by_tool["tool_a"]["not_relevant_count"] == 2
+        assert by_tool["tool_b"]["feedback_count"] == 0
+        assert by_tool["tool_b"]["not_relevant_count"] == 0
+
+    def test_per_tool_feedback_honors_since_filter(self, feedback_store: FeedbackStore):
+        """since= filters feedback rows via their parent event's created_at."""
+        feedback_store.record_surfacing("s_old", "sv", "t", "q", ["m1"], [0.9])
+        feedback_store._db.execute(  # type: ignore[union-attr]
+            "UPDATE surfacing_events SET created_at = ? WHERE id = ?",
+            (time.time() - 3600, "s_old"),
+        )
+        feedback_store._db.commit()  # type: ignore[union-attr]
+        feedback_store.record_feedback("s_old", "not_relevant")
+
+        feedback_store.record_surfacing("s_new", "sv", "t", "q", ["m2"], [0.9])
+        feedback_store.record_feedback("s_new", "helpful")
+
+        stats = feedback_store.get_stats(since=time.time() - 60)
+        row = stats["per_tool_breakdown"][0]
+        assert row["feedback_count"] == 1
+        assert row["not_relevant_count"] == 0
+
+
+class TestFeedbackStoreCoexistence:
+    """Regression: surfacing tables coexist with compression tables on the same DB.
+
+    Real ``~/.memtomem/stm_feedback.db`` files in the wild may have been
+    initialized by ``CompressionFeedbackStore`` alone (compression_feedback +
+    progressive_reads) before surfacing was ever enabled. When surfacing
+    starts up against such a DB, ``FeedbackStore.initialize()`` must add its
+    own tables without disturbing existing rows or schema.
+    """
+
+    def test_initialize_against_compression_only_db(self, tmp_path: Path):
+        db_path = tmp_path / "shared.db"
+
+        # Simulate the production state: compression store created first,
+        # with a row already written.
+        cstore = CompressionFeedbackStore(db_path)
+        cstore.initialize()
+        cstore.record(
+            server="server-x",
+            tool="tool-x",
+            kind="missing_field",
+            missing="x.y",
+            trace_id="trace-1",
+        )
+        cstore.close()
+
+        # FeedbackStore opens the same file later. Surfacing tables should
+        # appear; compression rows must remain.
+        fstore = FeedbackStore(db_path)
+        fstore.initialize()
+        try:
+            tables = {
+                r[0]
+                for r in fstore._db.execute(  # type: ignore[union-attr]
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert {"surfacing_events", "surfacing_feedback", "seen_memories"} <= tables
+            assert "compression_feedback" in tables
+
+            preserved = fstore._db.execute(  # type: ignore[union-attr]
+                "SELECT server, tool FROM compression_feedback"
+            ).fetchall()
+            assert preserved == [("server-x", "tool-x")]
+        finally:
+            fstore.close()
+
+    def test_initialize_is_idempotent(self, tmp_path: Path):
+        """Re-opening must be a no-op — no data loss, no schema errors."""
+        db_path = tmp_path / "shared.db"
+        fstore = FeedbackStore(db_path)
+        fstore.initialize()
+        fstore.record_surfacing("s1", "sv", "t", "q", ["m1"], [0.9])
+        fstore.record_feedback("s1", "helpful")
+        fstore.close()
+
+        fstore2 = FeedbackStore(db_path)
+        fstore2.initialize()  # second initialize on existing schema
+        try:
+            stats = fstore2.get_stats()
+            assert stats["events_total"] == 1
+            assert stats["rating_distribution"] == {"helpful": 1}
+        finally:
+            fstore2.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -177,6 +177,28 @@ class TestFeedbackStore:
         assert stats["rating_distribution"] == {"helpful": 1}
         assert all(r["tool"] == "tool_a" for r in stats["recent"])
 
+    def test_get_per_tool_feedback_counts_is_unfiltered(self, feedback_store: FeedbackStore):
+        """Powers the auto-tune readiness gate in ``stm_surfacing_stats`` —
+        must always return the full history, not honor any time window."""
+        feedback_store.record_surfacing("s_old", "sv", "t1", "q", ["m1"], [0.9])
+        feedback_store._db.execute(  # type: ignore[union-attr]
+            "UPDATE surfacing_events SET created_at = ? WHERE id = ?",
+            (time.time() - 7200, "s_old"),
+        )
+        feedback_store._db.commit()  # type: ignore[union-attr]
+        feedback_store.record_feedback("s_old", "helpful")
+        feedback_store.record_feedback("s_old", "not_relevant")
+
+        feedback_store.record_surfacing("s_new", "sv", "t2", "q", ["m2"], [0.9])
+        feedback_store.record_feedback("s_new", "helpful")
+
+        counts = feedback_store.get_per_tool_feedback_counts()
+        # Both tools present despite t1's feedback being well before "now".
+        assert counts == {"t1": 2, "t2": 1}
+
+    def test_get_per_tool_feedback_counts_empty(self, feedback_store: FeedbackStore):
+        assert feedback_store.get_per_tool_feedback_counts() == {}
+
     def test_not_relevant_ratio_computed(self, feedback_store: FeedbackStore):
         feedback_store.record_surfacing("s1", "sv", "t", "q", ["m1"], [0.5])
         for i in range(20):

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -385,10 +385,68 @@ class TestSurfacingStats:
         # Auto-tune readiness annotations:
         assert "tuned_tool: 30 events" in result and "auto-tuned" in result
         assert "ready_tool: 25 events" in result and "auto-tune ready" in result
-        assert "need 16 more for auto-tune" in result  # cold_tool: 20 - 4
+        # cold_tool has only 4 of its own samples, but the global pool here
+        # has 59 (25 + 30 + 4) — past the 20-sample threshold — so the
+        # tuner's cold-start fallback would fire on the next surfacing.
+        # Readiness label reflects that, not the per-tool count alone.
+        cold_row = next(
+            line
+            for line in result.splitlines()
+            if "cold_tool:" in line and "events" in line
+        )
+        assert "auto-tune ready" in cold_row
+        assert "need" not in cold_row
         # Negative ratio rendered where feedback exists.
         assert "negative 73.3%" in result  # tuned: 22/30
         assert "negative 20.0%" in result  # ready: 5/25
+
+    async def test_need_more_uses_global_gap_when_pool_also_below_threshold(self):
+        """When *both* the tool's own and the global pool are below
+        ``min_samples``, the "need N more" message must reflect the
+        cold-start gap — the global shortfall — since that's the smaller
+        of the two gates and is what the tuner is actually waiting on."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "events_total": 1,
+            "distinct_tools": 1,
+            "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
+            "per_tool_breakdown": [
+                {
+                    "tool": "lonely_tool",
+                    "events": 3,
+                    "avg_memory_count": 1.0,
+                    "feedback_count": 2,
+                    "not_relevant_count": 1,
+                },
+            ],
+            "rating_distribution": {"helpful": 1, "not_relevant": 1},
+            "total_feedback": 2,
+            "recent": [],
+        }
+        # Per-tool 2 + one other tool 5 → global 7, both well below 20.
+        mock_tracker.store.get_per_tool_feedback_counts.return_value = {
+            "lonely_tool": 2,
+            "other_tool": 5,
+        }
+        mock_engine = MagicMock()
+        mock_engine.observability = None
+        mock_engine.get_min_score_snapshot.return_value = {
+            "default": 0.030,
+            "auto_tune_enabled": True,
+            "auto_tune_min_samples": 20,
+            "adjusted": {},
+            "overrides": {},
+        }
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
+        result = await stm_surfacing_stats(ctx=ctx)
+
+        row = next(
+            line
+            for line in result.splitlines()
+            if "lonely_tool:" in line and "events" in line
+        )
+        # Gap reported against global pool (20 - 7 = 13), not per-tool (20 - 2 = 18).
+        assert "need 13 more for auto-tune" in row
 
     async def test_cold_start_tuned_tool_reported_as_tuned(self):
         """AutoTuner's cold-start fallback (feedback.py::maybe_adjust) can

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -384,6 +384,54 @@ class TestSurfacingStats:
         assert "negative 73.3%" in result  # tuned: 22/30
         assert "negative 20.0%" in result  # ready: 5/25
 
+    async def test_readiness_labels_suppressed_when_auto_tune_off(self):
+        """With auto_tune_enabled=False, the per-tool readiness labels must
+        NOT render — otherwise output contradicts its own "auto-tune off"
+        header for configs that have disabled tuning."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "events_total": 1,
+            "distinct_tools": 1,
+            "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
+            "per_tool_breakdown": [
+                {
+                    "tool": "ready_tool",
+                    "events": 25,
+                    "avg_memory_count": 2.0,
+                    "feedback_count": 25,
+                    "not_relevant_count": 5,
+                },
+                {
+                    "tool": "cold_tool",
+                    "events": 3,
+                    "avg_memory_count": 1.0,
+                    "feedback_count": 4,
+                    "not_relevant_count": 1,
+                },
+            ],
+            "rating_distribution": {"helpful": 20, "not_relevant": 9},
+            "total_feedback": 29,
+            "recent": [],
+        }
+        mock_engine = MagicMock()
+        mock_engine.observability = None
+        mock_engine.get_min_score_snapshot.return_value = {
+            "default": 0.030,
+            "auto_tune_enabled": False,
+            "auto_tune_min_samples": 20,
+            "adjusted": {},
+        }
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
+        result = await stm_surfacing_stats(ctx=ctx)
+
+        assert "Min score:       0.030 (auto-tune off, min 20 samples)" in result
+        # Negative ratio still rendered — orthogonal to auto-tune state.
+        assert "negative 20.0%" in result
+        # No readiness labels of any flavor:
+        assert "auto-tuned" not in result
+        assert "auto-tune ready" not in result
+        assert "for auto-tune" not in result
+
     async def test_invalid_since(self):
         """Malformed ISO timestamp is rejected cleanly, not raised."""
         mock_tracker = MagicMock()

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -285,8 +285,20 @@ class TestSurfacingStats:
             "distinct_tools": 2,
             "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
             "per_tool_breakdown": [
-                {"tool": "t", "events": 7, "avg_memory_count": 3.0},
-                {"tool": "u", "events": 3, "avg_memory_count": 2.0},
+                {
+                    "tool": "t",
+                    "events": 7,
+                    "avg_memory_count": 3.0,
+                    "feedback_count": 5,
+                    "not_relevant_count": 2,
+                },
+                {
+                    "tool": "u",
+                    "events": 3,
+                    "avg_memory_count": 2.0,
+                    "feedback_count": 0,
+                    "not_relevant_count": 0,
+                },
             ],
             "rating_distribution": {"helpful": 3, "not_relevant": 2},
             "total_feedback": 5,
@@ -314,6 +326,63 @@ class TestSurfacingStats:
         assert "Recent:" in result
         assert "hello world" in result
         assert "(filtered by tool: t)" in result
+
+    async def test_min_score_block_when_engine_present(self):
+        """With a surfacing engine, output includes the min_score snapshot
+        and per-tool auto-tune readiness annotations."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "events_total": 2,
+            "distinct_tools": 2,
+            "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
+            "per_tool_breakdown": [
+                {
+                    "tool": "ready_tool",
+                    "events": 25,
+                    "avg_memory_count": 2.0,
+                    "feedback_count": 25,
+                    "not_relevant_count": 5,
+                },
+                {
+                    "tool": "tuned_tool",
+                    "events": 30,
+                    "avg_memory_count": 2.0,
+                    "feedback_count": 30,
+                    "not_relevant_count": 22,
+                },
+                {
+                    "tool": "cold_tool",
+                    "events": 3,
+                    "avg_memory_count": 1.0,
+                    "feedback_count": 4,
+                    "not_relevant_count": 1,
+                },
+            ],
+            "rating_distribution": {"helpful": 25, "not_relevant": 28},
+            "total_feedback": 59,
+            "recent": [],
+        }
+        mock_engine = MagicMock()
+        mock_engine.observability = None
+        mock_engine.get_min_score_snapshot.return_value = {
+            "default": 0.030,
+            "auto_tune_enabled": True,
+            "auto_tune_min_samples": 20,
+            "adjusted": {"tuned_tool": 0.038},
+        }
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
+        result = await stm_surfacing_stats(ctx=ctx)
+
+        assert "Min score:       0.030 (auto-tune on, min 20 samples)" in result
+        assert "Per-tool adjustments:" in result
+        assert "tuned_tool: 0.038" in result
+        # Auto-tune readiness annotations:
+        assert "tuned_tool: 30 events" in result and "auto-tuned" in result
+        assert "ready_tool: 25 events" in result and "auto-tune ready" in result
+        assert "need 16 more for auto-tune" in result  # cold_tool: 20 - 4
+        # Negative ratio rendered where feedback exists.
+        assert "negative 73.3%" in result  # tuned: 22/30
+        assert "negative 20.0%" in result  # ready: 5/25
 
     async def test_invalid_since(self):
         """Malformed ISO timestamp is rejected cleanly, not raised."""
@@ -783,9 +852,9 @@ class TestAdvertiseOrder:
         caplog.clear()
         with caplog.at_level(logging.WARNING, logger="memtomem_stm.server"):
             _move_stm_tools_to_end(server)  # must not raise
-        assert any(
-            "FastMCP internal API changed" in rec.message for rec in caplog.records
-        ), [r.message for r in caplog.records]
+        assert any("FastMCP internal API changed" in rec.message for rec in caplog.records), [
+            r.message for r in caplog.records
+        ]
 
     def test_utility_tool_names_tuple_matches_registered_set(self):
         """Exhaustiveness guard: every STM utility tool registered by the
@@ -854,6 +923,5 @@ class TestMainExceptionBarrier:
 
         error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
         assert not error_records, (
-            f"clean exit should not emit ERROR logs; got: "
-            f"{[r.getMessage() for r in error_records]}"
+            f"clean exit should not emit ERROR logs; got: {[r.getMessage() for r in error_records]}"
         )

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -362,6 +362,11 @@ class TestSurfacingStats:
             "total_feedback": 59,
             "recent": [],
         }
+        mock_tracker.store.get_per_tool_feedback_counts.return_value = {
+            "ready_tool": 25,
+            "tuned_tool": 30,
+            "cold_tool": 4,
+        }
         mock_engine = MagicMock()
         mock_engine.observability = None
         mock_engine.get_min_score_snapshot.return_value = {
@@ -369,6 +374,7 @@ class TestSurfacingStats:
             "auto_tune_enabled": True,
             "auto_tune_min_samples": 20,
             "adjusted": {"tuned_tool": 0.038},
+            "overrides": {},
         }
         ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
         result = await stm_surfacing_stats(ctx=ctx)
@@ -408,6 +414,7 @@ class TestSurfacingStats:
             "total_feedback": 3,
             "recent": [],
         }
+        mock_tracker.store.get_per_tool_feedback_counts.return_value = {"cold_but_tuned": 3}
         mock_engine = MagicMock()
         mock_engine.observability = None
         mock_engine.get_min_score_snapshot.return_value = {
@@ -459,6 +466,10 @@ class TestSurfacingStats:
             "rating_distribution": {"helpful": 30, "not_relevant": 35},
             "total_feedback": 65,
             "recent": [],
+        }
+        mock_tracker.store.get_per_tool_feedback_counts.return_value = {
+            "pinned_tool": 40,
+            "tunable_tool": 25,
         }
         mock_engine = MagicMock()
         mock_engine.observability = None
@@ -523,6 +534,10 @@ class TestSurfacingStats:
             "total_feedback": 29,
             "recent": [],
         }
+        mock_tracker.store.get_per_tool_feedback_counts.return_value = {
+            "ready_tool": 25,
+            "cold_tool": 4,
+        }
         mock_engine = MagicMock()
         mock_engine.observability = None
         mock_engine.get_min_score_snapshot.return_value = {
@@ -530,6 +545,7 @@ class TestSurfacingStats:
             "auto_tune_enabled": False,
             "auto_tune_min_samples": 20,
             "adjusted": {},
+            "overrides": {},
         }
         ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
         result = await stm_surfacing_stats(ctx=ctx)
@@ -541,6 +557,105 @@ class TestSurfacingStats:
         assert "auto-tuned" not in result
         assert "auto-tune ready" not in result
         assert "for auto-tune" not in result
+
+    async def test_readiness_uses_unfiltered_count_under_since_window(self):
+        """``since=`` filters the stats rows but AutoTuner sees the full
+        history; readiness must reflect unfiltered counts or it will
+        under-report eligibility for tools with sparse recent activity."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "events_total": 1,
+            "distinct_tools": 1,
+            "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
+            "per_tool_breakdown": [
+                {
+                    "tool": "historic_tool",
+                    "events": 2,
+                    "avg_memory_count": 1.0,
+                    # Only 3 feedback rows fell in the since window — the row
+                    # count would otherwise drive a "need 17 more" label.
+                    "feedback_count": 3,
+                    "not_relevant_count": 1,
+                },
+            ],
+            "rating_distribution": {"helpful": 2, "not_relevant": 1},
+            "total_feedback": 3,
+            "recent": [],
+        }
+        # The full history has 50 samples — well past the 20-sample threshold —
+        # but not yet adjusted (ratio in [0.2, 0.6] no-op band).
+        mock_tracker.store.get_per_tool_feedback_counts.return_value = {"historic_tool": 50}
+        mock_engine = MagicMock()
+        mock_engine.observability = None
+        mock_engine.get_min_score_snapshot.return_value = {
+            "default": 0.030,
+            "auto_tune_enabled": True,
+            "auto_tune_min_samples": 20,
+            "adjusted": {},
+            "overrides": {},
+        }
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
+        result = await stm_surfacing_stats(since="2026-04-01T00:00:00", ctx=ctx)
+
+        row = next(
+            line
+            for line in result.splitlines()
+            if "historic_tool:" in line and "events" in line
+        )
+        assert "auto-tune ready" in row
+        # Windowed feedback count is still reported for the operator's audit,
+        # but the readiness gate honors the unfiltered total.
+        assert "feedback 3" in row
+        assert "need" not in row
+
+    async def test_min_score_lists_honor_tool_filter(self):
+        """When ``tool=`` is set, the per-tool adjustment / pinned sublists
+        must restrict to that tool — otherwise they contradict the trailing
+        ``(filtered by tool: ...)`` marker by leaking unrelated thresholds."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "events_total": 1,
+            "distinct_tools": 1,
+            "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
+            "per_tool_breakdown": [
+                {
+                    "tool": "alpha",
+                    "events": 10,
+                    "avg_memory_count": 1.0,
+                    "feedback_count": 10,
+                    "not_relevant_count": 0,
+                },
+            ],
+            "rating_distribution": {"helpful": 10},
+            "total_feedback": 10,
+            "recent": [],
+        }
+        mock_tracker.store.get_per_tool_feedback_counts.return_value = {
+            "alpha": 10,
+            "beta": 30,
+            "gamma": 30,
+        }
+        mock_engine = MagicMock()
+        mock_engine.observability = None
+        mock_engine.get_min_score_snapshot.return_value = {
+            "default": 0.030,
+            "auto_tune_enabled": True,
+            "auto_tune_min_samples": 20,
+            "adjusted": {"beta": 0.038},
+            "overrides": {"gamma": 0.045},
+        }
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
+        result = await stm_surfacing_stats(tool="alpha", ctx=ctx)
+
+        # Neither beta (adjusted) nor gamma (pinned) belong in an alpha-filtered
+        # report — the sublists must drop them entirely.
+        assert "beta:" not in result
+        assert "gamma:" not in result
+        # Without any alpha-specific adjustment/override, the sublists collapse.
+        assert "Per-tool adjustments:" not in result
+        assert "Per-tool pinned" not in result
+        # Filter marker still present.
+        assert "(filtered by tool: alpha)" in result
 
     async def test_invalid_since(self):
         """Malformed ISO timestamp is rejected cleanly, not raised."""

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -384,6 +384,52 @@ class TestSurfacingStats:
         assert "negative 73.3%" in result  # tuned: 22/30
         assert "negative 20.0%" in result  # ready: 5/25
 
+    async def test_cold_start_tuned_tool_reported_as_tuned(self):
+        """AutoTuner's cold-start fallback (feedback.py::maybe_adjust) can
+        tune a tool from the global feedback pool even when the tool's own
+        feedback count is below ``min_samples``. Such a tool appears in
+        ``adjusted`` despite low per-tool feedback — the formatter must
+        report it as ``auto-tuned``, not ``need N more for auto-tune``."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "events_total": 1,
+            "distinct_tools": 1,
+            "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
+            "per_tool_breakdown": [
+                {
+                    "tool": "cold_but_tuned",
+                    "events": 4,
+                    "avg_memory_count": 1.0,
+                    "feedback_count": 3,  # below the 20-sample threshold
+                    "not_relevant_count": 0,
+                },
+            ],
+            "rating_distribution": {"helpful": 3},
+            "total_feedback": 3,
+            "recent": [],
+        }
+        mock_engine = MagicMock()
+        mock_engine.observability = None
+        mock_engine.get_min_score_snapshot.return_value = {
+            "default": 0.030,
+            "auto_tune_enabled": True,
+            "auto_tune_min_samples": 20,
+            # AutoTuner has already adjusted this tool from the global pool.
+            "adjusted": {"cold_but_tuned": 0.026},
+            "overrides": {},
+        }
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
+        result = await stm_surfacing_stats(ctx=ctx)
+
+        row = next(
+            line
+            for line in result.splitlines()
+            if "cold_but_tuned:" in line and "events" in line
+        )
+        assert "auto-tuned" in row
+        assert "need" not in row
+        assert "auto-tune ready" not in row
+
     async def test_readiness_labels_suppressed_for_overridden_tools(self):
         """Tools pinned via context_tools.<tool>.min_score bypass the tuner
         entirely (engine.py:458-460). Stats output must show the pinned value

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -384,6 +384,70 @@ class TestSurfacingStats:
         assert "negative 73.3%" in result  # tuned: 22/30
         assert "negative 20.0%" in result  # ready: 5/25
 
+    async def test_readiness_labels_suppressed_for_overridden_tools(self):
+        """Tools pinned via context_tools.<tool>.min_score bypass the tuner
+        entirely (engine.py:458-460). Stats output must show the pinned value
+        and suppress readiness labels for them, while still reporting
+        readiness for un-overridden siblings."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = {
+            "events_total": 2,
+            "distinct_tools": 2,
+            "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
+            "per_tool_breakdown": [
+                {
+                    "tool": "pinned_tool",
+                    "events": 50,
+                    "avg_memory_count": 2.0,
+                    "feedback_count": 40,
+                    "not_relevant_count": 30,
+                },
+                {
+                    "tool": "tunable_tool",
+                    "events": 25,
+                    "avg_memory_count": 2.0,
+                    "feedback_count": 25,
+                    "not_relevant_count": 5,
+                },
+            ],
+            "rating_distribution": {"helpful": 30, "not_relevant": 35},
+            "total_feedback": 65,
+            "recent": [],
+        }
+        mock_engine = MagicMock()
+        mock_engine.observability = None
+        mock_engine.get_min_score_snapshot.return_value = {
+            "default": 0.030,
+            "auto_tune_enabled": True,
+            "auto_tune_min_samples": 20,
+            "adjusted": {},
+            "overrides": {"pinned_tool": 0.045},
+        }
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=mock_engine)
+        result = await stm_surfacing_stats(ctx=ctx)
+
+        # Pinned override listed in the Min score block:
+        assert "Per-tool pinned (bypass auto-tune):" in result
+        assert "pinned_tool: 0.045" in result
+        # Filter to "By tool:" breakdown rows (they include "events"), not the
+        # Min-score-block sublist row that also mentions pinned_tool.
+        pinned_row = next(
+            line
+            for line in result.splitlines()
+            if "pinned_tool:" in line and "events" in line
+        )
+        assert "pinned 0.045" in pinned_row
+        assert "auto-tuned" not in pinned_row
+        assert "auto-tune ready" not in pinned_row
+        assert "for auto-tune" not in pinned_row
+        # The un-overridden sibling still gets its readiness label:
+        tunable_row = next(
+            line
+            for line in result.splitlines()
+            if "tunable_tool:" in line and "events" in line
+        )
+        assert "auto-tune ready" in tunable_row
+
     async def test_readiness_labels_suppressed_when_auto_tune_off(self):
         """With auto_tune_enabled=False, the per-tool readiness labels must
         NOT render — otherwise output contradicts its own "auto-tune off"


### PR DESCRIPTION
## Summary

Productionization pass on the surfacing feedback path. The `surfacing_events` / `surfacing_feedback` tables and the `stm_surfacing_stats` / `stm_surfacing_feedback` MCP tools already exist; this PR adds the observability needed to actually act on production data, plus a regression test pinning the real on-disk DB layout.

## What changed

- **`FeedbackStore.get_stats()`** per-tool rows now include `feedback_count` and `not_relevant_count` from a single JOIN against `surfacing_feedback`. The `since=` filter applies to feedback via its parent event's `created_at`, so the new counts honor the same window as `events_total`. No new index — the existing `idx_feedback_surfacing` covers the JOIN.
- **`SurfacingEngine.get_min_score_snapshot()`** exposes config default, AutoTune on/off, `auto_tune_min_samples` threshold, and per-tool adjustments AutoTuner has made this process. `AutoTuner.adjustments` gains a read-only property returning a snapshot copy so callers cannot mutate the tuner's `_adjustments` dict.
- **`stm_surfacing_stats` formatting**:
  - New `Min score:` block — `default 0.030 (auto-tune on, min 20 samples)` + `Per-tool adjustments:` sublist when AutoTuner has moved any tool off the default.
  - Per-tool rows annotate auto-tune state: `auto-tuned`, `auto-tune ready` (≥ min_samples but inside [0.2, 0.6] no-op band), or `need N more for auto-tune`; render negative ratio as `feedback N (negative R%)` when feedback exists.
- **`TestFeedbackStoreCoexistence`** — regression test: opens a shared DB previously initialized by `CompressionFeedbackStore` (matching real `~/.memtomem/stm_feedback.db` layout: `compression_feedback` + `progressive_reads` only), then runs `FeedbackStore.initialize()` and verifies surfacing tables get added without touching existing rows. Plus an idempotency test on existing surfacing schema.

## What did NOT change

- AutoTuner clamps `[0.005, 0.05]` and the 0.6 / 0.2 ratio thresholds. Tightening the 0.05 upper clamp is still the natural next step, but its right input is production `surfacing_feedback` rows — which this PR makes *visible*, not the synthetic bench.
- The `_SCHEMA` block. Tables are unchanged; the productionization concern is observability, not schema evolution.

## Test plan

- [x] `uv run ruff check src && uv run ruff format --check src`
- [x] `uv run pytest -m \"not ollama\"` — 2132 passed (+5 new), 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)