### PR TITLE
feat(surfacing): persist AutoTuner min_score adjustments across restarts

### DIFF
--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -82,7 +82,9 @@ class AutoTuner:
     def __init__(self, config: SurfacingConfig, store: FeedbackStore) -> None:
         self._config = config
         self._store = store
-        self._adjustments: dict[str, float] = {}
+        # Resume tunings persisted from a previous process — without this
+        # every restart silently throws away the AutoTuner's view.
+        self._adjustments: dict[str, float] = dict(store.load_adjustments())
 
     def maybe_adjust(self, tool: str) -> float | None:
         """Check feedback ratio and adjust min_score for a tool.
@@ -116,6 +118,7 @@ class AutoTuner:
             new_score = min(current + increment, 0.05)
             if new_score != current:
                 self._adjustments[tool] = new_score
+                self._store.save_adjustment(tool, new_score)
                 logger.info(
                     "AutoTune: %s min_score %.2f → %.2f (not_relevant ratio: %.0f%%)",
                     tool,
@@ -129,6 +132,7 @@ class AutoTuner:
             new_score = max(current - increment, 0.005)
             if new_score != current:
                 self._adjustments[tool] = new_score
+                self._store.save_adjustment(tool, new_score)
                 logger.info(
                     "AutoTune: %s min_score %.2f → %.2f (not_relevant ratio: %.0f%%)",
                     tool,

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -39,6 +39,12 @@ CREATE TABLE IF NOT EXISTS seen_memories (
     seen_count      INTEGER NOT NULL DEFAULT 1
 );
 
+CREATE TABLE IF NOT EXISTS auto_tune_adjustments (
+    tool        TEXT    PRIMARY KEY,
+    min_score   REAL    NOT NULL,
+    updated_at  REAL    NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_feedback_surfacing ON surfacing_feedback(surfacing_id);
 CREATE INDEX IF NOT EXISTS idx_events_tool ON surfacing_events(tool);
 CREATE INDEX IF NOT EXISTS idx_seen_last ON seen_memories(last_seen_at);
@@ -418,6 +424,35 @@ class FeedbackStore:
                 "SELECT COUNT(*) FROM surfacing_feedback WHERE rating = 'not_relevant'"
             ).fetchone()[0]
         return not_relevant / total if total > 0 else 0.0
+
+    # ── AutoTuner persistence ──────────────────────────────────────────
+
+    def load_adjustments(self) -> dict[str, float]:
+        """Return persisted per-tool min_score adjustments.
+
+        Lets ``AutoTuner`` resume after a process restart instead of
+        losing every tuning decision the moment the server bounces.
+        Returns ``{}`` when the store is closed or empty.
+        """
+        if self._db is None:
+            return {}
+        rows = self._db.execute("SELECT tool, min_score FROM auto_tune_adjustments").fetchall()
+        return {tool: score for tool, score in rows}
+
+    def save_adjustment(self, tool: str, min_score: float) -> None:
+        """Upsert one per-tool min_score adjustment."""
+        if self._db is None:
+            return
+        with self._lock:
+            self._db.execute(
+                "INSERT INTO auto_tune_adjustments (tool, min_score, updated_at) "
+                "VALUES (?, ?, ?) "
+                "ON CONFLICT(tool) DO UPDATE SET "
+                "min_score = excluded.min_score, "
+                "updated_at = excluded.updated_at",
+                (tool, min_score, time.time()),
+            )
+            self._db.commit()
 
     def get_per_tool_feedback_counts(self) -> dict[str, int]:
         """Return total feedback rows per tool, ignoring any time window.

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -416,3 +416,33 @@ class TestAutoTuner:
         tuner.maybe_adjust("t")
         score = tuner.get_effective_min_score("t")
         assert score > 0.02
+
+    def test_adjustment_persists_across_restart(self, tmp_path: Path):
+        db_path = tmp_path / "fb.db"
+        store1 = FeedbackStore(db_path)
+        store1.initialize()
+        try:
+            self._seed_feedback(store1, "t", not_relevant=8, helpful=0)
+            tuner1 = self._make_tuner(store1)
+            adjusted = tuner1.maybe_adjust("t")
+            assert adjusted is not None
+        finally:
+            store1.close()
+
+        # Simulate restart: fresh store + tuner on same DB file.
+        store2 = FeedbackStore(db_path)
+        store2.initialize()
+        try:
+            tuner2 = self._make_tuner(store2)
+            # The previously-persisted tuning is visible without any
+            # further feedback being recorded.
+            assert tuner2.adjustments == {"t": adjusted}
+            assert tuner2.get_effective_min_score("t") == adjusted
+        finally:
+            store2.close()
+
+    def test_save_and_load_adjustments_roundtrip(self, feedback_store: FeedbackStore):
+        feedback_store.save_adjustment("tool_a", 0.025)
+        feedback_store.save_adjustment("tool_b", 0.015)
+        feedback_store.save_adjustment("tool_a", 0.030)  # upsert overwrites
+        assert feedback_store.load_adjustments() == {"tool_a": 0.030, "tool_b": 0.015}


### PR DESCRIPTION
## Summary
- AutoTuner's per-tool `_adjustments` lived in-memory only — every server restart silently threw away tunings the tuner had earned from feedback. With the readiness stats shipped in #331, this loss is now visible to operators, which makes it worth fixing.
- Adds an `auto_tune_adjustments(tool PK, min_score, updated_at)` table to the existing feedback DB. `AutoTuner.__init__` rehydrates `_adjustments` via `FeedbackStore.load_adjustments()`; every threshold change calls `FeedbackStore.save_adjustment(tool, new_score)`. No new file, no new connection.
- `stm_surfacing_stats.adjusted_scores` now reflects the tuner's accumulated view across restarts rather than only the current process.

## Test plan
- [x] `uv run pytest tests/test_feedback.py` — 31 passed, including two new tests:
  - `test_adjustment_persists_across_restart` — full round-trip via two `FeedbackStore` lifetimes on one DB file
  - `test_save_and_load_adjustments_roundtrip` — upsert overwrite
- [x] `uv run pytest -m "not ollama"` — 2142 passed, 7 skipped
- [x] `uv run ruff check src tests` + `ruff format --check`
- [ ] Manual: bring the server up, induce an adjustment (or hand-write a row via sqlite3), restart, confirm `stm_surfacing_stats` still shows the tuning under `adjusted_scores`

## Notes for the reviewer
- The schema uses `CREATE TABLE IF NOT EXISTS`, so existing feedback DBs upgrade in place — no migration step needed.
- `AutoTuner` always saves the absolute min_score (not a delta). If an operator later changes `SurfacingConfig.min_score`, persisted tool-specific tunings still take precedence — which preserves the tuner's prior decision, consistent with the pre-existing per-process behavior. Clearing rows in `auto_tune_adjustments` is the explicit reset path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)