### PR TITLE
feat(surfacing): expose bootstrap health

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -2185,6 +2185,60 @@ def _root_cause_message(exc: BaseException) -> str:
     return str(cur) or type(cur).__name__
 
 
+def _surfacing_bootstrap_status() -> dict[str, Any]:
+    """Return surfacing feedback DB readiness without starting the proxy."""
+    try:
+        from memtomem_stm.config import STMConfig
+        from memtomem_stm.surfacing.feedback_store import inspect_feedback_db
+
+        surfacing = STMConfig().surfacing
+        db_status = inspect_feedback_db(surfacing.feedback_db_path)
+        return {
+            "enabled": surfacing.enabled,
+            "feedback_enabled": surfacing.feedback_enabled,
+            "feedback_db": db_status,
+        }
+    except Exception as exc:
+        return {
+            "enabled": None,
+            "feedback_enabled": None,
+            "feedback_db": None,
+            "error": str(exc) or type(exc).__name__,
+        }
+
+
+def _format_surfacing_bootstrap(status: dict[str, Any]) -> list[str]:
+    lines = [_hdr("Surfacing Bootstrap"), "=" * 30]
+    if status.get("error"):
+        lines.append(f"  {_bad('ERROR')} — {status['error']}")
+        return lines
+
+    lines.append(f"  config: {'enabled' if status['enabled'] else 'disabled'}")
+    lines.append(
+        f"  feedback tracking: {'enabled' if status['feedback_enabled'] else 'disabled'}"
+    )
+
+    db = status.get("feedback_db")
+    if not isinstance(db, dict):
+        lines.append("  feedback db: unavailable")
+        return lines
+
+    lines.append(f"  feedback db: {db['path']}")
+    if db.get("error"):
+        lines.append(f"  feedback tables: {_bad('error')} — {db['error']}")
+    elif not db.get("exists"):
+        lines.append("  feedback tables: missing (DB has not been created)")
+    elif db.get("initialized"):
+        lines.append(f"  feedback tables: {_ok('ready')}")
+    else:
+        missing = ", ".join(str(t) for t in db.get("missing_tables", []))
+        lines.append(
+            f"  feedback tables: {_warn('missing')} ({missing}) — "
+            "surfacing has not initialized this DB"
+        )
+    return lines
+
+
 @contextmanager
 def _silenced_mcp_sdk_logs() -> Iterator[None]:
     """Temporarily raise the MCP SDK loggers above ``ERROR`` so probe-time
@@ -2284,21 +2338,37 @@ def health(
 
     data = _load(path)
     servers: dict[str, Any] = data.get("upstream_servers", {})
+    surfacing_status = _surfacing_bootstrap_status()
 
     # JSON output format matches ``status --json`` / ``list --json`` (indent=2,
     # ensure_ascii=False) so scripts piping the three commands through the
     # same formatter don't hit one compact-one-line outlier.
     if not servers:
         if as_json:
-            click.echo(json.dumps({"servers": {}}, indent=2, ensure_ascii=False))
+            click.echo(
+                json.dumps(
+                    {"servers": {}, "surfacing": surfacing_status},
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
         else:
             click.echo("No upstream servers configured.")
+            click.echo("")
+            for line in _format_surfacing_bootstrap(surfacing_status):
+                click.echo(line)
         return
 
     results = asyncio.run(_probe_servers(servers, timeout))
 
     if as_json:
-        click.echo(json.dumps({"servers": results}, indent=2, ensure_ascii=False))
+        click.echo(
+            json.dumps(
+                {"servers": results, "surfacing": surfacing_status},
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
         return
 
     click.echo(_hdr("Upstream Server Health"))
@@ -2320,6 +2390,9 @@ def health(
                     click.echo("    all tool names fit")
         else:
             click.echo(f"  {name}: {_bad('DISCONNECTED')} — {info['error']}")
+    click.echo("")
+    for line in _format_surfacing_bootstrap(surfacing_status):
+        click.echo(line)
 
 
 # `mms project ...` — RFC §7.1, lives in src/memtomem_stm/cli/mms_project.py

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -33,6 +33,7 @@ from memtomem_stm.utils.fileio import atomic_write_text
 _PREFIX_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
 
 _DEFAULT_CONFIG = Path("~/.memtomem/stm_proxy.json")
+logger = logging.getLogger(__name__)
 
 # `_DANGEROUS_ENV_KEYS`, `_BLOCKED_IMPORT_NAMES`, `_desktop_config_path`,
 # `_read_json_safely`, `_is_self_reference` — re-imported from
@@ -2199,6 +2200,7 @@ def _surfacing_bootstrap_status() -> dict[str, Any]:
             "feedback_db": db_status,
         }
     except Exception as exc:
+        logger.debug("Surfacing bootstrap status inspection failed", exc_info=True)
         return {
             "enabled": None,
             "feedback_enabled": None,
@@ -2214,9 +2216,7 @@ def _format_surfacing_bootstrap(status: dict[str, Any]) -> list[str]:
         return lines
 
     lines.append(f"  config: {'enabled' if status['enabled'] else 'disabled'}")
-    lines.append(
-        f"  feedback tracking: {'enabled' if status['feedback_enabled'] else 'disabled'}"
-    )
+    lines.append(f"  feedback tracking: {'enabled' if status['feedback_enabled'] else 'disabled'}")
 
     db = status.get("feedback_db")
     if not isinstance(db, dict):

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -170,8 +170,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
                         feedback_tables = (
                             "ready"
                             if db_status["initialized"]
-                            else "missing "
-                            + ", ".join(str(t) for t in db_status["missing_tables"])
+                            else "missing " + ", ".join(str(t) for t in db_status["missing_tables"])
                         )
                     logger.info(
                         "Surfacing path wired: engine=enabled feedback=%s "

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -162,6 +162,24 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
                         token_tracker=tracker,
                         observability=SurfacingObservability(),
                     )
+                    feedback_db = "disabled"
+                    feedback_tables = "disabled"
+                    if feedback_tracker is not None:
+                        db_status = feedback_tracker.bootstrap_status()
+                        feedback_db = str(db_status["path"])
+                        feedback_tables = (
+                            "ready"
+                            if db_status["initialized"]
+                            else "missing "
+                            + ", ".join(str(t) for t in db_status["missing_tables"])
+                        )
+                    logger.info(
+                        "Surfacing path wired: engine=enabled feedback=%s "
+                        "feedback_db=%s feedback_tables=%s",
+                        "enabled" if feedback_tracker is not None else "disabled",
+                        feedback_db,
+                        feedback_tables,
+                    )
 
             # Response cache
             if config.proxy.cache.enabled:

--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 
 from memtomem_stm.surfacing.config import SurfacingConfig
-from memtomem_stm.surfacing.feedback_store import FeedbackStore
+from memtomem_stm.surfacing.feedback_store import FeedbackStore, inspect_feedback_db
 
 logger = logging.getLogger(__name__)
 
@@ -19,12 +19,26 @@ class FeedbackTracker:
     def __init__(self, config: SurfacingConfig, db_path: Path | None = None) -> None:
         self._config = config
         resolved = db_path if db_path is not None else config.feedback_db_path.expanduser()
+        before = inspect_feedback_db(resolved)
         self._store = FeedbackStore(resolved)
         self._store.initialize()
+        after = inspect_feedback_db(resolved)
+        tables = "ready"
+        if after["missing_tables"]:
+            tables = "missing " + ", ".join(str(t) for t in after["missing_tables"])
+        logger.info(
+            "Surfacing feedback store initialized at %s (tables=%s, created_schema=%s)",
+            after["path"],
+            tables,
+            not before["initialized"] and after["initialized"],
+        )
 
     @property
     def store(self) -> FeedbackStore:
         return self._store
+
+    def bootstrap_status(self) -> dict[str, object]:
+        return inspect_feedback_db(self._store.db_path)
 
     def close(self) -> None:
         self._store.close()

--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -22,15 +22,11 @@ class FeedbackTracker:
         before = inspect_feedback_db(resolved)
         self._store = FeedbackStore(resolved)
         self._store.initialize()
-        after = inspect_feedback_db(resolved)
-        tables = "ready"
-        if after["missing_tables"]:
-            tables = "missing " + ", ".join(str(t) for t in after["missing_tables"])
         logger.info(
             "Surfacing feedback store initialized at %s (tables=%s, created_schema=%s)",
-            after["path"],
-            tables,
-            not before["initialized"] and after["initialized"],
+            self._store.db_path.expanduser().resolve(),
+            "ready",
+            not before["initialized"],
         )
 
     @property

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import sqlite3
 import threading
 import time
@@ -50,7 +51,9 @@ CREATE INDEX IF NOT EXISTS idx_events_tool ON surfacing_events(tool);
 CREATE INDEX IF NOT EXISTS idx_seen_last ON seen_memories(last_seen_at);
 """
 
-_REQUIRED_TABLES = ("surfacing_events", "surfacing_feedback", "seen_memories")
+_REQUIRED_TABLES = tuple(
+    re.findall(r"CREATE TABLE IF NOT EXISTS\s+([A-Za-z_][A-Za-z0-9_]*)", _SCHEMA)
+)
 
 
 def inspect_feedback_db(db_path: Path) -> dict[str, object]:
@@ -67,14 +70,15 @@ def inspect_feedback_db(db_path: Path) -> dict[str, object]:
         return status
 
     try:
-        db = sqlite3.connect(f"file:{resolved}?mode=ro", uri=True)
+        db = sqlite3.connect(f"{resolved.as_uri()}?mode=ro", uri=True)
     except sqlite3.Error as exc:
         status["error"] = str(exc)
         return status
 
     try:
+        placeholders = ", ".join("?" for _ in _REQUIRED_TABLES)
         rows = db.execute(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?)",
+            f"SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ({placeholders})",
             _REQUIRED_TABLES,
         ).fetchall()
     except sqlite3.Error as exc:

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -44,6 +44,45 @@ CREATE INDEX IF NOT EXISTS idx_events_tool ON surfacing_events(tool);
 CREATE INDEX IF NOT EXISTS idx_seen_last ON seen_memories(last_seen_at);
 """
 
+_REQUIRED_TABLES = ("surfacing_events", "surfacing_feedback", "seen_memories")
+
+
+def inspect_feedback_db(db_path: Path) -> dict[str, object]:
+    """Inspect surfacing feedback DB schema without creating or migrating it."""
+    resolved = db_path.expanduser().resolve()
+    status: dict[str, object] = {
+        "path": str(resolved),
+        "exists": resolved.exists(),
+        "initialized": False,
+        "missing_tables": list(_REQUIRED_TABLES),
+        "error": None,
+    }
+    if not resolved.exists():
+        return status
+
+    try:
+        db = sqlite3.connect(f"file:{resolved}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        status["error"] = str(exc)
+        return status
+
+    try:
+        rows = db.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?, ?)",
+            _REQUIRED_TABLES,
+        ).fetchall()
+    except sqlite3.Error as exc:
+        status["error"] = str(exc)
+        return status
+    finally:
+        db.close()
+
+    present = {row[0] for row in rows}
+    missing = [name for name in _REQUIRED_TABLES if name not in present]
+    status["missing_tables"] = missing
+    status["initialized"] = not missing
+    return status
+
 
 class FeedbackStore:
     """SQLite store for surfacing events and feedback ratings."""
@@ -52,6 +91,10 @@ class FeedbackStore:
         self._db_path = db_path
         self._db: sqlite3.Connection | None = None
         self._lock = threading.Lock()
+
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
 
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3723,19 +3723,43 @@ class TestFullFlow:
 
 
 class TestHealth:
+    @pytest.fixture(autouse=True)
+    def _isolated_home(self, monkeypatch, tmp_path):
+        set_home(monkeypatch, tmp_path / "home")
+
     def test_health_no_servers(self, runner, config):
         """Empty config → friendly message, no crash."""
         config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
         result = runner.invoke(cli, ["health", *_cfg_args(config)])
         assert result.exit_code == 0
         assert "No upstream servers configured" in result.output
+        assert "Surfacing Bootstrap" in result.output
+        assert "feedback tables: missing" in result.output
 
     def test_health_json_no_servers(self, runner, config):
         config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
         result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data == {"servers": {}}
+        assert data["servers"] == {}
+        assert data["surfacing"]["enabled"] is True
+        assert data["surfacing"]["feedback_enabled"] is True
+        assert data["surfacing"]["feedback_db"]["exists"] is False
+        assert data["surfacing"]["feedback_db"]["initialized"] is False
+
+    def test_health_flags_existing_uninitialized_surfacing_db(
+        self, runner, config, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "stm_feedback.db"
+        db_path.touch()
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH", str(db_path))
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+
+        result = runner.invoke(cli, ["health", *_cfg_args(config)])
+
+        assert result.exit_code == 0
+        assert f"feedback db: {db_path.resolve()}" in result.output
+        assert "surfacing has not initialized this DB" in result.output
 
     def test_health_missing_config(self, runner, config):
         """Missing file → distinguish from empty-config so a user pointing
@@ -3799,6 +3823,7 @@ class TestHealth:
         data = json.loads(result.output)
         assert data["servers"]["bad"]["connected"] is False
         assert data["servers"]["bad"]["error"]
+        assert "surfacing" in data
 
     def test_health_error_unwraps_taskgroup_wrapper(self, runner, config):
         """Probe failures inside an anyio TaskGroup are wrapped as
@@ -3908,7 +3933,7 @@ class TestHealth:
         result = runner.invoke(cli, ["health", *_cfg_args(config)])
         assert result.exit_code == 0
         assert "connected" in result.output
-        assert "overflow" not in result.output.lower()
+        assert "overflow:" not in result.output.lower()
 
         # With --names: the offending tool is named.
         result = runner.invoke(cli, ["health", "--names", *_cfg_args(config)])

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3761,6 +3761,48 @@ class TestHealth:
         assert f"feedback db: {db_path.resolve()}" in result.output
         assert "surfacing has not initialized this DB" in result.output
 
+    def test_health_json_flags_existing_uninitialized_surfacing_db(
+        self, runner, config, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "stm_feedback.db"
+        db_path.touch()
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH", str(db_path))
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+
+        result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        db = data["surfacing"]["feedback_db"]
+        assert db["path"] == str(db_path.resolve())
+        assert db["exists"] is True
+        assert db["initialized"] is False
+        assert "surfacing_events" in db["missing_tables"]
+
+    def test_health_surfaces_surfacing_bootstrap_errors(self, runner, config, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+        monkeypatch.setattr(
+            proxy_mod,
+            "_surfacing_bootstrap_status",
+            lambda: {
+                "enabled": None,
+                "feedback_enabled": None,
+                "feedback_db": None,
+                "error": "bad config",
+            },
+        )
+
+        text = runner.invoke(cli, ["health", *_cfg_args(config)])
+        assert text.exit_code == 0
+        assert "ERROR" in text.output
+        assert "bad config" in text.output
+
+        as_json = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
+        assert as_json.exit_code == 0
+        assert json.loads(as_json.output)["surfacing"]["error"] == "bad config"
+
     def test_health_missing_config(self, runner, config):
         """Missing file → distinguish from empty-config so a user pointing
         at the wrong path gets a clear hint instead of a silent no-op

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from memtomem_stm.proxy.compression_feedback_store import CompressionFeedbackStore
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.feedback import AutoTuner, FeedbackTracker
-from memtomem_stm.surfacing.feedback_store import FeedbackStore, inspect_feedback_db
+from memtomem_stm.surfacing.feedback_store import (
+    FeedbackStore,
+    _REQUIRED_TABLES,
+    inspect_feedback_db,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -22,11 +26,7 @@ class TestFeedbackStore:
 
         assert status["exists"] is False
         assert status["initialized"] is False
-        assert status["missing_tables"] == [
-            "surfacing_events",
-            "surfacing_feedback",
-            "seen_memories",
-        ]
+        assert status["missing_tables"] == list(_REQUIRED_TABLES)
 
     def test_inspect_feedback_db_existing_without_surfacing_tables(self, tmp_path: Path):
         db_path = tmp_path / "stm_feedback.db"
@@ -350,6 +350,17 @@ class TestFeedbackStoreCoexistence:
 
 
 class TestFeedbackTracker:
+    def test_bootstrap_status(self, tmp_path: Path):
+        tracker = FeedbackTracker(SurfacingConfig(), db_path=tmp_path / "fb.db")
+        try:
+            status = tracker.bootstrap_status()
+        finally:
+            tracker.close()
+
+        assert status["exists"] is True
+        assert status["initialized"] is True
+        assert status["missing_tables"] == []
+
     def test_invalid_rating_rejected(self, tmp_path: Path):
         tracker = FeedbackTracker(SurfacingConfig(), db_path=tmp_path / "fb.db")
         try:

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from memtomem_stm.proxy.compression_feedback_store import CompressionFeedbackStore
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.feedback import AutoTuner, FeedbackTracker
-from memtomem_stm.surfacing.feedback_store import FeedbackStore
+from memtomem_stm.surfacing.feedback_store import FeedbackStore, inspect_feedback_db
 
 
 # ---------------------------------------------------------------------------
@@ -17,6 +17,40 @@ from memtomem_stm.surfacing.feedback_store import FeedbackStore
 
 
 class TestFeedbackStore:
+    def test_inspect_feedback_db_missing(self, tmp_path: Path):
+        status = inspect_feedback_db(tmp_path / "missing.db")
+
+        assert status["exists"] is False
+        assert status["initialized"] is False
+        assert status["missing_tables"] == [
+            "surfacing_events",
+            "surfacing_feedback",
+            "seen_memories",
+        ]
+
+    def test_inspect_feedback_db_existing_without_surfacing_tables(self, tmp_path: Path):
+        db_path = tmp_path / "stm_feedback.db"
+        db_path.touch()
+
+        status = inspect_feedback_db(db_path)
+
+        assert status["exists"] is True
+        assert status["initialized"] is False
+        assert "surfacing_events" in status["missing_tables"]
+
+    def test_inspect_feedback_db_initialized(self, tmp_path: Path):
+        db_path = tmp_path / "stm_feedback.db"
+        store = FeedbackStore(db_path)
+        store.initialize()
+        try:
+            status = inspect_feedback_db(db_path)
+        finally:
+            store.close()
+
+        assert status["exists"] is True
+        assert status["initialized"] is True
+        assert status["missing_tables"] == []
+
     def test_record_and_retrieve_surfacing(self, feedback_store: FeedbackStore):
         feedback_store.record_surfacing(
             "surf1", "server", "tool", "query", ["mem1", "mem2"], [0.9, 0.8]


### PR DESCRIPTION
## Summary
- add a read-only surfacing feedback DB schema inspector
- show surfacing bootstrap readiness in `mms health` text and JSON output
- log feedback-store initialization and surfacing path wiring at startup

## Tests
- `uv run pytest tests/test_feedback.py tests/cli/test_proxy_cli.py::TestHealth tests/test_server_tools.py::TestLifespan`
- `uv run ruff check src/memtomem_stm/surfacing/feedback_store.py src/memtomem_stm/surfacing/feedback.py src/memtomem_stm/server.py src/memtomem_stm/cli/proxy.py tests/test_feedback.py tests/cli/test_proxy_cli.py`
- `uv run mypy src/memtomem_stm/surfacing/feedback_store.py src/memtomem_stm/surfacing/feedback.py src/memtomem_stm/server.py src/memtomem_stm/cli/proxy.py`
- `git diff --check`