### PR TITLE
test(surfacing): pin auto_tune_adjustments in bootstrap readiness

### DIFF
--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -51,6 +51,30 @@ class TestFeedbackStore:
         assert status["initialized"] is True
         assert status["missing_tables"] == []
 
+    def test_inspect_feedback_db_pre_auto_tune_schema(self, tmp_path: Path):
+        # Regression: pre-#332 DBs with only the three original tables must
+        # report not-initialized so AutoTuner SQL errors don't follow a
+        # "ready" signal from the inspector.
+        import sqlite3
+
+        db_path = tmp_path / "legacy.db"
+        db = sqlite3.connect(str(db_path))
+        try:
+            db.executescript(
+                "CREATE TABLE surfacing_events (id TEXT PRIMARY KEY);"
+                "CREATE TABLE surfacing_feedback (id INTEGER PRIMARY KEY);"
+                "CREATE TABLE seen_memories (memory_id TEXT PRIMARY KEY);"
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        status = inspect_feedback_db(db_path)
+
+        assert status["exists"] is True
+        assert status["initialized"] is False
+        assert status["missing_tables"] == ["auto_tune_adjustments"]
+
     def test_record_and_retrieve_surfacing(self, feedback_store: FeedbackStore):
         feedback_store.record_surfacing(
             "surf1", "server", "tool", "query", ["mem1", "mem2"], [0.9, 0.8]


### PR DESCRIPTION
## Summary
- Regression test pinning the contract that `inspect_feedback_db()`
  treats `auto_tune_adjustments` as a required table.
- Closes the P2 reviewer comment on #333: an older DB with only the
  pre-#332 three-table schema must report `initialized=false` so
  `AutoTuner.load_adjustments` / `save_adjustment` can't follow a
  false-positive readiness signal.

## Why test-only

The hardening commit folded into the #333 squash already derives
`_REQUIRED_TABLES` from `_SCHEMA` via regex, so live behavior is
correct (`_REQUIRED_TABLES` resolves to all four tables at import
time). What was missing is a test that pins the contract — without
it, a refactor that re-introduces a hand-maintained tuple would
silently regress the same bug the reviewer flagged.

## Test plan
- [ ] `uv run pytest tests/test_feedback.py -q` passes (new test
      `test_inspect_feedback_db_pre_auto_tune_schema` exercises a
      legacy three-table DB).
- [ ] `uv run ruff check src && uv run ruff format --check src`.