### PR TITLE
feat(surfacing): surface bootstrap readiness via stm_proxy_health

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -558,9 +558,12 @@ async def stm_proxy_health(
     app = _get_ctx(ctx)
     pm = app.proxy_manager
 
+    bootstrap_lines = _surfacing_bootstrap_lines(app)
+
     health = pm.get_upstream_health()
     if not health:
-        return "No upstream servers configured."
+        head = "No upstream servers configured."
+        return "\n".join([head, *bootstrap_lines]) if bootstrap_lines else head
 
     lines = ["Upstream Server Health", "====================="]
     for name, info in health.items():
@@ -573,7 +576,41 @@ async def stm_proxy_health(
         cb_state = "open (failing)" if cb.is_open else "closed (healthy)"
         lines.append(f"\nSurfacing circuit breaker: {cb_state}")
 
+    lines.extend(bootstrap_lines)
     return "\n".join(lines)
+
+
+def _surfacing_bootstrap_lines(app: STMContext) -> list[str]:
+    # Mirrors mms health's bootstrap section: lets agents see surfacing
+    # readiness via MCP without shelling out to the CLI.
+    surfacing_cfg = app.config.surfacing
+    if not surfacing_cfg.enabled:
+        return []
+
+    lines = ["", "Surfacing Bootstrap", "==================="]
+    tracker = app.feedback_tracker
+    if tracker is None:
+        if surfacing_cfg.feedback_enabled:
+            lines.append("  feedback tracking: enabled in config — runtime init failed")
+        else:
+            lines.append("  feedback tracking: disabled")
+        return lines
+
+    db = tracker.bootstrap_status()
+    lines.append("  feedback tracking: enabled")
+    lines.append(f"  feedback db: {db['path']}")
+    if db.get("error"):
+        lines.append(f"  feedback tables: error — {db['error']}")
+    elif not db.get("exists"):
+        lines.append("  feedback tables: missing (DB has not been created)")
+    elif db.get("initialized"):
+        lines.append("  feedback tables: ready")
+    else:
+        missing = ", ".join(str(t) for t in db.get("missing_tables", []))
+        lines.append(
+            f"  feedback tables: missing ({missing}) — surfacing has not initialized this DB"
+        )
+    return lines
 
 
 # ---------------------------------------------------------------------------

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -588,6 +588,13 @@ def _surfacing_bootstrap_lines(app: STMContext) -> list[str]:
         return []
 
     lines = ["", "Surfacing Bootstrap", "==================="]
+    # app_lifespan skips the entire surfacing init block when
+    # proxy.enabled=false (the default control-only mode), so a None
+    # tracker there is expected — not a runtime failure.
+    if not app.config.proxy.enabled:
+        lines.append("  feedback tracking: inactive (proxy disabled)")
+        return lines
+
     tracker = app.feedback_tracker
     if tracker is None:
         if surfacing_cfg.feedback_enabled:

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -233,6 +233,66 @@ class TestHealth:
         result = await stm_proxy_health(ctx=ctx)
         assert "srv: connected (2 tools)" in result
 
+    async def test_bootstrap_block_tracker_ready(self):
+        """Bootstrap section reports ready when tracker.bootstrap_status() says so."""
+        tracker = MagicMock()
+        tracker.bootstrap_status.return_value = {
+            "path": "/tmp/stm_feedback.db",
+            "exists": True,
+            "initialized": True,
+            "missing_tables": [],
+            "error": None,
+        }
+        ctx = _make_ctx(feedback_tracker=tracker)
+        result = await stm_proxy_health(ctx=ctx)
+        assert "Surfacing Bootstrap" in result
+        assert "feedback tracking: enabled" in result
+        assert "feedback db: /tmp/stm_feedback.db" in result
+        assert "feedback tables: ready" in result
+
+    async def test_bootstrap_block_tracker_missing_tables(self):
+        """Bootstrap section lists missing tables when the inspector flags them."""
+        tracker = MagicMock()
+        tracker.bootstrap_status.return_value = {
+            "path": "/tmp/stm_feedback.db",
+            "exists": True,
+            "initialized": False,
+            "missing_tables": ["auto_tune_adjustments"],
+            "error": None,
+        }
+        ctx = _make_ctx(feedback_tracker=tracker)
+        result = await stm_proxy_health(ctx=ctx)
+        assert "feedback tables: missing (auto_tune_adjustments)" in result
+
+    async def test_bootstrap_block_init_failed(self):
+        """When feedback_enabled but tracker is None, surface the runtime-init failure."""
+        ctx = _make_ctx(feedback_tracker=None)
+        # Default STMConfig has surfacing.enabled=True and feedback_enabled=True,
+        # so a None tracker means the lifespan init path failed.
+        result = await stm_proxy_health(ctx=ctx)
+        assert "Surfacing Bootstrap" in result
+        assert "runtime init failed" in result
+
+    async def test_bootstrap_block_absent_when_surfacing_disabled(self):
+        """No bootstrap section when surfacing is config-disabled."""
+        cfg = STMConfig()
+        cfg.surfacing.enabled = False
+        tracker_handle = TokenTracker()
+        proxy_cfg = ProxyConfig(config_path="/tmp/p.json", upstream_servers={})
+        pm = ProxyManager(proxy_cfg, tracker_handle)
+        app = STMContext(
+            config=cfg,
+            proxy_manager=pm,
+            tracker=tracker_handle,
+            surfacing_engine=None,
+            feedback_tracker=None,
+            compression_feedback_tracker=None,
+            progressive_reads_tracker=None,
+        )
+        ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
+        result = await stm_proxy_health(ctx=ctx)
+        assert "Surfacing Bootstrap" not in result
+
 
 # ── stm_surfacing_feedback ───────────────────────────────────────────────
 

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -40,6 +40,7 @@ def _make_ctx(
     feedback_tracker: object | None = None,
     compression_feedback_tracker: object | None = None,
     progressive_reads_tracker: object | None = None,
+    config: STMConfig | None = None,
 ) -> SimpleNamespace:
     """Build a fake CtxType that _get_ctx() can unwrap.
 
@@ -51,9 +52,11 @@ def _make_ctx(
     if proxy_manager is None:
         cfg = ProxyConfig(config_path="/tmp/proxy.json", upstream_servers={})
         proxy_manager = ProxyManager(cfg, tracker)
+    if config is None:
+        config = STMConfig()
 
     app = STMContext(
-        config=STMConfig(),
+        config=config,
         proxy_manager=proxy_manager,
         tracker=tracker,
         surfacing_engine=surfacing_engine,
@@ -233,6 +236,12 @@ class TestHealth:
         result = await stm_proxy_health(ctx=ctx)
         assert "srv: connected (2 tools)" in result
 
+    @staticmethod
+    def _proxy_enabled_config() -> STMConfig:
+        cfg = STMConfig()
+        cfg.proxy.enabled = True
+        return cfg
+
     async def test_bootstrap_block_tracker_ready(self):
         """Bootstrap section reports ready when tracker.bootstrap_status() says so."""
         tracker = MagicMock()
@@ -243,7 +252,7 @@ class TestHealth:
             "missing_tables": [],
             "error": None,
         }
-        ctx = _make_ctx(feedback_tracker=tracker)
+        ctx = _make_ctx(feedback_tracker=tracker, config=self._proxy_enabled_config())
         result = await stm_proxy_health(ctx=ctx)
         assert "Surfacing Bootstrap" in result
         assert "feedback tracking: enabled" in result
@@ -260,36 +269,33 @@ class TestHealth:
             "missing_tables": ["auto_tune_adjustments"],
             "error": None,
         }
-        ctx = _make_ctx(feedback_tracker=tracker)
+        ctx = _make_ctx(feedback_tracker=tracker, config=self._proxy_enabled_config())
         result = await stm_proxy_health(ctx=ctx)
         assert "feedback tables: missing (auto_tune_adjustments)" in result
 
     async def test_bootstrap_block_init_failed(self):
-        """When feedback_enabled but tracker is None, surface the runtime-init failure."""
-        ctx = _make_ctx(feedback_tracker=None)
-        # Default STMConfig has surfacing.enabled=True and feedback_enabled=True,
-        # so a None tracker means the lifespan init path failed.
+        """When proxy is up + feedback_enabled but tracker is None, surface runtime-init failure."""
+        ctx = _make_ctx(feedback_tracker=None, config=self._proxy_enabled_config())
         result = await stm_proxy_health(ctx=ctx)
         assert "Surfacing Bootstrap" in result
         assert "runtime init failed" in result
+
+    async def test_bootstrap_block_proxy_disabled(self):
+        """When proxy.enabled=false the lifespan skips surfacing init entirely —
+        a None tracker is expected, not a runtime failure. Report it as such.
+        """
+        # Default STMConfig has proxy.enabled=False, so _make_ctx() suffices.
+        ctx = _make_ctx(feedback_tracker=None)
+        result = await stm_proxy_health(ctx=ctx)
+        assert "Surfacing Bootstrap" in result
+        assert "feedback tracking: inactive (proxy disabled)" in result
+        assert "runtime init failed" not in result
 
     async def test_bootstrap_block_absent_when_surfacing_disabled(self):
         """No bootstrap section when surfacing is config-disabled."""
         cfg = STMConfig()
         cfg.surfacing.enabled = False
-        tracker_handle = TokenTracker()
-        proxy_cfg = ProxyConfig(config_path="/tmp/p.json", upstream_servers={})
-        pm = ProxyManager(proxy_cfg, tracker_handle)
-        app = STMContext(
-            config=cfg,
-            proxy_manager=pm,
-            tracker=tracker_handle,
-            surfacing_engine=None,
-            feedback_tracker=None,
-            compression_feedback_tracker=None,
-            progressive_reads_tracker=None,
-        )
-        ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
+        ctx = _make_ctx(config=cfg)
         result = await stm_proxy_health(ctx=ctx)
         assert "Surfacing Bootstrap" not in result
 


### PR DESCRIPTION
Closes #334 (first half — MCP-tool surfaces).

## Summary

- Extend `stm_proxy_health` to include a Surfacing Bootstrap section
  matching what `mms health` (CLI) emits since #333. Agents inspecting
  the proxy via MCP can now tell whether feedback tracking is wired,
  where the DB lives, and whether its tables are ready — without
  shelling out to the CLI.
- Reuse `FeedbackTracker.bootstrap_status()` so the inspection logic
  has one home in `surfacing/feedback_store.py` (also exercises the
  `auto_tune_adjustments` regression coverage pinned in #335).

## Out of scope (left for a follow-up)

- The original #334 also called for `stm_surfacing_stats` to short-
  circuit with a "DB not initialized" hint. Re-reading the lifespan
  path (`server.py:148-156`), `FeedbackTracker.__init__` failures are
  already caught and set `feedback_tracker=None`, so the existing
  "not enabled" branch already covers the bad-DB case — there is no
  raw SQL error path to short-circuit. Punting that scope rather than
  adding a message tweak that doesn't fix a real failure.

## Test plan

- [ ] `uv run pytest tests/test_server_tools.py::TestHealth -q` — six
      cases covering: no servers, with servers, tracker ready, tracker
      missing tables, tracker None with feedback_enabled
      (\"runtime init failed\"), surfacing disabled (no block).
- [ ] `uv run pytest -m "not ollama"` — full suite.
- [ ] `uv run ruff check src && uv run ruff format --check src`.
- [ ] `uv run mypy src/memtomem_stm/server.py` — advisory, passes.