### PR TITLE
feat(surfacing): type LTM adapter outcomes for distinct skip labels

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -492,13 +492,31 @@ class SurfacingEngine:
         search_kwargs: dict[str, Any] = {}
         if ctx_win:
             search_kwargs["context_window"] = ctx_win
-        results, hints = await self._mcp_adapter.search(
+        results, hints, outcome = await self._mcp_adapter.search(
             query=query,
             top_k=max_results * 2,
             namespace=namespace,
             trace_id=trace_id,
             **search_kwargs,
         )
+
+        # #295: branch on the adapter outcome before doing any further work
+        # so the operator-facing skip label distinguishes "LTM unavailable"
+        # (``no_session``/``transport_error``) from "LTM call raised"
+        # (``call_error``) from "core returned no text" (``empty_content``).
+        # ``ok`` and ``empty_results`` both fall through to the existing
+        # min_score / dedup / ``no_results_score`` path so that operators
+        # tuning min_score keep seeing the same signal for the genuine
+        # empty-namespace case.
+        if outcome in ("no_session", "transport_error"):
+            self._observability.record_skip(tool, "ltm_unavailable")
+            return response_text
+        if outcome == "call_error":
+            self._observability.record_skip(tool, "ltm_call_failed")
+            return response_text
+        if outcome == "empty_content":
+            self._observability.record_skip(tool, "ltm_parse_empty")
+            return response_text
 
         # Parent trust-UX hints (parent PR #231): log at INFO even when results
         # are empty or get filtered out below, since an operator may want to

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -10,7 +10,7 @@ import re
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from mcp import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
@@ -19,6 +19,21 @@ from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.utils.numeric import safe_float
 
 logger = logging.getLogger(__name__)
+
+# #295: outcome typing for ``McpClientSearchAdapter.search`` — five
+# different failure modes used to collapse to ``([], [])`` and looked
+# identical to a healthy empty namespace at the engine's observability
+# layer. The engine consumes this enum to record distinct skip labels
+# (``ltm_unavailable`` / ``ltm_call_failed`` / ``ltm_parse_empty``) so
+# operators can tell why surfacing is not firing.
+SearchOutcome = Literal[
+    "ok",
+    "no_session",
+    "transport_error",
+    "call_error",
+    "empty_content",
+    "empty_results",
+]
 
 
 @dataclass
@@ -324,17 +339,22 @@ class McpClientSearchAdapter:
         *,
         trace_id: str | None = None,
         **kwargs: Any,
-    ) -> tuple[list[RemoteSearchResult], list[str]]:
+    ) -> tuple[list[RemoteSearchResult], list[str], SearchOutcome]:
         """Call mem_search on the remote server and parse results.
 
-        Returns ``(results, hints)``. ``hints`` carries parent-side
+        Returns ``(results, hints, outcome)``. ``hints`` carries parent-side
         trust-UX annotations from the structured format (parent PR #231)
         and is always ``[]`` for the compact format or when the call
-        fails. Callers that do not care about hints should still accept
-        the tuple to stay compatible with mypy's inferred signature.
+        fails. ``outcome`` lets the engine distinguish "LTM unavailable"
+        from "LTM call failed" from "parser hit an empty response" from
+        "call OK, zero hits" (#295) — every failure path used to collapse
+        to ``([], [])`` and looked identical to a healthy empty
+        namespace. Callers that don't care about hints/outcome should
+        still accept the tuple to stay compatible with mypy's inferred
+        signature.
         """
         if not await self._heal_if_needed():
-            return [], []
+            return [], [], "no_session"
 
         args: dict[str, Any] = {"query": query}
         if top_k is not None:
@@ -359,11 +379,8 @@ class McpClientSearchAdapter:
                 result = await self._session.call_tool("mem_search", args)  # type: ignore[union-attr]
             except Exception as retry_exc:
                 # Upstream LTM is unreachable; surfacing will return empty.
-                # Bumped debug -> warning so operators can see the symptom at
-                # default log level (P2 partial fix; full propagation via a
-                # distinct error class is a follow-up).
                 logger.warning("MCP mem_search failed after reconnect: %s", retry_exc)
-                return [], []
+                return [], [], "transport_error"
         except asyncio.CancelledError:
             # #290: outer wait_for cancelled us mid-RPC. Mark for lazy
             # reconnect on the next call (the session's read/write streams
@@ -373,17 +390,21 @@ class McpClientSearchAdapter:
             raise
         except Exception as exc:
             logger.warning("MCP mem_search failed: %s", exc)
-            return [], []
+            return [], [], "call_error"
 
         # Parse text response into results
         # ``result.content or []`` tolerates spec-noncompliant upstreams that
         # return ``None`` instead of an empty list (mirrors PR #114 in proxy).
         text_parts = [c.text or "" for c in (result.content or []) if c.type == "text"]
         if not text_parts:
-            return [], []
+            return [], [], "empty_content"
 
         text = "\n".join(text_parts)
-        return self._parser.parse(text, max_content_chars=self._config.result_content_max_chars)
+        results, hints = self._parser.parse(
+            text, max_content_chars=self._config.result_content_max_chars
+        )
+        outcome: SearchOutcome = "ok" if results else "empty_results"
+        return results, hints, outcome
 
     async def increment_access(self, chunk_ids: list[str], *, trace_id: str | None = None) -> None:
         """Boost the access_count of the given chunks via mem_do(increment_access).

--- a/src/memtomem_stm/surfacing/observability.py
+++ b/src/memtomem_stm/surfacing/observability.py
@@ -43,6 +43,13 @@ SkipReason = Literal[
     "no_results_dedup",
     "no_results_invalidated",
     "no_results_empty_cache",
+    # #295: LTM adapter outcome typing — distinguish unreachable from
+    # call_failed from parse_empty so operators can tell "session never
+    # opened / transport down" from "core raised mid-call" from "core
+    # returned no text content" without grepping logs.
+    "ltm_unavailable",
+    "ltm_call_failed",
+    "ltm_parse_empty",
 ]
 
 Outcome = Literal[

--- a/tests/test_bench_pipeline.py
+++ b/tests/test_bench_pipeline.py
@@ -196,7 +196,9 @@ def _make_surfacing_config(**overrides) -> SurfacingConfig:
 
 def _make_mcp_adapter(results=None):
     adapter = AsyncMock()
-    adapter.search = AsyncMock(return_value=(results or [], []))
+    res = results or []
+    outcome = "ok" if res else "empty_results"
+    adapter.search = AsyncMock(return_value=(res, [], outcome))
     return adapter
 
 

--- a/tests/test_core_format_contract.py
+++ b/tests/test_core_format_contract.py
@@ -478,10 +478,13 @@ class TestAdapterHintsFlow:
         mock_session.call_tool = AsyncMock(return_value=mock_result)
         adapter._session = mock_session
 
-        results, hints = await adapter.search("q")
+        results, hints, outcome = await adapter.search("q")
         assert results == []
         assert len(hints) == 1
         assert "No results match your filters" in hints[0]
+        # Parser returned no result rows from a non-empty text response —
+        # call OK + parsed empty list is ``empty_results`` (#295).
+        assert outcome == "empty_results"
 
     @pytest.mark.asyncio
     async def test_search_returns_empty_hints_for_compact_format(self):
@@ -499,9 +502,10 @@ class TestAdapterHintsFlow:
         mock_session.call_tool = AsyncMock(return_value=mock_result)
         adapter._session = mock_session
 
-        results, hints = await adapter.search("q")
+        results, hints, outcome = await adapter.search("q")
         assert len(results) == 2
         assert hints == []
+        assert outcome == "ok"
 
     @pytest.mark.asyncio
     async def test_search_returns_empty_hints_on_transport_error(self):
@@ -516,9 +520,10 @@ class TestAdapterHintsFlow:
         adapter._session = mock_session
         adapter.start = AsyncMock(side_effect=_asyncio.TimeoutError())  # type: ignore[method-assign]
 
-        results, hints = await adapter.search("q")
+        results, hints, outcome = await adapter.search("q")
         assert results == []
         assert hints == []
+        assert outcome == "transport_error"
 
 
 class TestOutputFormatForwarding:

--- a/tests/test_cross_session_dedup.py
+++ b/tests/test_cross_session_dedup.py
@@ -65,7 +65,9 @@ def _make_config(**overrides) -> SurfacingConfig:
 
 def _make_mcp_adapter(results=None):
     adapter = AsyncMock()
-    adapter.search = AsyncMock(return_value=(results or [], []))
+    res = results or []
+    outcome = "ok" if res else "empty_results"
+    adapter.search = AsyncMock(return_value=(res, [], outcome))
     return adapter
 
 

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -68,7 +68,7 @@ class TestReconnectRetrySuccess:
         # hits the same mock.
         adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
 
-        results, hints = await adapter.search("anything")
+        results, hints, outcome = await adapter.search("anything")
 
         adapter._reconnect.assert_awaited_once()
         assert mock_session.call_tool.await_count == 2
@@ -76,6 +76,7 @@ class TestReconnectRetrySuccess:
         assert "retry worked" in results[0].chunk.content.lower()
         assert results[0].score == 0.95
         assert hints == []
+        assert outcome == "ok"
 
 
 class TestReconnectRetryFailure:
@@ -93,10 +94,11 @@ class TestReconnectRetryFailure:
 
         adapter._reconnect = AsyncMock(side_effect=ConnectionError("reconnect failed"))  # type: ignore[method-assign]
 
-        results, hints = await adapter.search("q")
+        results, hints, outcome = await adapter.search("q")
 
         assert results == []
         assert hints == []
+        assert outcome == "transport_error"
         adapter._reconnect.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -112,10 +114,11 @@ class TestReconnectRetryFailure:
         adapter._session = mock_session
         adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
 
-        results, hints = await adapter.search("q")
+        results, hints, outcome = await adapter.search("q")
 
         assert results == []
         assert hints == []
+        assert outcome == "transport_error"
         assert mock_session.call_tool.await_count == 2
 
 
@@ -133,10 +136,11 @@ class TestNonTransportErrorsDoNotReconnect:
         adapter._session = mock_session
         adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
 
-        results, hints = await adapter.search("q")
+        results, hints, outcome = await adapter.search("q")
 
         assert results == []
         assert hints == []
+        assert outcome == "call_error"
         adapter._reconnect.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -272,9 +276,12 @@ class TestNoneContentDefense:
         mock_session.call_tool = AsyncMock(return_value=bad)
         adapter._session = mock_session
 
-        results, hints = await adapter.search("anything")
+        results, hints, outcome = await adapter.search("anything")
         assert results == []
         assert hints == []
+        # ``result.content is None`` is treated as a missing-text response,
+        # not a transport error — outcome is ``empty_content`` (#295).
+        assert outcome == "empty_content"
 
     @pytest.mark.asyncio
     async def test_scratch_list_returns_empty_when_content_is_none(self):
@@ -367,9 +374,10 @@ class TestTextNoneTolerance:
         mock_session.call_tool = AsyncMock(return_value=result_obj)
         adapter._session = mock_session
 
-        results, _ = await adapter.search("test query")
+        results, _, outcome = await adapter.search("test query")
         assert len(results) == 1
         assert "real content" in results[0].chunk.content
+        assert outcome == "ok"
 
     @pytest.mark.asyncio
     async def test_search_all_none_text_returns_empty(self):
@@ -385,8 +393,13 @@ class TestTextNoneTolerance:
         mock_session.call_tool = AsyncMock(return_value=result_obj)
         adapter._session = mock_session
 
-        results, _ = await adapter.search("test query")
+        results, _, outcome = await adapter.search("test query")
         assert results == []
+        # All-None text → ``text_parts`` was non-empty but stringified to
+        # empty content; the parser still ran and returned ``[]`` →
+        # ``empty_results`` (#295). The all-None-string case is parser-empty,
+        # not adapter-empty.
+        assert outcome == "empty_results"
 
 
 # ── Outer wait_for cancellation (#290) ──────────────────────────────────
@@ -434,12 +447,13 @@ class TestOuterCancellationLazyReconnect:
         adapter._session = mock_session
         adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
 
-        results, _ = await adapter.search("q")
+        results, _, outcome = await adapter.search("q")
 
         adapter._reconnect.assert_awaited_once()
         assert adapter._needs_reconnect is False
         assert len(results) == 1
         assert "healed result" in results[0].chunk.content
+        assert outcome == "ok"
 
     @pytest.mark.asyncio
     async def test_failed_lazy_reconnect_returns_empty_and_keeps_flag(self):
@@ -453,10 +467,14 @@ class TestOuterCancellationLazyReconnect:
         adapter._session = mock_session
         adapter._reconnect = AsyncMock(side_effect=ConnectionError("still down"))  # type: ignore[method-assign]
 
-        results, hints = await adapter.search("q")
+        results, hints, outcome = await adapter.search("q")
 
         assert results == []
         assert hints == []
+        # Failed lazy heal leaves the adapter in the same surface state as
+        # ``_session is None`` — both report ``no_session`` so the engine
+        # records ``ltm_unavailable`` instead of a no-results bucket (#295).
+        assert outcome == "no_session"
         # Flag preserved so a later call retries the heal rather than
         # silently accepting the broken state.
         assert adapter._needs_reconnect is True

--- a/tests/test_stm_integration.py
+++ b/tests/test_stm_integration.py
@@ -80,7 +80,11 @@ class TestFullPipeline:
                 include_session_context=False,
                 fire_webhook=False,
             ),
-            mcp_adapter=AsyncMock(search=AsyncMock(return_value=(results, {}))),
+            mcp_adapter=AsyncMock(
+                search=AsyncMock(
+                    return_value=(results, [], "ok" if results else "empty_results"),
+                )
+            ),
         )
         final = await engine.surface(
             "api", "read_file",

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -388,9 +388,10 @@ class TestMcpClientSearchAdapter:
         from memtomem_stm.surfacing.config import SurfacingConfig
 
         adapter = McpClientSearchAdapter(SurfacingConfig())
-        results, hints = await adapter.search("test query")
+        results, hints, outcome = await adapter.search("test query")
         assert results == []
         assert hints == []
+        assert outcome == "no_session"
 
     @pytest.mark.asyncio
     async def test_search_calls_mem_search(self) -> None:
@@ -409,12 +410,13 @@ class TestMcpClientSearchAdapter:
         mock_session.call_tool.return_value = mock_result
         adapter._session = mock_session
 
-        results, _ = await adapter.search("what is X", top_k=5)
+        results, _, outcome = await adapter.search("what is X", top_k=5)
         mock_session.call_tool.assert_awaited_once_with(
             "mem_search", {"query": "what is X", "top_k": 5}
         )
         assert len(results) == 1
         assert results[0].score == 0.9
+        assert outcome == "ok"
 
     @pytest.mark.asyncio
     async def test_search_handles_exception(self) -> None:
@@ -427,9 +429,10 @@ class TestMcpClientSearchAdapter:
         # Prevent reconnect from hitting a real server
         adapter.start = AsyncMock(side_effect=ConnectionError("reconnect failed"))  # type: ignore[method-assign]
 
-        results, hints = await adapter.search("query")
+        results, hints, outcome = await adapter.search("query")
         assert results == []
         assert hints == []
+        assert outcome == "transport_error"
 
     @pytest.mark.asyncio
     async def test_search_timeout_triggers_reconnect(self) -> None:
@@ -444,8 +447,9 @@ class TestMcpClientSearchAdapter:
 
         adapter._reconnect = AsyncMock(side_effect=ConnectionError("reconnect failed"))  # type: ignore[method-assign]
 
-        results, hints = await adapter.search("query")
+        results, hints, outcome = await adapter.search("query")
         assert results == []
         assert hints == []
+        assert outcome == "transport_error"
         # Reconnect was attempted (TimeoutError treated as transport error)
         adapter._reconnect.assert_awaited_once()

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -65,10 +65,21 @@ def _make_mcp_adapter(
     results: list[FakeSearchResult] | None = None,
     *,
     hints: list[str] | None = None,
+    outcome: str | None = None,
 ):
-    """Build a mock McpClientSearchAdapter that returns the given results."""
+    """Build a mock McpClientSearchAdapter that returns the given results.
+
+    ``outcome`` defaults to ``"ok"`` when results are non-empty and
+    ``"empty_results"`` when they are — the two fall-through paths that
+    keep the existing engine flow intact (#295). Pass it explicitly to
+    drive the new failure-outcome dispatch (``no_session``,
+    ``transport_error``, ``call_error``, ``empty_content``).
+    """
+    res_list = results or []
+    if outcome is None:
+        outcome = "ok" if res_list else "empty_results"
     adapter = AsyncMock()
-    adapter.search = AsyncMock(return_value=(results or [], hints or []))
+    adapter.search = AsyncMock(return_value=(res_list, hints or [], outcome))
     return adapter
 
 
@@ -252,7 +263,7 @@ class TestSurfacingTimeout:
     async def test_timeout_returns_original(self):
         async def slow_search(*args, **kwargs):
             await asyncio.sleep(10)
-            return [], {}
+            return [], [], "empty_results"
 
         adapter = AsyncMock()
         adapter.search = slow_search
@@ -348,7 +359,7 @@ class TestSurfacingCacheStampede:
 
         async def slow_search(**_kwargs):
             await asyncio.sleep(0.01)
-            return (results, {})
+            return (results, [], "ok")
 
         adapter.search = AsyncMock(side_effect=slow_search)
 
@@ -406,7 +417,7 @@ class TestRelevanceGateConcurrency:
 
         async def slow_search(**_kwargs):
             await asyncio.sleep(0.01)
-            return ([FakeSearchResult(chunk=FakeChunk(content="hit"), score=0.5)], {})
+            return ([FakeSearchResult(chunk=FakeChunk(content="hit"), score=0.5)], [], "ok")
 
         adapter.search = AsyncMock(side_effect=slow_search)
 
@@ -1623,7 +1634,7 @@ class TestSurfacingEngineObservability:
 
         async def slow_search(*a, **kw):
             await asyncio.sleep(1.0)
-            return ([], [])
+            return ([], [], "empty_results")
 
         adapter = _make_mcp_adapter()
         adapter.search = AsyncMock(side_effect=slow_search)
@@ -1715,3 +1726,83 @@ class TestSurfacingEngineObservability:
         assert snap["outcomes"]["read_file"] == {"surfaced_cache_miss": 1}
         assert snap["skip_reasons"]["read_file"] == {"no_results_invalidated": 1}
         assert snap["cache"] == {"miss": 1, "hit": 1}
+
+
+class TestSurfacingLtmOutcomeDispatch:
+    """#295: adapter ``SearchOutcome`` → distinct engine skip label.
+
+    Five different failure modes used to collapse to ``([], [])`` and look
+    identical to a healthy empty namespace. The engine now reads the
+    adapter's outcome and records ``ltm_unavailable`` / ``ltm_call_failed``
+    / ``ltm_parse_empty`` so an operator looking at the surfacing stats
+    table can tell which of "session never opened", "core raised
+    mid-call", "core returned no text content", and "core returned no
+    rows" is happening. ``ok`` / ``empty_results`` still fall through to
+    the existing min_score / dedup path so the no_results_score signal an
+    operator uses to tune min_score is preserved.
+    """
+
+    def _engine(self, *, outcome: str, results: list | None = None):
+        from memtomem_stm.surfacing.observability import SurfacingObservability
+
+        adapter = _make_mcp_adapter(results, outcome=outcome)
+        obs = SurfacingObservability()
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=adapter,
+            observability=obs,
+        )
+        return engine, obs
+
+    async def test_no_session_outcome_records_ltm_unavailable(self):
+        engine, obs = self._engine(outcome="no_session")
+        out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert out == LONG_RESPONSE
+        assert obs.snapshot()["skip_reasons"]["read_file"] == {"ltm_unavailable": 1}
+
+    async def test_transport_error_outcome_records_ltm_unavailable(self):
+        engine, obs = self._engine(outcome="transport_error")
+        out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert out == LONG_RESPONSE
+        # Same bucket as ``no_session`` — both indicate "LTM not currently
+        # answering"; an operator just needs to know to look at LTM, not
+        # which of the two specific causes it was.
+        assert obs.snapshot()["skip_reasons"]["read_file"] == {"ltm_unavailable": 1}
+
+    async def test_call_error_outcome_records_ltm_call_failed(self):
+        engine, obs = self._engine(outcome="call_error")
+        out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert out == LONG_RESPONSE
+        assert obs.snapshot()["skip_reasons"]["read_file"] == {"ltm_call_failed": 1}
+
+    async def test_empty_content_outcome_records_ltm_parse_empty(self):
+        engine, obs = self._engine(outcome="empty_content")
+        out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert out == LONG_RESPONSE
+        assert obs.snapshot()["skip_reasons"]["read_file"] == {"ltm_parse_empty": 1}
+
+    async def test_empty_results_outcome_falls_through_to_no_results_score(self):
+        """A genuine empty-namespace ``mem_search`` still records
+        ``no_results_score`` so operators tuning min_score see the same
+        signal they did before the outcome refactor."""
+        engine, obs = self._engine(outcome="empty_results", results=[])
+        out = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert out == LONG_RESPONSE
+        skips = obs.snapshot()["skip_reasons"]["read_file"]
+        assert "ltm_unavailable" not in skips
+        assert "ltm_call_failed" not in skips
+        assert "ltm_parse_empty" not in skips
+        assert skips == {"no_results_score": 1}
+
+    async def test_failure_outcomes_do_not_populate_cache(self):
+        """An ``ltm_unavailable`` early return must NOT poison the cache
+        with an empty entry — the next call should retry LTM rather than
+        silently serving the empty cached result."""
+        engine, obs = self._engine(outcome="transport_error")
+        args = {"_context_query": "transport-error retry probe"}
+        await engine.surface("s", "read_file", args, LONG_RESPONSE)
+        await engine.surface("s", "read_file", args, LONG_RESPONSE)
+        snap = obs.snapshot()
+        # Two LTM attempts, two ``ltm_unavailable`` skips, no cache hits.
+        assert snap["skip_reasons"]["read_file"] == {"ltm_unavailable": 2}
+        assert snap["cache"].get("hit", 0) == 0


### PR DESCRIPTION
Closes #295.

## Summary
- `McpClientSearchAdapter.search` now returns `(results, hints, outcome)` with a `SearchOutcome` `Literal` (`ok` / `no_session` / `transport_error` / `call_error` / `empty_content` / `empty_results`) so the engine can tell five previously-indistinguishable failure modes apart.
- `SurfacingEngine._do_surface_miss` reads the outcome and records three new skip labels — `ltm_unavailable` (no session / transport error after reconnect retry), `ltm_call_failed` (non-transport exception), `ltm_parse_empty` (call OK but no text content). `ok` and `empty_results` fall through to the existing `no_results_score` path so `min_score` tuning signal is preserved.
- Failure outcomes early-return before `cache.set` so an `ltm_unavailable` does not poison the cache with an empty entry — pinned by `test_failure_outcomes_do_not_populate_cache`.

## Test plan
- [x] `uv run pytest -m "not ollama"` — 2161 passed
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run mypy src/memtomem_stm/surfacing/{mcp_client,engine,observability}.py` — 11 pre-existing `union-attr` errors, identical to `main` (advisory per CLAUDE.md)
- [x] Engine-level dispatch: `TestSurfacingLtmOutcomeDispatch` covers each new label + the empty_results regression assertion + the cache-non-poisoning invariant
- [x] Adapter-level outcomes: `TestReconnectRetry*`, `TestNonTransportErrorsDoNotReconnect`, `TestNoneContentDefense`, `TestOuterCancellationLazyReconnect`, `TestTextNoneTolerance` all assert the right outcome string for their scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)