### PR TITLE
fix(surfacing): defer LTM MCP client start to first RPC

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -127,14 +127,19 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             # MCP client adapter. The adapter spawns (or connects to) a
             # memtomem MCP server using
             # config.surfacing.ltm_mcp_command / ltm_mcp_args.
+            # The adapter's MCP connection is deferred to the first
+            # surfacing RPC (see ``McpClientSearchAdapter._heal_if_needed``);
+            # eagerly awaiting ``start()`` here used to block the proxy's
+            # own MCP initialize handshake long enough for hosts (e.g.
+            # codex with a 60s startup_timeout) to time out and respawn
+            # the proxy, leaving two parallel LTM children.
             if config.surfacing.enabled:
                 try:
                     from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
 
                     mcp_adapter = McpClientSearchAdapter(config.surfacing)
-                    await mcp_adapter.start()
                     logger.info(
-                        "Surfacing engine connected via MCP client to %s",
+                        "Surfacing engine MCP client configured for lazy start: %s",
                         config.surfacing.ltm_mcp_command,
                     )
                 except Exception:

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -235,6 +235,17 @@ class McpClientSearchAdapter:
         # cancellation must propagate), so we mark the session here and let
         # the next caller heal the connection lazily before issuing an RPC.
         self._needs_reconnect = False
+        # Lazy MCP client start: the LTM subprocess used to be spawned
+        # eagerly from app_lifespan, but its initialize+version_negotiate
+        # round trip blocked the proxy's own MCP startup long enough for
+        # hosts (e.g. codex with a 60s startup_timeout) to time out and
+        # respawn the proxy — creating two parallel LTM children. Defer
+        # the start to the first RPC. The lock serializes concurrent
+        # first-callers; the flag prevents retrying a permanently failing
+        # start on every subsequent RPC (matches the prior single-shot
+        # lifespan behavior).
+        self._start_attempted = False
+        self._start_lock = asyncio.Lock()
 
     async def start(self) -> None:
         """Connect to the memtomem MCP server."""
@@ -311,15 +322,36 @@ class McpClientSearchAdapter:
         logger.info("MCP adapter reconnected successfully")
 
     async def _heal_if_needed(self) -> bool:
-        """Reconnect lazily if a prior RPC was cancelled mid-message (#290).
+        """Ready the session for the next RPC.
 
-        Returns ``True`` when the session is ready to issue a new RPC,
-        ``False`` when no session was ever started or the reconnect failed.
-        Callers treat ``False`` the same as a missing session: return empty
-        results and let the next surfacing cycle retry.
+        Three transitions:
+
+        * No session yet → lazy-start the LTM client. First concurrent
+          caller wins; failure is sticky for this adapter's lifetime to
+          avoid respawning the LTM subprocess on every cycle (matches
+          the prior single-shot ``app_lifespan`` behavior).
+        * Session marked for reconnect (#290) → tear down and rebuild
+          before the RPC.
+        * Healthy session → fast path, no I/O.
+
+        Returns ``True`` when the session is ready, ``False`` when
+        callers should treat the adapter as unavailable.
         """
         if self._session is None:
-            return False
+            async with self._start_lock:
+                # Re-check under lock: another coroutine may have raced
+                # us through start() while we were waiting on the lock.
+                if self._session is not None:
+                    return True
+                if self._start_attempted:
+                    return False
+                self._start_attempted = True
+                try:
+                    await self.start()
+                except Exception as exc:
+                    logger.warning("Lazy MCP adapter start failed — surfacing disabled: %s", exc)
+                    return False
+                return True
         if not self._needs_reconnect:
             return True
         try:

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -348,6 +348,20 @@ class McpClientSearchAdapter:
                 self._start_attempted = True
                 try:
                     await self.start()
+                except asyncio.CancelledError:
+                    # Outer wait_for / timeout cancelled us mid-init
+                    # (SurfacingEngine wraps adapter calls in
+                    # ``asyncio.wait_for``). ``start()``'s BaseException
+                    # handler already cleared ``_session`` and unwound
+                    # the AsyncExitStack — without resetting
+                    # ``_start_attempted`` here, every subsequent cycle
+                    # would short-circuit on the sticky flag and
+                    # surfacing would stay permanently off in exactly
+                    # the slow-startup environments this patch targets.
+                    # Propagate per the cooperative cancellation
+                    # contract (#290).
+                    self._start_attempted = False
+                    raise
                 except Exception as exc:
                     logger.warning("Lazy MCP adapter start failed — surfacing disabled: %s", exc)
                     return False

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -515,3 +515,101 @@ class TestOuterCancellationLazyReconnect:
             await asyncio.wait_for(adapter.scratch_list(), timeout=0.05)
 
         assert adapter._needs_reconnect is True
+
+
+# ── Lazy start paths ─────────────────────────────────────────────────────
+
+
+class TestLazyStart:
+    """Adapter.start() is deferred from ``app_lifespan`` to the first RPC.
+
+    The host's proxy startup used to hang on ``mcp_adapter.start()`` waiting
+    for the LTM subprocess's MCP handshake, which exceeded codex's 60s
+    startup_timeout and caused codex to respawn the proxy — creating two
+    parallel LTM children. The fix moves start() into ``_heal_if_needed``
+    so the proxy's own initialize() returns immediately. These tests pin
+    the new contract: lazy bootstrap, sticky failure, lock-serialized
+    concurrent first-callers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_first_search_triggers_start_and_returns_results(self):
+        """No prior ``start()`` — search() must bootstrap the session itself
+        and deliver real results, not the silent ``no_session`` of the old
+        eager-start contract."""
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+
+        compact_output = "[1] 0.9 | [default] src/a.py\nfrom lazy start.\n"
+        good_result = _result_with_text(compact_output)
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=good_result)
+
+        async def fake_start():
+            adapter._session = mock_session
+
+        adapter.start = AsyncMock(side_effect=fake_start)  # type: ignore[method-assign]
+
+        results, hints, outcome = await adapter.search("q")
+
+        adapter.start.assert_awaited_once()
+        assert outcome == "ok"
+        assert len(results) == 1
+        assert "lazy start" in results[0].chunk.content.lower()
+        assert adapter._start_attempted is True
+
+    @pytest.mark.asyncio
+    async def test_failed_start_is_sticky_within_lifecycle(self):
+        """A start() that raises must flip ``_start_attempted`` and stop
+        retrying. Otherwise every surfacing cycle would respawn the LTM
+        subprocess — the exact thundering-herd the lifespan-shot avoided."""
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+        adapter.start = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ConnectionError("LTM unreachable"),
+        )
+
+        first = await adapter.search("q1")
+        second = await adapter.search("q2")
+
+        assert first == ([], [], "no_session")
+        assert second == ([], [], "no_session")
+        # Only the first call attempted start; the second short-circuits
+        # on the sticky flag instead of spawning a fresh LTM subprocess.
+        adapter.start.assert_awaited_once()
+        assert adapter._start_attempted is True
+        assert adapter._session is None
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_callers_serialize_start(self):
+        """Surfacing fires from multiple coroutines per request. Without the
+        lock, two coroutines hitting ``_session is None`` simultaneously
+        would each spawn a separate LTM subprocess — the same dual-process
+        regression we just fixed at the lifespan level."""
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=_result_with_text(""))
+
+        start_call_count = 0
+
+        async def fake_start():
+            nonlocal start_call_count
+            start_call_count += 1
+            # Yield once so a concurrent caller has a real chance to race
+            # the assignment — without the lock this is where the bug would
+            # show up as start_call_count == 2.
+            await asyncio.sleep(0)
+            adapter._session = mock_session
+
+        adapter.start = AsyncMock(side_effect=fake_start)  # type: ignore[method-assign]
+
+        results = await asyncio.gather(
+            adapter.search("q1"),
+            adapter.search("q2"),
+            adapter.search("q3"),
+        )
+
+        assert start_call_count == 1
+        adapter.start.assert_awaited_once()
+        # All three callers see the same healthy session.
+        for r in results:
+            assert r[2] in {"ok", "empty_content", "empty_results"}

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -613,3 +613,60 @@ class TestLazyStart:
         # All three callers see the same healthy session.
         for r in results:
             assert r[2] in {"ok", "empty_content", "empty_results"}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_start_resets_flag_and_propagates(self):
+        """If ``start()`` is cancelled mid-init (outer wait_for timeout),
+        the sticky flag must reset so a later cycle can retry — otherwise
+        a single timeout permanently disables surfacing in exactly the
+        slow-startup environments lazy-start was meant to help.
+        Cancellation must propagate (cooperative cancellation, #290)."""
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+
+        async def slow_start():
+            # Simulate a long-running LTM handshake that an outer
+            # wait_for will cancel before it completes.
+            await asyncio.sleep(10)
+
+        adapter.start = AsyncMock(side_effect=slow_start)  # type: ignore[method-assign]
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(adapter.search("q"), timeout=0.05)
+
+        # Flag reset → next caller can retry.
+        assert adapter._start_attempted is False
+        # No session ever materialized.
+        assert adapter._session is None
+
+    @pytest.mark.asyncio
+    async def test_cancelled_start_allows_retry_on_next_call(self):
+        """End-to-end: cancellation on attempt 1 must not block attempt 2.
+        Pairs with the unit test above — proves the reset actually
+        un-sticks the path rather than just clearing a flag in isolation."""
+        adapter = McpClientSearchAdapter(SurfacingConfig())
+
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value=_result_with_text(""))
+
+        attempt = 0
+
+        async def start_impl():
+            nonlocal attempt
+            attempt += 1
+            if attempt == 1:
+                # First attempt: hang until outer wait_for cancels us.
+                await asyncio.sleep(10)
+            # Second attempt: succeed instantly.
+            adapter._session = mock_session
+
+        adapter.start = AsyncMock(side_effect=start_impl)  # type: ignore[method-assign]
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(adapter.search("q1"), timeout=0.05)
+
+        # Second call must reach start() again (not short-circuit on the
+        # sticky flag) and succeed.
+        results, _, outcome = await adapter.search("q2")
+        assert attempt == 2
+        assert outcome in {"ok", "empty_content", "empty_results"}
+        assert adapter._session is mock_session


### PR DESCRIPTION
## Summary

- Move `McpClientSearchAdapter.start()` out of `app_lifespan` and into `_heal_if_needed` so the proxy's MCP `initialize()` returns immediately instead of blocking on the LTM subprocess handshake.
- Add an `asyncio.Lock` to serialize concurrent first-callers and a sticky `_start_attempted` flag to preserve the prior single-shot lifespan semantics when LTM is permanently unreachable.
- Add three `TestLazyStart` tests pinning the new contract.

## Why

Eagerly awaiting `mcp_adapter.start()` in `app_lifespan` blocks the proxy's own MCP `initialize()` while the LTM subprocess spawns and runs initialize + `mem_do(version)` round trips. On hosts with short startup timeouts (e.g. codex's 60s `startup_timeout_sec`), this regularly exceeded the budget. The host then respawned the proxy mid-init, leaving two parallel LTM children — exact symptom users reported as `Starting MCP servers (2/3): memtomem-stm` hanging indefinitely with duplicate `mms` / `memtomem-server` processes.

Diagnosis details:
- `mms` direct-launch initialize completed in ~4s
- Inside codex, same `mms` exceeded the 60s budget and codex respawned, producing two MCP-server groups under one `codex` PID — observed live, both groups sleeping waiting for handshake
- The expensive step in `start()` is the chain `stdio_client → ClientSession → session.initialize() → _negotiate_format()`, none of which is needed before the first surfacing RPC

## Behavior delta

| scenario | before | after |
|---|---|---|
| Proxy `initialize()` latency | LTM full handshake (often >60s under load) | sub-second |
| First surfacing RPC | always ready | first caller triggers `start()`, others lock-wait |
| Permanently unreachable LTM | `surfacing_engine = None`, single attempt | `_start_attempted` sticky, single attempt — equivalent |
| Mid-RPC cancellation reconnect (#290) | unchanged | unchanged |

The connection is established lazily; from the engine's perspective the only observable change is that the first cycle pays a one-time start cost instead of paying it during proxy boot.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 2164 passed, 7 skipped (no regressions)
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] New `TestLazyStart` covers:
  - first `search()` triggers `start()` and returns real results (not the old silent `no_session`)
  - failed `start()` flips `_start_attempted` and the next call short-circuits (no thundering herd of LTM respawns)
  - three concurrent `search()` callers serialize through the lock — `start()` runs exactly once
- [ ] Manual verification with codex: `Starting MCP servers (2/3): memtomem-stm` no longer hangs; only one LTM child group per proxy instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)