### PR TITLE
feat(circuit_breaker): expose opened_at as public read-only property (#277)

### DIFF
--- a/src/memtomem_stm/utils/circuit_breaker.py
+++ b/src/memtomem_stm/utils/circuit_breaker.py
@@ -51,6 +51,36 @@ class CircuitBreaker:
         return self._failures
 
     @property
+    def opened_at(self) -> float | None:
+        """Monotonic timestamp of the most recent open transition,
+        or None if the breaker has never opened.
+
+        After the breaker has opened at least once, this returns the
+        timestamp of the *most recent* open transition — even if the
+        breaker is currently closed. ``record_success`` flips state
+        back to ``closed`` and zeroes ``failure_count`` but does not
+        clear this timestamp, so the historical "last trip" is
+        preserved for diagnostics. Use ``state`` to distinguish
+        "currently open" from "previously opened, now recovered".
+
+        The value is a real ``time.monotonic()`` reading — typically in
+        the ~1e5 to 1e9 second range on long-running processes.
+        ``time_until_reset`` computes ``reset_timeout - (now - opened_at)``
+        from this; ``(opened_at + 10.0) - opened_at`` loses a few low
+        bits at those magnitudes and the result is ``~1e-14`` rather
+        than bit-exact ``0.0``. Callers subtracting two
+        ``opened_at``-derived values must tolerate a few ULPs of float
+        residue (the test at ``test_time_until_reset_at_boundary``
+        pins an absolute-tolerance check).
+
+        The backing field uses ``0.0`` as a "never opened" sentinel.
+        ``time.monotonic()`` is implementation-defined and could in
+        principle return ``0.0``, but does not in practice on CPython
+        (Linux/macOS/Windows).
+        """
+        return None if self._opened_at == 0.0 else self._opened_at
+
+    @property
     def time_until_reset(self) -> float | None:
         """Seconds until open breaker transitions to half-open. None if not open."""
         if self._state != "open":

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -58,7 +58,7 @@ class TestCircuitBreakerHalfOpen:
 
         # Simulate time passing beyond reset_timeout
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
-            mock_time.monotonic.return_value = cb._opened_at + 11.0
+            mock_time.monotonic.return_value = cb.opened_at + 11.0
             # Should transition to half-open and allow one probe
             assert not cb.is_open
             assert cb._state == "half-open"
@@ -68,7 +68,7 @@ class TestCircuitBreakerHalfOpen:
         cb.record_failure()
 
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
-            mock_time.monotonic.return_value = cb._opened_at + 11.0
+            mock_time.monotonic.return_value = cb.opened_at + 11.0
             assert not cb.is_open  # half-open
 
         cb.record_success()
@@ -80,7 +80,7 @@ class TestCircuitBreakerHalfOpen:
         cb.record_failure()
 
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
-            mock_time.monotonic.return_value = cb._opened_at + 11.0
+            mock_time.monotonic.return_value = cb.opened_at + 11.0
             assert not cb.is_open  # half-open
 
         cb.record_failure()
@@ -90,7 +90,7 @@ class TestCircuitBreakerHalfOpen:
     def test_half_open_failure_resets_timeout(self):
         cb = CircuitBreaker(max_failures=1, reset_timeout=10.0)
         cb.record_failure()
-        first_opened_at = cb._opened_at
+        first_opened_at = cb.opened_at
 
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = first_opened_at + 11.0
@@ -98,7 +98,7 @@ class TestCircuitBreakerHalfOpen:
 
         cb.record_failure()
         # opened_at should be refreshed
-        assert cb._opened_at > first_opened_at or cb._opened_at == first_opened_at
+        assert cb.opened_at > first_opened_at or cb.opened_at == first_opened_at
         # If time.monotonic was called normally, opened_at >= first_opened_at
 
     def test_repeated_open_close_cycles(self):
@@ -111,7 +111,7 @@ class TestCircuitBreakerHalfOpen:
 
         # Half-open → success → closed
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
-            mock_time.monotonic.return_value = cb._opened_at + 6.0
+            mock_time.monotonic.return_value = cb.opened_at + 6.0
             assert not cb.is_open
         cb.record_success()
         assert not cb.is_open
@@ -128,7 +128,7 @@ class TestCircuitBreakerHalfOpen:
         cb.record_failure()
 
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
-            mock_time.monotonic.return_value = cb._opened_at + 11.0
+            mock_time.monotonic.return_value = cb.opened_at + 11.0
             # First call: transitions to half-open, returns False
             assert not cb.is_open
             assert cb._state == "half-open"
@@ -157,7 +157,7 @@ class TestCircuitBreakerProperties:
         cb.record_failure()
 
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
-            mock_time.monotonic.return_value = cb._opened_at + 11.0
+            mock_time.monotonic.return_value = cb.opened_at + 11.0
             assert not cb.is_open  # triggers half-open
             # assertion inside the patch block — fix for timing concern
             assert cb.time_until_reset is None
@@ -167,16 +167,46 @@ class TestCircuitBreakerProperties:
         cb.record_failure()
 
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
-            mock_time.monotonic.return_value = cb._opened_at + 10.0
+            mock_time.monotonic.return_value = cb.opened_at + 10.0
             result = cb.time_until_reset
-            # ``time_until_reset`` computes ``reset_timeout - (now - opened_at)``.
-            # ``opened_at`` is a real ``time.monotonic()`` value (often ~1e5-1e9
-            # seconds on CI runners), so ``(opened_at + 10.0) - opened_at`` loses
-            # a few low bits and the result is ``~1e-14`` rather than bit-exact
-            # ``0.0``. The contract here is "not positive, effectively zero" —
-            # pick a tolerance several orders of magnitude below any observable
-            # reset window.
+            # The contract here is "not positive, effectively zero" — pick a
+            # tolerance several orders of magnitude below any observable reset
+            # window. See ``CircuitBreaker.opened_at`` docstring for the
+            # float-precision rationale (paragraph migrated there per #277).
             assert result is not None and abs(result) < 1e-9
+
+    def test_opened_at_lifecycle_preserves_most_recent_open(self):
+        """``opened_at`` is None initially, captures the open transition,
+        and survives the recover→close path so diagnostics retain the
+        historical "last trip" timestamp (#277).
+
+        ``record_success`` flips state to ``closed`` and zeroes
+        ``failure_count`` but intentionally does not clear
+        ``_opened_at`` — this regression pins that contract so a
+        future "reset on close" change does not silently erase the
+        diagnostic without updating the property docstring.
+        """
+        cb = CircuitBreaker(max_failures=1, reset_timeout=10.0)
+        assert cb.opened_at is None  # never opened
+
+        cb.record_failure()
+        assert cb.is_open
+        opened_when_tripped = cb.opened_at
+        assert opened_when_tripped is not None  # captured at open
+        # Still equals that value while currently open.
+        assert cb.opened_at == opened_when_tripped
+
+        with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
+            mock_time.monotonic.return_value = opened_when_tripped + 11.0
+            assert not cb.is_open  # auto-transitions to half-open
+            assert cb.state == "half-open"
+            # Half-open does not refresh opened_at.
+            assert cb.opened_at == opened_when_tripped
+
+        cb.record_success()
+        assert cb.state == "closed"
+        # Recovery does not clear opened_at — the "last trip" survives.
+        assert cb.opened_at == opened_when_tripped
 
     def test_backward_compat_failure_alias(self):
         cb = CircuitBreaker(max_failures=2)


### PR DESCRIPTION
## Summary

- `CircuitBreaker._opened_at` was effectively-public already: tests read it directly across 10 lines (mock anchors + assertions), and the production contract for its units/magnitude/float-precision lived as a paragraph inside `test_time_until_reset_at_boundary` (PR #122). Per #277, a production contract belongs on the symbol it describes.
- Add `CircuitBreaker.opened_at -> float | None` with the PR #122 paragraph migrated into its docstring, plus the explicit *most recent open transition* clarification. `record_success` only flips state + zeros failure count — it does not clear `_opened_at` — so the property surfaces the historical \"last trip\" timestamp. Use `state` to distinguish currently-open from previously-opened.
- Switch all 10 test reads from `cb._opened_at` to `cb.opened_at`. Replace the inline contract paragraph with a one-line pointer to the property docstring (keeping the absolute-tolerance rationale visible inline).
- Add `test_opened_at_lifecycle_preserves_most_recent_open`: pins `None → record_failure → still equals while open → still equals after half-open auto-transition → still equals after record_success closes` so a future \"reset on close\" change cannot silently erase the diagnostic.

No public-API behavior change. `_opened_at` field and its `0.0` sentinel unchanged; sentinel assumption noted in docstring (`time.monotonic()` is implementation-defined but never returns exactly 0.0 on CPython in practice).

Closes #277.

## Test plan

- [x] `uv run pytest tests/test_circuit_breaker.py -v` — 21 passed (20 baseline + 1 new)
- [x] `uv run ruff check src && uv run ruff format --check src` — clean
- [x] `uv run mypy src/memtomem_stm/utils/circuit_breaker.py` — no issues
- [x] `uv run pytest -m \"not ollama\"` — 2173 passed, 7 skipped (was 2172 + 1 new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)