### PR TITLE
Fix initial upstream connection cleanup

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -189,6 +189,15 @@ class ProxyManager:
         """Connect to all upstream servers, discover their tools."""
         # Guard against double start — close previous stack to avoid leaking connections
         if self._stack is not None:
+            for conn in self._connections.values():
+                if conn.stack is not None:
+                    try:
+                        await conn.stack.aclose()
+                    except Exception:
+                        logger.debug(
+                            "Failed to close connection stack in double-start guard",
+                            exc_info=True,
+                        )
             try:
                 await self._stack.aclose()
             except Exception:
@@ -288,13 +297,25 @@ class ProxyManager:
             logger.warning("Skipping server '%s': transport=%s requires url", name, cfg.transport)
             return
 
-        transport_ctx = self._open_transport(cfg)
-        streams = await self._stack.enter_async_context(transport_ctx)
-        read, write = streams[0], streams[1]
-        session = await self._stack.enter_async_context(ClientSession(read, write))
-        await asyncio.wait_for(session.initialize(), timeout=cfg.connect_timeout_seconds)
+        conn_stack = AsyncExitStack()
+        try:
+            transport_ctx = self._open_transport(cfg)
+            streams = await conn_stack.enter_async_context(transport_ctx)
+            read, write = streams[0], streams[1]
+            session = await conn_stack.enter_async_context(ClientSession(read, write))
+            await asyncio.wait_for(session.initialize(), timeout=cfg.connect_timeout_seconds)
+            result = await session.list_tools()
+        except BaseException:
+            # Roll back any contexts we entered before the connection becomes
+            # visible to stop()/reconnect cleanup.
+            try:
+                await conn_stack.aclose()
+            except Exception:
+                logger.debug(
+                    "Error during initial connection cleanup for '%s'", name, exc_info=True
+                )
+            raise
 
-        result = await session.list_tools()
         valid_tools = []
         for t in result.tools:
             prefixed = f"{cfg.prefix}__{t.name}"
@@ -326,7 +347,7 @@ class ProxyManager:
             valid_tools.append(t)
 
         self._connections[name] = UpstreamConnection(
-            name=name, config=cfg, session=session, tools=valid_tools
+            name=name, config=cfg, session=session, tools=valid_tools, stack=conn_stack
         )
         logger.info("Connected to '%s' (%s tools)", name, len(valid_tools))
 

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -112,6 +112,27 @@ class TestStart:
         mock_close.assert_awaited_once()
         assert mgr._stack is not first_stack
 
+    async def test_double_start_closes_existing_connection_stacks(self):
+        """Calling start() twice closes per-connection stacks before clearing them."""
+        mgr = _make_manager(servers={})
+        with patch.object(ProxyConfig, "load_from_file", return_value=None):
+            await mgr.start()
+
+        mock_stack = AsyncMock()
+        mgr._connections["srv"] = UpstreamConnection(
+            name="srv",
+            config=UpstreamServerConfig(prefix="test"),
+            session=AsyncMock(),
+            tools=[],
+            stack=mock_stack,
+        )
+
+        with patch.object(ProxyConfig, "load_from_file", return_value=None):
+            await mgr.start()
+
+        mock_stack.aclose.assert_awaited_once()
+        assert mgr._connections == {}
+
 
 # ── stop() ────────────────────────────────────────────────────────────────
 
@@ -214,6 +235,41 @@ class TestConnectTimeout:
             await mgr.start()
 
         assert "Failed to connect to upstream server 'slow'" in caplog.text
+
+
+class TestConnectServerCleanup:
+    async def test_connect_server_closes_partial_stack_when_list_tools_fails(self):
+        """Failed initial connection must not leave transport/session cleanup
+        deferred until ProxyManager.stop().
+        """
+        cfg = UpstreamServerConfig(prefix="bad")
+        mgr = _make_manager(servers={"bad": cfg})
+
+        with patch.object(mgr, "_connect_server", new_callable=AsyncMock):
+            await mgr.start()
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(side_effect=RuntimeError("catalog failed"))
+
+        mock_transport = AsyncMock()
+        mock_transport.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+        mock_transport.__aexit__ = AsyncMock(return_value=False)
+
+        import pytest as _pt
+
+        with (
+            patch.object(mgr, "_open_transport", return_value=mock_transport),
+            patch("memtomem_stm.proxy.manager.ClientSession", return_value=mock_session),
+        ):
+            with _pt.raises(RuntimeError, match="catalog failed"):
+                await mgr._connect_server("bad", cfg, set())
+
+        assert "bad" not in mgr._connections
+        mock_session.__aexit__.assert_awaited_once()
+        mock_transport.__aexit__.assert_awaited_once()
 
 
 # ── tool name overflow skip (#261) ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- stage initial upstream transport/session setup in a per-connection AsyncExitStack
- close partially-entered initial connection contexts immediately on initialize/list_tools failure
- add a regression test for failed initial list_tools cleanup

Closes #291

## Tests
- uv run pytest tests/test_proxy_manager_lifecycle.py
- uv run pytest tests/test_proxy_error_paths.py