### PR TITLE
docs(surfacing): cross-reference #297 at stdio LTM transport site

### DIFF
--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -252,6 +252,10 @@ class McpClientSearchAdapter:
         stack = AsyncExitStack()
         self._stack = stack
         try:
+            # #297: LTM transport is stdio-only by design (single-user local
+            # install). When a deployment needs SSE / streamable HTTP, mirror
+            # ``ProxyManager._open_transport`` and branch on a SurfacingConfig
+            # transport field.
             params = StdioServerParameters(
                 command=self._config.ltm_mcp_command,
                 args=self._config.ltm_mcp_args,

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -252,10 +252,9 @@ class McpClientSearchAdapter:
         stack = AsyncExitStack()
         self._stack = stack
         try:
-            # #297: LTM transport is stdio-only by design (single-user local
-            # install). When a deployment needs SSE / streamable HTTP, mirror
-            # ``ProxyManager._open_transport`` and branch on a SurfacingConfig
-            # transport field.
+            # #297: LTM transport is currently stdio-only. Adding SSE /
+            # streamable HTTP means giving SurfacingConfig a transport field
+            # and branching here, mirroring ``ProxyManager._open_transport``.
             params = StdioServerParameters(
                 command=self._config.ltm_mcp_command,
                 args=self._config.ltm_mcp_args,


### PR DESCRIPTION
## Summary
- Adds an in-code `#297` anchor next to the `StdioServerParameters` call in `McpClientSearchAdapter.start()` so the deferred non-stdio LTM transport issue is discoverable by grep.
- The line numbers in #297's body (`mcp_client.py:205-209`) drifted ~50 lines after intervening refactors; an in-code anchor is line-number-stable.

## Test plan
- [x] `ruff check` and `ruff format --check` clean on the changed file
- [x] No behavior change (comment-only)

Related: #297 (deferred tracking issue — wait-for-signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)