### PR TITLE
feat(cli/health): probe LTM MCP reachability in mms health (#349 part b)

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -2173,6 +2174,93 @@ async def _probe_one(cfg: dict[str, Any], timeout: float) -> dict[str, Any]:
             }
 
 
+def _format_command_for_display(command: str, args: list[str]) -> str:
+    return shlex.join([command, *args]) if args else command
+
+
+def _text_parts_from_tool_result(result: Any) -> list[str]:
+    return [
+        str(getattr(content, "text", "") or "")
+        for content in getattr(result, "content", [])
+        if getattr(content, "type", None) == "text"
+    ]
+
+
+def _version_from_tool_result(result: Any) -> str | None:
+    text_parts = _text_parts_from_tool_result(result)
+    if not text_parts:
+        return None
+    try:
+        data = json.loads(text_parts[0])
+    except json.JSONDecodeError:
+        return None
+    version = data.get("version")
+    return str(version) if version else None
+
+
+async def _probe_ltm_mcp_command(
+    command: str,
+    args: list[str],
+    timeout: float,
+) -> dict[str, Any]:
+    """Probe the configured LTM stdio MCP server without starting the proxy."""
+    from mcp import ClientSession
+    from mcp.client.stdio import StdioServerParameters, stdio_client
+
+    async with stdio_client(StdioServerParameters(command=command, args=args)) as streams:
+        async with ClientSession(streams[0], streams[1]) as session:
+            await asyncio.wait_for(session.initialize(), timeout=timeout)
+            version: str | None = None
+            try:
+                result = await asyncio.wait_for(
+                    session.call_tool("mem_do", {"action": "version"}),
+                    timeout=timeout,
+                )
+                version = _version_from_tool_result(result)
+            except Exception:
+                logger.debug("LTM version probe failed", exc_info=True)
+            return {"connected": True, "version": version, "error": None}
+
+
+def _ltm_mcp_status(surfacing: Any) -> dict[str, Any]:
+    command = str(getattr(surfacing, "ltm_mcp_command", "") or "")
+    args = [str(arg) for arg in (getattr(surfacing, "ltm_mcp_args", []) or [])]
+    display = _format_command_for_display(command, args) if command else "(empty command)"
+    status: dict[str, Any] = {
+        "command": command,
+        "args": args,
+        "display": display,
+        "connected": None,
+        "version": None,
+        "error": None,
+    }
+
+    if not getattr(surfacing, "enabled", False):
+        status["skipped"] = "surfacing_disabled"
+        return status
+    if not command:
+        status["connected"] = False
+        status["error"] = "ltm_mcp_command is empty"
+        return status
+    if shutil.which(command) is None:
+        status["connected"] = False
+        status["error"] = f"{command} not on PATH"
+        return status
+
+    timeout = max(0.1, float(getattr(surfacing, "timeout_seconds", 3.0) or 3.0))
+    try:
+        probe = asyncio.run(_probe_ltm_mcp_command(command, args, timeout))
+    except asyncio.TimeoutError:
+        status["connected"] = False
+        status["error"] = f"{display}: timeout ({timeout:g}s)"
+    except Exception as exc:
+        status["connected"] = False
+        status["error"] = f"{display}: {_root_cause_message(exc)}"
+    else:
+        status.update(probe)
+    return status
+
+
 def _root_cause_message(exc: BaseException) -> str:
     """Walk into ``BaseExceptionGroup`` (anyio TaskGroup wraps probe failures
     as ``unhandled errors in a TaskGroup (N sub-exception)``) to surface the
@@ -2187,7 +2275,7 @@ def _root_cause_message(exc: BaseException) -> str:
 
 
 def _surfacing_bootstrap_status() -> dict[str, Any]:
-    """Return surfacing feedback DB readiness without starting the proxy."""
+    """Return surfacing bootstrap readiness without starting the proxy."""
     try:
         from memtomem_stm.config import STMConfig
         from memtomem_stm.surfacing.feedback_store import inspect_feedback_db
@@ -2198,6 +2286,7 @@ def _surfacing_bootstrap_status() -> dict[str, Any]:
             "enabled": surfacing.enabled,
             "feedback_enabled": surfacing.feedback_enabled,
             "feedback_db": db_status,
+            "ltm_server": _ltm_mcp_status(surfacing),
         }
     except Exception as exc:
         logger.debug("Surfacing bootstrap status inspection failed", exc_info=True)
@@ -2205,6 +2294,7 @@ def _surfacing_bootstrap_status() -> dict[str, Any]:
             "enabled": None,
             "feedback_enabled": None,
             "feedback_db": None,
+            "ltm_server": None,
             "error": str(exc) or type(exc).__name__,
         }
 
@@ -2236,6 +2326,18 @@ def _format_surfacing_bootstrap(status: dict[str, Any]) -> list[str]:
             f"  feedback tables: {_warn('missing')} ({missing}) — "
             "surfacing has not initialized this DB"
         )
+    ltm_server = status.get("ltm_server")
+    if isinstance(ltm_server, dict):
+        if ltm_server.get("skipped") == "surfacing_disabled":
+            lines.append("  ltm server: skipped (surfacing disabled)")
+        elif ltm_server.get("connected"):
+            detail = str(ltm_server.get("display") or ltm_server.get("command") or "")
+            if ltm_server.get("version"):
+                detail = f"{detail}, version {ltm_server['version']}"
+            lines.append(f"  ltm server: {_ok('connectable')} ({detail})")
+        else:
+            err = ltm_server.get("error") or "unknown error"
+            lines.append(f"  ltm server: {_bad('UNREACHABLE')} — {err}")
     return lines
 
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -2242,9 +2242,7 @@ async def _probe_ltm_mcp_command(
     async with stdio_client(params, errlog=errlog) as streams:
         async with ClientSession(streams[0], streams[1]) as session:
             await asyncio.wait_for(session.initialize(), timeout=remaining())
-            tools_result = await asyncio.wait_for(
-                session.list_tools(), timeout=remaining()
-            )
+            tools_result = await asyncio.wait_for(session.list_tools(), timeout=remaining())
             tool_names = {t.name for t in tools_result.tools}
             if "mem_search" not in tool_names:
                 return {

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -2256,7 +2256,14 @@ async def _probe_ltm_mcp_command(
             return {"connected": True, "version": version, "error": None}
 
 
-def _ltm_mcp_status(surfacing: Any) -> dict[str, Any]:
+def _ltm_mcp_status(surfacing: Any, timeout: float) -> dict[str, Any]:
+    """Probe the configured LTM MCP server for ``mms health``.
+
+    *timeout* is the per-server bound from ``mms health --timeout``; the LTM
+    probe must honor it so a stalled LTM command can't push the health
+    diagnostic past the user-requested ceiling. ``surfacing.timeout_seconds``
+    (the runtime-call timeout) is not used here — it's a different SLA.
+    """
     command = str(getattr(surfacing, "ltm_mcp_command", "") or "")
     args = [str(arg) for arg in (getattr(surfacing, "ltm_mcp_args", []) or [])]
     display = _format_command_for_display(command, args) if command else "(empty command)"
@@ -2281,7 +2288,7 @@ def _ltm_mcp_status(surfacing: Any) -> dict[str, Any]:
         status["error"] = f"{command} not on PATH"
         return status
 
-    timeout = max(0.1, float(getattr(surfacing, "timeout_seconds", 3.0) or 3.0))
+    probe_timeout = max(0.1, float(timeout))
     try:
         # ``stdio_client`` forwards *errlog* directly to
         # ``asyncio.create_subprocess_exec(stderr=...)``, which requires a real
@@ -2289,33 +2296,50 @@ def _ltm_mcp_status(surfacing: Any) -> dict[str, Any]:
         # here. ``os.devnull`` gives us a fd-backed sink so server banners
         # and MCP-SDK stderr can't bleed into ``mms health`` output.
         with open(os.devnull, "w") as errnull, _silenced_mcp_sdk_logs():
-            probe = asyncio.run(_probe_ltm_mcp_command(command, args, timeout, errnull))
-    except asyncio.TimeoutError:
-        status["connected"] = False
-        status["error"] = f"{display}: timeout ({timeout:g}s)"
+            probe = asyncio.run(_probe_ltm_mcp_command(command, args, probe_timeout, errnull))
     except Exception as exc:
+        # ``asyncio.wait_for`` inside the probe raises ``TimeoutError``, but
+        # anyio's ``TaskGroup`` (wrapped by ``stdio_client``) re-raises it
+        # as an ``ExceptionGroup`` leaf — a bare ``except TimeoutError``
+        # would miss the wrapped case. Walk to the root cause and dispatch
+        # on the leaf type instead so ``--timeout N`` always renders as
+        # ``timeout (Ns)`` rather than a ``TimeoutError`` type name.
+        root = _root_cause_exc(exc)
         status["connected"] = False
-        status["error"] = f"{display}: {_root_cause_message(exc)}"
+        if isinstance(root, TimeoutError):
+            status["error"] = f"{display}: timeout ({probe_timeout:g}s)"
+        else:
+            status["error"] = f"{display}: {str(root) or type(root).__name__}"
     else:
         status.update(probe)
     return status
 
 
-def _root_cause_message(exc: BaseException) -> str:
+def _root_cause_exc(exc: BaseException) -> BaseException:
     """Walk into ``BaseExceptionGroup`` (anyio TaskGroup wraps probe failures
     as ``unhandled errors in a TaskGroup (N sub-exception)``) to surface the
-    first non-group leaf so users see the real cause instead of the wrapper.
+    first non-group leaf so callers can dispatch on the real cause's type
+    or message instead of the wrapper.
     """
     seen: set[int] = set()
     cur: BaseException = exc
     while isinstance(cur, BaseExceptionGroup) and cur.exceptions and id(cur) not in seen:
         seen.add(id(cur))
         cur = cur.exceptions[0]
+    return cur
+
+
+def _root_cause_message(exc: BaseException) -> str:
+    cur = _root_cause_exc(exc)
     return str(cur) or type(cur).__name__
 
 
-def _surfacing_bootstrap_status() -> dict[str, Any]:
-    """Return surfacing bootstrap readiness without starting the proxy."""
+def _surfacing_bootstrap_status(timeout: float) -> dict[str, Any]:
+    """Return surfacing bootstrap readiness without starting the proxy.
+
+    *timeout* is the ``mms health --timeout`` value, forwarded into the LTM
+    probe so the documented per-server bound covers it too.
+    """
     try:
         from memtomem_stm.config import STMConfig
         from memtomem_stm.surfacing.feedback_store import inspect_feedback_db
@@ -2326,7 +2350,7 @@ def _surfacing_bootstrap_status() -> dict[str, Any]:
             "enabled": surfacing.enabled,
             "feedback_enabled": surfacing.feedback_enabled,
             "feedback_db": db_status,
-            "ltm_server": _ltm_mcp_status(surfacing),
+            "ltm_server": _ltm_mcp_status(surfacing, timeout),
         }
     except Exception as exc:
         logger.debug("Surfacing bootstrap status inspection failed", exc_info=True)
@@ -2480,7 +2504,7 @@ def health(
 
     data = _load(path)
     servers: dict[str, Any] = data.get("upstream_servers", {})
-    surfacing_status = _surfacing_bootstrap_status()
+    surfacing_status = _surfacing_bootstrap_status(float(timeout))
 
     # JSON output format matches ``status --json`` / ``list --json`` (indent=2,
     # ensure_ascii=False) so scripts piping the three commands through the

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -2206,6 +2206,13 @@ async def _probe_ltm_mcp_command(
 ) -> dict[str, Any]:
     """Probe the configured LTM stdio MCP server without starting the proxy.
 
+    *timeout* is an **end-to-end** budget shared across initialize +
+    list_tools + the optional ``mem_do(action="version")`` probe — each
+    ``wait_for`` gets ``deadline - now`` so a stall in any phase can't push
+    the probe past the ``mms health --timeout`` ceiling. If the budget is
+    already exhausted when the version probe would run, it's skipped (the
+    version string is best-effort UX, not a correctness signal).
+
     Verifies that ``mem_search`` (the only tool the surfacing adapter strictly
     requires — see ``surfacing/mcp_client.py:423``) is advertised by the
     server before declaring ``connected``. A process that handshakes as MCP
@@ -2223,11 +2230,21 @@ async def _probe_ltm_mcp_command(
     from mcp import ClientSession
     from mcp.client.stdio import StdioServerParameters, stdio_client
 
+    deadline = asyncio.get_running_loop().time() + timeout
+
+    def remaining() -> float:
+        # ``asyncio.wait_for`` treats <=0 as "fire immediately"; clamp to a
+        # tiny positive so we always raise ``TimeoutError`` rather than
+        # returning a bogus result on a zero-budget call.
+        return max(1e-3, deadline - asyncio.get_running_loop().time())
+
     params = StdioServerParameters(command=command, args=args)
     async with stdio_client(params, errlog=errlog) as streams:
         async with ClientSession(streams[0], streams[1]) as session:
-            await asyncio.wait_for(session.initialize(), timeout=timeout)
-            tools_result = await asyncio.wait_for(session.list_tools(), timeout=timeout)
+            await asyncio.wait_for(session.initialize(), timeout=remaining())
+            tools_result = await asyncio.wait_for(
+                session.list_tools(), timeout=remaining()
+            )
             tool_names = {t.name for t in tools_result.tools}
             if "mem_search" not in tool_names:
                 return {
@@ -2240,17 +2257,24 @@ async def _probe_ltm_mcp_command(
                     ),
                 }
             version: str | None = None
-            if "mem_do" in tool_names:
+            # ``mem_search`` connectivity is already proven — don't burn what
+            # remains of the budget on the optional version probe if it'd
+            # push us past the deadline. The threshold is small enough to
+            # let a typical sub-second ``mem_do`` round-trip through but
+            # large enough to avoid spawning a ``wait_for`` we know will
+            # immediately raise.
+            budget_left = deadline - asyncio.get_running_loop().time()
+            if "mem_do" in tool_names and budget_left > 0.05:
                 try:
                     result = await asyncio.wait_for(
                         session.call_tool("mem_do", {"action": "version"}),
-                        timeout=timeout,
+                        timeout=remaining(),
                     )
                     version = _version_from_tool_result(result)
                 except Exception:
                     logger.debug(
-                        "LTM mem_do(version) probe failed; treating as "
-                        "unsupported on this server.",
+                        "LTM mem_do(version) probe failed or timed out within "
+                        "the shared budget; treating as unsupported.",
                         exc_info=True,
                     )
             return {"connected": True, "version": version, "error": None}

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -15,7 +15,7 @@ import tomllib
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 import click
 
@@ -2202,23 +2202,57 @@ async def _probe_ltm_mcp_command(
     command: str,
     args: list[str],
     timeout: float,
+    errlog: TextIO,
 ) -> dict[str, Any]:
-    """Probe the configured LTM stdio MCP server without starting the proxy."""
+    """Probe the configured LTM stdio MCP server without starting the proxy.
+
+    Verifies that ``mem_search`` (the only tool the surfacing adapter strictly
+    requires — see ``surfacing/mcp_client.py:423``) is advertised by the
+    server before declaring ``connected``. A process that handshakes as MCP
+    but doesn't expose ``mem_search`` would later silently fail every
+    surfacing call; flagging it here is the diagnostic operators want from
+    ``mms health``. The ``mem_do(action="version")`` probe stays best-effort
+    and only runs when ``mem_do`` is advertised — older servers that don't
+    recognize ``action=version`` should not poison the result.
+
+    Child stderr is routed to *errlog* so server banner / log lines don't
+    bleed into the ``mms health`` text/JSON output (caller passes an
+    fd-backed sink — ``stdio_client`` forwards this to
+    ``create_subprocess_exec(stderr=...)``, which requires ``fileno``).
+    """
     from mcp import ClientSession
     from mcp.client.stdio import StdioServerParameters, stdio_client
 
-    async with stdio_client(StdioServerParameters(command=command, args=args)) as streams:
+    params = StdioServerParameters(command=command, args=args)
+    async with stdio_client(params, errlog=errlog) as streams:
         async with ClientSession(streams[0], streams[1]) as session:
             await asyncio.wait_for(session.initialize(), timeout=timeout)
+            tools_result = await asyncio.wait_for(session.list_tools(), timeout=timeout)
+            tool_names = {t.name for t in tools_result.tools}
+            if "mem_search" not in tool_names:
+                return {
+                    "connected": False,
+                    "version": None,
+                    "error": (
+                        "server initialized but does not expose 'mem_search' "
+                        "(surfacing adapter calls this tool — config likely "
+                        "points at a non-memtomem MCP server)"
+                    ),
+                }
             version: str | None = None
-            try:
-                result = await asyncio.wait_for(
-                    session.call_tool("mem_do", {"action": "version"}),
-                    timeout=timeout,
-                )
-                version = _version_from_tool_result(result)
-            except Exception:
-                logger.debug("LTM version probe failed", exc_info=True)
+            if "mem_do" in tool_names:
+                try:
+                    result = await asyncio.wait_for(
+                        session.call_tool("mem_do", {"action": "version"}),
+                        timeout=timeout,
+                    )
+                    version = _version_from_tool_result(result)
+                except Exception:
+                    logger.debug(
+                        "LTM mem_do(version) probe failed; treating as "
+                        "unsupported on this server.",
+                        exc_info=True,
+                    )
             return {"connected": True, "version": version, "error": None}
 
 
@@ -2249,7 +2283,13 @@ def _ltm_mcp_status(surfacing: Any) -> dict[str, Any]:
 
     timeout = max(0.1, float(getattr(surfacing, "timeout_seconds", 3.0) or 3.0))
     try:
-        probe = asyncio.run(_probe_ltm_mcp_command(command, args, timeout))
+        # ``stdio_client`` forwards *errlog* directly to
+        # ``asyncio.create_subprocess_exec(stderr=...)``, which requires a real
+        # file descriptor — ``io.StringIO`` lacks ``fileno`` and would crash
+        # here. ``os.devnull`` gives us a fd-backed sink so server banners
+        # and MCP-SDK stderr can't bleed into ``mms health`` output.
+        with open(os.devnull, "w") as errnull, _silenced_mcp_sdk_logs():
+            probe = asyncio.run(_probe_ltm_mcp_command(command, args, timeout, errnull))
     except asyncio.TimeoutError:
         status["connected"] = False
         status["error"] = f"{display}: timeout ({timeout:g}s)"

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3941,6 +3941,86 @@ class TestHealth:
         assert "ltm server: UNREACHABLE" in proc.stdout
         assert "timeout (1s)" in proc.stdout
 
+    def test_health_ltm_probe_shares_timeout_across_phases(
+        self, config, monkeypatch, tmp_path
+    ):
+        """A server that handshakes + lists tools fast but stalls on
+        ``mem_do(action="version")`` must not extend total probe time past
+        ``--timeout``. The probe shares one end-to-end budget across
+        initialize + list_tools + the optional version call; the version
+        call's stall is absorbed and ``connected`` stays true because
+        ``mem_search`` connectivity was already proven."""
+        import subprocess
+        import textwrap
+        import time
+
+        stall_version_server = tmp_path / "_stall_version_server.py"
+        stall_version_server.write_text(
+            textwrap.dedent(
+                """\
+                import asyncio
+                from mcp.server.fastmcp import FastMCP
+
+                mcp = FastMCP("stall-version")
+
+                @mcp.tool()
+                async def mem_search(query: str) -> str:
+                    return ""
+
+                @mcp.tool()
+                async def mem_do(action: str, params: dict | None = None) -> str:
+                    if action == "version":
+                        await asyncio.sleep(60)
+                    return "{}"
+
+                if __name__ == "__main__":
+                    mcp.run()
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND", sys.executable)
+        monkeypatch.setenv(
+            "MEMTOMEM_STM_SURFACING__LTM_MCP_ARGS",
+            json.dumps([str(stall_version_server)]),
+        )
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS", "30")
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+
+        start = time.perf_counter()
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from memtomem_stm.cli.proxy import cli; cli()",
+                "health",
+                "--json",
+                "--timeout",
+                "1",
+                "--config",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        elapsed = time.perf_counter() - start
+
+        assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        data = json.loads(proc.stdout)
+        ltm = data["surfacing"]["ltm_server"]
+        # ``mem_search`` connectivity is proven before the version probe
+        # runs, so the version stall must not flip the verdict.
+        assert ltm["connected"] is True, ltm
+        # Version probe was budget-starved → silently dropped, not reported.
+        assert ltm["version"] is None, ltm
+        # Pre-fix this would have run ~30s (surfacing.timeout_seconds was the
+        # version probe's bound). Post-fix the shared budget caps it near
+        # the 1s ``--timeout``; ~5s gives plenty of room for subprocess
+        # spawn + Python startup on slow CI without being a no-op check.
+        assert elapsed < 5.0, f"shared-budget probe took {elapsed:.2f}s"
+
     def test_health_missing_config(self, runner, config):
         """Missing file → distinguish from empty-config so a user pointing
         at the wrong path gets a clear hint instead of a silent no-op

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3814,7 +3814,16 @@ class TestHealth:
         assert "ltm server: UNREACHABLE" in result.output
         assert "__missing_ltm__ not on PATH" in result.output
 
-    def test_health_reports_connectable_ltm_server(self, runner, config, monkeypatch):
+    def test_health_reports_connectable_ltm_server(self, config, monkeypatch):
+        """Probe a live MCP child via real subprocess.
+
+        Cannot use ``CliRunner`` here: Click's runner replaces ``sys.stderr``
+        with a buffer that has no ``fileno()``, and the MCP stdio client
+        forwards that stderr to ``asyncio.create_subprocess_exec`` which needs
+        a real file descriptor. Mirrors ``TestAddValidate``'s success-path
+        test, which hit the same constraint."""
+        import subprocess
+
         monkeypatch.setenv("MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND", sys.executable)
         monkeypatch.setenv(
             "MEMTOMEM_STM_SURFACING__LTM_MCP_ARGS",
@@ -3822,11 +3831,22 @@ class TestHealth:
         )
         config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
 
-        result = runner.invoke(cli, ["health", *_cfg_args(config)])
-
-        assert result.exit_code == 0
-        assert "ltm server: connectable" in result.output
-        assert "version 0.3.0-fake" in result.output
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from memtomem_stm.cli.proxy import cli; cli()",
+                "health",
+                "--config",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        assert "ltm server: connectable" in proc.stdout
+        assert "version 0.3.0-fake" in proc.stdout
 
     def test_health_missing_config(self, runner, config):
         """Missing file → distinguish from empty-config so a user pointing

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3726,6 +3726,7 @@ class TestHealth:
     @pytest.fixture(autouse=True)
     def _isolated_home(self, monkeypatch, tmp_path):
         set_home(monkeypatch, tmp_path / "home")
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND", "__missing_ltm__")
 
     def test_health_no_servers(self, runner, config):
         """Empty config → friendly message, no crash."""
@@ -3746,6 +3747,7 @@ class TestHealth:
         assert data["surfacing"]["feedback_enabled"] is True
         assert data["surfacing"]["feedback_db"]["exists"] is False
         assert data["surfacing"]["feedback_db"]["initialized"] is False
+        assert data["surfacing"]["ltm_server"]["connected"] is False
 
     def test_health_flags_existing_uninitialized_surfacing_db(
         self, runner, config, tmp_path, monkeypatch
@@ -3802,6 +3804,29 @@ class TestHealth:
         as_json = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
         assert as_json.exit_code == 0
         assert json.loads(as_json.output)["surfacing"]["error"] == "bad config"
+
+    def test_health_reports_unreachable_ltm_server(self, runner, config):
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+
+        result = runner.invoke(cli, ["health", *_cfg_args(config)])
+
+        assert result.exit_code == 0
+        assert "ltm server: UNREACHABLE" in result.output
+        assert "__missing_ltm__ not on PATH" in result.output
+
+    def test_health_reports_connectable_ltm_server(self, runner, config, monkeypatch):
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND", sys.executable)
+        monkeypatch.setenv(
+            "MEMTOMEM_STM_SURFACING__LTM_MCP_ARGS",
+            json.dumps([str(_FAKE_SERVER)]),
+        )
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+
+        result = runner.invoke(cli, ["health", *_cfg_args(config)])
+
+        assert result.exit_code == 0
+        assert "ltm server: connectable" in result.output
+        assert "version 0.3.0-fake" in result.output
 
     def test_health_missing_config(self, runner, config):
         """Missing file → distinguish from empty-config so a user pointing

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3988,23 +3988,37 @@ class TestHealth:
         monkeypatch.setenv("MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS", "30")
         config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
 
+        # ``--timeout 3`` (not 1) gives initialize + list_tools headroom on
+        # slow CI runners where Python child startup + FastMCP boot can eat
+        # several hundred ms; we still want the version stall to be bounded
+        # at ~3s, not 30s.
         start = time.perf_counter()
-        proc = subprocess.run(
-            [
-                sys.executable,
-                "-c",
-                "from memtomem_stm.cli.proxy import cli; cli()",
-                "health",
-                "--json",
-                "--timeout",
-                "1",
-                "--config",
-                str(config),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "from memtomem_stm.cli.proxy import cli; cli()",
+                    "health",
+                    "--json",
+                    "--timeout",
+                    "3",
+                    "--config",
+                    str(config),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        except subprocess.TimeoutExpired as exc:
+            # Pre-fix this is the canonical regression mode: the version
+            # probe gets the full ``TIMEOUT_SECONDS=30`` budget on top of
+            # initialize/list_tools, so the outer 20s watchdog trips before
+            # ``mms health`` returns.
+            raise AssertionError(
+                f"LTM probe didn't honor shared budget — outer subprocess "
+                f"timed out at {exc.timeout}s (expected ~3s wall time)"
+            ) from exc
         elapsed = time.perf_counter() - start
 
         assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
@@ -4015,11 +4029,12 @@ class TestHealth:
         assert ltm["connected"] is True, ltm
         # Version probe was budget-starved → silently dropped, not reported.
         assert ltm["version"] is None, ltm
-        # Pre-fix this would have run ~30s (surfacing.timeout_seconds was the
-        # version probe's bound). Post-fix the shared budget caps it near
-        # the 1s ``--timeout``; ~5s gives plenty of room for subprocess
-        # spawn + Python startup on slow CI without being a no-op check.
-        assert elapsed < 5.0, f"shared-budget probe took {elapsed:.2f}s"
+        # Pre-fix the version probe alone would burn ~30s; post-fix the
+        # shared budget caps it near the 3s ``--timeout``. 10s upper bound
+        # gives plenty of slack for slow CI without being a no-op check —
+        # pre-fix elapsed would actually trip the outer 20s
+        # ``subprocess.run`` first (caught above).
+        assert elapsed < 10.0, f"shared-budget probe took {elapsed:.2f}s"
 
     def test_health_missing_config(self, runner, config):
         """Missing file → distinguish from empty-config so a user pointing

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3788,7 +3788,7 @@ class TestHealth:
         monkeypatch.setattr(
             proxy_mod,
             "_surfacing_bootstrap_status",
-            lambda: {
+            lambda _timeout: {
                 "enabled": None,
                 "feedback_enabled": None,
                 "feedback_db": None,
@@ -3901,6 +3901,45 @@ class TestHealth:
         assert "ltm server: UNREACHABLE" in proc.stdout
         assert "mem_search" in proc.stdout
         assert "ltm server: connectable" not in proc.stdout
+
+    def test_health_ltm_probe_honors_cli_timeout(self, config, monkeypatch, tmp_path):
+        """``mms health --timeout N`` must bound the LTM probe at N seconds,
+        not at ``surfacing.timeout_seconds``. A stalled LTM command with a
+        large surfacing timeout would otherwise pin ``mms health`` past the
+        documented per-server bound."""
+        import subprocess
+
+        stall_server = tmp_path / "_stall_server.py"
+        stall_server.write_text("import time\ntime.sleep(60)\n", encoding="utf-8")
+
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND", sys.executable)
+        monkeypatch.setenv(
+            "MEMTOMEM_STM_SURFACING__LTM_MCP_ARGS",
+            json.dumps([str(stall_server)]),
+        )
+        # Surfacing's runtime timeout is set high so the CLI flag is the only
+        # thing that can bound the probe — pins the regression.
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS", "30")
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from memtomem_stm.cli.proxy import cli; cli()",
+                "health",
+                "--timeout",
+                "1",
+                "--config",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        assert "ltm server: UNREACHABLE" in proc.stdout
+        assert "timeout (1s)" in proc.stdout
 
     def test_health_missing_config(self, runner, config):
         """Missing file → distinguish from empty-config so a user pointing

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3848,6 +3848,60 @@ class TestHealth:
         assert "ltm server: connectable" in proc.stdout
         assert "version 0.3.0-fake" in proc.stdout
 
+    def test_health_flags_ltm_server_missing_mem_search(self, config, monkeypatch, tmp_path):
+        """An MCP server that initializes but doesn't expose ``mem_search``
+        cannot serve any surfacing call — flag it as UNREACHABLE instead of
+        falsely advertising ``connectable``.
+
+        Uses real subprocess for the same stderr-fileno reason as the
+        connectable test."""
+        import subprocess
+        import textwrap
+
+        bare_server = tmp_path / "_bare_mcp_server.py"
+        bare_server.write_text(
+            textwrap.dedent(
+                """\
+                from mcp.server.fastmcp import FastMCP
+
+                mcp = FastMCP("bare-no-mem-search")
+
+                @mcp.tool()
+                async def unrelated_tool() -> str:
+                    return "ok"
+
+                if __name__ == "__main__":
+                    mcp.run()
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND", sys.executable)
+        monkeypatch.setenv(
+            "MEMTOMEM_STM_SURFACING__LTM_MCP_ARGS",
+            json.dumps([str(bare_server)]),
+        )
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from memtomem_stm.cli.proxy import cli; cli()",
+                "health",
+                "--config",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}"
+        assert "ltm server: UNREACHABLE" in proc.stdout
+        assert "mem_search" in proc.stdout
+        assert "ltm server: connectable" not in proc.stdout
+
     def test_health_missing_config(self, runner, config):
         """Missing file → distinguish from empty-config so a user pointing
         at the wrong path gets a clear hint instead of a silent no-op


### PR DESCRIPTION
## Summary

- Add a stdio MCP probe (`ClientSession.initialize` + best-effort `mem_do(action="version")`) to `_surfacing_bootstrap_status`, gated by a fast `shutil.which` PATH check.
- Render the result in `mms health` as a new `ltm server:` row: `connectable (cmd, version X)`, `UNREACHABLE — <reason>`, or `skipped (surfacing disabled)`.
- Closes part (b) of #349. Part (a) (warn-once) shipped in #356. Part (c) (`mms init` LTM prompt) is deferred wait-for-signal per the #356 decision (operators commonly bootstrap STM before LTM; an init-time check would force a re-enable later).

## Why this is the next layer on top of #356

#356 added a single WARNING the first time the adapter returns `no_session` / `transport_error` — but the operator still has to read the log stream during a real call. `mms health` is the proactive diagnostic surface; failing to probe LTM there is the gap the issue calls out (`src/memtomem_stm/cli/proxy.py:2189-2209`). The probe is fast (PATH check first, then a stdio handshake bounded by `surfacing.timeout_seconds`), best-effort (failures are a warning row, not a non-zero exit — consistent with how upstream probes already report), and reuses `_root_cause_message` so anyio `TaskGroup` wrappers don't leak `"unhandled errors in a TaskGroup (1 sub-exception)"` into the line.

## Behavior change

- New health output row when surfacing is enabled:
  - `ltm server: connectable (memtomem-server, version 0.3.0)` — initialize succeeded; version is best-effort, omitted on parse failure.
  - `ltm server: UNREACHABLE — memtomem-server not on PATH` — fast-reject from `shutil.which`.
  - `ltm server: UNREACHABLE — <display>: timeout (3s)` — handshake exceeded `surfacing.timeout_seconds`.
  - `ltm server: UNREACHABLE — <display>: <root cause>` — other spawn/initialize errors.
  - `ltm server: skipped (surfacing disabled)` — when `surfacing.enabled=false`.
- `mms health --json` adds `surfacing.ltm_server` with `command`, `args`, `display`, `connected`, `version`, `error`, and optional `skipped`.
- No change to exit code, `mms health` does not gate on LTM reachability.
- No change to the WARNING-once behavior added in #356 — that path still fires the first time a real surfacing call hits an unreachable LTM.

## Test plan

- [x] `tests/cli/test_proxy_cli.py::TestHealth::test_health_reports_unreachable_ltm_server` — `__missing_ltm__` on PATH, asserts the `UNREACHABLE` line and `not on PATH` reason.
- [x] `tests/cli/test_proxy_cli.py::TestHealth::test_health_reports_connectable_ltm_server` — drives the probe against `tests/_fake_memtomem_server.py`, asserts the `connectable` line and `version 0.3.0-fake`.
- [x] Existing `TestHealth` cases extended: `test_health_default_surfacing_block` now also asserts `ltm_server.connected is False` under the autouse `__missing_ltm__` env, locking the JSON shape.
- [x] `uv run pytest tests/cli/test_proxy_cli.py -q` → 205 passed.
- [x] `uv run ruff check src/memtomem_stm/cli/proxy.py tests/cli/test_proxy_cli.py` → clean.
- [x] `uv run pytest tests/test_no_posix_only_imports.py -q` → 15 passed (the new `import shutil` is stdlib-portable; guard would catch a slip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)