### PR TITLE
fix(proxy/manager): assert embedding_base_url non-None (#164 part 1)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -506,6 +506,11 @@ class ProxyManager:
         from memtomem_stm.proxy.relevance import create_scorer
 
         sc = config.relevance_scorer
+        # ``embedding_base_url`` is typed ``str | None`` but the
+        # ``_apply_provider_default_url`` model validator substitutes the
+        # provider default (Ollama / OpenAI) whenever the field is omitted,
+        # so by this point it is always populated.
+        assert sc.embedding_base_url is not None
         return create_scorer(
             scorer_type=sc.scorer,
             provider=sc.embedding_provider,


### PR DESCRIPTION
## Summary

- Part 1 of #164 — fixes the `manager.py:513` mypy `[arg-type]` error.
- The `RelevanceScorerConfig._apply_provider_default_url` model validator already substitutes the Ollama / OpenAI provider default whenever `embedding_base_url` is omitted, so the value is always populated by the time `_create_scorer` runs. mypy could not see that invariant and flagged the `str | None` value flowing into `create_scorer`'s `str` parameter.
- Added an `assert ... is not None` to make the invariant visible to mypy, matching the existing pattern in `proxy/extraction.py:255` etc.

No behaviour change. The validator invariant is already covered by `tests/test_config_persistence.py:235-270`.

## Behavior change

None — the assertion encodes a runtime invariant that already held.

## Test plan

- [x] `uv run mypy src/memtomem_stm/proxy/manager.py` — error at L513 gone (L940 PendingStore error remains; that one is part 2)
- [x] `uv run ruff check src/memtomem_stm/proxy/manager.py`
- [x] `uv run pytest tests/test_config_persistence.py -m "not ollama"` — 27 passed

Refs #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)