### PR TITLE
fix(proxy/manager): widen progressive store local to PendingStore (#164 part 2)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from memtomem_stm.proxy.cache import ProxyCache
+    from memtomem_stm.proxy.pending_store import PendingStore
     from memtomem_stm.proxy.protocols import FileIndexer
     from memtomem_stm.proxy.relevance import RelevanceScorer
     from memtomem_stm.surfacing.engine import SurfacingEngine
@@ -929,11 +930,13 @@ class ProxyManager:
         if self._progressive_store is None or (
             sel_cfg is not None and sel_cfg != self._progressive_store_cfg
         ):
+            store: PendingStore
             if sel_cfg is not None and sel_cfg.pending_store == "sqlite":
                 from memtomem_stm.proxy.pending_store import SQLitePendingStore
 
-                store = SQLitePendingStore(sel_cfg.pending_store_path.expanduser())
-                store.initialize()
+                sqlite_store = SQLitePendingStore(sel_cfg.pending_store_path.expanduser())
+                sqlite_store.initialize()
+                store = sqlite_store
             else:
                 from memtomem_stm.proxy.pending_store import InMemoryPendingStore
 


### PR DESCRIPTION
## Summary

- Part 2 of #164 — fixes the `manager.py:940` mypy `[assignment]` error.
- mypy inferred the local `store` from its first assignment (`SQLitePendingStore`) and rejected the `InMemoryPendingStore` fallback branch. Both classes structurally satisfy the `PendingStore` Protocol that `ProgressiveStoreAdapter` consumes.
- Pre-declare `store: PendingStore` so each branch widens cleanly, and split out a narrow `sqlite_store` local for the `SQLitePendingStore.initialize()` call (which is not part of the Protocol).

Independent of #374 (part 1, `create_scorer` arg-type) — together they clear both pre-existing errors enumerated in #164.

## Behavior change

None — `ProgressiveStoreAdapter` already typed its `store` parameter as `object`, so this is purely a static-typing tightening.

## Test plan

- [x] `uv run mypy src/memtomem_stm/proxy/manager.py` — L940 error gone (L514 / part 1 still present on this branch since #374 is not in)
- [x] `uv run ruff check src/memtomem_stm/proxy/manager.py`
- [x] `uv run pytest -m "not ollama" -k "progressive_store or pending_store or selective"` — 64 passed

Refs #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)