### PR TITLE
fix(server): guard legacy feedback rating before str-typed dispatch

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -698,11 +698,19 @@ async def stm_surfacing_feedback(
         if app.surfacing_engine is not None:
             if ratings is not None:
                 return await app.surfacing_engine.handle_feedback_batch(surfacing_id, ratings)
+            # Legacy single-memory path requires a rating — the param is
+            # optional only to admit the batched ``ratings`` shape. Reject a
+            # ``memory_id``-only call so ``None`` never reaches the callee's
+            # ``rating: str`` (this also narrows ``rating`` for the type check).
+            if rating is None:
+                return "Error: `rating` is required for single-memory feedback."
             return await app.surfacing_engine.handle_feedback(surfacing_id, rating, memory_id)
         if app.feedback_tracker is None:
             return "Feedback tracking is not enabled."
         if ratings is not None:
             return _record_batched_via_tracker(app.feedback_tracker, surfacing_id, ratings)
+        if rating is None:
+            return "Error: `rating` is required for single-memory feedback."
         return app.feedback_tracker.record_feedback(surfacing_id, rating, memory_id)
 
 

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -385,6 +385,27 @@ class TestSurfacingFeedback:
         assert result.startswith("Error:")
         assert "required" in result
 
+    async def test_legacy_memory_id_only_rejected_before_engine_dispatch(self):
+        """`memory_id` without `rating` is the legacy shape but lacks the
+        mandatory rating — reject up-front so `None` never reaches the
+        engine's `rating: str` parameter."""
+        mock_engine = AsyncMock()
+        ctx = _make_ctx(surfacing_engine=mock_engine)
+        result = await stm_surfacing_feedback(surfacing_id="s1", memory_id="m1", ctx=ctx)
+        assert result.startswith("Error:")
+        assert "rating" in result and "required" in result
+        mock_engine.handle_feedback.assert_not_awaited()
+
+    async def test_legacy_memory_id_only_rejected_before_tracker_dispatch(self):
+        """Same guard on the engine-absent path — never reaches the tracker's
+        `rating: str` parameter."""
+        mock_tracker = MagicMock()
+        ctx = _make_ctx(surfacing_engine=None, feedback_tracker=mock_tracker)
+        result = await stm_surfacing_feedback(surfacing_id="s1", memory_id="m1", ctx=ctx)
+        assert result.startswith("Error:")
+        assert "rating" in result and "required" in result
+        mock_tracker.record_feedback.assert_not_called()
+
     async def test_batched_fallback_to_tracker(self):
         """Engine-absent path fans out via the tracker without boost/invalidation."""
         mock_tracker = MagicMock()


### PR DESCRIPTION
## Summary

Clears the **last 2 mypy errors** in `uv run mypy src` (`server.py:701`/`706`, `[arg-type]`) — after #376 dropped the 11 `mcp_client.py` `union-attr` errors, these `stm_surfacing_feedback` arg-type errors were all that remained, and they were untracked (the #164 umbrella that covered `proxy/manager.py` is closed).

## The bug

`stm_surfacing_feedback`'s `rating: str | None` is Optional **only** to admit the batched `ratings` shape. But `legacy_set` is true when *either* `rating` or `memory_id` is set:

```python
legacy_set = rating is not None or memory_id is not None
```

So a `memory_id`-only call (no `rating`) passes the guards and reaches `SurfacingEngine.handle_feedback` (`engine.py:280`) and `FeedbackTracker.record_feedback` (`feedback.py:75`) — both typed `rating: str` — with `rating=None`.

**Runtime was benign** (both callees reject `None` via `rating not in VALID_RATINGS` → a clean error string; no crash, no DB write). So this is a type-contract + error-message-quality fix, not a crash fix. The user-facing message was the imprecise `"rating must be one of [...]"` rather than `"rating is required"`.

## Fix

Add a `rating is None` guard **directly before each legacy dispatch call**, placed after the mutual-exclusion checks so `memory_id` + `ratings` still reports `"cannot mix"`. Guarding at the call site (vs. an up-front compound `ratings is None and rating is None` check) is what lets mypy narrow `rating` to `str` — a disjunctive cross-variable precheck does not propagate to the dispatch branches.

- Callee signatures are **not** widened — single feedback semantically requires a rating.
- Batched paths and the `"Feedback tracking is not enabled."` priority are **unchanged**.

## Behavior change

Only the error message on a `memory_id`-only legacy call (when a backend is available): `"rating must be one of [...]"` → `"rating is required for single-memory feedback."` No other path changes.

## Test plan

- [x] `uv run mypy src` — **0 errors** (was 2)
- [x] `uv run ruff check src tests/test_server_tools.py` + `ruff format --check`
- [x] `uv run pytest -m "not ollama" tests/test_server_tools.py::TestSurfacingFeedback` — 12 passed (2 new regression tests: engine path + tracker-only path both reject `memory_id`-only before dispatch)
- [x] Full `uv run pytest -m "not ollama"` — 2259 passed; the 2 failures (`test_double_start_no_leak`, `test_search_returns_empty_when_no_session`) are pre-existing **local-env** artifacts (a live LTM server running on the dev box makes the adapter return `empty_results` instead of `no_session`), reproduce identically on clean `main`, and are green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)