### PR TITLE
feat(cli): add `mms hook` to surface LTM memories for built-in tools

### DIFF
--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -1,0 +1,288 @@
+"""``mms hook`` — bridge a host's built-in tool calls into STM's surfacing.
+
+Claude Code (and compatible hosts) invoke a ``PostToolUse`` hook as a plain
+command: the hook payload arrives as JSON on **stdin** and the hook replies
+with JSON on **stdout**. This subcommand reads that payload, runs STM's
+proactive memory surfacing over the built-in tool's output, and — when
+relevant LTM memories are found — returns them through ``additionalContext``
+so the host appends them next to the tool result the model reads.
+
+Why surfacing-only (no ``updatedToolOutput``): appending context is the
+side-effect-free hook play. Compression-style *replacement* of a built-in
+tool's output is a separate, riskier stage (it must match each tool's output
+shape, and compressing ``Read`` breaks a later ``Edit``'s verbatim
+``old_string`` match) and is intentionally out of scope here. See the Stage B
+section of the project plan / ``project_stm_builtin_tool_hooks`` memory.
+
+Tool scope: we only surface for **read-like** built-in tools
+(:data:`_DEFAULT_SURFACE_TOOLS` — Read/Grep/Glob/Bash, overridable via
+``MEMTOMEM_STM_HOOK_SURFACE_TOOLS``). This allowlist is enforced here rather
+than relying on the host's hook ``matcher`` (a too-broad matcher would
+otherwise feed Write/Edit through) — surfacing on a write is semantically
+wrong, and a write's inputs (file contents, ``old_string``/``new_string``)
+should never become a search query. To keep extracted queries (which for
+``Bash`` may include secret-bearing commands) off disk, this MVP path runs
+**without** the feedback store, so no query text is persisted; the feedback
+loop, cross-session dedup, and a privacy gate for ingestion arrive with the
+daemon stage (P2/Stage D).
+
+Hard rule — a hook must never disrupt the host. This command **always exits
+0** and, on any malformed input, disabled surfacing, timeout, or internal
+error, emits an empty object ``{}`` so the original tool result passes through
+untouched.
+
+Register in Claude Code ``settings.json``::
+
+    {"hooks": {"PostToolUse": [
+      {"matcher": "Read|Grep|Glob|Bash",
+       "hooks": [{"type": "command", "command": "mms hook"}]}]}}
+
+Performance caveat — near-no-op with stock defaults: a fresh ``mms hook``
+process spawns a fresh LTM MCP child per call, and that cold start (embedding
++ reranker model load) measured ~6s here, which exceeds the default
+``surfacing.timeout_seconds`` of 3.0 — so surfacing usually times out and
+returns ``{}``. The default ``surfacing.min_response_chars`` of 5000 also
+gates out small tool outputs. To make surfacing actually fire before the
+daemon lands, raise ``MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS`` (e.g. 8) and
+lower ``MEMTOMEM_STM_SURFACING__MIN_RESPONSE_CHARS``, accepting the per-call
+latency. A persistent local daemon (warm LTM connection) is the real fix.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Any, TextIO
+
+import click
+
+logger = logging.getLogger(__name__)
+
+# Delimiters emitted by ``SurfacingFormatter`` around the injected block. We
+# slice this back out so ``additionalContext`` carries only the memories, not
+# a duplicate of the tool output the engine was handed as ``response_text``.
+_SURFACED_OPEN = "<surfaced-memories>"
+_SURFACED_CLOSE = "</surfaced-memories>"
+
+# Read-like built-in tools we surface against. Write/Edit/MultiEdit are
+# deliberately excluded (see module docstring). Matched case-sensitively
+# against Claude Code's PascalCase tool names — note the surfacing gate's own
+# ``write_tool_patterns`` can't be relied on here because ``fnmatch`` is
+# case-normalizing (identity on POSIX), so ``*write*`` never matches ``Write``.
+_DEFAULT_SURFACE_TOOLS = frozenset({"Read", "Grep", "Glob", "Bash"})
+
+
+def _surface_tools() -> frozenset[str]:
+    """Allowlist of tool names to surface for, overridable via env.
+
+    ``MEMTOMEM_STM_HOOK_SURFACE_TOOLS`` is a comma-separated list; empty or
+    unset falls back to :data:`_DEFAULT_SURFACE_TOOLS`.
+    """
+    raw = os.environ.get("MEMTOMEM_STM_HOOK_SURFACE_TOOLS")
+    if not raw:
+        return _DEFAULT_SURFACE_TOOLS
+    tools = {t.strip() for t in raw.split(",") if t.strip()}
+    return frozenset(tools) or _DEFAULT_SURFACE_TOOLS
+
+
+def _hook_budget_seconds() -> float:
+    """Outer wall-clock backstop for the whole hook call.
+
+    ``SurfacingEngine`` bounds its own LTM search via
+    ``surfacing.timeout_seconds``; this only guards against a hang *outside*
+    that window (e.g. tearing down a wedged LTM subprocess). Sized to sit above
+    the configured surfacing timeout so raising that env to beat LTM cold start
+    isn't silently clipped.
+    """
+    raw = os.environ.get("MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS")
+    try:
+        configured = float(raw) if raw else 3.0
+    except ValueError:
+        configured = 3.0
+    return max(configured + 8.0, 12.0)
+
+
+def _tool_response_to_text(tool_response: Any) -> str:
+    """Best-effort flatten of a built-in tool's output to a single string.
+
+    The surfaced *query* is derived from ``tool_input`` (the file path /
+    pattern / command), so this text matters mainly for surfacing's size gate
+    (``min_response_chars``). Shapes differ per tool and per host version, so
+    stay permissive: strings pass through; dicts surrender common text-ish
+    fields (``stdout``/``stderr``/``content``/``text``/``output``/``result``)
+    or fall back to a JSON dump; lists join their flattened parts.
+    """
+    if tool_response is None:
+        return ""
+    if isinstance(tool_response, str):
+        return tool_response
+    if isinstance(tool_response, list):
+        return "\n".join(_tool_response_to_text(part) for part in tool_response)
+    if isinstance(tool_response, dict):
+        parts = [
+            value
+            for key in ("stdout", "stderr", "content", "text", "output", "result")
+            if isinstance(value := tool_response.get(key), str) and value
+        ]
+        if parts:
+            return "\n".join(parts)
+        try:
+            return json.dumps(tool_response, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(tool_response)
+    return str(tool_response)
+
+
+def _extract_surfaced_block(original: str, injected: str, injection_mode: str) -> str | None:
+    """Return just the ``<surfaced-memories>…</surfaced-memories>`` block.
+
+    ``SurfacingEngine.surface`` returns ``response_text`` with the block
+    prepended or appended (or returns it unchanged when nothing surfaced).
+    ``injection_mode`` tells us which side the formatter added, so we recover
+    the exact delta; we then sanity-check the tag delimiters and fall back to a
+    direct tag scan if the slice looks wrong (defensive against formatter
+    changes). Returns ``None`` when nothing was surfaced.
+    """
+    if injected == original or len(injected) <= len(original):
+        return None
+    if injection_mode == "prepend":
+        block = injected[: len(injected) - len(original)]
+    else:  # "append" / "section"
+        block = injected[len(original) :]
+    block = block.strip()
+    if block.startswith(_SURFACED_OPEN) and block.endswith(_SURFACED_CLOSE):
+        return block
+    start = injected.find(_SURFACED_OPEN)
+    end = injected.rfind(_SURFACED_CLOSE)
+    if start == -1 or end == -1:
+        return None
+    return injected[start : end + len(_SURFACED_CLOSE)]
+
+
+async def run_surfacing_hook(
+    payload: dict[str, Any], *, engine: Any | None = None
+) -> dict[str, Any]:
+    """Core hook logic. Returns the hook-output dict (``{}`` means no-op).
+
+    **Never raises** — every failure path (bad payload, disabled surfacing,
+    LTM error/timeout, internal bug) degrades to ``{}`` so any caller (the CLI
+    today, a daemon/HTTP adapter later) can emit it and let the tool output
+    pass through. ``engine`` is a test seam: when provided it is used as-is
+    (caller owns its lifecycle); when ``None``, an engine + LTM adapter are
+    built from :class:`STMConfig` and torn down before returning.
+    """
+    try:
+        return await _run_surfacing_hook_inner(payload, engine=engine)
+    except Exception:
+        logger.warning("hook surfacing failed — passing tool output through", exc_info=True)
+        return {}
+
+
+async def _run_surfacing_hook_inner(
+    payload: dict[str, Any], *, engine: Any | None
+) -> dict[str, Any]:
+    if (payload.get("hook_event_name") or "PostToolUse") != "PostToolUse":
+        return {}
+    tool_name = payload.get("tool_name")
+    if not isinstance(tool_name, str) or tool_name not in _surface_tools():
+        return {}
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    response_text = _tool_response_to_text(payload.get("tool_response"))
+
+    if engine is not None:
+        injected = await engine.surface("builtin", tool_name, tool_input, response_text)
+        return _build_output(response_text, injected, engine.injection_mode)
+
+    # Lazy imports: keep ``mms hook --help`` and unrelated CLI paths off the
+    # surfacing/MCP import cost.
+    from memtomem_stm.config import STMConfig
+    from memtomem_stm.surfacing.engine import SurfacingEngine
+    from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
+    from memtomem_stm.surfacing.observability import SurfacingObservability
+
+    surfacing_cfg = STMConfig().surfacing
+    if not surfacing_cfg.enabled:
+        return {}
+
+    # No FeedbackTracker on this path: it would persist extracted query text
+    # (potentially secret-bearing Bash commands) to disk and contend on the
+    # server's SQLite store. The feedback loop + dedup return with the daemon
+    # stage (and an explicit privacy gate). ``feedback_tracker=None`` also means
+    # the injected block carries no ``surfacing_id`` / rating prompt.
+    adapter = McpClientSearchAdapter(surfacing_cfg)
+    built = SurfacingEngine(
+        surfacing_cfg,
+        mcp_adapter=adapter,
+        feedback_tracker=None,
+        observability=SurfacingObservability(),
+    )
+    try:
+        injected = await built.surface("builtin", tool_name, tool_input, response_text)
+    finally:
+        await _quiet_async(built.stop(), "surfacing engine stop")
+        await _quiet_async(adapter.stop(), "LTM adapter stop")
+
+    return _build_output(response_text, injected, surfacing_cfg.injection_mode)
+
+
+def _build_output(response_text: str, injected: str, injection_mode: str) -> dict[str, Any]:
+    block = _extract_surfaced_block(response_text, injected, injection_mode)
+    if not block:
+        return {}
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": block,
+        }
+    }
+
+
+async def _quiet_async(coro: Any, what: str) -> None:
+    """Await a cleanup coroutine, swallowing (and debug-logging) any error."""
+    try:
+        await coro
+    except Exception:
+        logger.debug("%s failed", what, exc_info=True)
+
+
+def _read_payload(stream: TextIO) -> dict[str, Any] | None:
+    """Read and JSON-parse the hook payload from ``stream``; ``None`` if absent
+    or malformed (caller treats that as a clean no-op)."""
+    try:
+        raw = stream.read()
+    except Exception:
+        return None
+    if not raw or not raw.strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+@click.command(name="hook")
+def hook_command() -> None:
+    """Surface STM memories for a host's built-in tool call (PostToolUse hook).
+
+    Reads the hook JSON payload on stdin and, for read-like built-in tools,
+    prints a hook response whose ``additionalContext`` carries relevant LTM
+    memories. Always exits 0; on any problem the tool output passes through
+    unchanged (prints ``{}``).
+    """
+    payload = _read_payload(sys.stdin)
+    output: dict[str, Any] = {}
+    if payload is not None:
+        try:
+            output = asyncio.run(
+                asyncio.wait_for(run_surfacing_hook(payload), timeout=_hook_budget_seconds())
+            )
+        except Exception:
+            logger.warning("hook surfacing failed — passing tool output through", exc_info=True)
+            output = {}
+    click.echo(json.dumps(output, ensure_ascii=False))

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -19,6 +19,7 @@ from typing import Any, TextIO
 
 import click
 
+from memtomem_stm.cli.hook_cmd import hook_command as _hook_command
 from memtomem_stm.cli.mms_host import host_group as _mms_host_group
 from memtomem_stm.cli.mms_import import import_command as _mms_import_command
 from memtomem_stm.cli.mms_project import project_group as _mms_project_group
@@ -2592,3 +2593,7 @@ cli.add_command(_mms_import_command)
 
 # `mms host ...` — RFC §7.3, lives in src/memtomem_stm/cli/mms_host.py.
 cli.add_command(_mms_host_group)
+
+# `mms hook` — bridge a host's built-in tool calls (Claude Code PostToolUse)
+# into STM surfacing; lives in src/memtomem_stm/cli/hook_cmd.py.
+cli.add_command(_hook_command)

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -503,8 +503,11 @@ class SurfacingEngine:
             return response_text
         self._observability.record_outcome(tool, "surfaced_cache_hit")
         logger.debug("Surfacing cache hit (%d results) for %s/%s", len(cached), server, tool)
-        surfacing_id: str | None = uuid.uuid4().hex[:16]
+        # See ``_do_surface_miss``: only advertise a feedback ID we actually
+        # recorded, so a no-tracker path doesn't prompt for an unresolvable ID.
+        surfacing_id: str | None = None
         if self._feedback_tracker is not None:
+            surfacing_id = uuid.uuid4().hex[:16]
             try:
                 self._feedback_tracker.record_surfacing(
                     surfacing_id=surfacing_id,
@@ -717,9 +720,14 @@ class SurfacingEngine:
                 logger.debug("Failed to fetch session scratch items", exc_info=True)
                 scratch_items = None
 
-        # Generate surfacing ID and record event
-        surfacing_id: str | None = uuid.uuid4().hex[:16]
+        # Generate surfacing ID and record event. Only mint an ID when a
+        # tracker is attached to record it — otherwise the formatter would
+        # advertise a ``stm_surfacing_feedback(...)`` prompt for an event the
+        # server can't resolve. Both the ``mms hook`` path and the
+        # feedback-disabled server path run with no tracker.
+        surfacing_id: str | None = None
         if self._feedback_tracker is not None:
+            surfacing_id = uuid.uuid4().hex[:16]
             try:
                 self._feedback_tracker.record_surfacing(
                     surfacing_id=surfacing_id,

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -143,6 +143,9 @@ async def test_run_hook_surfaces_into_additional_context():
     assert ctx.startswith("<surfaced-memories>")
     # additionalContext carries only the memories, not a copy of tool output.
     assert "JWT authentication handler." not in ctx
+    # No feedback store on this path → no unresolvable feedback prompt.
+    assert "stm_surfacing_feedback" not in ctx
+    assert "surfacing_id" not in ctx
 
 
 async def test_run_hook_empty_results_is_noop():

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -1,0 +1,218 @@
+"""Tests for ``mms hook`` — the built-in-tool → STM surfacing bridge.
+
+Coverage:
+
+- Pure helpers ``_tool_response_to_text`` / ``_extract_surfaced_block`` — the
+  novel logic that flattens a tool result and recovers the injected memory
+  block from the engine's combined output.
+- ``run_surfacing_hook`` via the ``engine=`` test seam (a real
+  :class:`SurfacingEngine` over a mock LTM adapter — no LTM subprocess) so the
+  end-to-end shape is locked without depending on a live memtomem server.
+- CLI degradation through ``CliRunner``: malformed / non-PostToolUse / disabled
+  inputs must all print ``{}`` and exit 0 so a hook can never disrupt the host.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem_stm.cli.hook_cmd import (
+    _extract_surfaced_block,
+    _tool_response_to_text,
+    run_surfacing_hook,
+)
+from memtomem_stm.cli.proxy import cli
+from memtomem_stm.surfacing.config import SurfacingConfig
+from memtomem_stm.surfacing.engine import SurfacingEngine
+
+
+# ── Fakes (mirror tests/test_surfacing_engine.py shapes) ─────────────────────
+
+
+@dataclass
+class _FakeMeta:
+    source_file: Path = Path("/notes/test.md")
+    namespace: str = "default"
+
+
+@dataclass
+class _FakeChunk:
+    id: str = ""
+    content: str = "some memory content"
+    metadata: _FakeMeta | None = None
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = str(uuid4())
+        if self.metadata is None:
+            self.metadata = _FakeMeta()
+
+
+@dataclass
+class _FakeResult:
+    chunk: _FakeChunk
+    score: float
+
+
+def _engine_with_results(results: list[_FakeResult] | None) -> SurfacingEngine:
+    """A real SurfacingEngine over a mock adapter returning ``results``."""
+    res = results or []
+    adapter = AsyncMock()
+    adapter.search = AsyncMock(return_value=(res, [], "ok" if res else "empty_results"))
+    config = SurfacingConfig(
+        enabled=True,
+        min_response_chars=10,
+        timeout_seconds=5.0,
+        min_score=0.02,
+        cooldown_seconds=0.0,
+        max_surfacings_per_minute=1000,
+        auto_tune_enabled=False,
+        include_session_context=False,
+        fire_webhook=False,
+    )
+    return SurfacingEngine(config, mcp_adapter=adapter)
+
+
+_LONG = "JWT authentication handler. " * 50  # well above min_response_chars
+_READ_PAYLOAD = {
+    "hook_event_name": "PostToolUse",
+    "tool_name": "Read",
+    "tool_input": {"file_path": "/src/auth/jwt_handler.py"},
+    "tool_response": {"content": _LONG},
+}
+
+
+# ── _tool_response_to_text ───────────────────────────────────────────────────
+
+
+def test_tool_response_to_text_passthrough_and_shapes():
+    assert _tool_response_to_text("raw output") == "raw output"
+    assert _tool_response_to_text(None) == ""
+    assert _tool_response_to_text({"stdout": "out", "stderr": "err"}) == "out\nerr"
+    assert _tool_response_to_text(["a", "b"]) == "a\nb"
+
+
+def test_tool_response_to_text_dict_without_text_fields_falls_back_to_json():
+    out = _tool_response_to_text({"exitCode": 0, "interrupted": False})
+    assert json.loads(out) == {"exitCode": 0, "interrupted": False}
+
+
+# ── _extract_surfaced_block ──────────────────────────────────────────────────
+
+_BLOCK = "<surfaced-memories>\nMEM\n</surfaced-memories>"
+
+
+def test_extract_block_append_mode():
+    injected = f"ORIG\n\n{_BLOCK}"
+    assert _extract_surfaced_block("ORIG", injected, "append") == _BLOCK
+
+
+def test_extract_block_prepend_mode():
+    injected = f"{_BLOCK}\n\nORIG"
+    assert _extract_surfaced_block("ORIG", injected, "prepend") == _BLOCK
+
+
+def test_extract_block_no_change_returns_none():
+    assert _extract_surfaced_block("ORIG", "ORIG", "append") is None
+
+
+def test_extract_block_defensive_fallback_on_wrong_mode():
+    # Mode says prepend but the block was actually appended → the slice won't
+    # match the tag delimiters, so the direct tag scan must still recover it.
+    injected = f"ORIG\n\n{_BLOCK}"
+    assert _extract_surfaced_block("ORIG", injected, "prepend") == _BLOCK
+
+
+# ── run_surfacing_hook (engine seam) ─────────────────────────────────────────
+
+
+async def test_run_hook_surfaces_into_additional_context():
+    engine = _engine_with_results([_FakeResult(_FakeChunk(content="Use RS256 for JWT"), 0.5)])
+    out = await run_surfacing_hook(_READ_PAYLOAD, engine=engine)
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PostToolUse"
+    ctx = hso["additionalContext"]
+    assert "Use RS256 for JWT" in ctx
+    assert ctx.startswith("<surfaced-memories>")
+    # additionalContext carries only the memories, not a copy of tool output.
+    assert "JWT authentication handler." not in ctx
+
+
+async def test_run_hook_empty_results_is_noop():
+    engine = _engine_with_results([])
+    assert await run_surfacing_hook(_READ_PAYLOAD, engine=engine) == {}
+
+
+async def test_run_hook_ignores_non_posttooluse():
+    engine = _engine_with_results([_FakeResult(_FakeChunk(), 0.9)])
+    payload = {**_READ_PAYLOAD, "hook_event_name": "PreToolUse"}
+    assert await run_surfacing_hook(payload, engine=engine) == {}
+
+
+async def test_run_hook_requires_tool_name():
+    engine = _engine_with_results([_FakeResult(_FakeChunk(), 0.9)])
+    payload = {"hook_event_name": "PostToolUse", "tool_input": {"file_path": "x"}}
+    assert await run_surfacing_hook(payload, engine=engine) == {}
+
+
+@pytest.mark.parametrize("tool", ["Write", "Edit", "MultiEdit", "NotebookEdit", "Task"])
+async def test_run_hook_rejects_non_readlike_tools(tool: str):
+    # Write/Edit/etc. must never surface — even with a matching engine and a
+    # broad host matcher — so their inputs don't become queries (the gate's
+    # write-tool block is case-sensitive and misses PascalCase names).
+    engine = _engine_with_results([_FakeResult(_FakeChunk(content="secret"), 0.9)])
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": tool,
+        "tool_input": {"file_path": "/a/b.py", "old_string": "x", "new_string": "y"},
+        "tool_response": {"content": _LONG},
+    }
+    assert await run_surfacing_hook(payload, engine=engine) == {}
+
+
+async def test_run_hook_allowlist_env_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK_SURFACE_TOOLS", "CustomRead")
+    engine = _engine_with_results([_FakeResult(_FakeChunk(content="hit"), 0.9)])
+    # A default-allowlisted tool is now rejected...
+    assert await run_surfacing_hook(_READ_PAYLOAD, engine=engine) == {}
+    # ...and the override tool is accepted.
+    out = await run_surfacing_hook({**_READ_PAYLOAD, "tool_name": "CustomRead"}, engine=engine)
+    assert "hit" in out["hookSpecificOutput"]["additionalContext"]
+
+
+async def test_run_hook_never_raises_on_engine_error():
+    # The "never raises" contract must hold for direct callers (a future
+    # daemon), not only the CLI's outer guard.
+    boom = AsyncMock()
+    boom.surface = AsyncMock(side_effect=RuntimeError("LTM exploded"))
+    boom.injection_mode = "append"
+    assert await run_surfacing_hook(_READ_PAYLOAD, engine=boom) == {}
+
+
+# ── CLI degradation (must always print {} and exit 0) ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "stdin",
+    ["", "   ", "not json", '{"hook_event_name": "PreToolUse"}', "[1,2,3]"],
+)
+def test_cli_degrades_to_empty_object(stdin: str):
+    result = CliRunner().invoke(cli, ["hook"], input=stdin)
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {}
+
+
+def test_cli_surfacing_disabled_is_noop(monkeypatch: pytest.MonkeyPatch):
+    # A valid PostToolUse payload, but surfacing off → returns {} without ever
+    # constructing the LTM adapter (so no subprocess spawn in CI).
+    monkeypatch.setenv("MEMTOMEM_STM_SURFACING__ENABLED", "false")
+    result = CliRunner().invoke(cli, ["hook"], input=json.dumps(_READ_PAYLOAD))
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {}

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -116,6 +116,17 @@ class TestSurfacingBasic:
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert output == LONG_RESPONSE
 
+    async def test_no_feedback_prompt_without_tracker(self):
+        # With no feedback tracker (mms-hook path / feedback-disabled server),
+        # the engine must not advertise a surfacing_id / stm_surfacing_feedback
+        # prompt — the event was never recorded, so the ID is unresolvable.
+        results = [FakeSearchResult(chunk=FakeChunk(content="Flask chosen"), score=0.5)]
+        engine = SurfacingEngine(config=_make_config(), mcp_adapter=_make_mcp_adapter(results))
+        output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert "Flask chosen" in output
+        assert "stm_surfacing_feedback" not in output
+        assert "surfacing_id" not in output
+
     async def test_disabled_returns_original(self):
         engine = SurfacingEngine(
             config=_make_config(enabled=False),


### PR DESCRIPTION
## What

Adds a `mms hook` subcommand that bridges a host's **built-in** editor tools into STM's surfacing pipeline. Hosts like Claude Code run a `PostToolUse` hook as a command that gets the tool call as JSON on stdin and replies on stdout; `mms hook` reads that payload and, for read-like built-in tools (`Read`/`Grep`/`Glob`/`Bash`), runs STM's existing surfacing over the tool output and returns relevant LTM memories via `additionalContext`.

This extends STM's value beyond MCP-proxied tools — until now, a host's built-in tool calls bypassed STM entirely.

## Why surfacing-only (no `updatedToolOutput`)

Appending context via `additionalContext` is the side-effect-free hook play. Compression-style output *replacement* is a separate, riskier stage: the replacement value must match each tool's output shape, and compressing a `Read` would break a later `Edit`'s verbatim `old_string` match. That work is deliberately deferred.

## Safety (a hook must never disrupt the host)

- **Read-like allowlist enforced in the hook itself** (`Read`/`Grep`/`Glob`/`Bash`, overridable via `MEMTOMEM_STM_HOOK_SURFACE_TOOLS`) — not relying on the host's matcher. A too-broad matcher therefore can't feed `Write`/`Edit` content in as a search query. The surfacing gate's own write-tool block can't be relied on here because `fnmatch` is case-normalizing (identity on POSIX), so `*write*` never matches `Write`.
- **No feedback store on this path** — extracted queries (e.g. secret-bearing `Bash` commands) are never persisted, and there's no SQLite contention with the server. The feedback loop, cross-session dedup, and an explicit privacy gate arrive with the planned daemon stage.
- **Never raises, always exits 0** — malformed input, disabled surfacing, timeout, or any internal error degrades to `{}` so the original tool result passes through untouched. The "never raises" contract holds for direct callers (a future daemon), not just the CLI's outer guard.

## Known limitation

A fresh `mms hook` process cold-starts the LTM MCP child each call (~6s embedding/reranker load, measured locally) which exceeds the default `surfacing.timeout_seconds` of 3.0 — so surfacing is **near-no-op with stock defaults**. Raise `MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS` and lower `MEMTOMEM_STM_SURFACING__MIN_RESPONSE_CHARS` to make it fire pre-daemon. A persistent local daemon (warm LTM connection) is the real fix and the planned next stage.

## Register in Claude Code

```json
{"hooks": {"PostToolUse": [
  {"matcher": "Read|Grep|Glob|Bash",
   "hooks": [{"type": "command", "command": "mms hook"}]}]}}
```

## Testing

- New `tests/cli/test_hook_cmd.py` (23 tests): pure helpers (`_tool_response_to_text`, `_extract_surfaced_block`); engine-seam end-to-end with a mock LTM adapter; allowlist rejection of `Write`/`Edit`/`MultiEdit`; allowlist env override; "never raises" on engine error; CLI degradation (empty / invalid JSON / non-PostToolUse / disabled → `{}`).
- `ruff check` / `ruff format` clean; `mypy` clean.
- Full suite: 2275 passed (2 pre-existing local-only failures from a live LTM on the dev box are unrelated and pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
