### PR TITLE
feat(daemon): warm surfacing daemon for `mms hook` (Stage 2, PR 1)

### DIFF
--- a/src/memtomem_stm/__main__.py
+++ b/src/memtomem_stm/__main__.py
@@ -1,0 +1,15 @@
+"""``python -m memtomem_stm`` → the Click CLI.
+
+Primarily so the daemon can re-spawn itself detached with a stable, path-free
+invocation (``[sys.executable, "-m", "memtomem_stm", "daemon", "run"]``) on
+every platform, rather than hunting for a console-script path. Because the CLI
+group only dispatches the bare-invocation MCP-server path when *no* subcommand
+is given, passing ``daemon run`` here invokes that subcommand directly.
+"""
+
+from __future__ import annotations
+
+from memtomem_stm.cli.proxy import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -149,7 +149,12 @@ def start_cmd() -> None:
             click.echo(_ok("daemon already running"))
             return
         _spawn_detached()
-    hs = _wait_ready(config, timeout=8.0)
+        # Hold the lock through readiness. Releasing it here would let a
+        # concurrent `start` acquire it, see ping return None (our child hasn't
+        # published its handshake yet), and spawn a *second* daemon — which,
+        # with ephemeral ports + last-writer-wins handshake, orphans an extra
+        # warm LTM process.
+        hs = _wait_ready(config, timeout=8.0)
     if hs is not None:
         click.echo(_ok(f"daemon started (pid={hs.get('pid')} port={hs.get('port')})"))
     else:

--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -1,0 +1,258 @@
+"""``mms daemon`` — manage the local surfacing daemon (Stage 2).
+
+The daemon keeps one warm LTM connection + ``SurfacingEngine`` so ``mms hook``
+avoids the ~6s cold start on every built-in tool call. Subcommands:
+
+- ``run``     — the actual long-lived server loop (foreground, or the target of
+  a detached spawn via ``--detached``).
+- ``start``   — spawn the daemon detached if one isn't already running.
+- ``stop``    — ask a running daemon to shut down (SIGTERM by pid as fallback).
+- ``status``  — running/stale/stopped, with pid/port/uptime/LTM warmth.
+- ``restart`` — ``stop`` then ``start``.
+
+Color helpers are defined locally (not imported from ``cli.proxy``) so this
+module stays import-cheap and free of an import cycle with the group that
+registers it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+import click
+
+if TYPE_CHECKING:
+    from memtomem_stm.config import STMConfig
+
+
+def _color_on() -> bool:
+    return "NO_COLOR" not in os.environ
+
+
+def _ok(s: str) -> str:
+    return click.style(s, fg="green") if _color_on() else s
+
+
+def _warn(s: str) -> str:
+    return click.style(s, fg="yellow") if _color_on() else s
+
+
+def _load_config() -> STMConfig:
+    from memtomem_stm.config import STMConfig
+
+    return STMConfig()
+
+
+def _configure_logging(config: STMConfig, *, detached: bool) -> None:
+    """Route daemon logs to a file under ``data_dir`` when detached (its stdio
+    is ``DEVNULL``), otherwise to stderr for foreground debugging."""
+    level = getattr(logging, config.log_level, logging.WARNING)
+    handler: logging.Handler
+    if detached:
+        logpath = (config.data_dir / "stm-daemon.log").expanduser()
+        logpath.parent.mkdir(parents=True, exist_ok=True)
+        handler = logging.FileHandler(logpath, encoding="utf-8")
+    else:
+        handler = logging.StreamHandler(sys.stderr)
+    logging.basicConfig(
+        level=level,
+        handlers=[handler],
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        force=True,
+    )
+
+
+def _spawn_detached() -> None:
+    """Launch ``mms daemon run --detached`` as a background process."""
+    cmd = [sys.executable, "-m", "memtomem_stm", "daemon", "run", "--detached"]
+    kwargs: dict[str, Any] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+        flags = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+        kwargs["creationflags"] = flags
+    else:
+        kwargs["start_new_session"] = True
+    subprocess.Popen(cmd, **kwargs)
+
+
+def _wait_ready(config: STMConfig, *, timeout: float) -> dict[str, Any] | None:
+    """Poll ``ping`` until the daemon answers or ``timeout`` elapses."""
+    from memtomem_stm.daemon import client
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        hs = asyncio.run(client.ping(config, timeout=1.0))
+        if hs is not None:
+            return hs
+        time.sleep(0.2)
+    return None
+
+
+@click.group(name="daemon")
+def daemon_group() -> None:
+    """Manage the local surfacing daemon (warm LTM connection for ``mms hook``)."""
+
+
+@daemon_group.command(name="run")
+@click.option(
+    "--detached",
+    is_flag=True,
+    help="Spawned-detached mode: log to a file under data_dir instead of stderr.",
+)
+@click.option(
+    "--foreground",
+    is_flag=True,
+    help="Run in the foreground (default). Kept for symmetry/clarity.",
+)
+def run_cmd(detached: bool, foreground: bool) -> None:
+    """Run the daemon server loop — this is the long-lived process."""
+    from memtomem_stm.daemon.server import run as run_daemon
+
+    config = _load_config()
+    _configure_logging(config, detached=detached)
+    raise SystemExit(run_daemon(config))
+
+
+@daemon_group.command(name="start")
+def start_cmd() -> None:
+    """Spawn the daemon detached if it isn't already running."""
+    from memtomem_stm.daemon import client
+    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+
+    config = _load_config()
+    existing = asyncio.run(client.ping(config, timeout=2.0))
+    if existing is not None:
+        click.echo(
+            _ok(f"daemon already running (pid={existing.get('pid')} port={existing.get('port')})")
+        )
+        return
+    with single_owner_lock(lock_path(config.data_dir)) as acquired:
+        if not acquired:
+            click.echo(_warn("another `mms daemon start` is in progress"))
+            return
+        # Re-check under the lock to avoid a double-spawn race.
+        if asyncio.run(client.ping(config, timeout=1.0)) is not None:
+            click.echo(_ok("daemon already running"))
+            return
+        _spawn_detached()
+    hs = _wait_ready(config, timeout=8.0)
+    if hs is not None:
+        click.echo(_ok(f"daemon started (pid={hs.get('pid')} port={hs.get('port')})"))
+    else:
+        click.echo(
+            _warn(
+                "daemon spawn requested but it did not become ready in time — "
+                "check the daemon log under data_dir (stm-daemon.log)"
+            )
+        )
+
+
+@daemon_group.command(name="stop")
+def stop_cmd() -> None:
+    """Ask a running daemon to shut down gracefully."""
+    from memtomem_stm.daemon import client
+    from memtomem_stm.daemon.discovery import handshake_path, is_pid_alive, read_handshake
+
+    config = _load_config()
+    if asyncio.run(client.shutdown(config)):
+        click.echo(_ok("daemon stopped"))
+        return
+    # Graceful path declined (no daemon, or its config fingerprint drifted).
+    raw = read_handshake(handshake_path(config.data_dir))
+    if raw is None:
+        click.echo("no running daemon")
+        return
+    pid = int(raw.get("pid", -1))
+    if os.name != "nt" and is_pid_alive(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            click.echo(_ok(f"sent SIGTERM to daemon pid={pid}"))
+            return
+        except OSError:
+            pass
+    try:
+        handshake_path(config.data_dir).unlink(missing_ok=True)
+    except OSError:
+        pass
+    click.echo(_warn("no responsive daemon; cleaned stale handshake"))
+
+
+@daemon_group.command(name="status")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
+def status_cmd(as_json: bool) -> None:
+    """Report whether a daemon is running, with pid/port/uptime/LTM warmth."""
+    from memtomem_stm.daemon import client
+    from memtomem_stm.daemon.discovery import handshake_path, is_pid_alive, read_handshake
+
+    config = _load_config()
+    use_daemon = config.hook.use_daemon
+    hs = asyncio.run(client.ping(config, timeout=2.0))
+    if hs is not None:
+        uptime = max(0.0, time.time() - float(hs.get("created_at", time.time())))
+        info: dict[str, Any] = {
+            "state": "running",
+            "pid": hs.get("pid"),
+            "host": hs.get("host"),
+            "port": hs.get("port"),
+            "ltm": hs.get("ltm"),
+            "uptime_seconds": round(uptime, 1),
+            "hook_will_use_daemon": use_daemon,
+        }
+    else:
+        raw = read_handshake(handshake_path(config.data_dir))
+        if raw is not None:
+            info = {
+                "state": "stale",
+                "pid": raw.get("pid"),
+                "pid_alive": is_pid_alive(int(raw.get("pid", -1))),
+                "hook_will_use_daemon": use_daemon,
+            }
+        else:
+            info = {"state": "stopped", "hook_will_use_daemon": use_daemon}
+
+    if as_json:
+        click.echo(json.dumps(info, indent=2))
+        return
+
+    state = info["state"]
+    if state == "running":
+        click.echo(
+            _ok(
+                f"running  pid={info['pid']} {info['host']}:{info['port']} "
+                f"ltm={info['ltm']} uptime={info['uptime_seconds']}s"
+            )
+        )
+    elif state == "stale":
+        click.echo(
+            _warn(
+                f"stale handshake (pid={info['pid']} alive={info['pid_alive']}) — "
+                "daemon not answering"
+            )
+        )
+    else:
+        click.echo("stopped")
+    hint = "yes" if use_daemon else "no (set MEMTOMEM_STM_HOOK__USE_DAEMON=1)"
+    click.echo(f"hook will use daemon: {hint}")
+
+
+@daemon_group.command(name="restart")
+@click.pass_context
+def restart_cmd(ctx: click.Context) -> None:
+    """Stop any running daemon, then start a fresh one."""
+    ctx.invoke(stop_cmd)
+    time.sleep(0.3)
+    ctx.invoke(start_cmd)

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -37,15 +37,17 @@ Register in Claude Code ``settings.json``::
       {"matcher": "Read|Grep|Glob|Bash",
        "hooks": [{"type": "command", "command": "mms hook"}]}]}}
 
-Performance caveat — near-no-op with stock defaults: a fresh ``mms hook``
-process spawns a fresh LTM MCP child per call, and that cold start (embedding
-+ reranker model load) measured ~6s here, which exceeds the default
-``surfacing.timeout_seconds`` of 3.0 — so surfacing usually times out and
-returns ``{}``. The default ``surfacing.min_response_chars`` of 5000 also
-gates out small tool outputs. To make surfacing actually fire before the
-daemon lands, raise ``MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS`` (e.g. 8) and
-lower ``MEMTOMEM_STM_SURFACING__MIN_RESPONSE_CHARS``, accepting the per-call
-latency. A persistent local daemon (warm LTM connection) is the real fix.
+Performance — cold path vs daemon: the in-process path spawns a fresh LTM MCP
+child per call, and that cold start (embedding + reranker model load) measured
+~6s here, exceeding the default ``surfacing.timeout_seconds`` of 3.0 — so
+surfacing usually times out and returns ``{}``. The real fix is the local
+daemon: set ``MEMTOMEM_STM_HOOK__USE_DAEMON=1`` (and run ``mms daemon start``,
+or let the hook reach an already-running daemon) so each call is a sub-second
+round trip to a warm LTM connection. When the daemon is unreachable the hook
+degrades per ``HookConfig.fallback`` — ``skip`` (default) returns ``{}``,
+``cold`` runs the in-process path. To exercise the cold path directly, raise
+``MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS`` (e.g. 8) and lower
+``MEMTOMEM_STM_SURFACING__MIN_RESPONSE_CHARS``, accepting the per-call latency.
 """
 
 from __future__ import annotations
@@ -266,21 +268,67 @@ def _read_payload(stream: TextIO) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
+def _daemon_enabled() -> bool:
+    """Whether the hook should route through the local daemon.
+
+    Read directly from the environment (mirroring ``HookConfig.use_daemon``'s
+    ``MEMTOMEM_STM_HOOK__USE_DAEMON`` binding) so the default daemon-off path
+    pays no extra config load and behaves byte-for-byte as it did before the
+    daemon landed. ``_surface_tools()`` already reads its env knob this way.
+    """
+    return os.environ.get("MEMTOMEM_STM_HOOK__USE_DAEMON", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the hook output, preferring the warm daemon when enabled.
+
+    Degradation ladder (every rung still yields a hook-output dict, never
+    raises): daemon disabled → cold in-process path (unchanged). Daemon enabled
+    → one bounded round trip; on unavailable/stale/slow either ``{}`` (default
+    ``fallback=skip`` — the daemon exists precisely to avoid the ~6s cold start)
+    or the cold path (``fallback=cold``). The whole call runs inside
+    ``_hook_budget_seconds()`` in :func:`hook_command`.
+    """
+    if _daemon_enabled():
+        from memtomem_stm.config import STMConfig
+        from memtomem_stm.daemon import client
+
+        config = STMConfig()
+        try:
+            out = await client.surface(config, payload, timeout=config.hook.daemon_timeout_seconds)
+        except Exception:
+            logger.debug("daemon surface request failed", exc_info=True)
+            out = None
+        if out is not None:
+            return out
+        if config.hook.fallback != "cold":
+            return {}
+        # fallback=cold → fall through to the in-process surfacing path.
+    return await run_surfacing_hook(payload)
+
+
 @click.command(name="hook")
 def hook_command() -> None:
     """Surface STM memories for a host's built-in tool call (PostToolUse hook).
 
     Reads the hook JSON payload on stdin and, for read-like built-in tools,
     prints a hook response whose ``additionalContext`` carries relevant LTM
-    memories. Always exits 0; on any problem the tool output passes through
-    unchanged (prints ``{}``).
+    memories. With ``MEMTOMEM_STM_HOOK__USE_DAEMON=1`` the surfacing runs in the
+    warm ``mms daemon`` (no per-call cold start); otherwise it runs in-process.
+    Always exits 0; on any problem the tool output passes through unchanged
+    (prints ``{}``).
     """
     payload = _read_payload(sys.stdin)
     output: dict[str, Any] = {}
     if payload is not None:
         try:
             output = asyncio.run(
-                asyncio.wait_for(run_surfacing_hook(payload), timeout=_hook_budget_seconds())
+                asyncio.wait_for(_run_hook(payload), timeout=_hook_budget_seconds())
             )
         except Exception:
             logger.warning("hook surfacing failed — passing tool output through", exc_info=True)

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -19,6 +19,7 @@ from typing import Any, TextIO
 
 import click
 
+from memtomem_stm.cli.daemon_cmd import daemon_group as _daemon_group
 from memtomem_stm.cli.hook_cmd import hook_command as _hook_command
 from memtomem_stm.cli.mms_host import host_group as _mms_host_group
 from memtomem_stm.cli.mms_import import import_command as _mms_import_command
@@ -2597,3 +2598,7 @@ cli.add_command(_mms_host_group)
 # `mms hook` — bridge a host's built-in tool calls (Claude Code PostToolUse)
 # into STM surfacing; lives in src/memtomem_stm/cli/hook_cmd.py.
 cli.add_command(_hook_command)
+
+# `mms daemon ...` — manage the local surfacing daemon (Stage 2 warm LTM
+# connection for `mms hook`); lives in src/memtomem_stm/cli/daemon_cmd.py.
+cli.add_command(_daemon_group)

--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -47,6 +47,53 @@ class LangfuseConfig(BaseModel):
         return self
 
 
+class HookConfig(BaseModel):
+    """Built-in tool hook (``mms hook``) settings — Stage 2 daemon integration.
+
+    Env keys are ``MEMTOMEM_STM_HOOK__<field>`` (note the double underscore for
+    nesting). The pre-existing ``MEMTOMEM_STM_HOOK_SURFACE_TOOLS`` (single
+    underscore) is a separate direct-read knob in ``cli/hook_cmd.py`` and is
+    unaffected by this model."""
+
+    use_daemon: bool = False
+    """When ``True``, ``mms hook`` routes surfacing through the local daemon
+    (warm LTM connection) instead of spawning a cold LTM subprocess per call.
+    Opt-in this release — default ``False`` keeps ``mms hook`` behaving exactly
+    as before (cold in-process path)."""
+    daemon_timeout_seconds: float = Field(default=2.5, gt=0.0)
+    """Per-request wall-clock budget for the hook→daemon round trip. Small and
+    independent of the cold-path ``_hook_budget_seconds()`` backstop — a warm
+    LTM search is sub-second, so this only needs to cover connect + RTT."""
+    fallback: Literal["skip", "cold"] = "skip"
+    """What ``mms hook`` does when the daemon is unreachable. ``skip`` (default)
+    degrades to ``{}`` immediately — the daemon exists precisely to avoid the
+    ~6s cold start, so the default never pays it. ``cold`` falls back to the
+    in-process surfacing path (still bounded by ``_hook_budget_seconds()``),
+    preserving pre-daemon behavior for callers who prefer it."""
+    record_feedback_events: bool = False
+    """Passed to the daemon's ``SurfacingEngine``. Default ``False`` keeps
+    cross-session dedup (``seen_memories``, memory IDs only) while persisting
+    *no* query text and emitting no ``stm_surfacing_feedback`` rating prompt:
+    the pure-hook path has no in-band channel for the model to return a rating,
+    and a ``Bash`` query may carry secrets. See
+    ``SurfacingEngine(record_feedback_events=...)``."""
+
+
+class DaemonConfig(BaseModel):
+    """Local surfacing daemon (``mms daemon``) settings — Stage 2.
+
+    Env keys are ``MEMTOMEM_STM_DAEMON__<field>``."""
+
+    host: str = "127.0.0.1"
+    """Loopback bind address. The daemon is local-only and authenticated by a
+    per-start random token, not by network ACLs — never bind a non-loopback
+    address."""
+    idle_timeout_seconds: float = Field(default=900.0, ge=0.0)
+    """Shut the daemon (and its warm LTM child) down after this many seconds
+    with no requests, so an abandoned coding session doesn't leak a
+    multi-GB process forever. ``0`` disables idle shutdown (pin the process)."""
+
+
 class STMConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="MEMTOMEM_STM_",
@@ -57,6 +104,8 @@ class STMConfig(BaseSettings):
     proxy: ProxyConfig = Field(default_factory=ProxyConfig)
     surfacing: SurfacingConfig = Field(default_factory=SurfacingConfig)
     langfuse: LangfuseConfig = Field(default_factory=LangfuseConfig)
+    hook: HookConfig = Field(default_factory=HookConfig)
+    daemon: DaemonConfig = Field(default_factory=DaemonConfig)
     data_dir: Path = Path("~/.memtomem")
 
     advertise_observability_tools: bool = False

--- a/src/memtomem_stm/daemon/__init__.py
+++ b/src/memtomem_stm/daemon/__init__.py
@@ -1,0 +1,18 @@
+"""Local short-term-memory surfacing daemon (``mms daemon``) — Stage 2.
+
+A long-lived loopback server that keeps one warm :class:`SurfacingEngine` and
+one warm LTM MCP connection so ``mms hook`` no longer pays the ~6s cold start
+(embedding + reranker model load) on every built-in tool call. See
+``docs`` / the project plan for the full design; the per-module docstrings here
+are the source of truth for the wire protocol, discovery, and lifecycle
+contracts.
+
+Submodules:
+
+- :mod:`~memtomem_stm.daemon.protocol` — newline-delimited JSON framing + token.
+- :mod:`~memtomem_stm.daemon.discovery` — the ``stm-daemon.json`` handshake file.
+- :mod:`~memtomem_stm.daemon.locking` — cross-platform single-owner spawn lock.
+- :mod:`~memtomem_stm.daemon.server` — the asyncio server loop + warm engine.
+"""
+
+from __future__ import annotations

--- a/src/memtomem_stm/daemon/client.py
+++ b/src/memtomem_stm/daemon/client.py
@@ -1,0 +1,125 @@
+"""Client side of the hook↔daemon link.
+
+Shared by ``mms hook`` (hot path) and ``mms daemon status/start`` (ops). Every
+helper is failure-tolerant: a missing/stale handshake, a refused connect, a
+fingerprint mismatch, a timeout, or a malformed reply all return ``None`` (or
+``False``) so the caller degrades cleanly — the hook to ``{}``, the CLI to a
+"not running" report. Nothing here ever raises on an unreachable daemon.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from memtomem_stm.daemon.discovery import (
+    HANDSHAKE_VERSION,
+    config_fingerprint,
+    handshake_path,
+    read_handshake,
+)
+from memtomem_stm.daemon.protocol import (
+    MAX_MESSAGE_BYTES,
+    OP_PING,
+    OP_SHUTDOWN,
+    OP_SURFACE,
+    build_request,
+    encode_line,
+    read_message,
+)
+
+if TYPE_CHECKING:
+    from memtomem_stm.config import STMConfig
+
+logger = logging.getLogger(__name__)
+
+
+async def _request(
+    handshake: dict[str, Any], op: str, payload: dict[str, Any] | None, *, timeout: float
+) -> dict[str, Any] | None:
+    """One connection-per-request round trip. ``None`` on any failure.
+
+    ``timeout`` is a single wall-clock budget for connect + write + read
+    together (via ``asyncio.timeout``), not applied per-step — so a half-open
+    peer can't stretch the call to roughly ``2 * timeout``.
+    """
+    token = handshake.get("token")
+    host = handshake.get("host")
+    port = handshake.get("port")
+    if not isinstance(token, str) or not isinstance(host, str) or not isinstance(port, int):
+        return None
+    writer: asyncio.StreamWriter | None = None
+    try:
+        async with asyncio.timeout(timeout):
+            reader, writer = await asyncio.open_connection(host, port, limit=MAX_MESSAGE_BYTES)
+            writer.write(encode_line(build_request(token, op, payload)))
+            await writer.drain()
+            return await read_message(reader)
+    except (OSError, asyncio.TimeoutError):
+        return None  # unreachable / refused / over-budget — quiet
+    except Exception:
+        logger.debug("daemon request failed (op=%s)", op, exc_info=True)
+        return None
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await asyncio.wait_for(writer.wait_closed(), timeout=1.0)
+            except Exception:
+                pass
+
+
+def _live_handshake_candidate(config: STMConfig) -> dict[str, Any] | None:
+    """Read the handshake and reject it if version or config fingerprint drift.
+
+    A fingerprint/version mismatch means the running daemon was started under
+    different wiring (LTM command, feedback DB, …) and would serve stale
+    behavior — treated as "not the daemon we want".
+    """
+    hs = read_handshake(handshake_path(config.data_dir))
+    if hs is None:
+        return None
+    if hs.get("v") != HANDSHAKE_VERSION:
+        return None
+    if hs.get("config_fingerprint") != config_fingerprint(config):
+        return None
+    return hs
+
+
+async def ping(config: STMConfig, *, timeout: float = 2.0) -> dict[str, Any] | None:
+    """Return the handshake dict iff a live, matching daemon answers ``ping``."""
+    hs = _live_handshake_candidate(config)
+    if hs is None:
+        return None
+    resp = await _request(hs, OP_PING, None, timeout=timeout)
+    if resp is not None and resp.get("ok"):
+        # Fold the ping status (e.g. LTM warmth) into the returned handshake so
+        # callers like ``mms daemon status`` can render it without a 2nd trip.
+        merged = dict(hs)
+        merged["ltm"] = resp.get("ltm")
+        return merged
+    return None
+
+
+async def surface(
+    config: STMConfig, payload: dict[str, Any], *, timeout: float
+) -> dict[str, Any] | None:
+    """Round-trip a ``surface`` request. Returns the hook-output dict, or
+    ``None`` if the daemon is unavailable/stale/slow (caller degrades)."""
+    hs = _live_handshake_candidate(config)
+    if hs is None:
+        return None
+    resp = await _request(hs, OP_SURFACE, payload, timeout=timeout)
+    if resp is not None and resp.get("ok") and isinstance(resp.get("output"), dict):
+        return resp["output"]
+    return None
+
+
+async def shutdown(config: STMConfig, *, timeout: float = 5.0) -> bool:
+    """Ask a running daemon to shut down gracefully. ``True`` if it acked."""
+    hs = _live_handshake_candidate(config)
+    if hs is None:
+        return False
+    resp = await _request(hs, OP_SHUTDOWN, None, timeout=timeout)
+    return resp is not None and bool(resp.get("ok"))

--- a/src/memtomem_stm/daemon/discovery.py
+++ b/src/memtomem_stm/daemon/discovery.py
@@ -49,20 +49,27 @@ def config_fingerprint(config: STMConfig) -> str:
     """Stable digest of the config that determines daemon/engine behavior.
 
     A running daemon froze its config at start; if a caller's effective config
-    differs, the daemon would serve stale behavior, so the caller must treat it
-    as stale. We therefore fingerprint the *whole* daemon-relevant surface
-    rather than a hand-picked subset: the full ``surfacing`` model (min_score,
+    differs *in a way that changes daemon behavior*, the daemon would serve
+    stale behavior and the caller must treat it as stale. So we fingerprint the
+    daemon-behavior-relevant surface: the full ``surfacing`` model (min_score,
     max_results, min_response_chars, default_namespace, result_format,
-    include_session_context, persist_query_text, the LTM command, …), the full
-    ``hook`` model (record_feedback_events, …), the bind host, and the flat
-    ``MEMTOMEM_STM_HOOK_SURFACE_TOOLS`` env that ``cli.hook_cmd`` reads directly
-    (so it isn't in any model). ``mode="json"`` makes ``Path``/enum values
-    serializable. Over-inclusion only costs an extra restart on a config
-    change, which is the safe direction.
+    include_session_context, persist_query_text, the LTM command, …), the bind
+    host, the flat ``MEMTOMEM_STM_HOOK_SURFACE_TOOLS`` env that ``cli.hook_cmd``
+    reads directly (so it isn't in any model), and exactly the one ``hook``
+    field the daemon engine wiring consumes: ``record_feedback_events``.
+
+    Deliberately **excluded**: the client-only ``hook`` fields ``use_daemon``,
+    ``fallback`` and ``daemon_timeout_seconds``. They govern how the *hook*
+    talks to the daemon, never what the daemon does — and a daemon is commonly
+    started without ``MEMTOMEM_STM_HOOK__USE_DAEMON=1`` (e.g. ``mms daemon
+    start`` in a plain shell) while the hook runs with it set. Including them
+    would make that live daemon look stale and the hook would reject it (then,
+    under the default ``fallback=skip``, return ``{}`` forever). ``mode="json"``
+    makes ``Path``/enum values serializable.
     """
     material = {
         "surfacing": config.surfacing.model_dump(mode="json"),
-        "hook": config.hook.model_dump(mode="json"),
+        "record_feedback_events": config.hook.record_feedback_events,
         "host": config.daemon.host,
         "surface_tools_env": os.environ.get("MEMTOMEM_STM_HOOK_SURFACE_TOOLS", ""),
     }

--- a/src/memtomem_stm/daemon/discovery.py
+++ b/src/memtomem_stm/daemon/discovery.py
@@ -1,0 +1,144 @@
+"""Daemon discovery — the ``stm-daemon.json`` handshake file.
+
+The daemon publishes its loopback endpoint + auth token to a single file under
+``data_dir`` (default ``~/.memtomem``). ``mms hook`` and ``mms daemon
+status/stop`` read it to find a running daemon; the daemon writes it
+**atomically at ``0o600`` only after a successful port bind**, so the file
+never advertises an endpoint that isn't accepting yet. The write is
+last-writer-wins, not a mutual-exclusion primitive (two daemons binding
+distinct ephemeral ports would overwrite each other here) — preventing a second
+daemon is the spawn lock's job (see :mod:`~memtomem_stm.daemon.locking`).
+Liveness is proven by a successful ``ping`` over the socket — not by the
+recorded ``pid`` — so a recycled PID can't be mistaken for the daemon.
+
+File shape::
+
+    {"v": 1, "pid": 1234, "host": "127.0.0.1", "port": 53412,
+     "token": "<hex>", "created_at": 1716600000.0, "config_fingerprint": "<sha>"}
+
+``config_fingerprint`` lets a reader detect a daemon started under stale config
+(different LTM command, feedback DB, etc.) and treat it as stale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from memtomem_stm.utils.fileio import atomic_write_text
+
+if TYPE_CHECKING:
+    from memtomem_stm.config import STMConfig
+
+logger = logging.getLogger(__name__)
+
+HANDSHAKE_VERSION = 1
+HANDSHAKE_FILENAME = "stm-daemon.json"
+
+
+def handshake_path(data_dir: Path) -> Path:
+    """Absolute path to the handshake file under ``data_dir``."""
+    return (data_dir / HANDSHAKE_FILENAME).expanduser()
+
+
+def config_fingerprint(config: STMConfig) -> str:
+    """Stable digest of the config that determines daemon/engine behavior.
+
+    A running daemon froze its config at start; if a caller's effective config
+    differs, the daemon would serve stale behavior, so the caller must treat it
+    as stale. We therefore fingerprint the *whole* daemon-relevant surface
+    rather than a hand-picked subset: the full ``surfacing`` model (min_score,
+    max_results, min_response_chars, default_namespace, result_format,
+    include_session_context, persist_query_text, the LTM command, …), the full
+    ``hook`` model (record_feedback_events, …), the bind host, and the flat
+    ``MEMTOMEM_STM_HOOK_SURFACE_TOOLS`` env that ``cli.hook_cmd`` reads directly
+    (so it isn't in any model). ``mode="json"`` makes ``Path``/enum values
+    serializable. Over-inclusion only costs an extra restart on a config
+    change, which is the safe direction.
+    """
+    material = {
+        "surfacing": config.surfacing.model_dump(mode="json"),
+        "hook": config.hook.model_dump(mode="json"),
+        "host": config.daemon.host,
+        "surface_tools_env": os.environ.get("MEMTOMEM_STM_HOOK_SURFACE_TOOLS", ""),
+    }
+    blob = json.dumps(material, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def write_handshake(
+    path: Path,
+    *,
+    pid: int,
+    host: str,
+    port: int,
+    token: str,
+    config_fingerprint: str,
+    created_at: float,
+) -> None:
+    """Atomically publish the handshake file at ``0o600`` (token is sensitive)."""
+    payload = {
+        "v": HANDSHAKE_VERSION,
+        "pid": pid,
+        "host": host,
+        "port": port,
+        "token": token,
+        "created_at": created_at,
+        "config_fingerprint": config_fingerprint,
+    }
+    atomic_write_text(path, json.dumps(payload), mode=0o600)
+
+
+def read_handshake(path: Path) -> dict[str, Any] | None:
+    """Parse the handshake file; ``None`` if absent, unreadable, or malformed."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def remove_handshake_if_owner(path: Path, *, pid: int, token: str) -> None:
+    """Unlink the handshake file only if it still describes *this* daemon.
+
+    Compares ``pid`` and ``token`` so a daemon tearing down does not delete a
+    successor's file (e.g. after a fast restart). Best-effort and quiet.
+    """
+    data = read_handshake(path)
+    if data is None:
+        return
+    if data.get("pid") == pid and data.get("token") == token:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            logger.debug("failed to remove handshake file %s", path, exc_info=True)
+
+
+def is_pid_alive(pid: int) -> bool:
+    """Best-effort liveness probe for a PID. Liveness for *daemon* decisions
+    should prefer a socket ``ping``; this is a secondary signal for status/stop.
+    """
+    if pid <= 0:
+        return False
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+        # No portable signal-0 on Windows; assume alive and let the ping decide.
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user
+    except OSError:
+        return False
+    return True

--- a/src/memtomem_stm/daemon/locking.py
+++ b/src/memtomem_stm/daemon/locking.py
@@ -1,0 +1,85 @@
+"""Cross-platform single-owner advisory lock.
+
+Used to keep two concurrent ``mms hook`` auto-spawns (or two ``mms daemon
+start`` invocations) from racing to launch a second daemon. **This lock is the
+ownership primitive** — the port bind is *not*: the daemon binds an
+OS-assigned ephemeral port (``port 0``), so two daemons would simply get two
+different ports and both succeed, and the handshake file is last-writer-wins
+(the second overwrites the first, orphaning it). The guard against a second
+daemon is therefore: hold this lock across the start decision and re-check a
+``ping`` under it before spawning. A caller that fails to acquire assumes
+another process is mid-spawn and just polls the handshake file.
+
+POSIX uses ``fcntl.flock``; Windows uses ``msvcrt.locking``. Both are advisory
+and auto-released if the holding process dies, so a crashed spawner never
+wedges the lock.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+LOCK_FILENAME = "stm-daemon.lock"
+
+
+def lock_path(data_dir: Path) -> Path:
+    """Absolute path to the spawn lock file under ``data_dir``."""
+    return (data_dir / LOCK_FILENAME).expanduser()
+
+
+@contextmanager
+def single_owner_lock(path: Path) -> Iterator[bool]:
+    """Try (non-blocking) to take an exclusive lock on ``path``.
+
+    Yields ``True`` if acquired (and releases on exit), ``False`` if another
+    process holds it. Never raises on contention — only on an inability to open
+    the lock file at all, which the caller may also treat as "don't spawn".
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o600)
+    acquired = False
+    try:
+        acquired = _try_lock(fd)
+        yield acquired
+    finally:
+        if acquired:
+            _unlock(fd)
+        os.close(fd)
+
+
+def _try_lock(fd: int) -> bool:
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+        import msvcrt
+
+        try:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    import fcntl
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except (BlockingIOError, OSError):
+        return False
+
+
+def _unlock(fd: int) -> None:
+    try:
+        if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        logger.debug("failed to release spawn lock", exc_info=True)

--- a/src/memtomem_stm/daemon/protocol.py
+++ b/src/memtomem_stm/daemon/protocol.py
@@ -1,0 +1,94 @@
+"""Wire protocol for the hook↔daemon link.
+
+Dead-simple by design: **newline-delimited JSON, one request line and one
+response line per connection** (connection-per-request — no multiplexing, no
+session state). ``json.dumps`` escapes any newline inside string values as
+``\\n``, so a serialized message is always a single physical line and
+``StreamReader.readline()`` is a correct frame boundary.
+
+Request  (hook → daemon)::
+
+    {"v": 1, "token": "<hex>", "op": "surface", "payload": {<PostToolUse JSON>}}
+
+Response (daemon → hook)::
+
+    {"v": 1, "ok": true, "output": {<hook-output JSON, possibly {}>}}      # surface
+    {"v": 1, "ok": true, "status": "ready", "ltm": "warm"}                 # ping
+
+``op`` is one of :data:`OP_SURFACE`, :data:`OP_PING`, :data:`OP_SHUTDOWN`. The
+token gates *use* of the loopback port (any local process can ``connect`` to
+it); it is validated with :func:`secrets.compare_digest` on every request and
+never logged. Messages are capped at :data:`MAX_MESSAGE_BYTES` so a malformed
+or oversized stdin can't blow up daemon memory — set the same value as the
+stream ``limit`` on both ends so ``readline`` enforces it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+from typing import Any
+
+PROTOCOL_VERSION = 1
+
+# Upper bound on a single framed message. A ``surface`` request embeds the
+# built-in tool's output (a large ``Read`` can be hundreds of KB), so this sits
+# well above the asyncio default 64 KiB stream limit; pass it as ``limit=`` to
+# both ``start_server`` and ``open_connection``.
+MAX_MESSAGE_BYTES = 4 * 1024 * 1024
+
+OP_SURFACE = "surface"
+OP_PING = "ping"
+OP_SHUTDOWN = "shutdown"
+
+
+class ProtocolError(Exception):
+    """Raised on a malformed/oversized/closed-early frame. Callers treat it as
+    a clean failure: the daemon closes the connection, the hook degrades."""
+
+
+def encode_line(obj: dict[str, Any]) -> bytes:
+    """Serialize ``obj`` to a single newline-terminated UTF-8 frame."""
+    return (json.dumps(obj, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+async def read_message(reader: asyncio.StreamReader) -> dict[str, Any]:
+    """Read and parse one framed JSON object, or raise :class:`ProtocolError`.
+
+    Relies on the stream having been opened with ``limit=MAX_MESSAGE_BYTES`` so
+    an over-long line surfaces as a read error rather than unbounded buffering.
+    """
+    try:
+        line = await reader.readline()
+    except Exception as exc:  # LimitOverrunError, ValueError, transport errors
+        raise ProtocolError(f"frame read failed: {exc}") from exc
+    if not line:
+        raise ProtocolError("connection closed before a frame was read")
+    try:
+        obj = json.loads(line)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ProtocolError("malformed JSON frame") from exc
+    if not isinstance(obj, dict):
+        raise ProtocolError("frame is not a JSON object")
+    return obj
+
+
+def build_request(token: str, op: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Construct a request frame body."""
+    req: dict[str, Any] = {"v": PROTOCOL_VERSION, "token": token, "op": op}
+    if payload is not None:
+        req["payload"] = payload
+    return req
+
+
+def surface_response(output: dict[str, Any]) -> dict[str, Any]:
+    """Construct a successful ``surface`` response carrying the hook-output dict."""
+    return {"v": PROTOCOL_VERSION, "ok": True, "output": output}
+
+
+def token_matches(expected: str, received: Any) -> bool:
+    """Constant-time token check tolerant of a missing/wrong-typed value."""
+    if not isinstance(received, str) or not expected:
+        return False
+    return secrets.compare_digest(expected, received)

--- a/src/memtomem_stm/daemon/server.py
+++ b/src/memtomem_stm/daemon/server.py
@@ -1,0 +1,301 @@
+"""The daemon server loop — one warm engine behind a loopback socket.
+
+Holds a single long-lived :class:`SurfacingEngine` and a single lazily-started
+LTM ``McpClientSearchAdapter`` for the process lifetime, so each ``mms hook``
+call is a sub-second round trip instead of a ~6s cold start. Requests are
+token-authenticated and dispatched over the newline-JSON
+:mod:`~memtomem_stm.daemon.protocol`.
+
+Engine wiring is the **dedup-only** variant of ``server.py``'s app_lifespan: a
+``FeedbackTracker`` is attached so cross-session dedup (``seen_memories``)
+survives restarts, but ``record_feedback_events=False`` means no query text is
+persisted and no rating prompt is emitted (the pure-hook path has no in-band
+feedback channel, and Bash queries may carry secrets). ``persist_query_text``
+is additionally forced off as defense-in-depth.
+
+Concurrency: LTM RPCs share one MCP ``ClientSession`` whose stdio framing is not
+safe under interleaved calls, so ``surface`` requests are serialized on a single
+lock. A warm search is sub-second and the engine's result cache absorbs repeats,
+so this is acceptable for the MVP; narrowing the lock to just the adapter RPC is
+a later optimization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import secrets
+import signal
+import time
+from typing import Any
+
+from memtomem_stm.cli.hook_cmd import run_surfacing_hook
+from memtomem_stm.config import STMConfig
+from memtomem_stm.daemon import client, discovery
+from memtomem_stm.daemon.protocol import (
+    MAX_MESSAGE_BYTES,
+    OP_PING,
+    OP_SHUTDOWN,
+    OP_SURFACE,
+    PROTOCOL_VERSION,
+    ProtocolError,
+    encode_line,
+    read_message,
+    surface_response,
+    token_matches,
+)
+
+logger = logging.getLogger(__name__)
+
+# Per-frame read budget. Bounds a wedged or half-open client from holding a
+# handler open forever; well above a warm surface round trip.
+_READ_TIMEOUT_SECONDS = 30.0
+
+
+async def _quiet(coro: Any, what: str) -> None:
+    """Await a cleanup coroutine, swallowing (and debug-logging) any error."""
+    try:
+        await coro
+    except Exception:
+        logger.debug("%s failed", what, exc_info=True)
+
+
+class DaemonServer:
+    """A single-process loopback surfacing daemon."""
+
+    def __init__(self, config: STMConfig) -> None:
+        self._config = config
+        self._host = config.daemon.host
+        self._idle_timeout = config.daemon.idle_timeout_seconds
+        self._token = secrets.token_hex(32)
+        self._port = 0
+        self._started_at = time.time()
+        self._last_request = time.monotonic()
+        self._shutdown_event = asyncio.Event()
+        self._surface_lock = asyncio.Lock()
+        self._handshake_written = False
+        self._engine: Any = None
+        self._adapter: Any = None
+        self._tracker: Any = None
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    async def serve(self) -> int:
+        """Run until shutdown (signal, idle timeout, or ``shutdown`` op).
+
+        Refuses to start a second daemon if a live one already answers ``ping``.
+        Returns a process exit code.
+        """
+        existing = await client.ping(self._config, timeout=2.0)
+        if existing is not None:
+            logger.warning(
+                "daemon already running (pid=%s port=%s) — not starting another",
+                existing.get("pid"),
+                existing.get("port"),
+            )
+            return 0
+
+        self._build_engine()
+        self._last_request = time.monotonic()
+        server = await asyncio.start_server(
+            self._handle_conn, self._host, 0, limit=MAX_MESSAGE_BYTES
+        )
+        self._port = server.sockets[0].getsockname()[1]
+        self._install_signals()
+        discovery.write_handshake(
+            discovery.handshake_path(self._config.data_dir),
+            pid=os.getpid(),
+            host=self._host,
+            port=self._port,
+            token=self._token,
+            config_fingerprint=discovery.config_fingerprint(self._config),
+            created_at=self._started_at,
+        )
+        self._handshake_written = True
+        logger.info("STM daemon listening on %s:%d (pid=%d)", self._host, self._port, os.getpid())
+
+        idle_task = asyncio.create_task(self._idle_watch())
+        try:
+            async with server:
+                await self._shutdown_event.wait()
+        finally:
+            idle_task.cancel()
+            try:
+                await idle_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            await self._teardown()
+        logger.info("STM daemon stopped")
+        return 0
+
+    def _build_engine(self) -> None:
+        """Construct the single warm engine + adapter (+ dedup tracker)."""
+        from memtomem_stm.surfacing.engine import SurfacingEngine
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+        from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
+        from memtomem_stm.surfacing.observability import SurfacingObservability
+
+        record_events = self._config.hook.record_feedback_events
+        updates: dict[str, Any] = {
+            # Defense-in-depth: the hook/daemon path never persists raw query
+            # text, even if an operator flips feedback events on.
+            # ``record_feedback_events`` already gates whether any event row is
+            # written at all.
+            "persist_query_text": False,
+            # Disable the result cache. A cache hit intentionally short-circuits
+            # the in-session ``_surfaced_ids`` dedup (documented engine
+            # behavior), which in a long-lived warm daemon would re-inject an
+            # already-seen memory for a repeated identical query within the TTL
+            # window. The daemon serializes requests against a warm LTM
+            # connection, so the cache's stampede/latency benefit is redundant
+            # here — turning it off makes dedup (``_surfaced_ids`` +
+            # ``seen_memories``) authoritative.
+            "cache_ttl_seconds": 0.0,
+        }
+        if not record_events:
+            # Dedup-only: the tracker exists solely for ``seen_memories``. Don't
+            # let AutoTuner learn min_score from feedback rows (possibly written
+            # by the proxy path sharing the same DB) — the daemon's ranking must
+            # be self-contained, not nudged by feedback this mode never records.
+            updates["auto_tune_enabled"] = False
+        surfacing_cfg = self._config.surfacing.model_copy(update=updates)
+
+        self._adapter = McpClientSearchAdapter(surfacing_cfg)  # lazy LTM start
+        want_tracker = surfacing_cfg.dedup_ttl_seconds > 0 or record_events
+        if want_tracker:
+            try:
+                self._tracker = FeedbackTracker(surfacing_cfg)
+            except Exception:
+                logger.warning(
+                    "FeedbackTracker init failed — cross-session dedup disabled", exc_info=True
+                )
+                self._tracker = None
+        self._engine = SurfacingEngine(
+            surfacing_cfg,
+            mcp_adapter=self._adapter,
+            feedback_tracker=self._tracker,
+            observability=SurfacingObservability(),
+            record_feedback_events=record_events,
+        )
+        logger.info(
+            "daemon engine wired: dedup=%s record_feedback_events=%s",
+            "on" if self._tracker is not None else "off",
+            record_events,
+        )
+
+    async def _teardown(self) -> None:
+        """Graceful resource release, mirroring app_lifespan's order: engine →
+        tracker → LTM adapter (terminates the warm LTM child), then handshake."""
+        if self._engine is not None:
+            await _quiet(self._engine.stop(), "engine stop")
+        if self._tracker is not None:
+            try:
+                self._tracker.close()
+            except Exception:
+                logger.debug("tracker close failed", exc_info=True)
+        if self._adapter is not None:
+            await _quiet(self._adapter.stop(), "LTM adapter stop")
+        if self._handshake_written:
+            discovery.remove_handshake_if_owner(
+                discovery.handshake_path(self._config.data_dir),
+                pid=os.getpid(),
+                token=self._token,
+            )
+
+    # ── connection handling ──────────────────────────────────────────────
+
+    async def _handle_conn(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            try:
+                req = await asyncio.wait_for(read_message(reader), timeout=_READ_TIMEOUT_SECONDS)
+            except (ProtocolError, asyncio.TimeoutError):
+                return  # malformed/oversized/slow → drop silently
+            if not token_matches(self._token, req.get("token")):
+                logger.debug("daemon rejected request with bad/missing token")
+                return  # never respond to an unauthenticated peer
+            resp = await self._dispatch(req)
+            if resp is not None:
+                writer.write(encode_line(resp))
+                await writer.drain()
+        except Exception:
+            logger.debug("daemon connection handler error", exc_info=True)
+        finally:
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def _dispatch(self, req: dict[str, Any]) -> dict[str, Any] | None:
+        op = req.get("op")
+        if op == OP_PING:
+            return {"v": PROTOCOL_VERSION, "ok": True, "status": "ready", "ltm": self._ltm_warmth()}
+        if op == OP_SHUTDOWN:
+            logger.info("daemon received shutdown request")
+            self._shutdown_event.set()
+            return {"v": PROTOCOL_VERSION, "ok": True, "status": "shutting_down"}
+        if op == OP_SURFACE:
+            payload = req.get("payload")
+            if not isinstance(payload, dict):
+                return surface_response({})
+            self._last_request = time.monotonic()
+            # Serialize: one LTM RPC at a time over the shared MCP session.
+            async with self._surface_lock:
+                output = await run_surfacing_hook(payload, engine=self._engine)
+            return surface_response(output)
+        return {"v": PROTOCOL_VERSION, "ok": False, "error": "unknown op"}
+
+    def _ltm_warmth(self) -> str:
+        """Best-effort LTM connection state for ``ping`` (status nicety)."""
+        if getattr(self._adapter, "_session", None) is not None:
+            return "warm"
+        if getattr(self._adapter, "_start_attempted", False):
+            return "down"
+        return "cold"
+
+    # ── idle + signals ────────────────────────────────────────────────────
+
+    async def _idle_watch(self) -> None:
+        if self._idle_timeout <= 0:
+            return
+        interval = min(30.0, max(1.0, self._idle_timeout / 2))
+        while not self._shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                pass
+            if self._shutdown_event.is_set():
+                return
+            if time.monotonic() - self._last_request >= self._idle_timeout:
+                logger.info("daemon idle for %.0fs — shutting down", self._idle_timeout)
+                self._shutdown_event.set()
+                return
+
+    def _install_signals(self) -> None:
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                loop.add_signal_handler(sig, self._shutdown_event.set)
+            except (NotImplementedError, RuntimeError):
+                # Windows: no add_signal_handler — fall back to signal.signal,
+                # which is also what ``mms daemon stop`` relies on via the
+                # ``shutdown`` op as the primary path there.
+                try:
+                    signal.signal(sig, self._signal_fallback)
+                except (ValueError, OSError):  # pragma: no cover - platform/thread dependent
+                    pass
+
+    def _signal_fallback(self, signum: int, frame: Any) -> None:  # pragma: no cover - Windows
+        try:
+            asyncio.get_event_loop().call_soon_threadsafe(self._shutdown_event.set)
+        except Exception:
+            pass
+
+
+def run(config: STMConfig | None = None) -> int:
+    """Synchronous entry point used by ``mms daemon run``."""
+    cfg = config if config is not None else STMConfig()
+    return asyncio.run(DaemonServer(cfg).serve())

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -50,12 +50,24 @@ class SurfacingEngine:
         feedback_tracker: Any | None = None,
         token_tracker: Any | None = None,
         observability: SurfacingObservability | None = None,
+        record_feedback_events: bool = True,
     ) -> None:
         self._config = config
         self._mcp_adapter = mcp_adapter
         self._webhook_manager = webhook_manager
         self._feedback_tracker = feedback_tracker
         self._token_tracker = token_tracker
+        # Decouple cross-session dedup from feedback-event recording. When a
+        # tracker is attached, it normally does two independent jobs: (1) seed
+        # ``_surfaced_ids`` + ``mark_surfaced`` for dedup (``seen_memories`` —
+        # memory IDs only, privacy-clean), and (2) mint a ``surfacing_id`` +
+        # ``record_surfacing`` the extracted query into ``surfacing_events`` +
+        # advertise a ``stm_surfacing_feedback`` rating prompt. The hook daemon
+        # path wants (1) but not (2): it has no in-band channel for the model to
+        # return a rating (the prompt would be unresolvable), and the query for
+        # ``Bash`` may carry secrets we refuse to persist. Set this ``False`` to
+        # keep dedup while skipping all feedback-event recording/prompting.
+        self._record_feedback_events = record_feedback_events
         # Public ``observability`` property still returns the original
         # ``SurfacingObservability | None`` so consumers (server.py) can
         # short-circuit on absence; ``_observability`` is the internal
@@ -504,9 +516,10 @@ class SurfacingEngine:
         self._observability.record_outcome(tool, "surfaced_cache_hit")
         logger.debug("Surfacing cache hit (%d results) for %s/%s", len(cached), server, tool)
         # See ``_do_surface_miss``: only advertise a feedback ID we actually
-        # recorded, so a no-tracker path doesn't prompt for an unresolvable ID.
+        # recorded, so neither a no-tracker path nor the dedup-only daemon path
+        # (``record_feedback_events=False``) prompts for an unresolvable ID.
         surfacing_id: str | None = None
-        if self._feedback_tracker is not None:
+        if self._feedback_tracker is not None and self._record_feedback_events:
             surfacing_id = uuid.uuid4().hex[:16]
             try:
                 self._feedback_tracker.record_surfacing(
@@ -721,12 +734,14 @@ class SurfacingEngine:
                 scratch_items = None
 
         # Generate surfacing ID and record event. Only mint an ID when a
-        # tracker is attached to record it — otherwise the formatter would
-        # advertise a ``stm_surfacing_feedback(...)`` prompt for an event the
-        # server can't resolve. Both the ``mms hook`` path and the
-        # feedback-disabled server path run with no tracker.
+        # tracker is attached *and* feedback-event recording is on — otherwise
+        # the formatter would advertise a ``stm_surfacing_feedback(...)`` prompt
+        # for an event no in-band channel can resolve. Three cases skip it: the
+        # no-tracker ``mms hook`` / feedback-disabled server paths, and the hook
+        # daemon's dedup-only wiring (``record_feedback_events=False``) which
+        # keeps a tracker for ``seen_memories`` dedup but persists no query.
         surfacing_id: str | None = None
-        if self._feedback_tracker is not None:
+        if self._feedback_tracker is not None and self._record_feedback_events:
             surfacing_id = uuid.uuid4().hex[:16]
             try:
                 self._feedback_tracker.record_surfacing(

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -14,6 +14,7 @@ Coverage:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,7 +25,9 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem_stm.cli.hook_cmd import (
+    _daemon_enabled,
     _extract_surfaced_block,
+    _run_hook,
     _tool_response_to_text,
     run_surfacing_hook,
 )
@@ -219,3 +222,62 @@ def test_cli_surfacing_disabled_is_noop(monkeypatch: pytest.MonkeyPatch):
     result = CliRunner().invoke(cli, ["hook"], input=json.dumps(_READ_PAYLOAD))
     assert result.exit_code == 0
     assert json.loads(result.output) == {}
+
+
+# ── Daemon routing + degradation ladder ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [("1", True), ("true", True), ("YES", True), ("on", True), ("0", False), ("", False)],
+)
+def test_daemon_enabled_env_parsing(monkeypatch: pytest.MonkeyPatch, value: str, expected: bool):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", value)
+    assert _daemon_enabled() is expected
+
+
+def test_daemon_disabled_uses_cold_path(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__USE_DAEMON", raising=False)
+    sentinel = {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "cold"}}
+    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=sentinel))
+    # client.surface must never be consulted when the daemon is disabled.
+    boom = AsyncMock(side_effect=AssertionError("daemon must not be used when disabled"))
+    monkeypatch.setattr("memtomem_stm.daemon.client.surface", boom)
+    out = asyncio.run(_run_hook(_READ_PAYLOAD))
+    assert out == sentinel
+    boom.assert_not_called()
+
+
+def test_daemon_used_when_enabled(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+    daemon_out = {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "warm"}}
+    monkeypatch.setattr("memtomem_stm.daemon.client.surface", AsyncMock(return_value=daemon_out))
+    # Cold path must not run when the daemon answers.
+    monkeypatch.setattr(
+        "memtomem_stm.cli.hook_cmd.run_surfacing_hook",
+        AsyncMock(side_effect=AssertionError("cold path must not run on a daemon hit")),
+    )
+    out = asyncio.run(_run_hook(_READ_PAYLOAD))
+    assert out == daemon_out
+
+
+def test_daemon_unavailable_skip_returns_empty(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__FALLBACK", raising=False)  # default = skip
+    monkeypatch.setattr("memtomem_stm.daemon.client.surface", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        "memtomem_stm.cli.hook_cmd.run_surfacing_hook",
+        AsyncMock(side_effect=AssertionError("skip must not fall back to the cold path")),
+    )
+    out = asyncio.run(_run_hook(_READ_PAYLOAD))
+    assert out == {}
+
+
+def test_daemon_unavailable_cold_fallback(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__FALLBACK", "cold")
+    monkeypatch.setattr("memtomem_stm.daemon.client.surface", AsyncMock(return_value=None))
+    sentinel = {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "cold"}}
+    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=sentinel))
+    out = asyncio.run(_run_hook(_READ_PAYLOAD))
+    assert out == sentinel

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -1,0 +1,159 @@
+"""Unit tests for the daemon's protocol / discovery / locking primitives."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.config import STMConfig
+from memtomem_stm.daemon import discovery, protocol
+from memtomem_stm.daemon.locking import single_owner_lock
+
+
+# ── protocol ──────────────────────────────────────────────────────────────
+
+
+def _reader_with(data: bytes) -> asyncio.StreamReader:
+    r = asyncio.StreamReader()
+    r.feed_data(data)
+    r.feed_eof()
+    return r
+
+
+def test_token_matches():
+    assert protocol.token_matches("abc", "abc") is True
+    assert protocol.token_matches("abc", "xyz") is False
+    assert protocol.token_matches("abc", None) is False
+    assert protocol.token_matches("abc", 123) is False
+    assert protocol.token_matches("", "") is False  # empty expected never matches
+
+
+async def test_encode_read_round_trip():
+    frame = protocol.build_request("tok", protocol.OP_SURFACE, {"a": 1, "msg": "line\nbreak"})
+    reader = _reader_with(protocol.encode_line(frame))
+    got = await protocol.read_message(reader)
+    assert got == frame  # embedded newline survived as an escaped char
+
+
+async def test_read_message_closed_stream():
+    with pytest.raises(protocol.ProtocolError):
+        await protocol.read_message(_reader_with(b""))
+
+
+async def test_read_message_malformed_and_non_object():
+    with pytest.raises(protocol.ProtocolError):
+        await protocol.read_message(_reader_with(b"not json\n"))
+    with pytest.raises(protocol.ProtocolError):
+        await protocol.read_message(_reader_with(b"[1,2,3]\n"))
+
+
+# ── discovery ───────────────────────────────────────────────────────────────
+
+
+def test_handshake_round_trip_and_mode(tmp_path: Path):
+    path = discovery.handshake_path(tmp_path)
+    discovery.write_handshake(
+        path,
+        pid=4321,
+        host="127.0.0.1",
+        port=5555,
+        token="secret",
+        config_fingerprint="fp",
+        created_at=1700000000.0,
+    )
+    data = discovery.read_handshake(path)
+    assert data is not None
+    assert data["pid"] == 4321 and data["port"] == 5555 and data["token"] == "secret"
+    if sys.platform != "win32":
+        assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_read_handshake_missing_and_malformed(tmp_path: Path):
+    assert discovery.read_handshake(tmp_path / "nope.json") is None
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert discovery.read_handshake(bad) is None
+
+
+def test_config_fingerprint_stable_and_broad(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK_SURFACE_TOOLS", raising=False)
+    fp = discovery.config_fingerprint(STMConfig())
+    assert fp == discovery.config_fingerprint(STMConfig())  # stable
+
+    # LTM command (subset of surfacing) moves it.
+    c1 = STMConfig()
+    c1.surfacing.ltm_mcp_command = "some-other-server"
+    assert discovery.config_fingerprint(c1) != fp
+
+    # A broad surfacing knob (min_score) must move it too — the old hand-picked
+    # subset missed this and would keep using a stale daemon.
+    c2 = STMConfig()
+    c2.surfacing.min_score = 0.5
+    assert discovery.config_fingerprint(c2) != fp
+
+    # The flat MEMTOMEM_STM_HOOK_SURFACE_TOOLS env (read directly by the hook,
+    # not bound to any model) must also move it.
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK_SURFACE_TOOLS", "Read,Custom")
+    assert discovery.config_fingerprint(STMConfig()) != fp
+
+
+async def test_request_respects_single_wall_clock_budget(monkeypatch: pytest.MonkeyPatch):
+    # connect that hangs past the budget → the whole _request is bounded by the
+    # single asyncio.timeout, returning None well within ~budget (not ~2x).
+    import asyncio as _asyncio
+    import time
+
+    from memtomem_stm.daemon import client
+
+    async def _slow_open(*args, **kwargs):
+        await _asyncio.sleep(5)
+
+    monkeypatch.setattr(_asyncio, "open_connection", _slow_open)
+    hs = {"token": "t", "host": "127.0.0.1", "port": 1}
+    start = time.monotonic()
+    out = await client._request(hs, protocol.OP_PING, None, timeout=0.2)
+    elapsed = time.monotonic() - start
+    assert out is None
+    assert elapsed < 1.5  # bounded by the 0.2 budget, not multiplied per step
+
+
+def test_remove_handshake_if_owner(tmp_path: Path):
+    path = discovery.handshake_path(tmp_path)
+    discovery.write_handshake(
+        path, pid=10, host="127.0.0.1", port=1, token="t", config_fingerprint="fp", created_at=0.0
+    )
+    # Wrong owner → kept.
+    discovery.remove_handshake_if_owner(path, pid=999, token="t")
+    assert path.exists()
+    discovery.remove_handshake_if_owner(path, pid=10, token="wrong")
+    assert path.exists()
+    # Correct owner → removed.
+    discovery.remove_handshake_if_owner(path, pid=10, token="t")
+    assert not path.exists()
+
+
+def test_is_pid_alive():
+    assert discovery.is_pid_alive(os.getpid()) is True
+    assert discovery.is_pid_alive(-1) is False
+    if sys.platform != "win32":
+        # A PID that almost certainly doesn't exist.
+        assert discovery.is_pid_alive(2**31 - 1) is False
+
+
+# ── locking ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock re-entrancy semantics")
+def test_single_owner_lock_excludes_second(tmp_path: Path):
+    p = tmp_path / "x.lock"
+    with single_owner_lock(p) as a:
+        assert a is True
+        with single_owner_lock(p) as b:
+            assert b is False  # second concurrent acquirer is locked out
+    # Released → acquirable again.
+    with single_owner_lock(p) as c:
+        assert c is True

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -101,6 +101,56 @@ def test_config_fingerprint_stable_and_broad(monkeypatch: pytest.MonkeyPatch):
     assert discovery.config_fingerprint(STMConfig()) != fp
 
 
+def test_config_fingerprint_excludes_client_only_hook_fields(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK_SURFACE_TOOLS", raising=False)
+    fp = discovery.config_fingerprint(STMConfig())
+    # Client-only hook fields must NOT move the fingerprint — a daemon started
+    # without USE_DAEMON must still match a hook that sets it (else the hook
+    # rejects the live daemon and returns {} forever under fallback=skip).
+    for field, value in [
+        ("use_daemon", True),
+        ("fallback", "cold"),
+        ("daemon_timeout_seconds", 9.9),
+    ]:
+        c = STMConfig()
+        setattr(c.hook, field, value)
+        assert discovery.config_fingerprint(c) == fp, field
+    # record_feedback_events DOES drive daemon engine wiring → must move it.
+    c = STMConfig()
+    c.hook.record_feedback_events = True
+    assert discovery.config_fingerprint(c) != fp
+
+
+def test_start_holds_spawn_lock_through_readiness(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Two concurrent `mms daemon start` must not both spawn. The lock has to be
+    # held across _wait_ready(), not just across the spawn call — otherwise a
+    # second start acquires it before our child publishes its handshake.
+    from unittest.mock import AsyncMock
+
+    from click.testing import CliRunner
+
+    from memtomem_stm.cli.proxy import cli
+    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr("memtomem_stm.daemon.client.ping", AsyncMock(return_value=None))
+    monkeypatch.setattr("memtomem_stm.cli.daemon_cmd._spawn_detached", lambda: None)
+
+    observed: dict[str, bool] = {}
+
+    def fake_wait_ready(config, *, timeout):
+        # start_cmd must still hold the lock here → a fresh acquire fails.
+        with single_owner_lock(lock_path(config.data_dir)) as got:
+            observed["acquired_during_wait"] = got
+        return None
+
+    monkeypatch.setattr("memtomem_stm.cli.daemon_cmd._wait_ready", fake_wait_ready)
+
+    result = CliRunner().invoke(cli, ["daemon", "start"])
+    assert result.exit_code == 0
+    assert observed["acquired_during_wait"] is False  # lock held across readiness
+
+
 async def test_request_respects_single_wall_clock_budget(monkeypatch: pytest.MonkeyPatch):
     # connect that hangs past the budget → the whole _request is bounded by the
     # single asyncio.timeout, returning None well within ~budget (not ~2x).

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -1,0 +1,264 @@
+"""End-to-end transport + lifecycle tests for the surfacing daemon.
+
+These never contact a real LTM server: the surface-hit path injects a
+``SurfacingEngine`` over a mock adapter, and the real-wiring path exercises a
+non-allowlisted tool so ``run_surfacing_hook`` returns ``{}`` before any LTM
+RPC. That keeps the suite deterministic even on a dev box with a live LTM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from memtomem_stm.config import STMConfig
+from memtomem_stm.daemon import client
+from memtomem_stm.daemon.discovery import handshake_path, read_handshake
+from memtomem_stm.daemon.protocol import (
+    MAX_MESSAGE_BYTES,
+    OP_SURFACE,
+    build_request,
+    encode_line,
+)
+from memtomem_stm.daemon.server import DaemonServer
+from memtomem_stm.surfacing.config import SurfacingConfig
+from memtomem_stm.surfacing.engine import SurfacingEngine
+
+
+@dataclass
+class _Meta:
+    source_file: Path = Path("/notes/test.md")
+    namespace: str = "default"
+
+
+@dataclass
+class _Chunk:
+    id: str = ""
+    content: str = "remembered detail about jwt"
+    metadata: _Meta | None = None
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = str(uuid4())
+        if self.metadata is None:
+            self.metadata = _Meta()
+
+
+@dataclass
+class _Result:
+    chunk: _Chunk
+    score: float
+
+
+_LONG = "JWT authentication handler. " * 50
+_READ_PAYLOAD = {
+    "hook_event_name": "PostToolUse",
+    "tool_name": "Read",
+    "tool_input": {"file_path": "/src/auth/jwt_handler.py"},
+    "tool_response": {"content": _LONG},
+}
+
+
+def _config(tmp_path: Path) -> STMConfig:
+    cfg = STMConfig()
+    cfg.data_dir = tmp_path
+    cfg.daemon.idle_timeout_seconds = 0.0
+    s = cfg.surfacing
+    s.feedback_db_path = tmp_path / "feedback.db"
+    s.enabled = True
+    s.min_response_chars = 10
+    s.timeout_seconds = 5.0
+    s.min_score = 0.02
+    s.cooldown_seconds = 0.0
+    s.max_surfacings_per_minute = 1000
+    s.auto_tune_enabled = False
+    s.include_session_context = False
+    s.fire_webhook = False
+    return cfg
+
+
+def _engine_with_result() -> SurfacingEngine:
+    adapter = AsyncMock()
+    adapter.search = AsyncMock(return_value=([_Result(_Chunk(), 0.5)], [], "ok"))
+    config = SurfacingConfig(
+        enabled=True,
+        min_response_chars=10,
+        timeout_seconds=5.0,
+        min_score=0.02,
+        cooldown_seconds=0.0,
+        max_surfacings_per_minute=1000,
+        auto_tune_enabled=False,
+        include_session_context=False,
+        fire_webhook=False,
+    )
+    return SurfacingEngine(config, mcp_adapter=adapter)
+
+
+async def _await_handshake(cfg: STMConfig, timeout: float = 3.0) -> None:
+    hp = handshake_path(cfg.data_dir)
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if hp.exists():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("daemon did not publish a handshake in time")
+
+
+async def _start(cfg: STMConfig, engine: SurfacingEngine | None = None):
+    server = DaemonServer(cfg)
+    if engine is not None:
+        # Bypass the real LTM/SQLite wiring; inject a ready engine instead.
+        server._build_engine = lambda: setattr(server, "_engine", engine)  # type: ignore[method-assign]
+    task = asyncio.create_task(server.serve())
+    await _await_handshake(cfg)
+    return server, task
+
+
+async def _stop(cfg: STMConfig, task: asyncio.Task) -> None:
+    await client.shutdown(cfg)
+    await asyncio.wait_for(task, timeout=5.0)
+
+
+async def test_ping_reports_ready_and_cold_ltm(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    _, task = await _start(cfg, engine=_engine_with_result())
+    try:
+        hs = await client.ping(cfg, timeout=2.0)
+        assert hs is not None
+        assert hs["ltm"] == "cold"  # injected engine: adapter never started
+    finally:
+        await _stop(cfg, task)
+
+
+async def test_surface_round_trip_injects_memories(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    _, task = await _start(cfg, engine=_engine_with_result())
+    try:
+        out = await client.surface(cfg, _READ_PAYLOAD, timeout=3.0)
+        assert out is not None
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "<surfaced-memories>" in ctx
+        # Stage-1 invariant survives the daemon path: no unresolvable prompt.
+        assert "surfacing_id" not in ctx
+        assert "stm_surfacing_feedback" not in ctx
+    finally:
+        await _stop(cfg, task)
+
+
+async def test_noop_surface_for_non_allowlisted_tool_real_wiring(tmp_path: Path) -> None:
+    # Real _build_engine (FeedbackTracker + lazy LTM adapter). A Write tool is
+    # not allowlisted, so run_surfacing_hook returns {} without touching LTM.
+    cfg = _config(tmp_path)
+    _, task = await _start(cfg)
+    try:
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/x"},
+            "tool_response": {"content": _LONG},
+        }
+        out = await client.surface(cfg, payload, timeout=3.0)
+        assert out == {}
+    finally:
+        await _stop(cfg, task)
+
+
+async def test_bad_token_is_rejected(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    _, task = await _start(cfg, engine=_engine_with_result())
+    try:
+        hs = read_handshake(handshake_path(cfg.data_dir))
+        assert hs is not None
+        reader, writer = await asyncio.open_connection(
+            hs["host"], hs["port"], limit=MAX_MESSAGE_BYTES
+        )
+        writer.write(encode_line(build_request("wrong-token", OP_SURFACE, _READ_PAYLOAD)))
+        await writer.drain()
+        # Server closes the connection without responding to an unauthenticated peer.
+        data = await asyncio.wait_for(reader.read(), timeout=3.0)
+        assert data == b""
+        writer.close()
+    finally:
+        await _stop(cfg, task)
+
+
+async def test_surface_returns_none_when_daemon_absent(tmp_path: Path) -> None:
+    # No daemon → client.surface returns None so the hook degrades to {}.
+    cfg = _config(tmp_path)
+    out = await client.surface(cfg, _READ_PAYLOAD, timeout=0.5)
+    assert out is None
+
+
+async def test_hook_run_hook_routes_to_live_daemon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # End-to-end: ``_run_hook`` (daemon enabled, env-driven config) reaches a
+    # live daemon and returns its surfaced output — the full hook→client→
+    # daemon→engine→back path, no LTM (engine injected).
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH", str(tmp_path / "fb.db"))
+    monkeypatch.setenv("MEMTOMEM_STM_DAEMON__IDLE_TIMEOUT_SECONDS", "0")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+
+    from memtomem_stm.cli.hook_cmd import _run_hook
+
+    cfg = STMConfig()  # reads the env above → data_dir == tmp_path
+    _, task = await _start(cfg, engine=_engine_with_result())
+    try:
+        out = await _run_hook(_READ_PAYLOAD)
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "<surfaced-memories>" in ctx
+    finally:
+        await _stop(cfg, task)
+
+
+async def test_build_engine_dedup_only_wiring(tmp_path: Path) -> None:
+    # Default (record_feedback_events=False) → dedup-only: result cache off so
+    # _surfaced_ids/seen_memories dedup is authoritative (F1), AutoTuner off so
+    # shared feedback rows can't nudge ranking (F3), query text never persisted.
+    cfg = _config(tmp_path)
+    assert cfg.hook.record_feedback_events is False
+    server = DaemonServer(cfg)
+    server._build_engine()
+    try:
+        ec = server._engine._config
+        assert ec.cache_ttl_seconds == 0.0
+        assert ec.auto_tune_enabled is False
+        assert ec.persist_query_text is False
+        assert server._engine._auto_tuner is None
+        assert server._engine._record_feedback_events is False
+        assert server._tracker is not None  # tracker still wired for dedup
+    finally:
+        if server._tracker is not None:
+            server._tracker.close()
+        await server._adapter.stop()
+
+
+async def test_idle_shutdown_stops_daemon(tmp_path: Path) -> None:
+    # With a tiny idle timeout and no requests, the daemon shuts itself down
+    # and removes its handshake — no leaked warm process after a quiet session.
+    cfg = _config(tmp_path)
+    cfg.daemon.idle_timeout_seconds = 0.2
+    server = DaemonServer(cfg)
+    server._build_engine = lambda: setattr(server, "_engine", _engine_with_result())  # type: ignore[method-assign]
+    task = asyncio.create_task(server.serve())
+    await _await_handshake(cfg)
+    await asyncio.wait_for(task, timeout=5.0)  # self-terminates on idle
+    assert not handshake_path(cfg.data_dir).exists()
+
+
+async def test_hook_run_hook_skips_when_daemon_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Daemon enabled but none running, default fallback=skip → {} (no cold path).
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__FALLBACK", raising=False)
+
+    from memtomem_stm.cli.hook_cmd import _run_hook
+
+    out = await _run_hook(_READ_PAYLOAD)
+    assert out == {}

--- a/tests/test_cross_session_dedup.py
+++ b/tests/test_cross_session_dedup.py
@@ -304,3 +304,62 @@ class TestCrossSessionDedup:
 
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert "memory" in output
+
+
+# ── record_feedback_events flag (hook daemon dedup-only wiring) ───────────
+
+
+class TestRecordFeedbackEventsFlag:
+    """The hook daemon wires a FeedbackTracker for cross-session dedup but sets
+    ``record_feedback_events=False`` so it persists *no* query text and emits no
+    unresolvable ``stm_surfacing_feedback`` rating prompt. Dedup
+    (``seen_memories``, memory IDs only) must keep working; the feedback-event
+    side (``surfacing_events``, ``surfacing_id``) must be fully suppressed."""
+
+    @staticmethod
+    def _event_count(tracker) -> int:
+        row = tracker.store._db.execute("SELECT COUNT(*) FROM surfacing_events").fetchone()
+        return row[0]
+
+    async def test_dedup_only_skips_event_and_prompt(self, tmp_path):
+        tracker = FeedbackTracker(config=_make_config(), db_path=tmp_path / "feedback.db")
+        chunk = FakeChunk(content="surfaced now")
+        results = [FakeSearchResult(chunk=chunk, score=0.5)]
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter(results),
+            feedback_tracker=tracker,
+            record_feedback_events=False,
+        )
+
+        output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+
+        # Memory still surfaced ...
+        assert "surfaced now" in output
+        # ... and dedup still persisted (seen_memories holds the ID).
+        assert chunk.id in tracker.store.get_seen_ids(ttl_seconds=3600)
+        # But no feedback event was recorded and no rating prompt leaked.
+        assert self._event_count(tracker) == 0
+        assert "stm_surfacing_feedback" not in output
+        assert "surfacing_id" not in output
+
+        tracker.close()
+
+    async def test_default_records_event(self, tmp_path):
+        """Default (record_feedback_events=True) preserves the proxy-path behavior:
+        a surfacing event is recorded so feedback/stats keep working."""
+        tracker = FeedbackTracker(config=_make_config(), db_path=tmp_path / "feedback.db")
+        chunk = FakeChunk(content="surfaced now")
+        results = [FakeSearchResult(chunk=chunk, score=0.5)]
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter(results),
+            feedback_tracker=tracker,
+        )
+
+        await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+
+        assert self._event_count(tracker) == 1
+        assert chunk.id in tracker.store.get_seen_ids(ttl_seconds=3600)
+
+        tracker.close()


### PR DESCRIPTION
## Why

`mms hook` (#378) surfaces LTM memories for built-in tools, but spawns a fresh
LTM MCP child **per call** — the ~6s cold start (embedding + reranker load)
exceeds the 3s surfacing timeout, so with stock defaults surfacing usually
times out and the hook is a near-no-op. The fix the code already pointed at:
a persistent local daemon holding a **warm** LTM connection.

This is **Stage 2, PR 1** — the transport + foreground daemon + the warm
engine, opt-in. Auto-spawn from the hook and ownership hardening land in PR 2.

## What

**Opt-in, additive.** With `MEMTOMEM_STM_HOOK__USE_DAEMON` unset, `mms hook`
behaves exactly as today (cold in-process path). When set, it does one bounded
loopback round trip to the daemon and degrades cleanly — `{}` (default) or the
cold path (`MEMTOMEM_STM_HOOK__FALLBACK=cold`) — if the daemon is unreachable.
The hook still always exits 0.

- **Transport** (`daemon/protocol.py`, `discovery.py`, `client.py`): loopback
  TCP (`127.0.0.1`, OS-assigned port) + per-start random token, newline-JSON
  framing, `0o600` handshake file. One code path across macOS/Linux/Windows
  (Windows is a required CI target → no UDS/named-pipe split). The token gates
  *use* of the port; it's checked with `secrets.compare_digest` and never
  logged.
- **Warm engine, dedup-only** (`daemon/server.py`): one long-lived
  `SurfacingEngine` + lazily-started LTM adapter. A `FeedbackTracker` is wired
  **only** for cross-session `seen_memories` dedup — a new
  `SurfacingEngine(record_feedback_events=...)` flag (default `True`, proxy
  path unchanged) lets the daemon keep dedup while persisting **no** query text
  and emitting **no** `stm_surfacing_feedback` rating prompt (the pure-hook
  path has no in-band feedback channel; `Bash` queries may carry secrets). The
  daemon also disables the result cache (so `_surfaced_ids`/`seen_memories`
  dedup is authoritative, not short-circuited by a cache hit) and AutoTuner
  (so ranking isn't nudged by feedback rows it never records), and forces
  `persist_query_text=False`.
- **CLI** (`cli/daemon_cmd.py`): `mms daemon run/start/stop/status/restart`
  (detached spawn, `--json`), registered in `proxy.py`. Adds
  `python -m memtomem_stm` for a path-free detached spawn.
- **Lifecycle**: idle shutdown, graceful teardown that terminates the warm LTM
  child, cross-platform spawn lock + signal handling. The handshake carries a
  broadened config fingerprint so a daemon started under different config is
  treated as stale.
- **Config**: new `HookConfig` (`MEMTOMEM_STM_HOOK__use_daemon` /
  `daemon_timeout_seconds` / `fallback` / `record_feedback_events`) and
  `DaemonConfig` (`MEMTOMEM_STM_DAEMON__host` / `idle_timeout_seconds`).

## Verification

- `ruff check src` + `ruff format --check src` + `mypy src` — clean.
- `pytest -m "not ollama"` — passes (the 2 unrelated failures are the
  documented live-LTM dev-box flakes; they fail identically on `main`).
- New tests: engine dedup/feedback-event decoupling, daemon protocol round
  trip + token rejection, discovery/locking primitives, idle shutdown, dedup
  -only wiring, broadened fingerprint, single-deadline client timeout, and the
  hook degradation ladder.
- Manual: `mms daemon start` → `status --json` (running, `ltm=cold`, `0o600`
  handshake) → `stop` (clean teardown, handshake removed).

## Deferred (PR 2+)

Auto-spawn-on-first-hook (lock-guarded detached spawn + readiness poll),
lock-held-for-lifetime ownership, optional POSIX UDS fast-path. Behavioral
feedback / rating loop remain out of scope (no in-band channel in the
pure-hook path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
