### PR TITLE
feat(daemon): hook auto-spawn (lock-guarded) + lifetime-lock ownership (Stage 2, PR 2)

### DIFF
--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -106,7 +106,12 @@ def start_cmd() -> None:
     *different-config* daemon stays alive and won't release — that we report.
     """
     from memtomem_stm.daemon import client
-    from memtomem_stm.daemon.discovery import config_fingerprint, handshake_path, read_handshake
+    from memtomem_stm.daemon.discovery import (
+        config_fingerprint,
+        handshake_path,
+        is_pid_alive,
+        read_handshake,
+    )
     from memtomem_stm.daemon.spawn import request_spawn
 
     config = _load_config()
@@ -118,6 +123,7 @@ def start_cmd() -> None:
         return
 
     deadline = time.time() + 10.0
+    spawned = False
     while time.time() < deadline:
         hs = asyncio.run(client.ping(config, timeout=1.0))
         if hs is not None:
@@ -127,21 +133,29 @@ def start_cmd() -> None:
             # We launched a child (lock was free). Give it a moment to acquire
             # the lock + publish, then loop back to ping it. We don't hold the
             # lock, so the child can take ownership.
+            spawned = True
             time.sleep(0.3)
             continue
-        # Lock held by another daemon. A *different-config* one stays alive and
-        # won't release the lock — report instead of waiting it out. (A matching
-        # daemon mid-startup, or any daemon mid-shutdown, falls through to wait:
-        # the next iteration re-attempts the spawn once the lock is free.)
-        raw = read_handshake(handshake_path(config.data_dir))
-        if raw is not None and raw.get("config_fingerprint") != config_fingerprint(config):
-            click.echo(
-                _warn(
-                    f"a daemon with a different config is running (pid={raw.get('pid')}) — "
-                    "run `mms daemon restart` to replace it"
+        # Lock held by another daemon. Only a *live* different-config daemon that
+        # we did not just spawn is a real conflict worth reporting: a stale
+        # handshake (dead pid) left by a crash, or the matching child we just
+        # spawned that hasn't published its handshake yet, must NOT be
+        # misreported. Everything else falls through to wait — the next
+        # iteration re-attempts the spawn once the lock frees.
+        if not spawned:
+            raw = read_handshake(handshake_path(config.data_dir))
+            if (
+                raw is not None
+                and raw.get("config_fingerprint") != config_fingerprint(config)
+                and is_pid_alive(int(raw.get("pid", -1)))
+            ):
+                click.echo(
+                    _warn(
+                        f"a daemon with a different config is running (pid={raw.get('pid')}) — "
+                        "run `mms daemon restart` to replace it"
+                    )
                 )
-            )
-            return
+                return
         time.sleep(0.2)
     click.echo(
         _warn(

--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -22,7 +22,6 @@ import json
 import logging
 import os
 import signal
-import subprocess
 import sys
 import time
 from typing import TYPE_CHECKING, Any
@@ -70,25 +69,6 @@ def _configure_logging(config: STMConfig, *, detached: bool) -> None:
     )
 
 
-def _spawn_detached() -> None:
-    """Launch ``mms daemon run --detached`` as a background process."""
-    cmd = [sys.executable, "-m", "memtomem_stm", "daemon", "run", "--detached"]
-    kwargs: dict[str, Any] = {
-        "stdin": subprocess.DEVNULL,
-        "stdout": subprocess.DEVNULL,
-        "stderr": subprocess.DEVNULL,
-        "close_fds": True,
-    }
-    if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
-        flags = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
-            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
-        )
-        kwargs["creationflags"] = flags
-    else:
-        kwargs["start_new_session"] = True
-    subprocess.Popen(cmd, **kwargs)
-
-
 def _wait_ready(config: STMConfig, *, timeout: float) -> dict[str, Any] | None:
     """Poll ``ping`` until the daemon answers or ``timeout`` elapses."""
     from memtomem_stm.daemon import client
@@ -129,9 +109,17 @@ def run_cmd(detached: bool, foreground: bool) -> None:
 
 @daemon_group.command(name="start")
 def start_cmd() -> None:
-    """Spawn the daemon detached if it isn't already running."""
+    """Spawn the daemon detached if it isn't already running.
+
+    The daemon now self-guards via its lifetime lock, so ``start`` no longer
+    holds the lock through readiness — it just classifies the current state:
+    a matching daemon already running, a spawn we launched, a *different-config*
+    daemon holding the lock (which it can't replace — points at ``restart``), or
+    a matching daemon mid-startup (waits for it).
+    """
     from memtomem_stm.daemon import client
-    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+    from memtomem_stm.daemon.discovery import config_fingerprint, handshake_path, read_handshake
+    from memtomem_stm.daemon.spawn import request_spawn
 
     config = _load_config()
     existing = asyncio.run(client.ping(config, timeout=2.0))
@@ -140,27 +128,41 @@ def start_cmd() -> None:
             _ok(f"daemon already running (pid={existing.get('pid')} port={existing.get('port')})")
         )
         return
-    with single_owner_lock(lock_path(config.data_dir)) as acquired:
-        if not acquired:
-            click.echo(_warn("another `mms daemon start` is in progress"))
-            return
-        # Re-check under the lock to avoid a double-spawn race.
-        if asyncio.run(client.ping(config, timeout=1.0)) is not None:
-            click.echo(_ok("daemon already running"))
-            return
-        _spawn_detached()
-        # Hold the lock through readiness. Releasing it here would let a
-        # concurrent `start` acquire it, see ping return None (our child hasn't
-        # published its handshake yet), and spawn a *second* daemon — which,
-        # with ephemeral ports + last-writer-wins handshake, orphans an extra
-        # warm LTM process.
+
+    if request_spawn(config):
+        # Lock was free → we launched a child. Poll for readiness (UX only; the
+        # child owns the lock now, we don't hold it).
         hs = _wait_ready(config, timeout=8.0)
+        if hs is not None:
+            click.echo(_ok(f"daemon started (pid={hs.get('pid')} port={hs.get('port')})"))
+        else:
+            click.echo(
+                _warn(
+                    "daemon spawn requested but it did not become ready in time — "
+                    "check the daemon log under data_dir (stm-daemon.log)"
+                )
+            )
+        return
+
+    # Lock held but no *matching* daemon answered ping. Distinguish a
+    # different-config daemon (can't be used by this config; needs an explicit
+    # restart) from a matching one still coming up.
+    raw = read_handshake(handshake_path(config.data_dir))
+    if raw is not None and raw.get("config_fingerprint") != config_fingerprint(config):
+        click.echo(
+            _warn(
+                f"a daemon with a different config is running (pid={raw.get('pid')}) — "
+                "run `mms daemon restart` to replace it"
+            )
+        )
+        return
+    hs = _wait_ready(config, timeout=8.0)
     if hs is not None:
         click.echo(_ok(f"daemon started (pid={hs.get('pid')} port={hs.get('port')})"))
     else:
         click.echo(
             _warn(
-                "daemon spawn requested but it did not become ready in time — "
+                "another daemon owns the lock but did not become ready in time — "
                 "check the daemon log under data_dir (stm-daemon.log)"
             )
         )
@@ -257,7 +259,21 @@ def status_cmd(as_json: bool) -> None:
 @daemon_group.command(name="restart")
 @click.pass_context
 def restart_cmd(ctx: click.Context) -> None:
-    """Stop any running daemon, then start a fresh one."""
+    """Stop any running daemon, then start a fresh one once the lock is free."""
+    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+
+    config = _load_config()
     ctx.invoke(stop_cmd)
-    time.sleep(0.3)
-    ctx.invoke(start_cmd)
+    # Wait for the old daemon to release its lifetime lock before starting. A
+    # fixed sleep could race: _teardown() awaits the warm LTM child's stop and
+    # has no hard timeout. Bounded so a wedged teardown reports clearly instead
+    # of letting start_cmd produce a misleading readiness timeout.
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        with single_owner_lock(lock_path(config.data_dir)) as acquired:
+            free = acquired
+        if free:
+            ctx.invoke(start_cmd)
+            return
+        time.sleep(0.2)
+    click.echo(_warn("previous daemon still shutting down — try `mms daemon start` again shortly"))

--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -69,19 +69,6 @@ def _configure_logging(config: STMConfig, *, detached: bool) -> None:
     )
 
 
-def _wait_ready(config: STMConfig, *, timeout: float) -> dict[str, Any] | None:
-    """Poll ``ping`` until the daemon answers or ``timeout`` elapses."""
-    from memtomem_stm.daemon import client
-
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        hs = asyncio.run(client.ping(config, timeout=1.0))
-        if hs is not None:
-            return hs
-        time.sleep(0.2)
-    return None
-
-
 @click.group(name="daemon")
 def daemon_group() -> None:
     """Manage the local surfacing daemon (warm LTM connection for ``mms hook``)."""
@@ -111,11 +98,12 @@ def run_cmd(detached: bool, foreground: bool) -> None:
 def start_cmd() -> None:
     """Spawn the daemon detached if it isn't already running.
 
-    The daemon now self-guards via its lifetime lock, so ``start`` no longer
-    holds the lock through readiness — it just classifies the current state:
-    a matching daemon already running, a spawn we launched, a *different-config*
-    daemon holding the lock (which it can't replace — points at ``restart``), or
-    a matching daemon mid-startup (waits for it).
+    The daemon self-guards via its lifetime lock, so ``start`` never holds the
+    lock — it reconciles toward a running daemon. The lock may currently be held
+    by a daemon that is *shutting down* (e.g. right after ``mms daemon stop``):
+    it won't answer ping and will soon release the lock, so we keep retrying the
+    spawn until the lock frees rather than polling ping once and giving up. A
+    *different-config* daemon stays alive and won't release — that we report.
     """
     from memtomem_stm.daemon import client
     from memtomem_stm.daemon.discovery import config_fingerprint, handshake_path, read_handshake
@@ -129,43 +117,38 @@ def start_cmd() -> None:
         )
         return
 
-    if request_spawn(config):
-        # Lock was free → we launched a child. Poll for readiness (UX only; the
-        # child owns the lock now, we don't hold it).
-        hs = _wait_ready(config, timeout=8.0)
+    deadline = time.time() + 10.0
+    while time.time() < deadline:
+        hs = asyncio.run(client.ping(config, timeout=1.0))
         if hs is not None:
             click.echo(_ok(f"daemon started (pid={hs.get('pid')} port={hs.get('port')})"))
-        else:
+            return
+        if request_spawn(config):
+            # We launched a child (lock was free). Give it a moment to acquire
+            # the lock + publish, then loop back to ping it. We don't hold the
+            # lock, so the child can take ownership.
+            time.sleep(0.3)
+            continue
+        # Lock held by another daemon. A *different-config* one stays alive and
+        # won't release the lock — report instead of waiting it out. (A matching
+        # daemon mid-startup, or any daemon mid-shutdown, falls through to wait:
+        # the next iteration re-attempts the spawn once the lock is free.)
+        raw = read_handshake(handshake_path(config.data_dir))
+        if raw is not None and raw.get("config_fingerprint") != config_fingerprint(config):
             click.echo(
                 _warn(
-                    "daemon spawn requested but it did not become ready in time — "
-                    "check the daemon log under data_dir (stm-daemon.log)"
+                    f"a daemon with a different config is running (pid={raw.get('pid')}) — "
+                    "run `mms daemon restart` to replace it"
                 )
             )
-        return
-
-    # Lock held but no *matching* daemon answered ping. Distinguish a
-    # different-config daemon (can't be used by this config; needs an explicit
-    # restart) from a matching one still coming up.
-    raw = read_handshake(handshake_path(config.data_dir))
-    if raw is not None and raw.get("config_fingerprint") != config_fingerprint(config):
-        click.echo(
-            _warn(
-                f"a daemon with a different config is running (pid={raw.get('pid')}) — "
-                "run `mms daemon restart` to replace it"
-            )
+            return
+        time.sleep(0.2)
+    click.echo(
+        _warn(
+            "daemon did not become ready in time — "
+            "check the daemon log under data_dir (stm-daemon.log)"
         )
-        return
-    hs = _wait_ready(config, timeout=8.0)
-    if hs is not None:
-        click.echo(_ok(f"daemon started (pid={hs.get('pid')} port={hs.get('port')})"))
-    else:
-        click.echo(
-            _warn(
-                "another daemon owns the lock but did not become ready in time — "
-                "check the daemon log under data_dir (stm-daemon.log)"
-            )
-        )
+    )
 
 
 @daemon_group.command(name="stop")

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -289,10 +289,12 @@ async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
 
     Degradation ladder (every rung still yields a hook-output dict, never
     raises): daemon disabled → cold in-process path (unchanged). Daemon enabled
-    → one bounded round trip; on unavailable/stale/slow either ``{}`` (default
-    ``fallback=skip`` — the daemon exists precisely to avoid the ~6s cold start)
-    or the cold path (``fallback=cold``). The whole call runs inside
-    ``_hook_budget_seconds()`` in :func:`hook_command`.
+    → one bounded round trip; on unavailable/stale/slow we (optionally)
+    fire-and-forget spawn the daemon so the *next* call is warm, then for *this*
+    call either return ``{}`` (default ``fallback=skip`` — the daemon exists
+    precisely to avoid the ~6s cold start) or take the cold path
+    (``fallback=cold``). The whole call runs inside ``_hook_budget_seconds()``
+    in :func:`hook_command`.
     """
     if _daemon_enabled():
         from memtomem_stm.config import STMConfig
@@ -306,6 +308,17 @@ async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
             out = None
         if out is not None:
             return out
+        # Daemon unreachable. Kick off a lock-guarded background spawn so the
+        # next call is warm (this call still degrades below). request_spawn is a
+        # quick flock probe + detached Popen — fire-and-forget, never blocking
+        # the hook budget, never raising into the hot path.
+        if config.hook.auto_spawn:
+            try:
+                from memtomem_stm.daemon.spawn import request_spawn
+
+                request_spawn(config)
+            except Exception:
+                logger.debug("daemon auto-spawn failed", exc_info=True)
         if config.hook.fallback != "cold":
             return {}
         # fallback=cold → fall through to the in-process surfacing path.

--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -70,6 +70,13 @@ class HookConfig(BaseModel):
     ~6s cold start, so the default never pays it. ``cold`` falls back to the
     in-process surfacing path (still bounded by ``_hook_budget_seconds()``),
     preserving pre-daemon behavior for callers who prefer it."""
+    auto_spawn: bool = True
+    """When ``True`` (and ``use_daemon``), ``mms hook`` fire-and-forget spawns
+    the daemon if none is running, so the *next* call is warm — no manual
+    ``mms daemon start`` needed. Lock-guarded against duplicate warm daemons.
+    Disable with ``MEMTOMEM_STM_HOOK__AUTO_SPAWN=0``. Client-only knob (like
+    ``use_daemon``/``fallback``) — excluded from the daemon config fingerprint,
+    so a daemon started with it off still matches an auto-spawning hook."""
     record_feedback_events: bool = False
     """Passed to the daemon's ``SurfacingEngine``. Default ``False`` keeps
     cross-session dedup (``seen_memories``, memory IDs only) while persisting

--- a/src/memtomem_stm/daemon/__init__.py
+++ b/src/memtomem_stm/daemon/__init__.py
@@ -11,7 +11,8 @@ Submodules:
 
 - :mod:`~memtomem_stm.daemon.protocol` — newline-delimited JSON framing + token.
 - :mod:`~memtomem_stm.daemon.discovery` — the ``stm-daemon.json`` handshake file.
-- :mod:`~memtomem_stm.daemon.locking` — cross-platform single-owner spawn lock.
+- :mod:`~memtomem_stm.daemon.locking` — cross-platform single-owner lifetime lock.
+- :mod:`~memtomem_stm.daemon.spawn` — lock-probed, fire-and-forget detached spawn.
 - :mod:`~memtomem_stm.daemon.server` — the asyncio server loop + warm engine.
 """
 

--- a/src/memtomem_stm/daemon/locking.py
+++ b/src/memtomem_stm/daemon/locking.py
@@ -1,18 +1,27 @@
-"""Cross-platform single-owner advisory lock.
+"""Cross-platform single-owner advisory lock — the daemon's lifetime ownership.
 
-Used to keep two concurrent ``mms hook`` auto-spawns (or two ``mms daemon
-start`` invocations) from racing to launch a second daemon. **This lock is the
-ownership primitive** — the port bind is *not*: the daemon binds an
-OS-assigned ephemeral port (``port 0``), so two daemons would simply get two
-different ports and both succeed, and the handshake file is last-writer-wins
-(the second overwrites the first, orphaning it). The guard against a second
-daemon is therefore: hold this lock across the start decision and re-check a
-``ping`` under it before spawning. A caller that fails to acquire assumes
-another process is mid-spawn and just polls the handshake file.
+**This lock is the ownership primitive** — the port bind is *not*: the daemon
+binds an OS-assigned ephemeral port (``port 0``), so two daemons would simply
+get two different ports and both succeed, and the handshake file is
+last-writer-wins (the second overwrites the first, orphaning it). Instead, the
+running daemon **holds this lock for its entire lifetime** (acquired before it
+warms its engine), so "lock held" is the authoritative "a daemon is alive"
+signal. A would-be spawner (``mms hook`` auto-spawn, ``mms daemon start``) only
+*probes* the lock: if it's held, a daemon already owns it, so don't launch a
+duplicate; if it's free, spawn — and the spawned child re-acquires the lock as
+the single owner, so a rare concurrent double-spawn just has the loser exit
+before warming an LTM.
+
+Two access shapes:
+- :func:`single_owner_lock` — a context manager for the *probe* (acquire,
+  yield, release). Used by ``request_spawn`` and ``mms daemon start``.
+- :func:`open_lock_fd` / :func:`try_lock` / :func:`release_lock` — the daemon
+  holds an fd across its whole asyncio run, retrying ``try_lock`` with
+  ``await asyncio.sleep`` and releasing on teardown.
 
 POSIX uses ``fcntl.flock``; Windows uses ``msvcrt.locking``. Both are advisory
-and auto-released if the holding process dies, so a crashed spawner never
-wedges the lock.
+and auto-released if the holding process dies, so a crashed daemon never wedges
+the lock (the next probe finds it free and self-heals).
 """
 
 from __future__ import annotations
@@ -29,8 +38,32 @@ LOCK_FILENAME = "stm-daemon.lock"
 
 
 def lock_path(data_dir: Path) -> Path:
-    """Absolute path to the spawn lock file under ``data_dir``."""
+    """Absolute path to the daemon's lifetime ownership lock under ``data_dir``."""
     return (data_dir / LOCK_FILENAME).expanduser()
+
+
+def open_lock_fd(path: Path) -> int:
+    """Open (creating) the lock file and return its fd. Caller owns the fd and
+    must :func:`release_lock` it. Raises ``OSError`` only if the file can't be
+    opened at all (which a caller may treat as "don't run / don't spawn")."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return os.open(str(path), os.O_RDWR | os.O_CREAT, 0o600)
+
+
+def try_lock(fd: int) -> bool:
+    """Non-blocking exclusive lock attempt on ``fd``. ``True`` iff acquired."""
+    return _try_lock(fd)
+
+
+def release_lock(fd: int) -> None:
+    """Best-effort unlock + close of a lock fd. Safe to call even if ``fd`` was
+    never locked (a never-acquired retry that timed out) — the unlock is
+    swallowed and the fd is always closed."""
+    _unlock(fd)
+    try:
+        os.close(fd)
+    except OSError:
+        logger.debug("failed to close lock fd", exc_info=True)
 
 
 @contextmanager

--- a/src/memtomem_stm/daemon/server.py
+++ b/src/memtomem_stm/daemon/server.py
@@ -6,6 +6,12 @@ call is a sub-second round trip instead of a ~6s cold start. Requests are
 token-authenticated and dispatched over the newline-JSON
 :mod:`~memtomem_stm.daemon.protocol`.
 
+Single-instance is enforced by the lifetime ownership lock
+(:mod:`~memtomem_stm.daemon.locking`): ``serve`` acquires it (with a brief
+retry) **before** building the engine and holds it until teardown, so a
+redundant/late daemon exits without warming an LTM. This replaces the older
+``ping``-based guard, closing its TOCTOU window and recycled-PID weakness.
+
 Engine wiring is the **dedup-only** variant of ``server.py``'s app_lifespan: a
 ``FeedbackTracker`` is attached so cross-session dedup (``seen_memories``)
 survives restarts, but ``record_feedback_events=False`` means no query text is
@@ -32,7 +38,7 @@ from typing import Any
 
 from memtomem_stm.cli.hook_cmd import run_surfacing_hook
 from memtomem_stm.config import STMConfig
-from memtomem_stm.daemon import client, discovery
+from memtomem_stm.daemon import discovery, locking
 from memtomem_stm.daemon.protocol import (
     MAX_MESSAGE_BYTES,
     OP_PING,
@@ -64,6 +70,12 @@ async def _quiet(coro: Any, what: str) -> None:
 class DaemonServer:
     """A single-process loopback surfacing daemon."""
 
+    # Lifetime-lock acquire: retry briefly so a losing/late child becomes a warm
+    # standby that grabs the lock the instant an incumbent releases (closes the
+    # crash-during-build dead window) without ever building an engine to lose it.
+    _LOCK_ACQUIRE_RETRY_SECONDS = 1.5
+    _LOCK_ACQUIRE_POLL_SECONDS = 0.05
+
     def __init__(self, config: STMConfig) -> None:
         self._config = config
         self._host = config.daemon.host
@@ -84,18 +96,42 @@ class DaemonServer:
     async def serve(self) -> int:
         """Run until shutdown (signal, idle timeout, or ``shutdown`` op).
 
-        Refuses to start a second daemon if a live one already answers ``ping``.
+        Holds the lifetime ownership lock for the whole run: a second daemon
+        that can't acquire it (within a brief retry window) exits *before*
+        warming an LTM, so "lock held" is the authoritative single-owner signal.
         Returns a process exit code.
         """
-        existing = await client.ping(self._config, timeout=2.0)
-        if existing is not None:
-            logger.warning(
-                "daemon already running (pid=%s port=%s) — not starting another",
-                existing.get("pid"),
-                existing.get("port"),
-            )
+        try:
+            fd = locking.open_lock_fd(locking.lock_path(self._config.data_dir))
+        except OSError:
+            logger.warning("daemon could not open the lock file — exiting", exc_info=True)
             return 0
+        try:
+            if not await self._acquire_lifetime_lock(fd):
+                return 0
+            return await self._serve_owned()
+        finally:
+            locking.release_lock(fd)
 
+    async def _acquire_lifetime_lock(self, fd: int) -> bool:
+        """Take the lifetime lock, retrying briefly so a losing/late child becomes
+        a warm standby that grabs it the instant an incumbent releases. Retry the
+        lock acquisition ONLY — the (expensive) engine build happens once, after.
+        Async sleep (never ``time.sleep``) so it doesn't block the event loop."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._LOCK_ACQUIRE_RETRY_SECONDS
+        while not locking.try_lock(fd):
+            if loop.time() >= deadline:
+                # Best-effort pid for a friendly log; gate nothing on it.
+                raw = discovery.read_handshake(discovery.handshake_path(self._config.data_dir))
+                pid = raw.get("pid") if isinstance(raw, dict) else None
+                logger.warning("another daemon already owns the lock (pid=%s) — exiting", pid)
+                return False
+            await asyncio.sleep(self._LOCK_ACQUIRE_POLL_SECONDS)
+        return True
+
+    async def _serve_owned(self) -> int:
+        """The serve body, run with the lifetime lock held."""
         self._build_engine()
         self._last_request = time.monotonic()
         server = await asyncio.start_server(

--- a/src/memtomem_stm/daemon/spawn.py
+++ b/src/memtomem_stm/daemon/spawn.py
@@ -1,0 +1,68 @@
+"""Spawn a detached surfacing daemon — shared by ``mms daemon start`` (ops) and
+``mms hook`` auto-spawn (hot path).
+
+The lock is used here only as a **liveness probe** (acquire + immediately
+release): if a daemon already owns the lifetime lock we don't launch a
+duplicate; if it's free we spawn a detached child *outside* the lock. The child
+re-acquires the lifetime lock as the authoritative single owner (see
+:mod:`~memtomem_stm.daemon.server`), so a rare concurrent double-spawn just has
+one child exit before warming an LTM — no orphaned warm process. Spawning is
+fire-and-forget: it never blocks on readiness, so the warm daemon serves the
+*next* call, not this one.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from memtomem_stm.config import STMConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _spawn_detached() -> None:
+    """Launch ``mms daemon run --detached`` as a background process."""
+    cmd = [sys.executable, "-m", "memtomem_stm", "daemon", "run", "--detached"]
+    kwargs: dict[str, Any] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+        flags = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+        kwargs["creationflags"] = flags
+    else:
+        kwargs["start_new_session"] = True
+    subprocess.Popen(cmd, **kwargs)
+
+
+def request_spawn(config: STMConfig) -> bool:
+    """Fire-and-forget spawn a detached daemon iff none currently owns the lock.
+
+    Returns ``True`` if a child was launched, ``False`` if a daemon already owns
+    the lifetime lock (alive or mid-startup) so we deferred, or if the lock file
+    couldn't be opened. Never blocks on readiness and never raises.
+
+    The lock is a probe only (acquire + release); the spawned child re-acquires
+    it for its lifetime as the single owner.
+    """
+    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+
+    try:
+        with single_owner_lock(lock_path(config.data_dir)) as acquired:
+            alive = not acquired  # held by a live/starting daemon → don't pile on
+    except OSError:
+        logger.debug("request_spawn: could not open lock file", exc_info=True)
+        return False
+    if alive:
+        return False
+    _spawn_detached()  # spawn OUTSIDE the lock (already released above)
+    return True

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -159,6 +159,111 @@ def test_start_retries_spawn_until_lock_frees(tmp_path: Path, monkeypatch: pytes
     assert "daemon started" in result.output
 
 
+def test_start_does_not_misreport_stale_handshake_after_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A crashed different-config daemon left a stale handshake. `start` spawns a
+    # matching child; while it's mid-startup (holds the lock, hasn't published)
+    # the stale handshake must NOT be misreported as a live config conflict.
+    from click.testing import CliRunner
+
+    from memtomem_stm.cli.proxy import cli
+
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    discovery.write_handshake(
+        discovery.handshake_path(tmp_path),
+        pid=2**31 - 1,  # not a live process
+        host="127.0.0.1",
+        port=1,
+        token="t",
+        config_fingerprint="stale-different-fp",
+        created_at=0.0,
+    )
+
+    state = {"spawns": 0, "pings": 0}
+
+    def fake_request_spawn(config):
+        state["spawns"] += 1
+        return state["spawns"] == 1  # lock free → spawn; then "held" by our child
+
+    async def fake_ping(config, *, timeout=2.0):
+        state["pings"] += 1
+        return {"pid": 99, "port": 4567} if state["pings"] >= 4 else None
+
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", fake_request_spawn)
+    monkeypatch.setattr("memtomem_stm.daemon.client.ping", fake_ping)
+
+    result = CliRunner().invoke(cli, ["daemon", "start"])
+    assert result.exit_code == 0
+    assert "different config" not in result.output  # stale handshake not misreported
+    assert "daemon started" in result.output
+
+
+def test_start_ignores_stale_handshake_with_dead_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Lock held by a matching daemon mid-startup we did NOT spawn, with a stale
+    # different-config handshake (dead pid) on disk. The dead pid means "not a
+    # live conflict" → wait it out rather than misreport.
+    from click.testing import CliRunner
+
+    from memtomem_stm.cli.proxy import cli
+
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    discovery.write_handshake(
+        discovery.handshake_path(tmp_path),
+        pid=2**31 - 1,
+        host="127.0.0.1",
+        port=1,
+        token="t",
+        config_fingerprint="stale-different-fp",
+        created_at=0.0,
+    )
+
+    state = {"pings": 0}
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda config: False)
+
+    async def fake_ping(config, *, timeout=2.0):
+        state["pings"] += 1
+        return {"pid": 7, "port": 4567} if state["pings"] >= 3 else None
+
+    monkeypatch.setattr("memtomem_stm.daemon.client.ping", fake_ping)
+
+    result = CliRunner().invoke(cli, ["daemon", "start"])
+    assert result.exit_code == 0
+    assert "different config" not in result.output
+    assert "daemon started" in result.output
+
+
+def test_start_reports_live_different_config_daemon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A genuinely live different-config daemon (alive pid) holds the lock → it
+    # won't release, so report it clearly instead of waiting out the deadline.
+    from unittest.mock import AsyncMock
+
+    from click.testing import CliRunner
+
+    from memtomem_stm.cli.proxy import cli
+
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    discovery.write_handshake(
+        discovery.handshake_path(tmp_path),
+        pid=os.getpid(),  # alive
+        host="127.0.0.1",
+        port=1,
+        token="t",
+        config_fingerprint="a-different-fp",
+        created_at=0.0,
+    )
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda config: False)
+    monkeypatch.setattr("memtomem_stm.daemon.client.ping", AsyncMock(return_value=None))
+
+    result = CliRunner().invoke(cli, ["daemon", "start"])
+    assert result.exit_code == 0
+    assert "a daemon with a different config is running" in result.output
+
+
 # ── spawn (request_spawn) ─────────────────────────────────────────────────────
 
 

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -199,6 +199,12 @@ def test_start_does_not_misreport_stale_handshake_after_spawn(
     assert "daemon started" in result.output
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="is_pid_alive() always returns True on Windows (no signal-0) → the "
+    "dead-pid guard is a documented no-op there; the spawned-flag guard is "
+    "what protects the common case cross-platform.",
+)
 def test_start_ignores_stale_handshake_with_dead_pid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -123,37 +123,40 @@ def test_config_fingerprint_excludes_client_only_hook_fields(monkeypatch: pytest
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock re-entrancy semantics")
-def test_start_does_not_hold_lock_through_readiness(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
-    # Inverted invariant (vs the pre-lifetime-lock design): single-owner
-    # protection now lives in the daemon, so `mms daemon start` must NOT hold the
-    # lock while polling readiness — the spawned child needs to acquire it. A
-    # fresh acquire during _wait_ready() therefore SUCCEEDS.
-    from unittest.mock import AsyncMock
-
+def test_start_retries_spawn_until_lock_frees(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # A daemon shutting down still holds the lifetime lock, so request_spawn
+    # declines — but it WILL release the lock and never become ready. `start`
+    # must keep retrying the spawn (not poll ping once and give up), and must
+    # never hold the lock itself (so the spawned child can take ownership).
     from click.testing import CliRunner
 
     from memtomem_stm.cli.proxy import cli
     from memtomem_stm.daemon.locking import lock_path, single_owner_lock
 
     monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
-    monkeypatch.setattr("memtomem_stm.daemon.client.ping", AsyncMock(return_value=None))
-    # request_spawn reports "spawned" without launching a real detached daemon.
-    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda config: True)
 
-    observed: dict[str, bool] = {}
+    state = {"spawns": 0, "lock_free_seen": []}
 
-    def fake_wait_ready(config, *, timeout):
+    def fake_request_spawn(config):
+        # The real request_spawn probes the lock; if start_cmd held it this would
+        # see it taken. Assert it's free → start holds nothing across the loop.
         with single_owner_lock(lock_path(config.data_dir)) as got:
-            observed["acquired_during_wait"] = got
-        return None
+            state["lock_free_seen"].append(got)
+        state["spawns"] += 1
+        return state["spawns"] >= 3  # declined twice (lock "held"), then spawns
 
-    monkeypatch.setattr("memtomem_stm.cli.daemon_cmd._wait_ready", fake_wait_ready)
+    async def fake_ping(config, *, timeout=2.0):
+        # Answers only once the (faked) shutdown finished and we spawned.
+        return {"pid": 123, "port": 4567} if state["spawns"] >= 3 else None
+
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", fake_request_spawn)
+    monkeypatch.setattr("memtomem_stm.daemon.client.ping", fake_ping)
 
     result = CliRunner().invoke(cli, ["daemon", "start"])
     assert result.exit_code == 0
-    assert observed["acquired_during_wait"] is True  # lock NOT held across readiness
+    assert state["spawns"] >= 3  # retried past the initial declines
+    assert all(state["lock_free_seen"])  # start never held the lock
+    assert "daemon started" in result.output
 
 
 # ── spawn (request_spawn) ─────────────────────────────────────────────────────

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -111,6 +111,7 @@ def test_config_fingerprint_excludes_client_only_hook_fields(monkeypatch: pytest
         ("use_daemon", True),
         ("fallback", "cold"),
         ("daemon_timeout_seconds", 9.9),
+        ("auto_spawn", False),
     ]:
         c = STMConfig()
         setattr(c.hook, field, value)
@@ -121,10 +122,14 @@ def test_config_fingerprint_excludes_client_only_hook_fields(monkeypatch: pytest
     assert discovery.config_fingerprint(c) != fp
 
 
-def test_start_holds_spawn_lock_through_readiness(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    # Two concurrent `mms daemon start` must not both spawn. The lock has to be
-    # held across _wait_ready(), not just across the spawn call — otherwise a
-    # second start acquires it before our child publishes its handshake.
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock re-entrancy semantics")
+def test_start_does_not_hold_lock_through_readiness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Inverted invariant (vs the pre-lifetime-lock design): single-owner
+    # protection now lives in the daemon, so `mms daemon start` must NOT hold the
+    # lock while polling readiness — the spawned child needs to acquire it. A
+    # fresh acquire during _wait_ready() therefore SUCCEEDS.
     from unittest.mock import AsyncMock
 
     from click.testing import CliRunner
@@ -134,12 +139,12 @@ def test_start_holds_spawn_lock_through_readiness(tmp_path: Path, monkeypatch: p
 
     monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
     monkeypatch.setattr("memtomem_stm.daemon.client.ping", AsyncMock(return_value=None))
-    monkeypatch.setattr("memtomem_stm.cli.daemon_cmd._spawn_detached", lambda: None)
+    # request_spawn reports "spawned" without launching a real detached daemon.
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda config: True)
 
     observed: dict[str, bool] = {}
 
     def fake_wait_ready(config, *, timeout):
-        # start_cmd must still hold the lock here → a fresh acquire fails.
         with single_owner_lock(lock_path(config.data_dir)) as got:
             observed["acquired_during_wait"] = got
         return None
@@ -148,7 +153,69 @@ def test_start_holds_spawn_lock_through_readiness(tmp_path: Path, monkeypatch: p
 
     result = CliRunner().invoke(cli, ["daemon", "start"])
     assert result.exit_code == 0
-    assert observed["acquired_during_wait"] is False  # lock held across readiness
+    assert observed["acquired_during_wait"] is True  # lock NOT held across readiness
+
+
+# ── spawn (request_spawn) ─────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock re-entrancy semantics")
+def test_request_spawn_skips_when_lock_held(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from memtomem_stm.daemon import spawn
+    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+
+    cfg = STMConfig()
+    cfg.data_dir = tmp_path
+    calls: list[int] = []
+    monkeypatch.setattr(spawn, "_spawn_detached", lambda: calls.append(1))
+    with single_owner_lock(lock_path(cfg.data_dir)) as held:
+        assert held is True
+        assert spawn.request_spawn(cfg) is False  # a live owner → defer
+    assert calls == []  # no duplicate spawn launched
+
+
+def test_request_spawn_spawns_when_lock_free(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from memtomem_stm.daemon import spawn
+    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+
+    cfg = STMConfig()
+    cfg.data_dir = tmp_path
+    calls: list[int] = []
+    monkeypatch.setattr(spawn, "_spawn_detached", lambda: calls.append(1))
+    assert spawn.request_spawn(cfg) is True
+    assert calls == [1]  # spawned exactly once
+    # The probe released the lock → the child can still acquire it.
+    with single_owner_lock(lock_path(cfg.data_dir)) as got:
+        assert got is True
+
+
+def test_request_spawn_swallows_oserror(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from memtomem_stm.daemon import locking, spawn
+
+    cfg = STMConfig()
+    cfg.data_dir = tmp_path
+    calls: list[int] = []
+    monkeypatch.setattr(spawn, "_spawn_detached", lambda: calls.append(1))
+
+    def _boom(_path):
+        raise OSError("cannot open lock file")
+
+    monkeypatch.setattr(locking, "single_owner_lock", _boom)
+    assert spawn.request_spawn(cfg) is False  # never raises into the hot path
+    assert calls == []
+
+
+# ── config (hook auto_spawn) ──────────────────────────────────────────────────
+
+
+def test_hook_auto_spawn_default_true(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__AUTO_SPAWN", raising=False)
+    assert STMConfig().hook.auto_spawn is True
+
+
+def test_hook_auto_spawn_env_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__AUTO_SPAWN", "0")
+    assert STMConfig().hook.auto_spawn is False
 
 
 async def test_request_respects_single_wall_clock_budget(monkeypatch: pytest.MonkeyPatch):

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -9,10 +9,13 @@ RPC. That keeps the suite deterministic even on a dev box with a live LTM.
 from __future__ import annotations
 
 import asyncio
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import AsyncMock
 from uuid import uuid4
+
+import pytest
 
 from memtomem_stm.config import STMConfig
 from memtomem_stm.daemon import client
@@ -253,12 +256,181 @@ async def test_idle_shutdown_stops_daemon(tmp_path: Path) -> None:
 async def test_hook_run_hook_skips_when_daemon_absent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Daemon enabled but none running, default fallback=skip → {} (no cold path).
+    # Daemon enabled but none running, default fallback=skip → {} (no cold path),
+    # AND auto-spawn (default on) kicks off a background spawn for the next call.
     monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
     monkeypatch.delenv("MEMTOMEM_STM_HOOK__FALLBACK", raising=False)
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__AUTO_SPAWN", raising=False)
+
+    from memtomem_stm.daemon import spawn
+
+    calls: list[int] = []
+    monkeypatch.setattr(spawn, "request_spawn", lambda cfg: bool(calls.append(1)) or True)
 
     from memtomem_stm.cli.hook_cmd import _run_hook
 
     out = await _run_hook(_READ_PAYLOAD)
     assert out == {}
+    assert calls == [1]  # fire-and-forget spawn requested
+
+
+async def test_hook_run_hook_no_autospawn_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # AUTO_SPAWN=0 → degrade to {} without requesting a spawn.
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__AUTO_SPAWN", "0")
+
+    from memtomem_stm.daemon import spawn
+
+    calls: list[int] = []
+    monkeypatch.setattr(spawn, "request_spawn", lambda cfg: calls.append(1))
+
+    from memtomem_stm.cli.hook_cmd import _run_hook
+
+    out = await _run_hook(_READ_PAYLOAD)
+    assert out == {}
+    assert calls == []
+
+
+async def test_hook_run_hook_autospawn_never_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A spawn failure must never break the hook — it still degrades to {}.
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+
+    from memtomem_stm.daemon import spawn
+
+    def _boom(cfg):
+        raise RuntimeError("spawn blew up")
+
+    monkeypatch.setattr(spawn, "request_spawn", _boom)
+
+    from memtomem_stm.cli.hook_cmd import _run_hook
+
+    out = await _run_hook(_READ_PAYLOAD)
+    assert out == {}
+
+
+async def test_hook_run_hook_autospawn_with_fallback_cold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # fallback=cold → request a spawn (for next call) AND still run the cold
+    # in-process path for THIS call. The two are independent.
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__FALLBACK", "cold")
+
+    import memtomem_stm.cli.hook_cmd as hook_cmd
+    from memtomem_stm.daemon import spawn
+
+    spawned: list[int] = []
+    monkeypatch.setattr(spawn, "request_spawn", lambda cfg: spawned.append(1))
+
+    cold: list[dict] = []
+
+    async def _fake_cold(payload):
+        cold.append(payload)
+        return {"cold": True}
+
+    monkeypatch.setattr(hook_cmd, "run_surfacing_hook", _fake_cold)
+
+    out = await hook_cmd._run_hook(_READ_PAYLOAD)
+    assert spawned == [1]  # spawn kicked off for next call
+    assert cold == [_READ_PAYLOAD]  # cold path ran this call
+    assert out == {"cold": True}
+
+
+async def test_hook_run_hook_no_autospawn_when_daemon_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A live daemon answers surface → no spawn requested (we only spawn on None).
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH", str(tmp_path / "fb.db"))
+    monkeypatch.setenv("MEMTOMEM_STM_DAEMON__IDLE_TIMEOUT_SECONDS", "0")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+
+    from memtomem_stm.daemon import spawn
+
+    calls: list[int] = []
+    monkeypatch.setattr(spawn, "request_spawn", lambda cfg: calls.append(1))
+
+    from memtomem_stm.cli.hook_cmd import _run_hook
+
+    cfg = STMConfig()
+    _, task = await _start(cfg, engine=_engine_with_result())
+    try:
+        out = await _run_hook(_READ_PAYLOAD)
+        assert "<surfaced-memories>" in out["hookSpecificOutput"]["additionalContext"]
+        assert calls == []  # live daemon → no duplicate spawn
+    finally:
+        await _stop(cfg, task)
+
+
+# ── lifetime ownership lock ───────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="same-process flock contention")
+async def test_second_daemon_returns_without_building_engine(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # While daemon 1 owns the lifetime lock, a second daemon must exit 0 WITHOUT
+    # building an engine (the load-bearing ordering: no orphaned warm LTM).
+    cfg = _config(tmp_path)
+    _, task = await _start(cfg, engine=_engine_with_result())
+    try:
+        monkeypatch.setattr(DaemonServer, "_LOCK_ACQUIRE_RETRY_SECONDS", 0.2)
+        d2 = DaemonServer(cfg)
+        built: list[int] = []
+        d2._build_engine = lambda: built.append(1)  # type: ignore[method-assign]
+        rc = await d2.serve()
+        assert rc == 0
+        assert built == []  # loser never warms an engine
+        assert d2._handshake_written is False
+    finally:
+        await _stop(cfg, task)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="same-process flock contention")
+async def test_daemon_holds_lock_for_lifetime(tmp_path: Path) -> None:
+    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+
+    cfg = _config(tmp_path)
+    _, task = await _start(cfg, engine=_engine_with_result())
+    try:
+        with single_owner_lock(lock_path(cfg.data_dir)) as got:
+            assert got is False  # held by the serving daemon
+    finally:
+        await _stop(cfg, task)
+    # Released on teardown → acquirable again.
+    with single_owner_lock(lock_path(cfg.data_dir)) as got:
+        assert got is True
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="same-process flock contention")
+async def test_lifetime_lock_retry_acquires_after_incumbent_releases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A late/losing daemon retries the acquire and becomes the owner the instant
+    # the incumbent releases — no dead window, and it builds exactly once after.
+    from memtomem_stm.daemon import locking
+
+    cfg = _config(tmp_path)
+    monkeypatch.setattr(DaemonServer, "_LOCK_ACQUIRE_RETRY_SECONDS", 3.0)
+
+    fd = locking.open_lock_fd(locking.lock_path(cfg.data_dir))
+    assert locking.try_lock(fd) is True  # hold it like a (mock) incumbent
+
+    server = DaemonServer(cfg)
+    server._build_engine = lambda: setattr(server, "_engine", _engine_with_result())  # type: ignore[method-assign]
+    task = asyncio.create_task(server.serve())
+    await asyncio.sleep(0.2)  # daemon is now retrying the acquire
+    assert not handshake_path(cfg.data_dir).exists()  # hasn't built/published yet
+    locking.release_lock(fd)  # incumbent leaves
+    try:
+        await _await_handshake(cfg)  # proves it acquired → built → published
+    finally:
+        await _stop(cfg, task)


### PR DESCRIPTION
## Context

Stage 2 PR 1 (#379) shipped a warm surfacing daemon for `mms hook`, but left two gaps:
- The hook only **uses** a daemon if one is already running — the operator had to `mms daemon start` by hand. No auto-spawn.
- Single-instance protection leaned on a `ping`-based check at the top of `serve()`, which has a TOCTOU window and a recycled-PID weakness. The `stm-daemon.lock` was only a transient spawn lock.

This PR shifts the ownership model from the **spawner** to the **daemon**.

## What changed

**1. Daemon holds the lifetime ownership lock** (`daemon/server.py`, `daemon/locking.py`)
- `serve()` acquires `stm-daemon.lock` with a brief **async** retry (~1.5s, `await asyncio.sleep`) **before** `_build_engine()`, and holds it until teardown. "Lock held" is now the authoritative "a daemon is alive" signal.
- A redundant/late daemon exits **before** warming an LTM (load-bearing ordering). The retry lets a losing/late child become a warm standby that grabs the lock the instant an incumbent releases — closing the crash-during-build dead window.
- Replaces the old `ping` guard. New primitives: `open_lock_fd` / `try_lock` / `release_lock`.

**2. Hook auto-spawn, lock-guarded, fire-and-forget** (`daemon/spawn.py` new, `cli/hook_cmd.py`, `config.py`)
- `request_spawn(config)`: probes the lock (acquire+release), spawns a detached daemon **outside** the lock if free. The spawned child re-acquires the lock for its lifetime, so a concurrent double-spawn just has the loser exit cheaply.
- `_run_hook` calls it fire-and-forget when the daemon is unreachable, so the **next** call is warm; this call still degrades per `fallback`.
- New `HookConfig.auto_spawn` (default `True`, env `MEMTOMEM_STM_HOOK__AUTO_SPAWN`, excluded from the config fingerprint).

**3. `mms daemon start` / `restart`** (`cli/daemon_cmd.py`)
- `start` no longer holds the lock through readiness; it classifies state (running / spawned / **different-config daemon → restart** / matching daemon mid-startup).
- `restart` waits **bounded** for the lock to free instead of a fixed `sleep`, reporting clearly if teardown wedges (`_teardown` has no hard timeout).

## Codex review

Incorporated a Codex review: async retry (no event-loop blocking), bounded restart wait, and honest wording ("duplicate warm daemons", not "spawn storms"). Two cases are documented **known limitations**, both recoverable via `mms daemon restart`:
- Config-drift coexistence (different-config daemons sharing `~/.memtomem`) — proper fix is a fingerprint-keyed handshake+lock (follow-up).
- `request_spawn` declines then the holder dies — the hot hook path self-heals on its next call.

## Tests

- `tests/daemon` — **34 passed**. New/changed: lifetime-lock invariant (loser never builds an engine), retry-acquires-after-release, `request_spawn` (held/free/OSError), hook auto-spawn (skip/disabled/never-raises/fallback=cold/live-daemon), config default+env, and the **inverted** `start` invariant (no longer holds the lock through readiness).
- Full suite: **2329 passed**; the only 2 failures are pre-existing live-LTM-on-dev-box artifacts that reproduce identically on a clean `main` (not regressions).
- `ruff check src` ✅ · `ruff format --check src` ✅ · `mypy src` ✅

All same-process lock-contention tests are `skipif win32` (POSIX flock per-OFD vs Windows `msvcrt` re-entrancy), matching the existing `test_single_owner_lock_excludes_second`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)