### PR TITLE
feat(hook): default daemon mode on (use_daemon=True) (Stage 2, PR 3)

### DIFF
--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -249,7 +249,7 @@ def status_cmd(as_json: bool) -> None:
         )
     else:
         click.echo("stopped")
-    hint = "yes" if use_daemon else "no (set MEMTOMEM_STM_HOOK__USE_DAEMON=1)"
+    hint = "yes" if use_daemon else "no (opted out via MEMTOMEM_STM_HOOK__USE_DAEMON=0)"
     click.echo(f"hook will use daemon: {hint}")
 
 

--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -203,7 +203,10 @@ def status_cmd(as_json: bool) -> None:
     from memtomem_stm.daemon.discovery import handshake_path, is_pid_alive, read_handshake
 
     config = _load_config()
-    use_daemon = config.hook.use_daemon
+    # The hook only reaches the daemon for eligible surfacing calls, so global
+    # surfacing-off means it never will — regardless of the use_daemon knob.
+    surfacing_on = config.surfacing.enabled
+    use_daemon = config.hook.use_daemon and surfacing_on
     hs = asyncio.run(client.ping(config, timeout=2.0))
     if hs is not None:
         uptime = max(0.0, time.time() - float(hs.get("created_at", time.time())))
@@ -249,7 +252,12 @@ def status_cmd(as_json: bool) -> None:
         )
     else:
         click.echo("stopped")
-    hint = "yes" if use_daemon else "no (opted out via MEMTOMEM_STM_HOOK__USE_DAEMON=0)"
+    if use_daemon:
+        hint = "yes"
+    elif not surfacing_on:
+        hint = "no (surfacing disabled)"
+    else:
+        hint = "no (opted out via MEMTOMEM_STM_HOOK__USE_DAEMON=0)"
     click.echo(f"hook will use daemon: {hint}")
 
 

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -291,6 +291,19 @@ def _daemon_enabled() -> bool:
     return val.strip().lower() not in ("0", "false", "f", "no", "n", "off")
 
 
+def _hook_eligible(payload: dict[str, Any]) -> bool:
+    """Cheap pre-gate mirroring the head of :func:`_run_surfacing_hook_inner` —
+    a PostToolUse call for a surface-allowlisted tool. ``_run_hook`` uses it to
+    reject ineligible payloads (non-PostToolUse, or a missing/non-allowlisted
+    tool) before routing to — or auto-spawning — the daemon, so an off-target
+    hook call never warms a pointless daemon. The inner re-checks, so this is an
+    optimization, never the authority."""
+    if (payload.get("hook_event_name") or "PostToolUse") != "PostToolUse":
+        return False
+    tool_name = payload.get("tool_name")
+    return isinstance(tool_name, str) and tool_name in _surface_tools()
+
+
 async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
     """Resolve the hook output, preferring the warm daemon when enabled.
 
@@ -308,9 +321,11 @@ async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
         from memtomem_stm.daemon import client
 
         config = STMConfig()
-        if not config.surfacing.enabled:
-            # Surfacing globally off → nothing to route or warm a daemon for;
-            # mirror the cold path's no-op instead of spawning a pointless daemon.
+        # Reject ineligible payloads (surfacing globally off, non-PostToolUse, or
+        # a non-allowlisted tool) before routing to / spawning the daemon — an
+        # off-target hook call must not warm a pointless daemon. The cold path
+        # (run_surfacing_hook) re-checks, so this gate is an optimization.
+        if not config.surfacing.enabled or not _hook_eligible(payload):
             return {}
         try:
             out = await client.surface(config, payload, timeout=config.hook.daemon_timeout_seconds)

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -37,15 +37,18 @@ Register in Claude Code ``settings.json``::
       {"matcher": "Read|Grep|Glob|Bash",
        "hooks": [{"type": "command", "command": "mms hook"}]}]}}
 
-Performance — cold path vs daemon: the in-process path spawns a fresh LTM MCP
-child per call, and that cold start (embedding + reranker model load) measured
-~6s here, exceeding the default ``surfacing.timeout_seconds`` of 3.0 — so
-surfacing usually times out and returns ``{}``. The real fix is the local
-daemon: set ``MEMTOMEM_STM_HOOK__USE_DAEMON=1`` (and run ``mms daemon start``,
-or let the hook reach an already-running daemon) so each call is a sub-second
-round trip to a warm LTM connection. When the daemon is unreachable the hook
+Performance — daemon by default: surfacing routes through the local daemon
+(``HookConfig.use_daemon`` defaults ``True``), a warm LTM connection that turns
+each call into a sub-second round trip. The daemon is auto-spawned on first use
+(``auto_spawn``), so the first call typically returns ``{}`` while it warms up
+and later calls hit the warm process. The legacy in-process path spawns a fresh
+LTM MCP child per call, whose cold start (embedding + reranker model load)
+measured ~6s here — exceeding the default ``surfacing.timeout_seconds`` of 3.0,
+so it usually times out to ``{}``. Opt out with
+``MEMTOMEM_STM_HOOK__USE_DAEMON=0``; when the daemon is unreachable the hook
 degrades per ``HookConfig.fallback`` — ``skip`` (default) returns ``{}``,
-``cold`` runs the in-process path. To exercise the cold path directly, raise
+``cold`` runs the in-process path. To exercise the cold path directly, set
+``MEMTOMEM_STM_HOOK__USE_DAEMON=0``, raise
 ``MEMTOMEM_STM_SURFACING__TIMEOUT_SECONDS`` (e.g. 8) and lower
 ``MEMTOMEM_STM_SURFACING__MIN_RESPONSE_CHARS``, accepting the per-call latency.
 """
@@ -271,17 +274,19 @@ def _read_payload(stream: TextIO) -> dict[str, Any] | None:
 def _daemon_enabled() -> bool:
     """Whether the hook should route through the local daemon.
 
-    Read directly from the environment (mirroring ``HookConfig.use_daemon``'s
-    ``MEMTOMEM_STM_HOOK__USE_DAEMON`` binding) so the default daemon-off path
-    pays no extra config load and behaves byte-for-byte as it did before the
-    daemon landed. ``_surface_tools()`` already reads its env knob this way.
+    Daemon mode is the default (``HookConfig.use_daemon=True``); unset → on. We
+    read ``MEMTOMEM_STM_HOOK__USE_DAEMON`` directly here (mirroring the field's
+    env binding) so the explicit opt-out path pays no extra config load —
+    ``_surface_tools()`` reads its env knob the same way. The falsy-token set
+    matches Pydantic's bool parsing so this and ``mms daemon status`` (which
+    reads the parsed field) never disagree on a value Pydantic accepts; values
+    Pydantic rejects outright (empty/garbage) fall to the default-on side here
+    while a config load would raise.
     """
-    return os.environ.get("MEMTOMEM_STM_HOOK__USE_DAEMON", "").strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
+    val = os.environ.get("MEMTOMEM_STM_HOOK__USE_DAEMON")
+    if val is None:
+        return True
+    return val.strip().lower() not in ("0", "false", "f", "no", "n", "off")
 
 
 async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
@@ -331,8 +336,9 @@ def hook_command() -> None:
 
     Reads the hook JSON payload on stdin and, for read-like built-in tools,
     prints a hook response whose ``additionalContext`` carries relevant LTM
-    memories. With ``MEMTOMEM_STM_HOOK__USE_DAEMON=1`` the surfacing runs in the
-    warm ``mms daemon`` (no per-call cold start); otherwise it runs in-process.
+    memories. By default the surfacing runs in the warm ``mms daemon`` (no
+    per-call cold start), auto-spawned on first use; set
+    ``MEMTOMEM_STM_HOOK__USE_DAEMON=0`` to run the legacy cold in-process path.
     Always exits 0; on any problem the tool output passes through unchanged
     (prints ``{}``).
     """

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -279,9 +279,11 @@ def _daemon_enabled() -> bool:
     env binding) so the explicit opt-out path pays no extra config load —
     ``_surface_tools()`` reads its env knob the same way. The falsy-token set
     matches Pydantic's bool parsing so this and ``mms daemon status`` (which
-    reads the parsed field) never disagree on a value Pydantic accepts; values
-    Pydantic rejects outright (empty/garbage) fall to the default-on side here
-    while a config load would raise.
+    reads the parsed field) agree on every value Pydantic accepts. We strip and
+    lower-case first, so a padded token like ``" off "`` still disables (Pydantic
+    doesn't strip and would reject it); any other value Pydantic rejects (empty,
+    garbage) returns enabled here, while a config load like ``mms daemon status``
+    would raise.
     """
     val = os.environ.get("MEMTOMEM_STM_HOOK__USE_DAEMON")
     if val is None:
@@ -306,6 +308,10 @@ async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
         from memtomem_stm.daemon import client
 
         config = STMConfig()
+        if not config.surfacing.enabled:
+            # Surfacing globally off → nothing to route or warm a daemon for;
+            # mirror the cold path's no-op instead of spawning a pointless daemon.
+            return {}
         try:
             out = await client.surface(config, payload, timeout=config.hook.daemon_timeout_seconds)
         except Exception:

--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -55,11 +55,13 @@ class HookConfig(BaseModel):
     underscore) is a separate direct-read knob in ``cli/hook_cmd.py`` and is
     unaffected by this model."""
 
-    use_daemon: bool = False
-    """When ``True``, ``mms hook`` routes surfacing through the local daemon
-    (warm LTM connection) instead of spawning a cold LTM subprocess per call.
-    Opt-in this release — default ``False`` keeps ``mms hook`` behaving exactly
-    as before (cold in-process path)."""
+    use_daemon: bool = True
+    """When ``True`` (the default), ``mms hook`` routes surfacing through the
+    local daemon (warm LTM connection) instead of spawning a cold LTM subprocess
+    per call. The daemon is auto-spawned on first use (see ``auto_spawn``), so no
+    manual ``mms daemon start`` is needed. Set
+    ``MEMTOMEM_STM_HOOK__USE_DAEMON=0`` to opt out to the legacy cold in-process
+    path."""
     daemon_timeout_seconds: float = Field(default=2.5, gt=0.0)
     """Per-request wall-clock budget for the hook→daemon round trip. Small and
     independent of the cold-path ``_hook_budget_seconds()`` backstop — a warm

--- a/src/memtomem_stm/daemon/discovery.py
+++ b/src/memtomem_stm/daemon/discovery.py
@@ -60,12 +60,12 @@ def config_fingerprint(config: STMConfig) -> str:
 
     Deliberately **excluded**: the client-only ``hook`` fields ``use_daemon``,
     ``fallback`` and ``daemon_timeout_seconds``. They govern how the *hook*
-    talks to the daemon, never what the daemon does — and a daemon is commonly
-    started without ``MEMTOMEM_STM_HOOK__USE_DAEMON=1`` (e.g. ``mms daemon
-    start`` in a plain shell) while the hook runs with it set. Including them
-    would make that live daemon look stale and the hook would reject it (then,
-    under the default ``fallback=skip``, return ``{}`` forever). ``mode="json"``
-    makes ``Path``/enum values serializable.
+    talks to the daemon, never what the daemon does — the daemon's behavior is
+    independent of them (``mms daemon start`` warms the same daemon whether or
+    not the hook has opted out via ``MEMTOMEM_STM_HOOK__USE_DAEMON=0``).
+    Including them would make a live daemon look stale and the hook would reject
+    it (then, under the default ``fallback=skip``, return ``{}`` forever).
+    ``mode="json"`` makes ``Path``/enum values serializable.
     """
     material = {
         "surfacing": config.surfacing.model_dump(mode="json"),

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -230,6 +230,7 @@ def test_cli_degrades_to_empty_object(stdin: str):
 def test_cli_surfacing_disabled_is_noop(monkeypatch: pytest.MonkeyPatch):
     # Default daemon-on path + surfacing globally off → {} immediately, and the
     # hook must NOT spawn a daemon (nothing to surface) or build an LTM adapter.
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__USE_DAEMON", raising=False)  # prove default-on
     monkeypatch.setenv("MEMTOMEM_STM_SURFACING__ENABLED", "false")
     spawns: list[int] = []
     monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda cfg: spawns.append(1))
@@ -294,6 +295,20 @@ def test_daemon_used_when_enabled(monkeypatch: pytest.MonkeyPatch):
     )
     out = asyncio.run(_run_hook(_READ_PAYLOAD))
     assert out == daemon_out
+
+
+def test_daemon_not_used_for_ineligible_tool(monkeypatch: pytest.MonkeyPatch):
+    # Default daemon-on, but a non-allowlisted tool (Write) → {} without
+    # consulting or spawning the daemon: an off-target call must not warm one.
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__USE_DAEMON", raising=False)  # prove default-on
+    spawns: list[int] = []
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda cfg: spawns.append(1))
+    surface = AsyncMock(side_effect=AssertionError("daemon must not be consulted for an ineligible tool"))
+    monkeypatch.setattr("memtomem_stm.daemon.client.surface", surface)
+    out = asyncio.run(_run_hook({**_READ_PAYLOAD, "tool_name": "Write"}))
+    assert out == {}
+    assert spawns == []
+    surface.assert_not_called()
 
 
 def test_daemon_unavailable_skip_returns_empty(monkeypatch: pytest.MonkeyPatch):

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -36,6 +36,18 @@ from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.engine import SurfacingEngine
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_daemon(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Daemon mode is on by default now (``HookConfig.use_daemon=True``), so any
+    ``mms hook`` / ``_run_hook`` call here would otherwise read the real
+    ``~/.memtomem`` handshake and fire-and-forget ``Popen`` a detached daemon.
+    Isolate state to a tmp dir and neutralize the spawn so these CLI tests never
+    touch the dev box's daemon or leak a subprocess. (Spawn behavior itself is
+    covered in tests/daemon/test_server.py.)"""
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda cfg: None)
+
+
 # ── Fakes (mirror tests/test_surfacing_engine.py shapes) ─────────────────────
 
 
@@ -216,8 +228,9 @@ def test_cli_degrades_to_empty_object(stdin: str):
 
 
 def test_cli_surfacing_disabled_is_noop(monkeypatch: pytest.MonkeyPatch):
-    # A valid PostToolUse payload, but surfacing off → returns {} without ever
+    # Cold path (daemon opted out) + surfacing off → returns {} without ever
     # constructing the LTM adapter (so no subprocess spawn in CI).
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
     monkeypatch.setenv("MEMTOMEM_STM_SURFACING__ENABLED", "false")
     result = CliRunner().invoke(cli, ["hook"], input=json.dumps(_READ_PAYLOAD))
     assert result.exit_code == 0
@@ -229,18 +242,38 @@ def test_cli_surfacing_disabled_is_noop(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.parametrize(
     "value,expected",
-    [("1", True), ("true", True), ("YES", True), ("on", True), ("0", False), ("", False)],
+    [
+        ("1", True),
+        ("true", True),
+        ("YES", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("f", False),
+        ("no", False),
+        ("n", False),
+        ("off", False),
+    ],
 )
 def test_daemon_enabled_env_parsing(monkeypatch: pytest.MonkeyPatch, value: str, expected: bool):
+    # Falsy-token set matches Pydantic's bool parsing, so the hot path and
+    # `mms daemon status` (the parsed field) never disagree on a value Pydantic
+    # accepts.
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", value)
     assert _daemon_enabled() is expected
 
 
-def test_daemon_disabled_uses_cold_path(monkeypatch: pytest.MonkeyPatch):
+def test_daemon_enabled_default_when_unset(monkeypatch: pytest.MonkeyPatch):
+    # Daemon mode is the default now — unset → enabled.
     monkeypatch.delenv("MEMTOMEM_STM_HOOK__USE_DAEMON", raising=False)
+    assert _daemon_enabled() is True
+
+
+def test_daemon_explicitly_disabled_uses_cold_path(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
     sentinel = {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "cold"}}
     monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=sentinel))
-    # client.surface must never be consulted when the daemon is disabled.
+    # client.surface must never be consulted when the daemon is opted out.
     boom = AsyncMock(side_effect=AssertionError("daemon must not be used when disabled"))
     monkeypatch.setattr("memtomem_stm.daemon.client.surface", boom)
     out = asyncio.run(_run_hook(_READ_PAYLOAD))

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -228,13 +228,15 @@ def test_cli_degrades_to_empty_object(stdin: str):
 
 
 def test_cli_surfacing_disabled_is_noop(monkeypatch: pytest.MonkeyPatch):
-    # Cold path (daemon opted out) + surfacing off → returns {} without ever
-    # constructing the LTM adapter (so no subprocess spawn in CI).
-    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
+    # Default daemon-on path + surfacing globally off → {} immediately, and the
+    # hook must NOT spawn a daemon (nothing to surface) or build an LTM adapter.
     monkeypatch.setenv("MEMTOMEM_STM_SURFACING__ENABLED", "false")
+    spawns: list[int] = []
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda cfg: spawns.append(1))
     result = CliRunner().invoke(cli, ["hook"], input=json.dumps(_READ_PAYLOAD))
     assert result.exit_code == 0
     assert json.loads(result.output) == {}
+    assert spawns == []  # surfacing disabled → no daemon spawn
 
 
 # ── Daemon routing + degradation ladder ──────────────────────────────────────

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -104,11 +104,13 @@ def test_config_fingerprint_stable_and_broad(monkeypatch: pytest.MonkeyPatch):
 def test_config_fingerprint_excludes_client_only_hook_fields(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("MEMTOMEM_STM_HOOK_SURFACE_TOOLS", raising=False)
     fp = discovery.config_fingerprint(STMConfig())
-    # Client-only hook fields must NOT move the fingerprint — a daemon started
-    # without USE_DAEMON must still match a hook that sets it (else the hook
-    # rejects the live daemon and returns {} forever under fallback=skip).
+    # Client-only hook fields must NOT move the fingerprint — the daemon's
+    # behavior is independent of them, so a live daemon must still match a hook
+    # that has opted out (else the hook rejects it and returns {} forever under
+    # fallback=skip). use_daemon defaults True now, so toggle it OFF to prove
+    # it's actually excluded.
     for field, value in [
-        ("use_daemon", True),
+        ("use_daemon", False),
         ("fallback", "cold"),
         ("daemon_timeout_seconds", 9.9),
         ("auto_spawn", False),
@@ -319,7 +321,17 @@ def test_request_spawn_swallows_oserror(tmp_path: Path, monkeypatch: pytest.Monk
     assert calls == []
 
 
-# ── config (hook auto_spawn) ──────────────────────────────────────────────────
+# ── config (hook use_daemon / auto_spawn) ─────────────────────────────────────
+
+
+def test_hook_use_daemon_default_true(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__USE_DAEMON", raising=False)
+    assert STMConfig().hook.use_daemon is True
+
+
+def test_hook_use_daemon_env_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
+    assert STMConfig().hook.use_daemon is False
 
 
 def test_hook_auto_spawn_default_true(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## What & why

Stage 2 PRs #379 (warm surfacing daemon) and #380 (lock-guarded auto-spawn + lifetime-lock) built everything needed to make daemon mode safe on by default. This PR flips the switch: `mms hook` now routes built-in-tool surfacing through the warm daemon by default.

Previously `use_daemon` was opt-in (`False`), so the default path spawned a fresh LTM child per call — a ~6s embedding+reranker cold start that exceeds the 3s surfacing timeout, meaning the default effectively surfaced nothing. With the daemon as the default, the first read-like tool call returns `{}` while fire-and-forget spawning the daemon, and subsequent calls are sub-second warm hits (idle-timing-out after 15 min).

## The non-obvious part: two sources of truth

`use_daemon` is read in two places:
- `HookConfig.use_daemon` (Pydantic field) — only `mms daemon status` reads this.
- `_daemon_enabled()` (the hook hot path) — reads `MEMTOMEM_STM_HOOK__USE_DAEMON` from the env **directly** (to skip a config load), and returned `True` only for explicit truthy values.

So flipping the field default alone would be **inert** for runtime behavior. This PR inverts `_daemon_enabled()` so unset → on, using a falsy-token set (`0/false/f/no/n/off`) that **matches Pydantic's bool parsing** — so the hook and `mms daemon status` never disagree on a value Pydantic accepts. (A Codex review caught an earlier draft that missed `n`/`f` and would have silently split the two.)

`fallback=skip` and `auto_spawn=True` are unchanged — both correct under default-on.

## Tests

- **Hermeticity fixture** (`tests/cli/test_hook_cmd.py`): with daemon-on, any `mms hook` invocation without a live daemon would read the real `~/.memtomem` handshake and `Popen` a detached daemon. An autouse fixture isolates `DATA_DIR` to tmp and neutralizes `request_spawn`, keeping CLI tests off the dev box's daemon and out of CI subprocess leaks. (Spawn behavior itself stays covered in `tests/daemon/test_server.py`.)
- Parsing test now pins the hook↔config agreement (Pydantic-recognized tokens only) + a separate unset→`True` test.
- New `test_hook_use_daemon_default_true`; the fingerprint-exclusion test now toggles `use_daemon` **off** the default so it still proves the field is excluded.

## Verification

End-to-end on an isolated temp data dir:
- unset → `hook will use daemon: yes`; `=0` → cold path
- first `mms hook` → `{}` + daemon auto-spawned (status `running`)
- warm `mms hook` → ~0.27s round trip (vs ~6s cold)

`ruff` + `mypy` clean; 2339 passed (the 2 failures are the pre-existing live-LTM-on-dev-box failures, reproduce with this change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)