### PR TITLE
feat(daemon): key handshake+lock files by config fingerprint (Stage 2, PR 4)

### DIFF
--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -96,22 +96,19 @@ def run_cmd(detached: bool, foreground: bool) -> None:
 
 @daemon_group.command(name="start")
 def start_cmd() -> None:
-    """Spawn the daemon detached if it isn't already running.
+    """Spawn the daemon detached if one isn't already running for this config.
 
-    The daemon self-guards via its lifetime lock, so ``start`` never holds the
-    lock — it reconciles toward a running daemon. The lock may currently be held
-    by a daemon that is *shutting down* (e.g. right after ``mms daemon stop``):
-    it won't answer ping and will soon release the lock, so we keep retrying the
-    spawn until the lock frees rather than polling ping once and giving up. A
-    *different-config* daemon stays alive and won't release — that we report.
+    Reconciles toward a running daemon *for the current config*. The daemon
+    self-guards via its (per-config) lifetime lock, so ``start`` never holds the
+    lock. The lock may briefly be held by a *same-config* daemon that is
+    *shutting down* (e.g. right after ``mms daemon stop``): it won't answer ping
+    and will soon release the lock, so we keep retrying the spawn until it frees
+    rather than polling ping once and giving up. A daemon started under a
+    *different* config owns a different lock + handshake (config-drift
+    coexistence), so it never blocks this spawn and is left untouched — there is
+    no cross-config conflict to report.
     """
     from memtomem_stm.daemon import client
-    from memtomem_stm.daemon.discovery import (
-        config_fingerprint,
-        handshake_path,
-        is_pid_alive,
-        read_handshake,
-    )
     from memtomem_stm.daemon.spawn import request_spawn
 
     config = _load_config()
@@ -123,40 +120,18 @@ def start_cmd() -> None:
         return
 
     deadline = time.time() + 10.0
-    spawned = False
     while time.time() < deadline:
         hs = asyncio.run(client.ping(config, timeout=1.0))
         if hs is not None:
             click.echo(_ok(f"daemon started (pid={hs.get('pid')} port={hs.get('port')})"))
             return
-        if request_spawn(config):
-            # We launched a child (lock was free). Give it a moment to acquire
-            # the lock + publish, then loop back to ping it. We don't hold the
-            # lock, so the child can take ownership.
-            spawned = True
-            time.sleep(0.3)
-            continue
-        # Lock held by another daemon. Only a *live* different-config daemon that
-        # we did not just spawn is a real conflict worth reporting: a stale
-        # handshake (dead pid) left by a crash, or the matching child we just
-        # spawned that hasn't published its handshake yet, must NOT be
-        # misreported. Everything else falls through to wait — the next
-        # iteration re-attempts the spawn once the lock frees.
-        if not spawned:
-            raw = read_handshake(handshake_path(config.data_dir))
-            if (
-                raw is not None
-                and raw.get("config_fingerprint") != config_fingerprint(config)
-                and is_pid_alive(int(raw.get("pid", -1)))
-            ):
-                click.echo(
-                    _warn(
-                        f"a daemon with a different config is running (pid={raw.get('pid')}) — "
-                        "run `mms daemon restart` to replace it"
-                    )
-                )
-                return
-        time.sleep(0.2)
+        # request_spawn launches a detached child iff our config's lock is free;
+        # it returns False only when a same-config daemon already holds it
+        # (mid-startup → ping succeeds soon, or mid-shutdown → the lock frees and
+        # the next attempt wins). Either way we just keep retrying. We never hold
+        # the lock, so the spawned child can take ownership.
+        request_spawn(config)
+        time.sleep(0.3)
     click.echo(
         _warn(
             "daemon did not become ready in time — "
@@ -169,14 +144,22 @@ def start_cmd() -> None:
 def stop_cmd() -> None:
     """Ask a running daemon to shut down gracefully."""
     from memtomem_stm.daemon import client
-    from memtomem_stm.daemon.discovery import handshake_path, is_pid_alive, read_handshake
+    from memtomem_stm.daemon.discovery import (
+        config_fingerprint,
+        handshake_path,
+        is_pid_alive,
+        read_handshake,
+    )
 
     config = _load_config()
     if asyncio.run(client.shutdown(config)):
         click.echo(_ok("daemon stopped"))
         return
-    # Graceful path declined (no daemon, or its config fingerprint drifted).
-    raw = read_handshake(handshake_path(config.data_dir))
+    # Graceful path declined → no daemon for *this config*. Only ever act on our
+    # own config's handshake; a different-config daemon owns a different file and
+    # is none of our business here.
+    hs_path = handshake_path(config.data_dir, config_fingerprint(config))
+    raw = read_handshake(hs_path)
     if raw is None:
         click.echo("no running daemon")
         return
@@ -189,7 +172,7 @@ def stop_cmd() -> None:
         except OSError:
             pass
     try:
-        handshake_path(config.data_dir).unlink(missing_ok=True)
+        hs_path.unlink(missing_ok=True)
     except OSError:
         pass
     click.echo(_warn("no responsive daemon; cleaned stale handshake"))
@@ -200,7 +183,12 @@ def stop_cmd() -> None:
 def status_cmd(as_json: bool) -> None:
     """Report whether a daemon is running, with pid/port/uptime/LTM warmth."""
     from memtomem_stm.daemon import client
-    from memtomem_stm.daemon.discovery import handshake_path, is_pid_alive, read_handshake
+    from memtomem_stm.daemon.discovery import (
+        config_fingerprint,
+        handshake_path,
+        is_pid_alive,
+        read_handshake,
+    )
 
     config = _load_config()
     # The hook only reaches the daemon for eligible surfacing calls, so global
@@ -220,7 +208,7 @@ def status_cmd(as_json: bool) -> None:
             "hook_will_use_daemon": use_daemon,
         }
     else:
-        raw = read_handshake(handshake_path(config.data_dir))
+        raw = read_handshake(handshake_path(config.data_dir, config_fingerprint(config)))
         if raw is not None:
             info = {
                 "state": "stale",
@@ -264,7 +252,10 @@ def status_cmd(as_json: bool) -> None:
 @daemon_group.command(name="restart")
 @click.pass_context
 def restart_cmd(ctx: click.Context) -> None:
-    """Stop any running daemon, then start a fresh one once the lock is free."""
+    """Stop this config's running daemon, then start a fresh one once its lock is
+    free. Daemons under other configs are left running (config-drift coexistence).
+    """
+    from memtomem_stm.daemon.discovery import config_fingerprint
     from memtomem_stm.daemon.locking import lock_path, single_owner_lock
 
     config = _load_config()
@@ -273,9 +264,10 @@ def restart_cmd(ctx: click.Context) -> None:
     # fixed sleep could race: _teardown() awaits the warm LTM child's stop and
     # has no hard timeout. Bounded so a wedged teardown reports clearly instead
     # of letting start_cmd produce a misleading readiness timeout.
+    fp = config_fingerprint(config)
     deadline = time.time() + 5.0
     while time.time() < deadline:
-        with single_owner_lock(lock_path(config.data_dir)) as acquired:
+        with single_owner_lock(lock_path(config.data_dir, fp)) as acquired:
             free = acquired
         if free:
             ctx.invoke(start_cmd)

--- a/src/memtomem_stm/daemon/client.py
+++ b/src/memtomem_stm/daemon/client.py
@@ -71,18 +71,22 @@ async def _request(
 
 
 def _live_handshake_candidate(config: STMConfig) -> dict[str, Any] | None:
-    """Read the handshake and reject it if version or config fingerprint drift.
+    """Read *this config's* handshake and reject it on version/fingerprint drift.
 
-    A fingerprint/version mismatch means the running daemon was started under
-    different wiring (LTM command, feedback DB, …) and would serve stale
-    behavior — treated as "not the daemon we want".
+    The handshake path is keyed by ``config``'s fingerprint, so we only ever read
+    the file a daemon under *our* config published — a different-config daemon's
+    handshake lives at a different path and is invisible here. The in-file
+    ``config_fingerprint`` check is then a belt-and-suspenders guard against a
+    corrupted/hand-edited file whose content doesn't match its keyed name; a
+    version mismatch likewise means "not the daemon we want".
     """
-    hs = read_handshake(handshake_path(config.data_dir))
+    fp = config_fingerprint(config)
+    hs = read_handshake(handshake_path(config.data_dir, fp))
     if hs is None:
         return None
     if hs.get("v") != HANDSHAKE_VERSION:
         return None
-    if hs.get("config_fingerprint") != config_fingerprint(config):
+    if hs.get("config_fingerprint") != fp:
         return None
     return hs
 

--- a/src/memtomem_stm/daemon/discovery.py
+++ b/src/memtomem_stm/daemon/discovery.py
@@ -1,23 +1,32 @@
-"""Daemon discovery — the ``stm-daemon.json`` handshake file.
+"""Daemon discovery — the per-config ``stm-daemon-<fingerprint>.json`` handshake.
 
-The daemon publishes its loopback endpoint + auth token to a single file under
+The daemon publishes its loopback endpoint + auth token to a file under
 ``data_dir`` (default ``~/.memtomem``). ``mms hook`` and ``mms daemon
 status/stop`` read it to find a running daemon; the daemon writes it
 **atomically at ``0o600`` only after a successful port bind**, so the file
-never advertises an endpoint that isn't accepting yet. The write is
-last-writer-wins, not a mutual-exclusion primitive (two daemons binding
-distinct ephemeral ports would overwrite each other here) — preventing a second
-daemon is the spawn lock's job (see :mod:`~memtomem_stm.daemon.locking`).
+never advertises an endpoint that isn't accepting yet.
+
+The filename is **keyed by the config fingerprint** (``stm-daemon-<fp>.json``),
+so daemons started under different configs (different LTM command, feedback DB,
+…) own *distinct* handshake files and coexist instead of clobbering one shared
+file — config-drift coexistence. A reader only ever opens the file for *its
+own* config's fingerprint, so it never even sees a mismatched daemon's
+handshake; the in-file ``config_fingerprint`` then double-checks the content
+matches the path (defense against a corrupted/hand-edited file). Within a
+single fingerprint the write is still last-writer-wins, not a mutual-exclusion
+primitive — preventing a second *same-config* daemon is the (likewise
+fingerprint-keyed) lock's job (see :mod:`~memtomem_stm.daemon.locking`).
 Liveness is proven by a successful ``ping`` over the socket — not by the
 recorded ``pid`` — so a recycled PID can't be mistaken for the daemon.
+
+A config change leaves the old fingerprint's handshake behind as an orphan; it
+is harmless (no reader keys to it anymore) and the old daemon removes its own on
+graceful teardown / idle timeout.
 
 File shape::
 
     {"v": 1, "pid": 1234, "host": "127.0.0.1", "port": 53412,
      "token": "<hex>", "created_at": 1716600000.0, "config_fingerprint": "<sha>"}
-
-``config_fingerprint`` lets a reader detect a daemon started under stale config
-(different LTM command, feedback DB, etc.) and treat it as stale.
 """
 
 from __future__ import annotations
@@ -37,12 +46,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 HANDSHAKE_VERSION = 1
-HANDSHAKE_FILENAME = "stm-daemon.json"
+# Filenames are ``stm-daemon-<fingerprint>.{json,lock}`` (the lock half lives in
+# ``locking.py`` with the same prefix). The fingerprint is a 16-hex digest, so
+# it is always a filesystem-safe filename component.
+HANDSHAKE_PREFIX = "stm-daemon"
 
 
-def handshake_path(data_dir: Path) -> Path:
-    """Absolute path to the handshake file under ``data_dir``."""
-    return (data_dir / HANDSHAKE_FILENAME).expanduser()
+def handshake_path(data_dir: Path, fingerprint: str) -> Path:
+    """Per-config handshake file ``stm-daemon-<fingerprint>.json`` under ``data_dir``.
+
+    Keyed by the config fingerprint so daemons under different configs publish to
+    distinct files and coexist (see the module docstring). Callers pass
+    :func:`config_fingerprint` of their own effective config.
+    """
+    return (data_dir / f"{HANDSHAKE_PREFIX}-{fingerprint}.json").expanduser()
 
 
 def config_fingerprint(config: STMConfig) -> str:

--- a/src/memtomem_stm/daemon/locking.py
+++ b/src/memtomem_stm/daemon/locking.py
@@ -12,6 +12,13 @@ duplicate; if it's free, spawn — and the spawned child re-acquires the lock as
 the single owner, so a rare concurrent double-spawn just has the loser exit
 before warming an LTM.
 
+The lock file is **keyed by the config fingerprint** (``stm-daemon-<fp>.lock``),
+mirroring the handshake file, so a daemon under one config holds a *different*
+lock than a daemon under another: they coexist, and a config-A daemon never
+blocks a config-B hook from spawning the daemon it actually needs (config-drift
+coexistence). "Single owner" is therefore per-config — exactly one daemon *per
+distinct config*.
+
 Two access shapes:
 - :func:`single_owner_lock` — a context manager for the *probe* (acquire,
   yield, release). Used by ``request_spawn`` and ``mms daemon start``.
@@ -34,12 +41,20 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-LOCK_FILENAME = "stm-daemon.lock"
+# Shares the handshake's ``stm-daemon`` prefix; differs only by extension. The
+# fingerprint is a 16-hex digest, always a filesystem-safe filename component.
+LOCK_PREFIX = "stm-daemon"
 
 
-def lock_path(data_dir: Path) -> Path:
-    """Absolute path to the daemon's lifetime ownership lock under ``data_dir``."""
-    return (data_dir / LOCK_FILENAME).expanduser()
+def lock_path(data_dir: Path, fingerprint: str) -> Path:
+    """Per-config lifetime ownership lock ``stm-daemon-<fingerprint>.lock``.
+
+    Keyed by the config fingerprint so daemons under different configs hold
+    different locks and coexist (see the module docstring). Callers pass
+    :func:`~memtomem_stm.daemon.discovery.config_fingerprint` of their own
+    effective config — the same value used to derive the handshake path.
+    """
+    return (data_dir / f"{LOCK_PREFIX}-{fingerprint}.lock").expanduser()
 
 
 def open_lock_fd(path: Path) -> int:

--- a/src/memtomem_stm/daemon/server.py
+++ b/src/memtomem_stm/daemon/server.py
@@ -80,6 +80,11 @@ class DaemonServer:
         self._config = config
         self._host = config.daemon.host
         self._idle_timeout = config.daemon.idle_timeout_seconds
+        # Freeze the config fingerprint at construction and reuse it for the lock
+        # path, handshake path, and handshake content — one value, so the lock we
+        # hold, the file we publish, and the fingerprint we advertise can never
+        # disagree (and a mid-run env change can't repoint us at a different file).
+        self._fingerprint = discovery.config_fingerprint(config)
         self._token = secrets.token_hex(32)
         self._port = 0
         self._started_at = time.time()
@@ -102,7 +107,7 @@ class DaemonServer:
         Returns a process exit code.
         """
         try:
-            fd = locking.open_lock_fd(locking.lock_path(self._config.data_dir))
+            fd = locking.open_lock_fd(locking.lock_path(self._config.data_dir, self._fingerprint))
         except OSError:
             logger.warning("daemon could not open the lock file — exiting", exc_info=True)
             return 0
@@ -123,7 +128,9 @@ class DaemonServer:
         while not locking.try_lock(fd):
             if loop.time() >= deadline:
                 # Best-effort pid for a friendly log; gate nothing on it.
-                raw = discovery.read_handshake(discovery.handshake_path(self._config.data_dir))
+                raw = discovery.read_handshake(
+                    discovery.handshake_path(self._config.data_dir, self._fingerprint)
+                )
                 pid = raw.get("pid") if isinstance(raw, dict) else None
                 logger.warning("another daemon already owns the lock (pid=%s) — exiting", pid)
                 return False
@@ -140,12 +147,12 @@ class DaemonServer:
         self._port = server.sockets[0].getsockname()[1]
         self._install_signals()
         discovery.write_handshake(
-            discovery.handshake_path(self._config.data_dir),
+            discovery.handshake_path(self._config.data_dir, self._fingerprint),
             pid=os.getpid(),
             host=self._host,
             port=self._port,
             token=self._token,
-            config_fingerprint=discovery.config_fingerprint(self._config),
+            config_fingerprint=self._fingerprint,
             created_at=self._started_at,
         )
         self._handshake_written = True
@@ -234,7 +241,7 @@ class DaemonServer:
             await _quiet(self._adapter.stop(), "LTM adapter stop")
         if self._handshake_written:
             discovery.remove_handshake_if_owner(
-                discovery.handshake_path(self._config.data_dir),
+                discovery.handshake_path(self._config.data_dir, self._fingerprint),
                 pid=os.getpid(),
                 token=self._token,
             )

--- a/src/memtomem_stm/daemon/spawn.py
+++ b/src/memtomem_stm/daemon/spawn.py
@@ -45,19 +45,23 @@ def _spawn_detached() -> None:
 
 
 def request_spawn(config: STMConfig) -> bool:
-    """Fire-and-forget spawn a detached daemon iff none currently owns the lock.
+    """Fire-and-forget spawn a detached daemon iff none owns *this config's* lock.
 
-    Returns ``True`` if a child was launched, ``False`` if a daemon already owns
-    the lifetime lock (alive or mid-startup) so we deferred, or if the lock file
-    couldn't be opened. Never blocks on readiness and never raises.
+    The lock is keyed by ``config``'s fingerprint, so a daemon running under a
+    *different* config holds a different lock and never blocks this spawn — the
+    new daemon coexists with it. Returns ``True`` if a child was launched,
+    ``False`` if a same-config daemon already owns the lifetime lock (alive or
+    mid-startup) so we deferred, or if the lock file couldn't be opened. Never
+    blocks on readiness and never raises.
 
     The lock is a probe only (acquire + release); the spawned child re-acquires
     it for its lifetime as the single owner.
     """
+    from memtomem_stm.daemon.discovery import config_fingerprint
     from memtomem_stm.daemon.locking import lock_path, single_owner_lock
 
     try:
-        with single_owner_lock(lock_path(config.data_dir)) as acquired:
+        with single_owner_lock(lock_path(config.data_dir, config_fingerprint(config))) as acquired:
             alive = not acquired  # held by a live/starting daemon → don't pile on
     except OSError:
         logger.debug("request_spawn: could not open lock file", exc_info=True)

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -55,7 +55,7 @@ async def test_read_message_malformed_and_non_object():
 
 
 def test_handshake_round_trip_and_mode(tmp_path: Path):
-    path = discovery.handshake_path(tmp_path)
+    path = discovery.handshake_path(tmp_path, "fp")
     discovery.write_handshake(
         path,
         pid=4321,
@@ -77,6 +77,19 @@ def test_read_handshake_missing_and_malformed(tmp_path: Path):
     bad = tmp_path / "bad.json"
     bad.write_text("{not json", encoding="utf-8")
     assert discovery.read_handshake(bad) is None
+
+
+def test_handshake_and_lock_paths_keyed_by_fingerprint(tmp_path: Path):
+    # Distinct fingerprints → distinct files (so different-config daemons can
+    # coexist); same fingerprint → stable path; the two files share the
+    # ``stm-daemon`` prefix and differ only by extension.
+    from memtomem_stm.daemon.locking import lock_path
+
+    assert discovery.handshake_path(tmp_path, "aaaa").name == "stm-daemon-aaaa.json"
+    assert lock_path(tmp_path, "aaaa").name == "stm-daemon-aaaa.lock"
+    assert discovery.handshake_path(tmp_path, "aaaa") != discovery.handshake_path(tmp_path, "bbbb")
+    assert lock_path(tmp_path, "aaaa") != lock_path(tmp_path, "bbbb")
+    assert discovery.handshake_path(tmp_path, "aaaa") == discovery.handshake_path(tmp_path, "aaaa")
 
 
 def test_config_fingerprint_stable_and_broad(monkeypatch: pytest.MonkeyPatch):
@@ -140,9 +153,10 @@ def test_start_retries_spawn_until_lock_frees(tmp_path: Path, monkeypatch: pytes
     state = {"spawns": 0, "lock_free_seen": []}
 
     def fake_request_spawn(config):
-        # The real request_spawn probes the lock; if start_cmd held it this would
-        # see it taken. Assert it's free → start holds nothing across the loop.
-        with single_owner_lock(lock_path(config.data_dir)) as got:
+        # The real request_spawn probes the (per-config) lock; if start_cmd held
+        # it this would see it taken. Assert it's free → start holds nothing.
+        lp = lock_path(config.data_dir, discovery.config_fingerprint(config))
+        with single_owner_lock(lp) as got:
             state["lock_free_seen"].append(got)
         state["spawns"] += 1
         return state["spawns"] >= 3  # declined twice (lock "held"), then spawns
@@ -161,102 +175,21 @@ def test_start_retries_spawn_until_lock_frees(tmp_path: Path, monkeypatch: pytes
     assert "daemon started" in result.output
 
 
-def test_start_does_not_misreport_stale_handshake_after_spawn(
+def test_start_coexists_with_different_config_daemon(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    # A crashed different-config daemon left a stale handshake. `start` spawns a
-    # matching child; while it's mid-startup (holds the lock, hasn't published)
-    # the stale handshake must NOT be misreported as a live config conflict.
+    # config-drift coexistence: a daemon under a *different* config is alive (it
+    # owns its own keyed handshake + lock). `start` under our config must just
+    # spawn our daemon and report success — never treat the other as a conflict.
     from click.testing import CliRunner
 
     from memtomem_stm.cli.proxy import cli
 
     monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    # A different-config daemon's live handshake, at ITS keyed path. Our config
+    # never reads this file, so it must not influence `start` at all.
     discovery.write_handshake(
-        discovery.handshake_path(tmp_path),
-        pid=2**31 - 1,  # not a live process
-        host="127.0.0.1",
-        port=1,
-        token="t",
-        config_fingerprint="stale-different-fp",
-        created_at=0.0,
-    )
-
-    state = {"spawns": 0, "pings": 0}
-
-    def fake_request_spawn(config):
-        state["spawns"] += 1
-        return state["spawns"] == 1  # lock free → spawn; then "held" by our child
-
-    async def fake_ping(config, *, timeout=2.0):
-        state["pings"] += 1
-        return {"pid": 99, "port": 4567} if state["pings"] >= 4 else None
-
-    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", fake_request_spawn)
-    monkeypatch.setattr("memtomem_stm.daemon.client.ping", fake_ping)
-
-    result = CliRunner().invoke(cli, ["daemon", "start"])
-    assert result.exit_code == 0
-    assert "different config" not in result.output  # stale handshake not misreported
-    assert "daemon started" in result.output
-
-
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="is_pid_alive() always returns True on Windows (no signal-0) → the "
-    "dead-pid guard is a documented no-op there; the spawned-flag guard is "
-    "what protects the common case cross-platform.",
-)
-def test_start_ignores_stale_handshake_with_dead_pid(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
-    # Lock held by a matching daemon mid-startup we did NOT spawn, with a stale
-    # different-config handshake (dead pid) on disk. The dead pid means "not a
-    # live conflict" → wait it out rather than misreport.
-    from click.testing import CliRunner
-
-    from memtomem_stm.cli.proxy import cli
-
-    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
-    discovery.write_handshake(
-        discovery.handshake_path(tmp_path),
-        pid=2**31 - 1,
-        host="127.0.0.1",
-        port=1,
-        token="t",
-        config_fingerprint="stale-different-fp",
-        created_at=0.0,
-    )
-
-    state = {"pings": 0}
-    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda config: False)
-
-    async def fake_ping(config, *, timeout=2.0):
-        state["pings"] += 1
-        return {"pid": 7, "port": 4567} if state["pings"] >= 3 else None
-
-    monkeypatch.setattr("memtomem_stm.daemon.client.ping", fake_ping)
-
-    result = CliRunner().invoke(cli, ["daemon", "start"])
-    assert result.exit_code == 0
-    assert "different config" not in result.output
-    assert "daemon started" in result.output
-
-
-def test_start_reports_live_different_config_daemon(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
-    # A genuinely live different-config daemon (alive pid) holds the lock → it
-    # won't release, so report it clearly instead of waiting out the deadline.
-    from unittest.mock import AsyncMock
-
-    from click.testing import CliRunner
-
-    from memtomem_stm.cli.proxy import cli
-
-    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
-    discovery.write_handshake(
-        discovery.handshake_path(tmp_path),
+        discovery.handshake_path(tmp_path, "a-different-fp"),
         pid=os.getpid(),  # alive
         host="127.0.0.1",
         port=1,
@@ -264,12 +197,25 @@ def test_start_reports_live_different_config_daemon(
         config_fingerprint="a-different-fp",
         created_at=0.0,
     )
-    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda config: False)
-    monkeypatch.setattr("memtomem_stm.daemon.client.ping", AsyncMock(return_value=None))
+
+    state = {"spawns": 0}
+
+    def fake_request_spawn(config):
+        state["spawns"] += 1
+        return True  # our config's lock is free → spawn proceeds
+
+    async def fake_ping(config, *, timeout=2.0):
+        # Our config has no daemon until we've spawned one.
+        return {"pid": 99, "port": 4567} if state["spawns"] >= 1 else None
+
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", fake_request_spawn)
+    monkeypatch.setattr("memtomem_stm.daemon.client.ping", fake_ping)
 
     result = CliRunner().invoke(cli, ["daemon", "start"])
     assert result.exit_code == 0
-    assert "a daemon with a different config is running" in result.output
+    assert state["spawns"] >= 1  # spawned our own daemon despite the other one
+    assert "different config" not in result.output  # no obsolete conflict report
+    assert "daemon started" in result.output
 
 
 # ── spawn (request_spawn) ─────────────────────────────────────────────────────
@@ -284,9 +230,9 @@ def test_request_spawn_skips_when_lock_held(tmp_path: Path, monkeypatch: pytest.
     cfg.data_dir = tmp_path
     calls: list[int] = []
     monkeypatch.setattr(spawn, "_spawn_detached", lambda: calls.append(1))
-    with single_owner_lock(lock_path(cfg.data_dir)) as held:
+    with single_owner_lock(lock_path(cfg.data_dir, discovery.config_fingerprint(cfg))) as held:
         assert held is True
-        assert spawn.request_spawn(cfg) is False  # a live owner → defer
+        assert spawn.request_spawn(cfg) is False  # a live same-config owner → defer
     assert calls == []  # no duplicate spawn launched
 
 
@@ -301,8 +247,30 @@ def test_request_spawn_spawns_when_lock_free(tmp_path: Path, monkeypatch: pytest
     assert spawn.request_spawn(cfg) is True
     assert calls == [1]  # spawned exactly once
     # The probe released the lock → the child can still acquire it.
-    with single_owner_lock(lock_path(cfg.data_dir)) as got:
+    with single_owner_lock(lock_path(cfg.data_dir, discovery.config_fingerprint(cfg))) as got:
         assert got is True
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock re-entrancy semantics")
+def test_request_spawn_unblocked_by_different_config_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # config-drift coexistence: a daemon under a *different* config holds ITS
+    # (differently-keyed) lock. Our spawn keys to our own fingerprint, finds it
+    # free, and spawns anyway — the other daemon never blocks us.
+    from memtomem_stm.daemon import spawn
+    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+
+    cfg = STMConfig()
+    cfg.data_dir = tmp_path
+    other_fp = "different00000fp"
+    assert other_fp != discovery.config_fingerprint(cfg)
+    calls: list[int] = []
+    monkeypatch.setattr(spawn, "_spawn_detached", lambda: calls.append(1))
+    with single_owner_lock(lock_path(cfg.data_dir, other_fp)) as held:
+        assert held is True  # the other config's lock is taken
+        assert spawn.request_spawn(cfg) is True  # ours is free → spawn proceeds
+    assert calls == [1]
 
 
 def test_request_spawn_swallows_oserror(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -365,7 +333,7 @@ async def test_request_respects_single_wall_clock_budget(monkeypatch: pytest.Mon
 
 
 def test_remove_handshake_if_owner(tmp_path: Path):
-    path = discovery.handshake_path(tmp_path)
+    path = discovery.handshake_path(tmp_path, "fp")
     discovery.write_handshake(
         path, pid=10, host="127.0.0.1", port=1, token="t", config_fingerprint="fp", created_at=0.0
     )

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -19,7 +19,7 @@ import pytest
 
 from memtomem_stm.config import STMConfig
 from memtomem_stm.daemon import client
-from memtomem_stm.daemon.discovery import handshake_path, read_handshake
+from memtomem_stm.daemon.discovery import config_fingerprint, handshake_path, read_handshake
 from memtomem_stm.daemon.protocol import (
     MAX_MESSAGE_BYTES,
     OP_SURFACE,
@@ -83,6 +83,18 @@ def _config(tmp_path: Path) -> STMConfig:
     return cfg
 
 
+def _hs_path(cfg: STMConfig) -> Path:
+    """This config's keyed handshake path — what the running daemon publishes."""
+    return handshake_path(cfg.data_dir, config_fingerprint(cfg))
+
+
+def _lock_path(cfg: STMConfig) -> Path:
+    """This config's keyed lifetime-lock path."""
+    from memtomem_stm.daemon.locking import lock_path
+
+    return lock_path(cfg.data_dir, config_fingerprint(cfg))
+
+
 def _engine_with_result() -> SurfacingEngine:
     adapter = AsyncMock()
     adapter.search = AsyncMock(return_value=([_Result(_Chunk(), 0.5)], [], "ok"))
@@ -101,7 +113,7 @@ def _engine_with_result() -> SurfacingEngine:
 
 
 async def _await_handshake(cfg: STMConfig, timeout: float = 3.0) -> None:
-    hp = handshake_path(cfg.data_dir)
+    hp = _hs_path(cfg)
     deadline = asyncio.get_running_loop().time() + timeout
     while asyncio.get_running_loop().time() < deadline:
         if hp.exists():
@@ -173,7 +185,7 @@ async def test_bad_token_is_rejected(tmp_path: Path) -> None:
     cfg = _config(tmp_path)
     _, task = await _start(cfg, engine=_engine_with_result())
     try:
-        hs = read_handshake(handshake_path(cfg.data_dir))
+        hs = read_handshake(_hs_path(cfg))
         assert hs is not None
         reader, writer = await asyncio.open_connection(
             hs["host"], hs["port"], limit=MAX_MESSAGE_BYTES
@@ -250,7 +262,7 @@ async def test_idle_shutdown_stops_daemon(tmp_path: Path) -> None:
     task = asyncio.create_task(server.serve())
     await _await_handshake(cfg)
     await asyncio.wait_for(task, timeout=5.0)  # self-terminates on idle
-    assert not handshake_path(cfg.data_dir).exists()
+    assert not _hs_path(cfg).exists()
 
 
 async def test_hook_run_hook_skips_when_daemon_absent(
@@ -396,17 +408,17 @@ async def test_second_daemon_returns_without_building_engine(
 
 @pytest.mark.skipif(sys.platform == "win32", reason="same-process flock contention")
 async def test_daemon_holds_lock_for_lifetime(tmp_path: Path) -> None:
-    from memtomem_stm.daemon.locking import lock_path, single_owner_lock
+    from memtomem_stm.daemon.locking import single_owner_lock
 
     cfg = _config(tmp_path)
     _, task = await _start(cfg, engine=_engine_with_result())
     try:
-        with single_owner_lock(lock_path(cfg.data_dir)) as got:
+        with single_owner_lock(_lock_path(cfg)) as got:
             assert got is False  # held by the serving daemon
     finally:
         await _stop(cfg, task)
     # Released on teardown → acquirable again.
-    with single_owner_lock(lock_path(cfg.data_dir)) as got:
+    with single_owner_lock(_lock_path(cfg)) as got:
         assert got is True
 
 
@@ -421,14 +433,14 @@ async def test_lifetime_lock_retry_acquires_after_incumbent_releases(
     cfg = _config(tmp_path)
     monkeypatch.setattr(DaemonServer, "_LOCK_ACQUIRE_RETRY_SECONDS", 3.0)
 
-    fd = locking.open_lock_fd(locking.lock_path(cfg.data_dir))
+    fd = locking.open_lock_fd(_lock_path(cfg))
     assert locking.try_lock(fd) is True  # hold it like a (mock) incumbent
 
     server = DaemonServer(cfg)
     server._build_engine = lambda: setattr(server, "_engine", _engine_with_result())  # type: ignore[method-assign]
     task = asyncio.create_task(server.serve())
     await asyncio.sleep(0.2)  # daemon is now retrying the acquire
-    assert not handshake_path(cfg.data_dir).exists()  # hasn't built/published yet
+    assert not _hs_path(cfg).exists()  # hasn't built/published yet
     locking.release_lock(fd)  # incumbent leaves
     try:
         await _await_handshake(cfg)  # proves it acquired → built → published


### PR DESCRIPTION
## What

Key the daemon's handshake and lifetime-lock **filenames** by the config fingerprint:
`stm-daemon.json` / `stm-daemon.lock` → `stm-daemon-<fp>.json` / `stm-daemon-<fp>.lock`.

## Why

The handshake already carried a `config_fingerprint` and the client (`_live_handshake_candidate`) already rejected a fingerprint-mismatched daemon. But both files were still **single shared paths**, so config-drift coexistence was broken:

- A daemon started under **config A** holds the one shared `stm-daemon.lock` for its lifetime.
- A hook running under **config B** reads the shared handshake, sees the fingerprint mismatch, and rejects it (good) — then tries to auto-spawn its own daemon. `request_spawn` probes the **one** lock, finds it held by daemon A, and defers. **Forever.** Under the default `fallback=skip`, hook B returns `{}` on every call and never gets a daemon.
- Even if it could spawn, daemon B would publish to the **same** `stm-daemon.json`, clobbering A's handshake and breaking discovery for both.

## What changed

- `discovery.handshake_path(data_dir, fingerprint)` and `locking.lock_path(data_dir, fingerprint)` now take the fingerprint and produce per-config filenames (shared `stm-daemon` prefix, differing only by extension). Fingerprint is a 16-hex digest → always filesystem-safe.
- `DaemonServer` freezes the fingerprint once in `__init__` (`self._fingerprint`) and reuses it for the lock path, handshake path, and handshake content — so the lock held, file published, and fingerprint advertised can never disagree (and a mid-run env change can't repoint the daemon at a different file).
- `request_spawn` / `_live_handshake_candidate` / all `mms daemon` subcommands thread the current config's fingerprint through.
- **Removed** `mms daemon start`'s now-dead "a daemon with a different config is running — run `restart` to replace it" branch. Under coexistence a different-config daemon owns a *different, invisible* lock+handshake and is no longer a conflict; `start` simply reconciles toward its own config's daemon. `stop`/`status`/`restart` act only on the current config's keyed files.

## Result

Exactly **one daemon per distinct config**; daemons for different configs coexist, and a hook always reaches (or spawns) the daemon matching its own effective config.

## Tests

- New: `test_handshake_and_lock_paths_keyed_by_fingerprint`, `test_request_spawn_unblocked_by_different_config_lock`, `test_start_coexists_with_different_config_daemon`.
- Replaced the three obsolete different-config misreport tests (the behavior they guarded is gone).
- Updated all daemon test call sites to the keyed signatures.
- `ruff check` + `ruff format --check` clean; `mypy src` clean; `pytest -m "not ollama"` green except the 2 pre-existing local-LTM failures (also fail on `main`, pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review (Codex)

One **P2** raised — *"keep legacy daemon paths discoverable"*: on upgrade, an old daemon owning the pre-#382 shared `stm-daemon.{json,lock}` becomes invisible to new fingerprint-keyed clients (`status`/`stop` see nothing, `start` spawns a duplicate, and a `idle_timeout=0` orphan can't be stopped via the CLI).

**Declined — no migration surface exists:**
- The entire daemon feature (#378–#381) is **unreleased** — it lands after the latest tag `v0.1.23`. No shipped version ever had the old shared-path daemon, so no end-user upgrade crosses that boundary; only a dev tracking `main` could, and `pkill -f "memtomem_stm daemon"` resolves it.
- Default `idle_timeout_seconds = 900.0`, so an orphaned old daemon self-terminates within 15 min anyway; old/new use different lock filenames, so they coexist without contention.
- A legacy read/stop/migration path would be dead code at release (no shipped `stm-daemon.json` format to be compatible with), so it's deliberately out of scope.
