### PR TITLE
feat(hook): compress Bash tool output via updatedToolOutput (P1a)

### DIFF
--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -7,12 +7,16 @@ proactive memory surfacing over the built-in tool's output, and — when
 relevant LTM memories are found — returns them through ``additionalContext``
 so the host appends them next to the tool result the model reads.
 
-Why surfacing-only (no ``updatedToolOutput``): appending context is the
-side-effect-free hook play. Compression-style *replacement* of a built-in
-tool's output is a separate, riskier stage (it must match each tool's output
-shape, and compressing ``Read`` breaks a later ``Edit``'s verbatim
-``old_string`` match) and is intentionally out of scope here. See the Stage B
-section of the project plan / ``project_stm_builtin_tool_hooks`` memory.
+Two stages, two hook fields. *Surfacing* appends ``additionalContext`` (the
+side-effect-free play). *Compression* (P1a) *replaces* a built-in tool's output
+via ``updatedToolOutput`` and is **Bash-only and opt-in**
+(``MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED=1``): for the built-in Bash tool the
+value must be a structured object mirroring the tool result, so we clone the
+original ``tool_response`` and shrink only its ``stdout`` channel (preserving
+``stderr`` / exit / ``interrupted`` / ``isImage`` verbatim). Compression stays
+Bash-only because replacing ``Read`` would break a later ``Edit`` whose
+``old_string`` must match the file verbatim. The two halves merge into one
+``hookSpecificOutput`` (:func:`_orchestrate` / :func:`_build_hook_output`).
 
 Tool scope: we only surface for **read-like** built-in tools
 (:data:`_DEFAULT_SURFACE_TOOLS` — Read/Grep/Glob/Bash, overridable via
@@ -60,9 +64,12 @@ import json
 import logging
 import os
 import sys
-from typing import Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
 import click
+
+if TYPE_CHECKING:
+    from memtomem_stm.config import HookCompressionConfig, STMConfig
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +85,20 @@ _SURFACED_CLOSE = "</surfaced-memories>"
 # ``write_tool_patterns`` can't be relied on here because ``fnmatch`` is
 # case-normalizing (identity on POSIX), so ``*write*`` never matches ``Write``.
 _DEFAULT_SURFACE_TOOLS = frozenset({"Read", "Grep", "Glob", "Bash"})
+
+# Unique marker prepended to compressed ``stdout`` so a re-fired hook recognizes
+# its own output and no-ops (idempotency). Matched *exactly* — never via
+# ``TruncateCompressor``'s generic markers (``(truncated`` / ``(original:`` /
+# ``… omitted``), which appear in real logs and would falsely skip compression.
+_COMPRESS_SENTINEL = "⟦stm-compressed⟧"
+
+# Hard cap on the ``tool_response`` text forwarded to surfacing, independent of
+# the compression budget. Keeps a multi-MB built-in result from overflowing the
+# daemon's ``MAX_MESSAGE_BYTES`` (4 MiB) frame even when compression is disabled
+# or no-ops. Comfortably below 4 MiB after JSON escaping; surfacing only needs
+# enough text to clear its ``min_response_chars`` gate (the query comes from
+# ``tool_input``), so capping costs nothing for relevance.
+_SAFE_DAEMON_BUDGET = 256 * 1024
 
 
 def _surface_tools() -> frozenset[str]:
@@ -139,6 +160,91 @@ def _tool_response_to_text(tool_response: Any) -> str:
         except (TypeError, ValueError):
             return str(tool_response)
     return str(tool_response)
+
+
+def _bash_stdout(tool_response: Any) -> tuple[str | None, dict[str, Any] | None]:
+    """Extract the compressible ``stdout`` channel of a Bash tool result.
+
+    Returns ``(stdout_text, original_dict)`` when ``tool_response`` is a dict
+    carrying a string ``stdout`` (so the caller can clone the dict and replace
+    only that field, preserving ``stderr`` / exit / ``interrupted`` / ``isImage``
+    verbatim), or ``(text, None)`` when ``tool_response`` is itself a plain
+    string (replace wholesale). ``(None, None)`` when there is nothing
+    string-like to compress. Unlike :func:`_tool_response_to_text` this never
+    folds ``stderr`` into the compressible channel — replacement must not lose
+    the error stream or merge it into stdout.
+    """
+    if isinstance(tool_response, str):
+        return tool_response, None
+    if isinstance(tool_response, dict):
+        stdout = tool_response.get("stdout")
+        if isinstance(stdout, str):
+            return stdout, tool_response
+    return None, None
+
+
+def _already_compressed(text: str) -> bool:
+    """Whether ``text`` already carries our compression sentinel (idempotency)."""
+    return _COMPRESS_SENTINEL in text
+
+
+def maybe_compress_builtin(payload: dict[str, Any], cfg: "HookCompressionConfig") -> Any | None:
+    """Compress a Bash tool's ``stdout`` for the PostToolUse ``updatedToolOutput``.
+
+    Returns the value to place in ``updatedToolOutput`` — a dict mirroring the
+    original Bash ``tool_response`` with only ``stdout`` shrunk (every other
+    field preserved verbatim), or a plain string when the original response was a
+    string — or ``None`` to leave the tool output untouched. **Never raises.**
+
+    Gate: ``cfg.enabled`` + PostToolUse + ``tool_name == "Bash"`` + ``stdout``
+    longer than ``cfg.max_chars`` + not already compressed. The strategy is fixed
+    to :class:`TruncateCompressor` (self-contained — no chunk-store callback,
+    unlike SELECTIVE/HYBRID/PROGRESSIVE, whose retrieval tools live in the
+    separate ``mms`` server process).
+    """
+    try:
+        if not cfg.enabled:
+            return None
+        if (payload.get("hook_event_name") or "PostToolUse") != "PostToolUse":
+            return None
+        if payload.get("tool_name") != "Bash":
+            return None
+        stdout, original = _bash_stdout(payload.get("tool_response"))
+        if stdout is None or len(stdout) <= cfg.max_chars or _already_compressed(stdout):
+            return None
+
+        # Lazy import: keep ``mms hook --help`` and the no-op path off the
+        # compression module's import cost.
+        from memtomem_stm.proxy.compression import TruncateCompressor
+
+        compressed = TruncateCompressor().compress(stdout, max_chars=cfg.max_chars)
+        compressed = f"{_COMPRESS_SENTINEL}\n{compressed}"
+        if original is None:
+            return compressed
+        clone = dict(original)
+        clone["stdout"] = compressed
+        return clone
+    except Exception:
+        logger.debug(
+            "builtin output compression failed — leaving tool output unchanged", exc_info=True
+        )
+        return None
+
+
+def _bounded_surfacing_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return ``payload`` with its ``tool_response`` text capped to
+    :data:`_SAFE_DAEMON_BUDGET`.
+
+    Independent of compression: a multi-MB built-in result must never overflow
+    the daemon's 4 MiB frame, even when compression is disabled or no-ops.
+    Pass-through (same object) when the response is already small, so the common
+    case is untouched. The cap keeps the head of the flattened text (stdout, then
+    stderr), which is all surfacing needs to clear its size gate.
+    """
+    text = _tool_response_to_text(payload.get("tool_response"))
+    if len(text) <= _SAFE_DAEMON_BUDGET:
+        return payload
+    return {**payload, "tool_response": text[:_SAFE_DAEMON_BUDGET]}
 
 
 def _extract_surfaced_block(original: str, injected: str, injection_mode: str) -> str | None:
@@ -247,6 +353,34 @@ def _build_output(response_text: str, injected: str, injection_mode: str) -> dic
     }
 
 
+def _extract_surfaced_context(surf_out: dict[str, Any]) -> str | None:
+    """Pull the surfaced ``additionalContext`` string out of a surfacing
+    hook-output dict (as produced by :func:`_build_output`), or ``None`` when
+    surfacing produced nothing."""
+    hso = surf_out.get("hookSpecificOutput")
+    if isinstance(hso, dict):
+        ctx = hso.get("additionalContext")
+        if isinstance(ctx, str) and ctx:
+            return ctx
+    return None
+
+
+def _build_hook_output(
+    updated_tool_output: Any | None, additional_context: str | None
+) -> dict[str, Any]:
+    """Merge optional compression + surfacing results into a single PostToolUse
+    ``hookSpecificOutput`` so neither stage overwrites the other. Returns ``{}``
+    when both are absent (the tool output passes through untouched)."""
+    inner: dict[str, Any] = {"hookEventName": "PostToolUse"}
+    if updated_tool_output is not None:
+        inner["updatedToolOutput"] = updated_tool_output
+    if additional_context:
+        inner["additionalContext"] = additional_context
+    if len(inner) == 1:  # only hookEventName — nothing to say
+        return {}
+    return {"hookSpecificOutput": inner}
+
+
 async def _quiet_async(coro: Any, what: str) -> None:
     """Await a cleanup coroutine, swallowing (and debug-logging) any error."""
     try:
@@ -304,8 +438,10 @@ def _hook_eligible(payload: dict[str, Any]) -> bool:
     return isinstance(tool_name, str) and tool_name in _surface_tools()
 
 
-async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
-    """Resolve the hook output, preferring the warm daemon when enabled.
+async def _run_hook(
+    payload: dict[str, Any], *, config: "STMConfig | None" = None
+) -> dict[str, Any]:
+    """Resolve the *surfacing* hook output, preferring the warm daemon when enabled.
 
     Degradation ladder (every rung still yields a hook-output dict, never
     raises): daemon disabled → cold in-process path (unchanged). Daemon enabled
@@ -314,13 +450,15 @@ async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
     call either return ``{}`` (default ``fallback=skip`` — the daemon exists
     precisely to avoid the ~6s cold start) or take the cold path
     (``fallback=cold``). The whole call runs inside ``_hook_budget_seconds()``
-    in :func:`hook_command`.
+    in :func:`hook_command`. ``config`` is reused from :func:`_orchestrate` when
+    given (saving a redundant ``STMConfig()`` load); ``None`` loads on demand.
     """
     if _daemon_enabled():
         from memtomem_stm.config import STMConfig
         from memtomem_stm.daemon import client
 
-        config = STMConfig()
+        if config is None:
+            config = STMConfig()
         # Reject ineligible payloads (surfacing globally off, non-PostToolUse, or
         # a non-allowlisted tool) before routing to / spawning the daemon — an
         # off-target hook call must not warm a pointless daemon. The cold path
@@ -351,16 +489,36 @@ async def _run_hook(payload: dict[str, Any]) -> dict[str, Any]:
     return await run_surfacing_hook(payload)
 
 
+async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the full hook output: in-process Bash *compression* merged with
+    LTM *surfacing*, as one ``hookSpecificOutput``.
+
+    Ordering matters. Compression runs **first and in-process** so a multi-MB
+    Bash result is shrunk before it could be sent whole to the daemon's 4 MiB
+    frame, and it is **independent of the surfacing gate** — it still runs when
+    surfacing is disabled or Bash is not in the *surface* allowlist. Surfacing
+    then runs on a frame-bounded copy of the payload. Never raises (the CLI
+    wrapper also backstops); each half degrades to "absent" on any failure.
+    """
+    from memtomem_stm.config import STMConfig
+
+    config = STMConfig()
+    updated = maybe_compress_builtin(payload, config.hook.compression)
+    surf_out = await _run_hook(_bounded_surfacing_payload(payload), config=config)
+    return _build_hook_output(updated, _extract_surfaced_context(surf_out))
+
+
 @click.command(name="hook")
 def hook_command() -> None:
-    """Surface STM memories for a host's built-in tool call (PostToolUse hook).
+    """Compress and/or surface for a host's built-in tool call (PostToolUse hook).
 
-    Reads the hook JSON payload on stdin and, for read-like built-in tools,
-    prints a hook response whose ``additionalContext`` carries relevant LTM
-    memories. By default the surfacing runs in the warm ``mms daemon`` (no
-    per-call cold start), auto-spawned on first use; set
-    ``MEMTOMEM_STM_HOOK__USE_DAEMON=0`` to run the legacy cold in-process path.
-    Always exits 0; on any problem the tool output passes through unchanged
+    Reads the hook JSON payload on stdin and prints a hook response that may
+    carry ``updatedToolOutput`` (compressed Bash output — opt-in via
+    ``MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED=1``) and/or ``additionalContext``
+    (relevant LTM memories, for read-like tools). Surfacing runs in the warm
+    ``mms daemon`` by default (no per-call cold start), auto-spawned on first
+    use; set ``MEMTOMEM_STM_HOOK__USE_DAEMON=0`` for the legacy cold in-process
+    path. Always exits 0; on any problem the tool output passes through unchanged
     (prints ``{}``).
     """
     payload = _read_payload(sys.stdin)
@@ -368,9 +526,9 @@ def hook_command() -> None:
     if payload is not None:
         try:
             output = asyncio.run(
-                asyncio.wait_for(_run_hook(payload), timeout=_hook_budget_seconds())
+                asyncio.wait_for(_orchestrate(payload), timeout=_hook_budget_seconds())
             )
         except Exception:
-            logger.warning("hook surfacing failed — passing tool output through", exc_info=True)
+            logger.warning("hook processing failed — passing tool output through", exc_info=True)
             output = {}
     click.echo(json.dumps(output, ensure_ascii=False))

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -162,25 +162,27 @@ def _tool_response_to_text(tool_response: Any) -> str:
     return str(tool_response)
 
 
-def _bash_stdout(tool_response: Any) -> tuple[str | None, dict[str, Any] | None]:
+def _bash_stdout(tool_response: Any) -> tuple[str, dict[str, Any]] | None:
     """Extract the compressible ``stdout`` channel of a Bash tool result.
 
-    Returns ``(stdout_text, original_dict)`` when ``tool_response`` is a dict
-    carrying a string ``stdout`` (so the caller can clone the dict and replace
-    only that field, preserving ``stderr`` / exit / ``interrupted`` / ``isImage``
-    verbatim), or ``(text, None)`` when ``tool_response`` is itself a plain
-    string (replace wholesale). ``(None, None)`` when there is nothing
-    string-like to compress. Unlike :func:`_tool_response_to_text` this never
-    folds ``stderr`` into the compressible channel — replacement must not lose
-    the error stream or merge it into stdout.
+    Returns ``(stdout_text, original_dict)`` only when ``tool_response`` is a
+    dict carrying a string ``stdout`` — so the caller can clone the dict and
+    replace just that field, preserving ``stderr`` / exit / ``interrupted`` /
+    ``isImage`` verbatim. ``None`` for any other shape.
+
+    We deliberately do **not** handle a plain-string ``tool_response``: for the
+    built-in Bash tool ``updatedToolOutput`` must be a structured object
+    mirroring the tool result, so a bare string would be ignored by the host
+    (silently leaving the original output visible). An unknown shape is left
+    untouched rather than replaced with something the host rejects. Unlike
+    :func:`_tool_response_to_text` this never folds ``stderr`` into the
+    compressible channel — replacement must not lose or merge the error stream.
     """
-    if isinstance(tool_response, str):
-        return tool_response, None
     if isinstance(tool_response, dict):
         stdout = tool_response.get("stdout")
         if isinstance(stdout, str):
             return stdout, tool_response
-    return None, None
+    return None
 
 
 def _already_compressed(text: str) -> bool:
@@ -188,19 +190,24 @@ def _already_compressed(text: str) -> bool:
     return _COMPRESS_SENTINEL in text
 
 
-def maybe_compress_builtin(payload: dict[str, Any], cfg: "HookCompressionConfig") -> Any | None:
+def maybe_compress_builtin(
+    payload: dict[str, Any], cfg: "HookCompressionConfig"
+) -> dict[str, Any] | None:
     """Compress a Bash tool's ``stdout`` for the PostToolUse ``updatedToolOutput``.
 
     Returns the value to place in ``updatedToolOutput`` — a dict mirroring the
     original Bash ``tool_response`` with only ``stdout`` shrunk (every other
-    field preserved verbatim), or a plain string when the original response was a
-    string — or ``None`` to leave the tool output untouched. **Never raises.**
+    field preserved verbatim) — or ``None`` to leave the tool output untouched.
+    Only structured Bash results are handled (see :func:`_bash_stdout`).
+    **Never raises.**
 
     Gate: ``cfg.enabled`` + PostToolUse + ``tool_name == "Bash"`` + ``stdout``
     longer than ``cfg.max_chars`` + not already compressed. The strategy is fixed
     to :class:`TruncateCompressor` (self-contained — no chunk-store callback,
     unlike SELECTIVE/HYBRID/PROGRESSIVE, whose retrieval tools live in the
-    separate ``mms`` server process).
+    separate ``mms`` server process). ``cfg.max_chars`` budgets the *whole*
+    replacement stdout: the sentinel prefix is reserved out of the compressor's
+    budget so the result stays at/near the configured size.
     """
     try:
         if not cfg.enabled:
@@ -209,20 +216,25 @@ def maybe_compress_builtin(payload: dict[str, Any], cfg: "HookCompressionConfig"
             return None
         if payload.get("tool_name") != "Bash":
             return None
-        stdout, original = _bash_stdout(payload.get("tool_response"))
-        if stdout is None or len(stdout) <= cfg.max_chars or _already_compressed(stdout):
+        extracted = _bash_stdout(payload.get("tool_response"))
+        if extracted is None:
+            return None
+        stdout, original = extracted
+        if len(stdout) <= cfg.max_chars or _already_compressed(stdout):
             return None
 
         # Lazy import: keep ``mms hook --help`` and the no-op path off the
         # compression module's import cost.
         from memtomem_stm.proxy.compression import TruncateCompressor
 
-        compressed = TruncateCompressor().compress(stdout, max_chars=cfg.max_chars)
-        compressed = f"{_COMPRESS_SENTINEL}\n{compressed}"
-        if original is None:
-            return compressed
+        # Reserve the sentinel prefix out of the budget so sentinel + body stays
+        # at/near ``max_chars`` (TruncateCompressor's own suffix may still add a
+        # small, bounded overage — the budget is a target, not a hard cap).
+        prefix = f"{_COMPRESS_SENTINEL}\n"
+        body_budget = max(1, cfg.max_chars - len(prefix))
+        compressed = TruncateCompressor().compress(stdout, max_chars=body_budget)
         clone = dict(original)
-        clone["stdout"] = compressed
+        clone["stdout"] = prefix + compressed
         return clone
     except Exception:
         logger.debug(
@@ -497,14 +509,20 @@ async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
     Bash result is shrunk before it could be sent whole to the daemon's 4 MiB
     frame, and it is **independent of the surfacing gate** — it still runs when
     surfacing is disabled or Bash is not in the *surface* allowlist. Surfacing
-    then runs on a frame-bounded copy of the payload. Never raises (the CLI
-    wrapper also backstops); each half degrades to "absent" on any failure.
+    then runs on a frame-bounded copy of the payload, wrapped so that a
+    surfacing failure degrades to "no memories" while still returning the
+    compression half (``maybe_compress_builtin`` is itself non-raising). The CLI
+    wrapper backstops the whole call.
     """
     from memtomem_stm.config import STMConfig
 
     config = STMConfig()
     updated = maybe_compress_builtin(payload, config.hook.compression)
-    surf_out = await _run_hook(_bounded_surfacing_payload(payload), config=config)
+    surf_out: dict[str, Any] = {}
+    try:
+        surf_out = await _run_hook(_bounded_surfacing_payload(payload), config=config)
+    except Exception:
+        logger.debug("surfacing failed — keeping the compression half", exc_info=True)
     return _build_hook_output(updated, _extract_surfaced_context(surf_out))
 
 

--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -68,9 +68,12 @@ class HookCompressionConfig(BaseModel):
     ``MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED=1`` after the empirical hook test
     confirms the host honors ``updatedToolOutput`` for Bash."""
     max_chars: int = Field(default=16000, gt=0)
-    """Character budget for the compressed ``stdout`` channel, and the threshold
-    below which output is left untouched (only stdout longer than this is
-    compressed). Matches the proxy's ``default_max_result_chars`` default."""
+    """Target character budget for the replacement ``stdout`` channel, and the
+    threshold below which output is left untouched (only stdout longer than this
+    is compressed). The sentinel prefix is reserved out of this budget; the
+    compressor's own truncation suffix may still add a small, bounded overage, so
+    treat it as a target rather than a hard ceiling. Matches the proxy's
+    ``default_max_result_chars`` default."""
 
 
 class HookConfig(BaseModel):

--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -47,6 +47,32 @@ class LangfuseConfig(BaseModel):
         return self
 
 
+class HookCompressionConfig(BaseModel):
+    """``mms hook`` built-in tool *output compression* settings (P1a — Bash).
+
+    A gate **independent of surfacing**: compressing a built-in tool's output
+    (via the PostToolUse ``updatedToolOutput`` field) replaces what the model
+    reads, whereas surfacing only *appends* ``additionalContext``. Env keys are
+    ``MEMTOMEM_STM_HOOK__COMPRESSION__<field>``.
+
+    Scope is **Bash only** for now — compressing ``Read`` would break a later
+    ``Edit`` whose ``old_string`` must match the file verbatim. The allowlist is
+    intentionally hardcoded (not a Pydantic list field): pydantic-settings parses
+    complex env values as JSON, so a comma-separated ``…__TOOLS=Bash,Grep`` would
+    raise rather than split. The compression strategy is likewise fixed to
+    ``TruncateCompressor`` (self-contained, no chunk-store callback)."""
+
+    enabled: bool = False
+    """Opt-in (default ``False``), mirroring ``proxy.enabled``. Because
+    compression *replaces* model-visible output it ships dormant; enable with
+    ``MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED=1`` after the empirical hook test
+    confirms the host honors ``updatedToolOutput`` for Bash."""
+    max_chars: int = Field(default=16000, gt=0)
+    """Character budget for the compressed ``stdout`` channel, and the threshold
+    below which output is left untouched (only stdout longer than this is
+    compressed). Matches the proxy's ``default_max_result_chars`` default."""
+
+
 class HookConfig(BaseModel):
     """Built-in tool hook (``mms hook``) settings — Stage 2 daemon integration.
 
@@ -86,6 +112,9 @@ class HookConfig(BaseModel):
     the pure-hook path has no in-band channel for the model to return a rating,
     and a ``Bash`` query may carry secrets. See
     ``SurfacingEngine(record_feedback_events=...)``."""
+    compression: HookCompressionConfig = Field(default_factory=HookCompressionConfig)
+    """Built-in tool *output compression* (P1a — Bash). Independent of surfacing:
+    see :class:`HookCompressionConfig`. Env: ``MEMTOMEM_STM_HOOK__COMPRESSION__*``."""
 
 
 class DaemonConfig(BaseModel):

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -25,13 +25,20 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem_stm.cli.hook_cmd import (
+    _COMPRESS_SENTINEL,
+    _SAFE_DAEMON_BUDGET,
+    _bounded_surfacing_payload,
+    _build_hook_output,
     _daemon_enabled,
     _extract_surfaced_block,
+    _orchestrate,
     _run_hook,
     _tool_response_to_text,
+    maybe_compress_builtin,
     run_surfacing_hook,
 )
 from memtomem_stm.cli.proxy import cli
+from memtomem_stm.config import HookCompressionConfig
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.engine import SurfacingEngine
 
@@ -275,7 +282,9 @@ def test_daemon_enabled_default_when_unset(monkeypatch: pytest.MonkeyPatch):
 def test_daemon_explicitly_disabled_uses_cold_path(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
     sentinel = {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "cold"}}
-    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=sentinel))
+    monkeypatch.setattr(
+        "memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=sentinel)
+    )
     # client.surface must never be consulted when the daemon is opted out.
     boom = AsyncMock(side_effect=AssertionError("daemon must not be used when disabled"))
     monkeypatch.setattr("memtomem_stm.daemon.client.surface", boom)
@@ -286,7 +295,9 @@ def test_daemon_explicitly_disabled_uses_cold_path(monkeypatch: pytest.MonkeyPat
 
 def test_daemon_used_when_enabled(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
-    daemon_out = {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "warm"}}
+    daemon_out = {
+        "hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "warm"}
+    }
     monkeypatch.setattr("memtomem_stm.daemon.client.surface", AsyncMock(return_value=daemon_out))
     # Cold path must not run when the daemon answers.
     monkeypatch.setattr(
@@ -303,7 +314,9 @@ def test_daemon_not_used_for_ineligible_tool(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("MEMTOMEM_STM_HOOK__USE_DAEMON", raising=False)  # prove default-on
     spawns: list[int] = []
     monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", lambda cfg: spawns.append(1))
-    surface = AsyncMock(side_effect=AssertionError("daemon must not be consulted for an ineligible tool"))
+    surface = AsyncMock(
+        side_effect=AssertionError("daemon must not be consulted for an ineligible tool")
+    )
     monkeypatch.setattr("memtomem_stm.daemon.client.surface", surface)
     out = asyncio.run(_run_hook({**_READ_PAYLOAD, "tool_name": "Write"}))
     assert out == {}
@@ -328,6 +341,189 @@ def test_daemon_unavailable_cold_fallback(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__FALLBACK", "cold")
     monkeypatch.setattr("memtomem_stm.daemon.client.surface", AsyncMock(return_value=None))
     sentinel = {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "cold"}}
-    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=sentinel))
+    monkeypatch.setattr(
+        "memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=sentinel)
+    )
     out = asyncio.run(_run_hook(_READ_PAYLOAD))
     assert out == sentinel
+
+
+# ── Bash output compression (P1a — updatedToolOutput) ─────────────────────────
+
+_BIG_STDOUT = "log line %d\n" % 0 + "".join(f"log line {i}\n" for i in range(1, 4000))  # ~50KB
+_CFG = HookCompressionConfig(enabled=True, max_chars=2000)
+
+
+def _bash_payload(tool_response, *, tool="Bash", event="PostToolUse"):
+    return {
+        "hook_event_name": event,
+        "tool_name": tool,
+        "tool_input": {"command": "seq 1 4000"},
+        "tool_response": tool_response,
+    }
+
+
+def test_compress_dict_preserves_metadata_and_shrinks_stdout():
+    resp = {"stdout": _BIG_STDOUT, "stderr": "a warning", "interrupted": False, "isImage": False}
+    out = maybe_compress_builtin(_bash_payload(resp), _CFG)
+    assert isinstance(out, dict)
+    # Only stdout is replaced; it is shrunk and carries the sentinel.
+    assert out["stdout"].startswith(_COMPRESS_SENTINEL)
+    assert len(out["stdout"]) < len(_BIG_STDOUT)
+    # Every other channel survives verbatim (Codex: must not lose stderr/metadata).
+    assert out["stderr"] == "a warning"
+    assert out["interrupted"] is False
+    assert out["isImage"] is False
+    # Original payload is not mutated in place.
+    assert resp["stdout"] == _BIG_STDOUT
+
+
+def test_compress_plain_string_response():
+    out = maybe_compress_builtin(_bash_payload(_BIG_STDOUT), _CFG)
+    assert isinstance(out, str)
+    assert out.startswith(_COMPRESS_SENTINEL)
+    assert len(out) < len(_BIG_STDOUT)
+
+
+def test_compress_noop_when_small():
+    assert maybe_compress_builtin(_bash_payload({"stdout": "tiny"}), _CFG) is None
+
+
+def test_compress_noop_when_disabled():
+    cfg = HookCompressionConfig(enabled=False, max_chars=2000)
+    assert maybe_compress_builtin(_bash_payload({"stdout": _BIG_STDOUT}), cfg) is None
+
+
+def test_compress_noop_for_non_bash_tool():
+    # Read output must never be replaced (a later Edit needs it verbatim).
+    assert maybe_compress_builtin(_bash_payload({"stdout": _BIG_STDOUT}, tool="Read"), _CFG) is None
+
+
+def test_compress_noop_for_non_posttooluse():
+    assert (
+        maybe_compress_builtin(_bash_payload({"stdout": _BIG_STDOUT}, event="PreToolUse"), _CFG)
+        is None
+    )
+
+
+def test_compress_is_idempotent_on_sentinel():
+    out = maybe_compress_builtin(_bash_payload({"stdout": _BIG_STDOUT}), _CFG)
+    # Feeding the already-compressed stdout back must not re-compress.
+    assert maybe_compress_builtin(_bash_payload({"stdout": out["stdout"]}), _CFG) is None
+
+
+def test_compress_no_false_positive_on_truncate_marker():
+    # A real log that happens to contain TruncateCompressor's generic marker text
+    # must STILL be compressed — only the unique sentinel suppresses (Codex Major).
+    poisoned = (
+        _BIG_STDOUT + "\n... (truncated, original: 5 chars)\n... (12 similar lines omitted)\n"
+    )
+    out = maybe_compress_builtin(_bash_payload({"stdout": poisoned}), _CFG)
+    assert out is not None and out["stdout"].startswith(_COMPRESS_SENTINEL)
+
+
+def test_compress_never_raises(monkeypatch: pytest.MonkeyPatch):
+    class _Boom:
+        def compress(self, *a, **k):
+            raise RuntimeError("compressor exploded")
+
+    monkeypatch.setattr("memtomem_stm.proxy.compression.TruncateCompressor", _Boom)
+    assert maybe_compress_builtin(_bash_payload({"stdout": _BIG_STDOUT}), _CFG) is None
+
+
+# ── bounded surfacing payload + merge builder ────────────────────────────────
+
+
+def test_bounded_surfacing_payload_passthrough_when_small():
+    payload = _bash_payload({"stdout": "small"})
+    assert _bounded_surfacing_payload(payload) is payload  # same object, no copy
+
+
+def test_bounded_surfacing_payload_caps_huge_output():
+    huge = "x" * (_SAFE_DAEMON_BUDGET + 5000)
+    payload = _bash_payload({"stdout": huge, "stderr": "y" * 100})
+    bounded = _bounded_surfacing_payload(payload)
+    assert bounded is not payload
+    assert len(bounded["tool_response"]) == _SAFE_DAEMON_BUDGET
+
+
+def test_build_hook_output_merges_both_halves():
+    out = _build_hook_output({"stdout": "c"}, "<surfaced-memories>m</surfaced-memories>")
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PostToolUse"
+    assert hso["updatedToolOutput"] == {"stdout": "c"}
+    assert hso["additionalContext"] == "<surfaced-memories>m</surfaced-memories>"
+
+
+def test_build_hook_output_each_half_alone():
+    assert _build_hook_output({"stdout": "c"}, None)["hookSpecificOutput"].keys() == {
+        "hookEventName",
+        "updatedToolOutput",
+    }
+    assert _build_hook_output(None, "ctx")["hookSpecificOutput"].keys() == {
+        "hookEventName",
+        "additionalContext",
+    }
+    assert _build_hook_output(None, None) == {}
+
+
+# ── _orchestrate: compression + surfacing merge, independent gates ───────────
+
+
+def test_orchestrate_merges_compression_and_surfacing(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED", "1")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__MAX_CHARS", "2000")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")  # cold path → run_surfacing_hook
+    surfaced = {
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": "<surfaced-memories>m</surfaced-memories>",
+        }
+    }
+    monkeypatch.setattr(
+        "memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=surfaced)
+    )
+    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT})))
+    hso = out["hookSpecificOutput"]
+    assert hso["updatedToolOutput"]["stdout"].startswith(_COMPRESS_SENTINEL)
+    assert hso["additionalContext"] == "<surfaced-memories>m</surfaced-memories>"
+
+
+def test_orchestrate_compression_runs_when_surfacing_yields_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Independent gate: surfacing produced {} (disabled / no hits) yet the Bash
+    # output is still compressed.
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED", "1")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__MAX_CHARS", "2000")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
+    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value={}))
+    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT})))
+    hso = out["hookSpecificOutput"]
+    assert hso["updatedToolOutput"]["stdout"].startswith(_COMPRESS_SENTINEL)
+    assert "additionalContext" not in hso
+
+
+def test_cli_compresses_bash_output_end_to_end(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED", "1")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__MAX_CHARS", "2000")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
+    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value={}))
+    result = CliRunner().invoke(
+        cli, ["hook"], input=json.dumps(_bash_payload({"stdout": _BIG_STDOUT}))
+    )
+    assert result.exit_code == 0
+    hso = json.loads(result.output)["hookSpecificOutput"]
+    assert hso["updatedToolOutput"]["stdout"].startswith(_COMPRESS_SENTINEL)
+
+
+def test_cli_compression_default_off_is_passthrough(monkeypatch: pytest.MonkeyPatch):
+    # Opt-in: with the flag unset, a large Bash output is NOT replaced.
+    monkeypatch.delenv("MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED", raising=False)
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
+    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value={}))
+    result = CliRunner().invoke(
+        cli, ["hook"], input=json.dumps(_bash_payload({"stdout": _BIG_STDOUT}))
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {}

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -370,6 +370,9 @@ def test_compress_dict_preserves_metadata_and_shrinks_stdout():
     # Only stdout is replaced; it is shrunk and carries the sentinel.
     assert out["stdout"].startswith(_COMPRESS_SENTINEL)
     assert len(out["stdout"]) < len(_BIG_STDOUT)
+    # Budget is a target: sentinel reserved out of it, small compressor-suffix
+    # overage tolerated — but the result must stay close to max_chars, not blow it.
+    assert len(out["stdout"]) <= _CFG.max_chars + 200
     # Every other channel survives verbatim (Codex: must not lose stderr/metadata).
     assert out["stderr"] == "a warning"
     assert out["interrupted"] is False
@@ -378,11 +381,11 @@ def test_compress_dict_preserves_metadata_and_shrinks_stdout():
     assert resp["stdout"] == _BIG_STDOUT
 
 
-def test_compress_plain_string_response():
-    out = maybe_compress_builtin(_bash_payload(_BIG_STDOUT), _CFG)
-    assert isinstance(out, str)
-    assert out.startswith(_COMPRESS_SENTINEL)
-    assert len(out) < len(_BIG_STDOUT)
+def test_compress_noop_for_plain_string_response():
+    # For the built-in Bash tool, updatedToolOutput must be a structured object;
+    # a bare string would be ignored by the host, so an unstructured response is
+    # left untouched rather than replaced (Codex Major).
+    assert maybe_compress_builtin(_bash_payload(_BIG_STDOUT), _CFG) is None
 
 
 def test_compress_noop_when_small():
@@ -498,6 +501,22 @@ def test_orchestrate_compression_runs_when_surfacing_yields_nothing(
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__MAX_CHARS", "2000")
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
     monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value={}))
+    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT})))
+    hso = out["hookSpecificOutput"]
+    assert hso["updatedToolOutput"]["stdout"].startswith(_COMPRESS_SENTINEL)
+    assert "additionalContext" not in hso
+
+
+def test_orchestrate_keeps_compression_when_surfacing_raises(monkeypatch: pytest.MonkeyPatch):
+    # A surfacing failure must NOT discard the already-computed compression half
+    # (Codex Major — the never-raises/independence contract).
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED", "1")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__MAX_CHARS", "2000")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
+    monkeypatch.setattr(
+        "memtomem_stm.cli.hook_cmd.run_surfacing_hook",
+        AsyncMock(side_effect=RuntimeError("surfacing exploded")),
+    )
     out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT})))
     hso = out["hookSpecificOutput"]
     assert hso["updatedToolOutput"]["stdout"].startswith(_COMPRESS_SENTINEL)

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -381,6 +381,26 @@ def test_compress_dict_preserves_metadata_and_shrinks_stdout():
     assert resp["stdout"] == _BIG_STDOUT
 
 
+def test_compress_reserves_sentinel_from_budget(monkeypatch: pytest.MonkeyPatch):
+    # Directly prove the sentinel prefix is reserved out of the compressor's
+    # budget (Codex nit): capture the max_chars handed to TruncateCompressor and
+    # assert it is cfg.max_chars minus the prefix length — a regression back to
+    # passing the full budget would fail here even though the repetitive fixture
+    # compresses well under max_chars.
+    seen: dict[str, int] = {}
+
+    class _Spy:
+        def compress(self, text: str, *, max_chars: int) -> str:
+            seen["budget"] = max_chars
+            return "BODY"
+
+    monkeypatch.setattr("memtomem_stm.proxy.compression.TruncateCompressor", _Spy)
+    out = maybe_compress_builtin(_bash_payload({"stdout": _BIG_STDOUT}), _CFG)
+    prefix_len = len(_COMPRESS_SENTINEL) + 1  # sentinel + "\n"
+    assert seen["budget"] == _CFG.max_chars - prefix_len
+    assert out["stdout"] == f"{_COMPRESS_SENTINEL}\nBODY"
+
+
 def test_compress_noop_for_plain_string_response():
     # For the built-in Bash tool, updatedToolOutput must be a structured object;
     # a bare string would be ignored by the host, so an unstructured response is


### PR DESCRIPTION
## What

Extends `mms hook` beyond surfacing: large **Bash** stdout is shrunk and returned through the PostToolUse `updatedToolOutput` field, so the model reads a compact form. First compression slice of the built-in-tool-hooks project (after surfacing #378 + daemon #379–#382).

**Opt-in / default-off** via `MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED=1` (mirrors `proxy.enabled=False`).

## Why Bash-only

Compressing `Read` would break a later `Edit` whose `old_string` must match the file verbatim. Bash output is read-and-reason (logs/build/test) and never feeds an exact-match follow-up. `Read`/`Grep`/`Glob` and stderr-channel compression are out of scope here.

## Design (validated by Codex review + Gemini docs research)

- **Structured `updatedToolOutput`.** For the built-in Bash tool the value must be an object mirroring the tool result, *not* a plain string (a bare string is silently ignored). We clone the original `tool_response` and shrink only `stdout`, preserving `stderr` / exit / `interrupted` / `isImage` verbatim.
- **In-process, before surfacing.** `TruncateCompressor` needs no warm state, so the surfacing daemon buys nothing — no `OP_COMPRESS`. Compression runs first, on a payload bounded to a hard **256 KiB** cap so a multi-MB result can never overflow the daemon's 4 MiB frame (applied **even when compression is disabled**).
- **Independent of the surfacing gate** — still compresses when surfacing is off or Bash is dropped from the surface allowlist.
- **Idempotent.** A unique `⟦stm-compressed⟧` sentinel (not `TruncateCompressor`'s generic markers, which occur in real logs) suppresses re-compression on a re-fired hook.
- **Merged output.** Compression + surfacing combine into one `hookSpecificOutput` (neither overwrites the other).
- **Strategy fixed to TRUNCATE** (self-contained). SELECTIVE/HYBRID/PROGRESSIVE need a cross-process chunk store + `stm_proxy_read_more` served by the separate `mms` server — deferred follow-up.

## Config

`HookCompressionConfig{enabled=False, max_chars=16000}` on `HookConfig.compression`. No list/tuple `tools` field — pydantic-settings parses complex env values as JSON, so the allowlist is hardcoded to Bash for now.

## Tests / verification

- 18 new tests in `tests/cli/test_hook_cmd.py` (structured-output shape + metadata preservation, plain-string case, all no-op gates, sentinel idempotency incl. no false-positive on a literal `(truncated` in logs, bounded-payload cap, merge, never-raises).
- `ruff check` + `ruff format --check src` clean; `mypy src` clean.
- Full suite: 2357 passed (only the 2 documented live-LTM-on-dev-box failures, confirmed identical on base).
- End-to-end via the real `mms hook` CLI: 158 KB stdout → 1252 chars, sentinel present, metadata preserved.

**Reviewer note — remaining hard gate:** the producer side (correct JSON shape) is proven, but whether a given Claude Code build honors `updatedToolOutput` for the built-in Bash tool needs a live-session check (register the hook with the flag on, run a big Bash command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)