### PR TITLE
fix(compression): hold TruncateCompressor output invariants (len≤max_chars, valid JSON, preserved content)

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -151,10 +151,18 @@ class TruncateCompressor:
         if result:
             return result
 
-        # Fallback: position-based truncation
-        break_at = self._find_break(text, max_chars)
+        # Fallback: position-based truncation. Reserve the suffix out of the
+        # budget so break_at + suffix never exceeds max_chars — the suffix used
+        # to be appended *after* a budget-filling break point, overshooting it.
+        # When the budget is too small to hold the informative note, fall back
+        # to a 1-char marker so the body (the useful part) still gets the room.
         summary = _content_summary(text)
-        return text[:break_at] + f"\n... (truncated, original: {len(text)} chars){summary}"
+        suffix = f"\n... (truncated, original: {len(text)} chars){summary}"
+        if len(suffix) >= max_chars:
+            suffix = "…"
+        break_at = self._find_break(text, max(1, max_chars - len(suffix)))
+        result = text[:break_at] + suffix
+        return result if len(result) <= max_chars else result[:max_chars]
 
     _SUMMARY_RE = re.compile(
         r"summary|conclusion|결론|요약|security|root\s*cause|remediation"
@@ -212,10 +220,25 @@ class TruncateCompressor:
                 inner = part.strip()[1:-1].strip()
                 parts.append(inner)
 
-        result = "{\n" + ",\n".join(parts) + "\n}"
-        if len(result) > max_chars:
-            result = result[:max_chars] + "\n... (truncated)"
-        return result
+        # Assemble as valid JSON. The old path sliced the assembled string to
+        # max_chars and appended a note — producing INVALID JSON and STILL
+        # overshooting the budget. Instead drop whole trailing keys (recording
+        # the count in a valid ``_truncated`` member) until the object fits, so
+        # the result always parses and never exceeds max_chars.
+        def _assemble(kept: list[str], omitted: int) -> str:
+            members = list(kept)
+            if omitted:
+                members.append(f'"_truncated": "{omitted} of {len(parts)} keys omitted"')
+            return "{\n" + ",\n".join(members) + "\n}"
+
+        result = _assemble(parts, 0)
+        if len(result) <= max_chars:
+            return result
+        for keep in range(len(parts) - 1, -1, -1):
+            candidate = _assemble(parts[:keep], len(parts) - keep)
+            if len(candidate) <= max_chars:
+                return candidate
+        return "{}"
 
     def _truncate_json_value(self, value: object, budget: int) -> object:
         """Truncate a JSON value to fit within character budget."""
@@ -295,10 +318,18 @@ class TruncateCompressor:
         head_text = "\n".join(head_lines)
         omitted = max(0, len(lines) - sample_count - len(tail_lines))
 
-        result = f"{head_text}\n... ({omitted} similar lines omitted)\n{tail_text}"
-        if len(result) > max_chars:
-            result = result[:max_chars]
-        return result
+        # The tail anomaly is the payload this path exists to surface, so it is
+        # reserved first. The old code sliced from the START on overflow, which
+        # cut the anomaly off entirely — destroying what it set out to preserve.
+        # When even the tail overflows the budget, keep its most-recent end
+        # (where anomalies surface) together with the marker.
+        marker = f"\n... ({omitted} similar lines omitted)\n"
+        head_budget = max_chars - len(marker) - len(tail_text)
+        if head_budget < 0:
+            body = marker + tail_text
+            return body[-max_chars:] if len(body) > max_chars else body
+        head_kept = head_text if len(head_text) <= head_budget else head_text[:head_budget]
+        return head_kept + marker + tail_text
 
     def _section_aware_truncate(
         self,
@@ -426,13 +457,12 @@ class TruncateCompressor:
         for i, section_text in enumerate(enriched):
             parts.append(section_text)
 
-        result = "\n\n".join(parts)
+        body = "\n\n".join(parts)
         footer = f"\n(original: {len(text)} chars)"
-        result += footer
-
-        if len(result) > max_chars:
-            result = result[:max_chars]
-        return result
+        # Reserve the footer (and a sentinel when cutting) so neither is sliced
+        # off; the old ``result[:max_chars]`` dropped the footer and tail
+        # sections with no truncation marker when the minimums overflowed.
+        return self._fit_with_footer(body, footer, max_chars)
 
     def _enrich_by_relevance(
         self,
@@ -575,11 +605,9 @@ class TruncateCompressor:
                 parts.append(f"\n... ({len(remaining)} more blocks)\n")
                 parts.extend(sig_parts)
 
-        result = "\n\n".join(parts)
-        result += f"\n(original: {len(text)} chars)"
-        if len(result) > max_chars:
-            result = result[:max_chars]
-        return result
+        body = "\n\n".join(parts)
+        footer = f"\n(original: {len(text)} chars)"
+        return self._fit_with_footer(body, footer, max_chars)
 
     @staticmethod
     def _find_break(text: str, max_chars: int) -> int:
@@ -594,6 +622,36 @@ class TruncateCompressor:
             if i < len(text) and text[i] in " \n\t":
                 return i
         return max_chars
+
+    @staticmethod
+    def _fit_with_footer(
+        body: str, footer: str, max_chars: int, *, sentinel: str = "\n... (truncated)"
+    ) -> str:
+        """Assemble ``body + footer`` within ``max_chars`` without slicing the footer.
+
+        Fixes the family of defects where ``(body + footer)[:max_chars]`` both
+        overshot the budget (the footer was appended after the body already
+        filled it) and silently dropped the footer / tail content with no
+        marker. The footer — and, when a cut is needed, a truncation
+        ``sentinel`` — are reserved out of the budget, and the body is cut at a
+        line boundary when one is reasonably close.
+
+        The result is always ``<= max_chars`` for any
+        ``max_chars >= len(sentinel) + len(footer)``; for a pathologically tiny
+        budget that cannot hold even the footer, it degrades to a hard slice.
+        """
+        full = body + footer
+        if len(full) <= max_chars:
+            return full
+        reserve = len(sentinel) + len(footer)
+        keep = max_chars - reserve
+        if keep <= 0:
+            return full[:max_chars]
+        cut = body[:keep]
+        nl = cut.rfind("\n")
+        if nl >= keep // 2:
+            cut = cut[:nl]
+        return cut + sentinel + footer
 
 
 @dataclass

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -224,7 +224,13 @@ class TruncateCompressor:
         # max_chars and appended a note — producing INVALID JSON and STILL
         # overshooting the budget. Instead drop whole trailing keys (recording
         # the count in a valid ``_truncated`` member) until the object fits, so
-        # the result always parses and never exceeds max_chars.
+        # the result always parses and stays within budget.
+        #
+        # Contract floor: valid JSON cannot be shorter than ``{}`` (2 chars).
+        # For any ``max_chars >= 2`` the result is ``<= max_chars``; at a
+        # pathological sub-2-char budget (never produced by config or the
+        # manager retention ladder, which raises tiny budgets) JSON validity
+        # takes precedence and we still return ``{}``.
         def _assemble(kept: list[str], omitted: int) -> str:
             members = list(kept)
             if omitted:

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -45,10 +45,17 @@ class TestTruncateCompressor:
         assert c.compress("short", max_chars=100) == "short"
 
     def test_truncates_at_sentence_boundary(self):
-        text = "First sentence. Second sentence. Third sentence."
-        result = TruncateCompressor().compress(text, max_chars=20)
+        # Budget comfortably holds the first sentence plus the truncation note.
+        # (Pre-fix, max_chars=20 only "passed" because compress() overshot to
+        # ~52 chars — the very overshoot the output-length invariant now forbids;
+        # see test_truncate_output_invariants.py. A 48-char source has no budget
+        # that fits sentence + full note under that invariant, so use a longer
+        # source where the sentence-boundary contract is actually expressible.)
+        text = "First sentence. " + "Filler sentence here. " * 20
+        result = TruncateCompressor().compress(text, max_chars=80)
         assert "First sentence." in result
         assert "truncated" in result
+        assert len(result) <= 80
 
     def test_truncation_metadata_includes_summary(self):
         text = "# Heading\n\nSome text.\n\n```code```\n\n- item1\n- item2"

--- a/tests/test_truncate_output_invariants.py
+++ b/tests/test_truncate_output_invariants.py
@@ -123,6 +123,19 @@ def test_json_key_truncate_records_omitted_keys() -> None:
     assert "omitted" in parsed["_truncated"]
 
 
+@pytest.mark.parametrize("budget", [1, 2, 5])
+def test_json_path_stays_valid_json_at_pathological_budget(budget: int) -> None:
+    """Contract floor: valid JSON cannot be shorter than ``{}`` (2 chars), so a
+    sub-2-char budget keeps JSON validity over the length cap (it returns
+    ``{}``). This documents/pins the one edge where len > max_chars is allowed —
+    a budget never produced by config or the manager retention ladder. Above the
+    2-char floor the length cap holds (budget=5 → still ``<= 5``)."""
+    text = _config_json(8)
+    out = TruncateCompressor().compress(text, max_chars=budget)
+    json.loads(out)  # always parseable
+    assert len(out) <= max(2, budget)
+
+
 def test_tail_anomaly_is_preserved_under_tight_budget() -> None:
     """Invariant C: the repetitive-content path keeps the tail anomaly (the
     whole reason the path exists). Pre-fix the START-anchored slice cut it off."""

--- a/tests/test_truncate_output_invariants.py
+++ b/tests/test_truncate_output_invariants.py
@@ -1,0 +1,174 @@
+"""Output-contract invariants for TruncateCompressor.
+
+These pin three guarantees that several assemble-then-``[:max_chars]`` paths
+used to violate (each silently): the output never exceeds ``max_chars``, the
+config-dict JSON path always emits parseable JSON, and the
+preserve-the-anomaly / preserve-the-footer paths never slice off the very
+content they set out to keep.
+
+Pre-fix, the production paths overshot the budget (suffix/footer appended
+after a budget-filling break) and the hard ``[:max_chars]`` cut destroyed the
+tail anomaly, the markdown footer, and produced invalid JSON. The existing
+suite did not catch any of these, so this file is the regression net.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memtomem_stm.proxy.compression import TruncateCompressor
+from memtomem_stm.proxy.relevance import BM25Scorer
+
+_SENTINEL = "... (truncated"  # both "(truncated)" and "(truncated, original:" forms
+
+
+def _config_json(n: int = 8) -> str:
+    # All values are dicts → routes to TruncateCompressor._json_key_truncate.
+    data = {
+        f"section_{i}": {
+            "enabled": True,
+            "params": {"a": i, "b": "x" * 60},
+            "items": list(range(8)),
+        }
+        for i in range(n)
+    }
+    return json.dumps(data, indent=2)
+
+
+def _markdown(sections: int = 14) -> str:
+    body = "\n\n".join(
+        f"## Section {i}\n\nLine one for section {i}.\nLine two with more detail " + ("blah " * 12)
+        for i in range(sections)
+    )
+    return f"# Doc\n\nIntro.\n\n{body}\n\n## Summary\n\nThe conclusion that matters."
+
+
+def _repetitive_log(lines: int = 40) -> str:
+    head = "\n".join(
+        f"2026-05-30T10:00:{i:02d} INFO request handled in {i}ms" for i in range(lines)
+    )
+    return head + "\n2026-05-30T10:01:00 ERROR fatal: connection refused after retries"
+
+
+def _code(funcs: int = 20) -> str:
+    return "\n\n".join(
+        f"def func_{i}(x):\n    # does thing {i}\n    y = x + {i}\n    return y * {i}"
+        for i in range(funcs)
+    )
+
+
+def _ndjson(lines: int = 40) -> str:
+    return "\n".join(
+        json.dumps({"ts": i, "level": "info", "msg": f"event {i} happened"}) for i in range(lines)
+    )
+
+
+def _csv(rows: int = 50) -> str:
+    return "id,name,value,desc\n" + "\n".join(
+        f"{i},name{i},{i * 10},description text here {i}" for i in range(rows)
+    )
+
+
+def _plain(paras: int = 30) -> str:
+    return "\n\n".join(
+        f"Paragraph {i} explains a thing. It has a second sentence with detail."
+        for i in range(paras)
+    )
+
+
+_FIXTURES = {
+    "config_json": _config_json(),
+    "markdown": _markdown(),
+    "repetitive_log": _repetitive_log(),
+    "code": _code(),
+    "ndjson": _ndjson(),
+    "csv": _csv(),
+    "plain": _plain(),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_FIXTURES))
+@pytest.mark.parametrize("budget", [200, 600, 1200])
+def test_output_never_exceeds_max_chars(name: str, budget: int) -> None:
+    """Invariant A: len(output) <= max_chars for every content type and budget.
+
+    Covers the plain-suffix, JSON-key, tail-anomaly, section-aware and
+    code-aware paths (each a former overshoot site).
+    """
+    text = _FIXTURES[name]
+    out = TruncateCompressor(scorer=BM25Scorer()).compress(text, max_chars=budget)
+    assert len(out) <= budget, f"{name}@{budget}: produced {len(out)} chars (+{len(out) - budget})"
+
+
+@pytest.mark.parametrize("budget", [200, 400, 800, 1200])
+def test_json_key_truncate_emits_valid_json(budget: int) -> None:
+    """Invariant B: the config-dict JSON path always emits parseable JSON."""
+    text = _config_json(10)
+    assert len(text) > 1200  # ensure all budgets force truncation
+    out = TruncateCompressor().compress(text, max_chars=budget)
+    parsed = json.loads(out)  # raises if invalid — the core regression
+    assert isinstance(parsed, dict)
+    assert len(out) <= budget
+
+
+def test_json_key_truncate_records_omitted_keys() -> None:
+    """Dropped trailing keys are reported in a valid ``_truncated`` member,
+    rather than silently lost behind an invalid mid-string cut."""
+    text = _config_json(12)
+    out = TruncateCompressor().compress(text, max_chars=400)
+    parsed = json.loads(out)
+    assert "_truncated" in parsed
+    assert "omitted" in parsed["_truncated"]
+
+
+def test_tail_anomaly_is_preserved_under_tight_budget() -> None:
+    """Invariant C: the repetitive-content path keeps the tail anomaly (the
+    whole reason the path exists). Pre-fix the START-anchored slice cut it off."""
+    text = _repetitive_log(60)
+    out = TruncateCompressor().compress(text, max_chars=300)
+    assert len(out) <= 300
+    assert "ERROR fatal: connection refused" in out, "tail anomaly was sliced off"
+    assert "omitted" in out  # the repetition marker survives too
+
+
+def test_section_aware_keeps_footer_and_marks_truncation() -> None:
+    """Invariant C: many sections at a tight budget still carry the
+    ``(original: N chars)`` footer and a truncation sentinel — the footer used
+    to be sliced off with no marker when the minimums overflowed."""
+    text = _markdown(20)
+    out = TruncateCompressor().compress(text, max_chars=500)
+    assert len(out) <= 500
+    assert "(original:" in out, "footer was sliced off"
+    assert _SENTINEL in out, "no truncation marker after cut"
+
+
+def test_plain_truncate_suffix_within_budget() -> None:
+    """The plain-text fallback reserves its suffix instead of appending past
+    the budget."""
+    text = _plain(40)
+    out = TruncateCompressor().compress(text, max_chars=300)
+    assert len(out) <= 300
+    assert _SENTINEL in out
+
+
+class TestFitWithFooterHelper:
+    """Direct unit coverage of the shared budget helper."""
+
+    def test_passthrough_when_fits(self) -> None:
+        out = TruncateCompressor._fit_with_footer("body", "\nfooter", 100)
+        assert out == "body\nfooter"
+
+    def test_footer_survives_and_within_budget(self) -> None:
+        body = "line\n" * 200
+        footer = "\n(original: 1000 chars)"
+        out = TruncateCompressor._fit_with_footer(body, footer, 120)
+        assert len(out) <= 120
+        assert out.endswith(footer), "footer was sliced off"
+        assert "... (truncated)" in out
+
+    def test_degrades_for_tiny_budget(self) -> None:
+        # Budget smaller than footer+sentinel: still never exceeds max_chars.
+        out = TruncateCompressor._fit_with_footer("x" * 100, "\n(original: 100 chars)", 10)
+        assert len(out) <= 10


### PR DESCRIPTION
## Problem

Several `TruncateCompressor` paths assembled `head + content + footer/suffix` and then hard-sliced the result to `max_chars`. That pattern both **overshot** the budget (footer/suffix appended *after* the body already filled it) and **destroyed the very content the path set out to preserve**, silently and with no marker.

Reproduced (compressor in isolation):

| Path | Input | `max_chars` | Before | After |
|---|---|---|---|---|
| `_json_key_truncate` | config dict | 360 | 376 chars, **JSONDecodeError** | 360 chars, **valid JSON** |
| plain fallback | NDJSON | 800 | 836 (+36) | 790 |
| plain fallback | CSV | 600 | 636 (+36) | 600 |
| `_tail_anomaly_truncate` | log + tail ERROR | tight | tail anomaly **sliced off** | anomaly preserved |
| `_section_aware_truncate` | many sections | tight | footer **sliced off**, no marker | footer + sentinel kept |

## Fix (TruncateCompressor only)

The manager-level retention ladder is a separate concern (follow-up PR).

- Add a shared `_fit_with_footer` helper that reserves the footer (and a truncation sentinel when cutting) out of the budget and cuts the body at a line boundary — used by the section-aware and code-aware paths.
- `_json_key_truncate` drops whole trailing keys, recording the count in a valid `"_truncated"` member, so the result always parses and fits the budget.
- `_tail_anomaly_truncate` reserves the tail anomaly first; only the head sample is trimmed.
- the plain-text fallback reserves its suffix, falling back to a 1-char marker when the budget is too small for the informative note.

## Behavior change

Compression output in **overflow cases** changes: it no longer exceeds `max_chars`, the config-dict JSON path now emits valid JSON (previously could be invalid), and preserved content (tail anomaly / footer) survives instead of being sliced. Non-overflow output is unchanged.

## Tests

`tests/test_truncate_output_invariants.py` pins the contract across content types × budgets: output `≤ max_chars`, config-dict JSON always parses, tail anomaly + markdown footer survive a tight budget. The existing suite caught none of these. `test_truncates_at_sentence_boundary` was updated — it only "passed" by relying on the overshoot now forbidden (its intent is preserved at a budget where it is expressible).

## Follow-up (separate PR)

`FieldExtractCompressor` / `SchemaPruningCompressor` / `SkeletonCompressor` share the same `result[:max_chars] + suffix` overshoot (SchemaPruning's also breaks JSON validity); they are mitigated today by the manager retention guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)