### PR TITLE
fix(proxy): unify heading detection, re-check truncate-fallback ratio, thread context_query (retention ladder)

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -55,6 +55,19 @@ def _content_summary(text: str) -> str:
     return f" [{', '.join(counts)}]" if counts else ""
 
 
+def count_markdown_headings(text: str) -> int:
+    """Count ATX markdown headings with the canonical regex.
+
+    Shared by ``auto_select_strategy`` (HYBRID routing) and the proxy's
+    retention-ladder hybrid-fallback gate so the two agree on what a "heading"
+    is. Requires ``#``..``######`` followed by whitespace and matches a heading
+    at offset 0 — unlike a bare ``text.count("\\n#")``, which both misses an
+    offset-0 heading and over-counts a ``#`` that is not a heading (e.g. a shell
+    comment line, or ``#`` inside prose without a following space).
+    """
+    return len(_HEADINGS_RE.findall(text))
+
+
 class Compressor(Protocol):
     def compress(self, text: str, *, max_chars: int) -> str: ...
 
@@ -1520,7 +1533,7 @@ def auto_select_strategy(text: str, *, max_chars: int = 0) -> CompressionStrateg
             pass
 
     # Markdown detection
-    heading_count = len(re.findall(r"(?:^|\n)#{1,6}\s", stripped))
+    heading_count = count_markdown_headings(stripped)
 
     if heading_count >= 4:
         # Skeleton for API-docs with HTTP method endpoints

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -31,6 +31,7 @@ from memtomem_stm.proxy.compression import (
     SelectiveCompressor,
     TruncateCompressor,
     auto_select_strategy,
+    count_markdown_headings,
     get_compressor,
 )
 from memtomem_stm.proxy.config import (
@@ -722,7 +723,7 @@ class ProxyManager:
             )
             return (
                 TruncateCompressor(scorer=self._relevance_scorer).compress(
-                    text, max_chars=max_chars
+                    text, max_chars=max_chars, context_query=context_query
                 ),
                 "no_config",
             )
@@ -1661,7 +1662,12 @@ class ProxyManager:
                         # truncate loses little structural information.
                         _MIN_HEADINGS_FOR_HYBRID = 3
                         if not progressive_fallback:
-                            heading_count = cleaned.count("\n#")
+                            # Canonical heading count (shared with
+                            # auto_select_strategy) — the old ``count("\n#")``
+                            # missed a heading at offset 0 and over-counted any
+                            # ``#`` not followed by whitespace, so the ladder and
+                            # AUTO could disagree on whether content is "markdown".
+                            heading_count = count_markdown_headings(cleaned)
                             if heading_count >= _MIN_HEADINGS_FOR_HYBRID:
                                 try:
                                     compressed = await self._apply_hybrid(
@@ -1695,19 +1701,43 @@ class ProxyManager:
                         # and lacks structure for hybrid.
                         if not progressive_fallback and not hybrid_fallback:
                             compressed = TruncateCompressor(scorer=self._relevance_scorer).compress(
-                                cleaned, max_chars=effective_max_chars
+                                cleaned,
+                                max_chars=effective_max_chars,
+                                context_query=context_query,
                             )
                             metrics_strategy = f"{original_strategy}→truncate_fallback"
-                            logger.warning(
-                                "Ratio guard truncate fallback for %s/%s: %s "
-                                "(ratio %.3f→%.3f, budget=%d)",
-                                server,
-                                tool,
-                                metrics_strategy,
-                                compressed_ratio,
-                                (len(compressed) / cleaned_len if cleaned_len else 0),
-                                effective_max_chars,
-                            )
+                            # Re-check the ratio symmetrically with the hybrid
+                            # tier (which gates on the floor): truncate is the
+                            # terminal tier, so we only record the outcome — but
+                            # an operator still needs to see when even the
+                            # "guaranteed floor" tier landed below it (e.g.
+                            # tail-anomaly content that fills far less than the
+                            # budget). Pre-fix this path logged unconditionally
+                            # without comparing against the floor.
+                            truncate_ratio = len(compressed) / cleaned_len if cleaned_len else 0
+                            if truncate_ratio >= dynamic:
+                                logger.info(
+                                    "Ratio guard truncate fallback for %s/%s: %s "
+                                    "(ratio %.3f→%.3f, budget=%d)",
+                                    server,
+                                    tool,
+                                    metrics_strategy,
+                                    compressed_ratio,
+                                    truncate_ratio,
+                                    effective_max_chars,
+                                )
+                            else:
+                                logger.warning(
+                                    "Ratio guard truncate fallback for %s/%s still below floor: %s "
+                                    "(ratio %.3f→%.3f < %.3f, budget=%d)",
+                                    server,
+                                    tool,
+                                    metrics_strategy,
+                                    compressed_ratio,
+                                    truncate_ratio,
+                                    dynamic,
+                                    effective_max_chars,
+                                )
 
             # Record metrics BEFORE surfacing (surfacing adds content, not compresses)
             compressed_chars_for_metrics = len(compressed)

--- a/tests/test_retention_ladder_invariants.py
+++ b/tests/test_retention_ladder_invariants.py
@@ -1,0 +1,178 @@
+"""Invariants for the manager-level compression retention ladder.
+
+Pins three corrections, kept separate from the TruncateCompressor output
+invariants (see test_truncate_output_invariants.py):
+
+1. Heading detection in the hybrid-fallback gate uses the canonical markdown
+   regex (shared with auto_select_strategy), not a naive ``count("\\n#")`` that
+   missed an offset-0 heading and over-counted non-heading ``#``.
+2. The truncate (tier-3) fallback re-checks its own ratio against the floor and
+   logs distinctly when it lands below — symmetric with the hybrid tier, which
+   gates on the floor.
+3. ``context_query`` reaches the LLM-no-config and truncate-fallback
+   compressor calls, not only the main TRUNCATE path.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memtomem_stm.proxy.compression import count_markdown_headings
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ProxyConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
+from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.metrics_store import MetricsStore
+
+
+# ── 1. Canonical heading count ──────────────────────────────────────────
+
+
+class TestCountMarkdownHeadings:
+    def test_counts_offset_zero_heading(self) -> None:
+        # Heading at position 0 (no leading newline) must be counted — the old
+        # ``count("\n#")`` missed it.
+        text = "# Title\n## A\n### B"
+        assert count_markdown_headings(text) == 3
+        assert text.count("\n#") == 2  # the bug the regex fixes
+
+    def test_does_not_overcount_non_headings(self) -> None:
+        # ``#`` not followed by whitespace (shebang, no-space comment, 7+ hashes)
+        # is not a heading; the naive count would inflate these.
+        text = "# Real heading\n#!/bin/bash\n#nospace\n####### too many"
+        assert count_markdown_headings(text) == 1
+        assert text.count("\n#") == 3  # naive overcount
+
+    def test_empty(self) -> None:
+        assert count_markdown_headings("") == 0
+        assert count_markdown_headings("no headings here at all") == 0
+
+
+# ── Ladder integration harness (mirrors test_fallback_ladder.py) ─────────
+
+
+def _make_result(text: str):
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=text)], isError=False)
+
+
+def _make_manager(
+    tmp_path: Path, *, min_retention: float = 0.65, max_result_chars: int = 500
+) -> tuple[ProxyManager, MetricsStore]:
+    store = MetricsStore(tmp_path / "metrics.db")
+    store.initialize()
+    server_cfg = UpstreamServerConfig(
+        prefix="test",
+        compression=CompressionStrategy.TRUNCATE,
+        max_result_chars=max_result_chars,
+        max_retries=0,
+        reconnect_delay_seconds=0.0,
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={"srv": server_cfg},
+        min_result_retention=min_retention,
+    )
+    mgr = ProxyManager(proxy_cfg, TokenTracker(metrics_store=store))
+    mgr._connections["srv"] = UpstreamConnection(
+        name="srv", config=server_cfg, session=AsyncMock(), tools=[]
+    )
+    return mgr, store
+
+
+def _latest_strategy(store: MetricsStore) -> str:
+    row = store._db.execute(
+        "SELECT compression_strategy FROM proxy_metrics ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    return row[0]
+
+
+# ── 2. Heading detection drives the ladder consistently ─────────────────
+
+
+@pytest.mark.asyncio
+class TestLadderHeadingDetection:
+    async def test_offset_zero_heading_routes_to_hybrid(self, tmp_path) -> None:
+        """A markdown doc whose first heading sits at offset 0, with exactly the
+        3-heading minimum, now routes to the hybrid tier. The old
+        ``count("\\n#")`` saw only 2 (missing the offset-0 heading) and fell
+        through to truncate."""
+        body = "Detail paragraph text. " * 22  # ~500 chars/section
+        # First heading at offset 0 (no leading newline); 3 headings total.
+        text = f"# Section 0\n\n{body}" + "".join(
+            f"\n## Section {i}\n\n{body}" for i in range(1, 3)
+        )
+        assert count_markdown_headings(text) == 3
+        assert text.count("\n#") == 2  # old gate would skip hybrid
+        assert len(text) < 4000  # under progressive chunk_size
+
+        mgr, store = _make_manager(tmp_path)
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(text)
+        # Force the ratio guard to fire so the ladder runs.
+        mgr._apply_compression = AsyncMock(return_value=("x" * 40, None))
+
+        await mgr.call_tool("srv", "tool", {})
+
+        assert "→hybrid_fallback" in _latest_strategy(store)
+        store.close()
+
+
+# ── 3. Truncate fallback re-checks its ratio against the floor ──────────
+
+
+@pytest.mark.asyncio
+class TestTruncateFallbackRatioRecheck:
+    async def test_below_floor_truncate_logs_warning(self, tmp_path, caplog) -> None:
+        """Repetitive content with a tail anomaly truncates to far below the
+        budget, so the terminal truncate tier lands under the floor and must say
+        so (symmetric with the hybrid tier's floor gate)."""
+        # No headings (skip hybrid), under chunk_size (skip progressive),
+        # highly repetitive with a single tail anomaly → tail-anomaly truncate
+        # yields a tiny output relative to the cleaned length.
+        text = "\n".join(f"row {i} identical-shape line aaaa" for i in range(100))
+        text += "\nTOTALLY DIFFERENT ANOMALOUS TAIL LINE"
+        assert len(text) < 4000
+
+        mgr, store = _make_manager(tmp_path)
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(text)
+        mgr._apply_compression = AsyncMock(return_value=("x" * 40, None))
+
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr.call_tool("srv", "tool", {})
+
+        assert "→truncate_fallback" in _latest_strategy(store)
+        assert any("still below floor" in r.message for r in caplog.records), (
+            "truncate fallback below the floor should log the distinct warning"
+        )
+        store.close()
+
+
+# ── 4. context_query reaches the fallback compressor calls ──────────────
+
+
+class TestContextQueryPropagation:
+    """Shape-identical TruncateCompressor.compress call sites are hard to tell
+    apart with a spy, so pin them by source inspection (repo precedent:
+    test_both_apply_progressive_call_sites_pass_trace_id_kwarg)."""
+
+    def test_llm_no_config_fallback_passes_context_query(self) -> None:
+        src = inspect.getsource(ProxyManager._apply_compression)
+        # The no-config branch returns a TruncateCompressor result tagged
+        # "no_config"; it must thread context_query like the main TRUNCATE path.
+        idx = src.index('"no_config"')
+        window = src[max(0, idx - 400) : idx]
+        assert "context_query=context_query" in window
+
+    def test_truncate_fallback_passes_context_query(self) -> None:
+        src = inspect.getsource(ProxyManager._call_tool_inner)
+        idx = src.index("→truncate_fallback")
+        window = src[max(0, idx - 400) : idx]
+        assert "context_query=context_query" in window


### PR DESCRIPTION
PR2 of the compression info-preservation series (PR1 = #384, TruncateCompressor output invariants). Independent of #384 (separate files); both branch from `main`.

## Three manager-level retention-ladder corrections

**1. Heading detection inconsistency.** The hybrid-fallback gate counted headings with `cleaned.count("\n#")`, which **misses a heading at offset 0** and **over-counts any `#` not followed by whitespace** (shebangs, no-space comments, 7+ hashes). `auto_select_strategy` used a different, correct regex — so the ladder and AUTO could disagree on whether content is "markdown". Extracted the canonical `count_markdown_headings` helper and used it in both places.

**2. Asymmetric ratio re-check.** The hybrid tier gates on the floor (`len/cleaned >= dynamic`) before claiming success, but the terminal truncate tier accepted its output and logged unconditionally, never comparing against the floor. Now computes the truncate ratio and logs a distinct **"still below floor"** WARNING when even the guaranteed-floor tier lands under it (e.g. tail-anomaly content that fills far less than the budget); INFO otherwise. The `→truncate_fallback` metrics label is unchanged.

**3. `context_query` not threaded to the fallback compressors.** The main TRUNCATE path forwards `context_query` for query-aware truncation, but the LLM-no-config fallback and the tier-3 truncate fallback dropped it. Threaded through both so relevance-aware section selection survives the fallback path.

## Behavior change

- Content with an offset-0 markdown heading (and ≥3 headings total) now routes to the hybrid tier instead of truncate under the ratio guard.
- A truncate fallback that lands below the floor now logs at WARNING with `"still below floor"` (was an unconditional WARNING with no floor comparison); the floor-met case logs at INFO.
- Fallback truncation is now query-aware when `_context_query` is supplied.

## Tests

`tests/test_retention_ladder_invariants.py`: `count_markdown_headings` unit cases (offset-0 counted, non-headings not over-counted, vs the naive `count("\n#")`); an offset-0 heading doc routes to `hybrid_fallback` (was `truncate_fallback`); a below-floor truncate logs the distinct warning; source-inspection pins that both fallback `compress()` calls pass `context_query`. Full suite green (no new failures).

## Not in scope (later PRs)

Query-aware threading into SELECTIVE / `get_compressor` / Hybrid-TOC (#384 follow-up PR3); surfacing query-extraction + gate fixes (PR4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)