### PR TITLE
feat(compression): make SELECTIVE / Hybrid-TOC query-aware (relevance-ranked TOC)

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -635,11 +635,13 @@ class SelectiveCompressor:
         json_depth: int = 1,
         min_section_chars: int = 50,
         store: object | None = None,
+        scorer: RelevanceScorer | None = None,
     ) -> None:
         self._max_pending = max_pending
         self._ttl = pending_ttl_seconds
         self._json_depth = json_depth
         self._min_section_chars = min_section_chars
+        self._scorer = scorer or BM25Scorer()
         if store is not None:
             self._store = store
         else:
@@ -647,7 +649,7 @@ class SelectiveCompressor:
 
             self._store = InMemoryPendingStore()
 
-    def compress(self, text: str, *, max_chars: int) -> str:
+    def compress(self, text: str, *, max_chars: int, context_query: str | None = None) -> str:
         if not text or len(text) <= max_chars:
             return text
 
@@ -656,19 +658,25 @@ class SelectiveCompressor:
         if len(chunks) <= 1:
             chunks = self._decompose_single_chunk(chunks, fmt)
             if len(chunks) <= 1:
-                return TruncateCompressor().compress(text, max_chars=max_chars)
+                return TruncateCompressor().compress(
+                    text, max_chars=max_chars, context_query=context_query
+                )
 
-        return self._store_and_build_toc(text, fmt, chunks)
+        return self._store_and_build_toc(text, fmt, chunks, context_query)
 
-    def compress_full_toc(self, text: str, *, max_chars: int) -> str | None:
+    def compress_full_toc(
+        self, text: str, *, max_chars: int, context_query: str | None = None
+    ) -> str | None:
         fmt, chunks = self._detect_and_parse(text)
         if len(chunks) <= 1:
             chunks = self._decompose_single_chunk(chunks, fmt)
             if len(chunks) <= 1:
                 return None
-        return self._store_and_build_toc(text, fmt, chunks)
+        return self._store_and_build_toc(text, fmt, chunks, context_query)
 
-    def _store_and_build_toc(self, text: str, fmt: str, chunks: dict[str, str]) -> str:
+    def _store_and_build_toc(
+        self, text: str, fmt: str, chunks: dict[str, str], context_query: str | None = None
+    ) -> str:
         selection_key = uuid.uuid4().hex[:16]
 
         self._store.put(
@@ -697,6 +705,22 @@ class SelectiveCompressor:
                     "inline": is_inline,
                 }
             )
+
+        # Query-aware ordering: when a context query is supplied, surface the
+        # most relevant sections first so the agent sees them at the top of the
+        # TOC. Selection by key is unaffected — ``chunks`` still holds every
+        # section. With no query (or no signal) the original insertion order is
+        # preserved, which callers and tests rely on. Stable sort keeps ties in
+        # insertion order.
+        if context_query and context_query.strip():
+            # ``entries`` is built from ``chunks.items()`` in order, so the
+            # i-th entry and the i-th chunk are the same section — score the
+            # (key, content) pairs directly and reorder entries by that index.
+            chunk_items = list(chunks.items())
+            scores = self._scorer.score_sections(context_query, chunk_items)
+            if any(s > 0 for s in scores):
+                order = sorted(range(len(entries)), key=lambda i: -scores[i])
+                entries = [entries[i] for i in order]
 
         toc = {
             "type": "toc",
@@ -1421,7 +1445,9 @@ class HybridCompressor:
             )
 
         if self._tail_mode == TailMode.TOC:
-            tail_compressed = self._selective.compress(tail_text, max_chars=toc_budget)
+            tail_compressed = self._selective.compress(
+                tail_text, max_chars=toc_budget, context_query=context_query
+            )
         else:
             tail_compressed = TruncateCompressor().compress(
                 tail_text, max_chars=toc_budget, context_query=context_query

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -686,7 +686,12 @@ class ProxyManager:
                 if self._selective_compressor is None or self._selective_compressor_cfg != sel_cfg:
                     self._selective_compressor = self._create_selective(sel_cfg)
                     self._selective_compressor_cfg = sel_cfg
-            return self._selective_compressor.compress(text, max_chars=max_chars), None
+            return (
+                self._selective_compressor.compress(
+                    text, max_chars=max_chars, context_query=context_query
+                ),
+                None,
+            )
 
         if compression == CompressionStrategy.LLM_SUMMARY:
             if llm_cfg is not None:

--- a/tests/test_query_aware_selective.py
+++ b/tests/test_query_aware_selective.py
@@ -1,0 +1,121 @@
+"""Query-aware wiring for SELECTIVE / Hybrid-TOC compression.
+
+Closes the two gaps where ``context_query`` was threaded into the pipeline but
+dropped before it reached the SELECTIVE compressor and the Hybrid TOC tail.
+With a query the SELECTIVE table-of-contents now surfaces the most relevant
+sections first; selection-by-key is unaffected. Propagation is pinned with
+behavioral spies (not source inspection) per review feedback.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from memtomem_stm.proxy.compression import HybridCompressor, SelectiveCompressor
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ProxyConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager
+from memtomem_stm.proxy.metrics import TokenTracker
+
+
+def _doc() -> str:
+    return (
+        "## Authentication\n\n"
+        + "JWT tokens and oauth login flows. " * 8
+        + "\n\n## Billing\n\n"
+        + "Invoices payments and subscription charges. " * 8
+        + "\n\n## Logging\n\n"
+        + "Log files rotation and verbosity levels. " * 8
+    )
+
+
+class TestSelectiveQueryAware:
+    def test_default_preserves_insertion_order(self) -> None:
+        toc = json.loads(SelectiveCompressor().compress(_doc(), max_chars=120))
+        assert [e["key"] for e in toc["entries"]] == ["Authentication", "Billing", "Logging"]
+
+    def test_query_surfaces_relevant_section_first(self) -> None:
+        toc = json.loads(
+            SelectiveCompressor().compress(
+                _doc(), max_chars=120, context_query="billing invoice payment"
+            )
+        )
+        assert toc["entries"][0]["key"] == "Billing"
+        # All sections are still listed — ranking reorders, never drops.
+        assert {e["key"] for e in toc["entries"]} == {"Authentication", "Billing", "Logging"}
+
+    def test_select_by_key_unaffected_by_reorder(self) -> None:
+        c = SelectiveCompressor()
+        toc = json.loads(c.compress(_doc(), max_chars=120, context_query="billing"))
+        key = toc["selection_key"]
+        selected = c.select(key, ["Authentication"])
+        assert "JWT tokens" in selected  # retrieval works regardless of TOC order
+
+    def test_irrelevant_query_keeps_insertion_order(self) -> None:
+        # No section scores against the query → original order preserved.
+        toc = json.loads(
+            SelectiveCompressor().compress(_doc(), max_chars=120, context_query="zzzzz qqqqq")
+        )
+        assert [e["key"] for e in toc["entries"]] == ["Authentication", "Billing", "Logging"]
+
+
+class TestHybridForwardsQuery:
+    def test_hybrid_forwards_context_query_to_selective(self) -> None:
+        received: dict[str, object] = {}
+        sel = SelectiveCompressor()
+        original = sel.compress
+
+        def spy(text, *, max_chars, context_query=None):
+            received["context_query"] = context_query
+            return original(text, max_chars=max_chars, context_query=context_query)
+
+        sel.compress = spy  # type: ignore[method-assign]
+        HybridCompressor(head_chars=120, selective_compressor=sel).compress(
+            _doc(), max_chars=400, context_query="billing"
+        )
+        assert received["context_query"] == "billing"
+
+
+@pytest.mark.asyncio
+class TestManagerSelectiveForwardsQuery:
+    async def test_apply_compression_selective_forwards_query(self, tmp_path) -> None:
+        proxy_cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={
+                "srv": UpstreamServerConfig(
+                    prefix="test", compression=CompressionStrategy.SELECTIVE
+                )
+            },
+        )
+        mgr = ProxyManager(proxy_cfg, TokenTracker(metrics_store=None))
+
+        captured: dict[str, object] = {}
+
+        def spy_compress(text, *, max_chars, context_query=None):
+            captured["context_query"] = context_query
+            return "{}"
+
+        # Pre-seed the cached compressor (cfg None matches the None passed below)
+        # so _apply_compression reuses our spy instead of building a real one.
+        mgr._selective_compressor = SimpleNamespace(compress=spy_compress)
+        mgr._selective_compressor_cfg = None
+
+        out, fallback = await mgr._apply_compression(
+            "x" * 500,
+            CompressionStrategy.SELECTIVE,
+            100,
+            None,  # sel_cfg
+            None,  # llm_cfg
+            None,  # hybrid_cfg
+            "srv",
+            "tool",
+            context_query="billing invoice",
+        )
+        assert fallback is None
+        assert captured["context_query"] == "billing invoice"


### PR DESCRIPTION
PR3 of the compression series (PR1 #384 output invariants, PR2 #385 retention ladder). Closes the compression cluster's query-aware gaps. Independent of #384/#385 (non-overlapping hunks); branches from `main`.

## Problem

`context_query` is threaded through the proxy pipeline, but two table-of-contents strategies dropped it before use:

- the manager's **SELECTIVE** branch called `SelectiveCompressor.compress(text, max_chars=...)` with no query;
- **HybridCompressor**'s TOC tail called `self._selective.compress(...)` with no query (its truncate fallbacks already forwarded it).

So relevance-aware selection was inert for SELECTIVE and Hybrid-TOC.

## Change

`SelectiveCompressor` now accepts `context_query` and, when supplied, orders the TOC entries by BM25 relevance — the agent sees the most relevant sections first. Selection-by-key is unaffected: every section is still listed and retrievable; ranking only reorders, never drops. With no query (or no signal) the original insertion order is preserved (callers/tests rely on it).

- `SelectiveCompressor.compress` / `compress_full_toc` / `_store_and_build_toc` take `context_query`; a default `BM25Scorer` (zero-latency) ranks entries.
- `HybridCompressor` forwards `context_query` into its SELECTIVE TOC tail.
- `ProxyManager`'s SELECTIVE branch forwards `context_query`.

## Behavior change

When `_context_query` is supplied, a SELECTIVE / Hybrid-TOC response lists sections most-relevant-first instead of in document order. No query → unchanged.

## Tests

`tests/test_query_aware_selective.py`: relevant section surfaces first; default + no-signal keep insertion order; `select()` still works after reorder; **behavioral spies** pin that Hybrid and the manager SELECTIVE branch forward `context_query` (per review feedback — not source inspection). Full suite green (no new failures).

## Not in scope (follow-up)

The `get_compressor` structural compressors (`SchemaPruning` / `FieldExtract` / `Skeleton`) need per-compressor relevance logic to act on a query — a separate change from this TOC-ordering wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)