### PR TITLE
fix(surfacing): tokenize Grep/Glob patterns, stabilize + filter query extraction

### DIFF
--- a/src/memtomem_stm/surfacing/context_extractor.py
+++ b/src/memtomem_stm/surfacing/context_extractor.py
@@ -12,6 +12,10 @@ _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
 _HEX_RE = re.compile(r"^[0-9a-f]{24,}$", re.I)
 _SEMANTIC_KEYS = {"query", "search", "path", "file", "url", "topic", "name", "title", "description"}
 _PATH_KEYS = {"path", "file", "filepath", "file_path", "filename"}
+# Grep/Glob carry their search target in ``pattern`` (or ``glob``); tokenizing
+# it turns one opaque regex/glob token into searchable words so the query can
+# clear ``min_query_tokens`` and surfacing actually fires for those tools.
+_PATTERN_KEYS = {"pattern", "glob"}
 
 
 class ContextExtractor:
@@ -44,20 +48,30 @@ class ContextExtractor:
             if isinstance(cq, str) and cq.strip():
                 return cq.strip()
 
-        # 3. Heuristic extraction — prioritize argument values over tool name
+        # 3. Heuristic extraction — prioritize argument values over tool name.
+        # Iterate in sorted key order so two identical calls whose arguments
+        # were built in a different order produce the same query string (the
+        # surfacing cache is keyed on that string, and a stable query keeps the
+        # cooldown/dedup heuristics consistent).
         parts: list[str] = []
 
-        for key, value in arguments.items():
+        for key, value in sorted(arguments.items()):
             if key.startswith("_"):
                 continue
             if isinstance(value, str) and len(value) > 2 and not self._is_identifier(value):
-                # Tokenize pure file paths into meaningful words
-                # Only tokenize if value looks like a path (no spaces)
+                # Tokenize file paths and Grep/Glob patterns into meaningful
+                # words; otherwise keep the first sentence of free text.
                 if key in _PATH_KEYS and ("/" in value or "\\" in value) and " " not in value:
                     parts.append(self._tokenize_path(value))
+                elif key in _PATTERN_KEYS:
+                    parts.append(self._tokenize_pattern(value))
                 else:
                     parts.append(self._first_sentence(value, max_chars=200))
-            elif key in _SEMANTIC_KEYS:
+            elif key in _SEMANTIC_KEYS and not self._is_identifier(str(value)):
+                # A semantic key whose value is an opaque id (uuid/hex/bool) is
+                # filtered here too — pre-fix only the free-text branch applied
+                # the identifier filter, so a semantic-keyed id leaked into the
+                # query (inconsistent and a poor search term).
                 parts.append(str(value))
 
         # Fall back to tool name only if no semantic args found
@@ -100,6 +114,21 @@ class ContextExtractor:
         # Strip leading slashes and split by / . _ -
         parts = re.split(r"[/._\-]+", path.strip("/"))
         # Filter out empty, very short, or purely numeric parts
+        tokens = [p for p in parts if len(p) > 1 and not p.isdigit()]
+        return " ".join(tokens)
+
+    @staticmethod
+    def _tokenize_pattern(pattern: str) -> str:
+        """Convert a Grep/Glob pattern into space-separated searchable words.
+
+        Splits on regex/glob metacharacters and separators so a pattern like
+        ``auth.*token`` or ``**/*.jwt_handler.py`` yields real terms
+        (``auth token`` / ``jwt handler py``) instead of one opaque token that
+        trips ``min_query_tokens`` and suppresses surfacing. Drops empty,
+        single-char, and purely numeric fragments; Unicode word characters
+        (e.g. Hangul) are preserved.
+        """
+        parts = re.split(r"[\W_]+", pattern)
         tokens = [p for p in parts if len(p) > 1 and not p.isdigit()]
         return " ".join(tokens)
 

--- a/tests/test_surfacing_query_extraction.py
+++ b/tests/test_surfacing_query_extraction.py
@@ -1,0 +1,63 @@
+"""Query-extraction improvements for surfacing.
+
+Three corrections in ContextExtractor:
+1. Grep/Glob ``pattern`` (and ``glob``) values are tokenized into searchable
+   words, so those tools produce a query that can clear ``min_query_tokens``
+   instead of one opaque regex/glob token that suppressed surfacing.
+2. Arguments are read in sorted-key order, so two identical calls built in a
+   different order yield the same query (stable surfacing cache key + dedup).
+3. The identifier filter applies to semantic-keyed values too — a uuid/hex id
+   under a key like ``name`` no longer leaks into the query.
+"""
+
+from __future__ import annotations
+
+from memtomem_stm.surfacing.config import SurfacingConfig
+from memtomem_stm.surfacing.context_extractor import ContextExtractor
+
+_UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+
+def _extract(tool: str, arguments: dict) -> str | None:
+    return ContextExtractor().extract_query("builtin", tool, arguments, SurfacingConfig())
+
+
+class TestPatternTokenization:
+    def test_tokenize_pattern_splits_metacharacters(self) -> None:
+        assert ContextExtractor._tokenize_pattern("auth.*token_handler") == "auth token handler"
+        assert ContextExtractor._tokenize_pattern("**/*.jwt_handler.py") == "jwt handler py"
+
+    def test_tokenize_pattern_drops_short_and_numeric(self) -> None:
+        # single chars, empties, and pure numbers are dropped
+        assert ContextExtractor._tokenize_pattern("a.*b/123/name") == "name"
+
+    def test_grep_pattern_produces_searchable_query(self) -> None:
+        # Pre-fix: "auth.*token_handler" was one token → below min_query_tokens
+        # (3) → surfacing suppressed. Now it tokenizes and surfaces.
+        q = _extract("Grep", {"pattern": "auth.*token_handler", "path": "src/auth"})
+        assert q is not None
+        assert "auth" in q and "token" in q and "handler" in q
+
+    def test_glob_pattern_tokenized(self) -> None:
+        q = _extract("Glob", {"pattern": "**/*.jwt_handler.py"})
+        assert q == "jwt handler py"
+
+
+class TestArgumentOrderDeterminism:
+    def test_reordered_args_produce_same_query(self) -> None:
+        a = _extract("tool", {"zebra": "alpha bravo charlie", "apple": "delta echo foxtrot"})
+        b = _extract("tool", {"apple": "delta echo foxtrot", "zebra": "alpha bravo charlie"})
+        assert a == b
+        assert a is not None
+
+
+class TestSemanticKeyIdentifierFilter:
+    def test_uuid_under_semantic_key_is_filtered(self) -> None:
+        # A uuid under "name" must not become the query (it is an opaque id).
+        assert _extract("tool", {"name": _UUID}) is None
+
+    def test_real_semantic_value_still_used(self) -> None:
+        assert _extract("tool", {"name": "jwt token handler"}) == "jwt token handler"
+
+    def test_hex_under_semantic_key_is_filtered(self) -> None:
+        assert _extract("tool", {"title": "abcdef0123456789abcdef0123456789"}) is None


### PR DESCRIPTION
PR4 — first of the surfacing-quality series (gate asymmetry and cache-hit dedup follow as separate PRs, per review). Independent of the compression PRs (#384/#385/#386); branches from `main`.

## Three corrections in `ContextExtractor`

**1. Grep/Glob surfacing never fired.** Those tools carry their search target in a `pattern` (or `glob`) argument, which fell through to `_first_sentence` and stayed one opaque token (e.g. `auth.*token_handler`). With the default `min_query_tokens=3`, that single token was dropped → surfacing suppressed for Grep/Glob entirely. Added `_tokenize_pattern` (splits on regex/glob metacharacters, drops short/numeric fragments, preserves Unicode words) routed via a new `_PATTERN_KEYS` set, so `auth.*token_handler` → `auth token handler` and `**/*.jwt_handler.py` → `jwt handler py`.

**2. Non-deterministic query composition.** Arguments were read in dict order, so the same call assembled in a different order produced a different query string — splitting the surfacing cache (keyed on the query) and confusing the cooldown/dedup heuristics. Now iterates in sorted-key order.

**3. Identifier-filter inconsistency.** The free-text branch dropped uuid/hex/bool values, but the semantic-key branch did not — so a uuid under a key like `name` leaked into the query as a useless search term. The identifier filter now applies to the semantic-key branch too.

## Behavior change

- Grep/Glob calls now produce a tokenized, multi-word query and can surface memories (previously suppressed).
- Query strings are stable across argument reordering.
- A uuid/hex value under a semantic key no longer becomes (part of) the query.

## Tests

`tests/test_surfacing_query_extraction.py`: `_tokenize_pattern` unit cases + Grep/Glob end-to-end; reordered args yield an identical query; uuid/hex under a semantic key is filtered while real values pass. The 26 existing extractor tests stay green.

## Out of scope (noted)

`min_query_tokens=3` still drops genuinely single-token queries (e.g. a bare filename) — a calibration concern tracked separately, not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)