### PR TITLE
fix(surfacing): match write_tool_patterns against the server__tool full name

### DIFF
--- a/src/memtomem_stm/surfacing/relevance.py
+++ b/src/memtomem_stm/surfacing/relevance.py
@@ -67,9 +67,12 @@ class RelevanceGate:
                 self._observability.record_skip(tool, "gate_excluded_tool")
                 return False
 
-        # Write-tool heuristic
+        # Write-tool heuristic. Match against both the bare tool name and the
+        # ``server__tool`` full name — symmetric with ``exclude_tools`` above —
+        # so a write pattern can target a specific server's tool (e.g.
+        # ``github__create_*``) instead of only matching unqualified tool names.
         for pattern in self._config.write_tool_patterns:
-            if fnmatch(tool, pattern):
+            if fnmatch(full_name, pattern) or fnmatch(tool, pattern):
                 self._observability.record_skip(tool, "gate_write_tool")
                 return False
 

--- a/tests/test_relevance_gate.py
+++ b/tests/test_relevance_gate.py
@@ -45,6 +45,17 @@ class TestRelevanceGateExclusions:
         assert gate.should_surface("s", "list_repos", "query about listing repos")
         assert gate.should_surface("s", "get_issue", "query about getting issues")
 
+    def test_write_pattern_matches_server_prefixed_full_name(self):
+        # write_tool_patterns now matches the ``server__tool`` full name too
+        # (symmetric with exclude_tools), so a server-qualified write pattern
+        # gates that server's tool. Pre-fix it only matched the bare tool name,
+        # so ``github__sync_*`` never fired.
+        gate = _gate(write_tool_patterns=["github__sync_*"])
+        assert not gate.should_surface("github", "sync_state", "query text here")
+        # The same tool name on another server is not gated by the qualified
+        # pattern (and bare ``sync_state`` is not a default write verb).
+        assert gate.should_surface("gitlab", "sync_state", "query text here")
+
 
 class TestRelevanceGatePerTool:
     def test_per_tool_disabled(self):


### PR DESCRIPTION
PR5 — second of the surfacing-quality series (PR4 #387 query extraction; cache-hit dedup follows as PR6). Independent; branches from `main`.

## Problem

The surfacing gate's write-tool heuristic matched each pattern only against the **bare tool name**:

```python
for pattern in self._config.write_tool_patterns:
    if fnmatch(tool, pattern):  # tool only
```

while the sibling `exclude_tools` check just above matched **both** the bare name and the `server__tool` full name. That asymmetry meant a server-qualified write pattern (e.g. `github__create_*`) could never gate anything — the heuristic only ever compared it against the unqualified tool name.

## Fix

Match `write_tool_patterns` against both the bare name and `server__tool`, symmetric with `exclude_tools`, so an operator can scope a write pattern to one server's tool without also suppressing a same-named tool on other servers.

## Tests

A `github__sync_*` pattern gates `github/sync_state` but leaves `gitlab/sync_state` surfacing. Existing gate tests stay green (140 passed across the surfacing suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)