### PR TITLE
fix(compression): route multi-array dicts to SCHEMA_PRUNING by summed length

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1618,6 +1618,13 @@ def auto_select_strategy(text: str, *, max_chars: int = 0) -> CompressionStrateg
                 nested = sum(1 for v in data.values() if isinstance(v, (dict, list)))
                 if nested >= 3:
                     return CompressionStrategy.EXTRACT_FIELDS
+                # Several smaller arrays whose combined length is large (no single
+                # array ≥ 20, nested < 3) → schema_pruning preserves the shared row
+                # schema across every array, vs truncate dropping whole arrays once
+                # the byte budget runs out. Mirrors the top-level list ≥ 20 cutoff.
+                list_values = [v for v in data.values() if isinstance(v, list)]
+                if list_values and sum(len(v) for v in list_values) >= 20:
+                    return CompressionStrategy.SCHEMA_PRUNING
             return CompressionStrategy.TRUNCATE
         except (json.JSONDecodeError, ValueError):
             pass

--- a/tests/test_auto_select_adversarial.py
+++ b/tests/test_auto_select_adversarial.py
@@ -140,9 +140,26 @@ class TestJsonDictArrayBoundary:
 
     def test_dict_multiple_arrays_all_under_20(self):
         data = {"a": [{"k": i} for i in range(19)], "b": [{"k": i} for i in range(15)]}
-        # No array ≥ 20 → skip SCHEMA_PRUNING
-        # nested count = 2 (both lists) → < 3 → TRUNCATE
+        # No single array ≥ 20 and nested count = 2 (< 3), but the combined item
+        # count is 34 (≥ 20) → SCHEMA_PRUNING preserves the shared row schema
+        # across both arrays instead of TRUNCATE dropping a whole array.
+        assert auto_select_strategy(json.dumps(data), max_chars=10) == S.SCHEMA_PRUNING
+
+    def test_dict_two_small_arrays_sum_at_20(self):
+        # Combined length exactly at the 20-item boundary → SCHEMA_PRUNING.
+        data = {"a": [{"k": i} for i in range(11)], "b": [{"k": i} for i in range(9)]}
+        assert auto_select_strategy(json.dumps(data), max_chars=10) == S.SCHEMA_PRUNING
+
+    def test_dict_two_small_arrays_sum_19(self):
+        # Combined length 19 (< 20) and nested count 2 (< 3) → still TRUNCATE.
+        data = {"a": [{"k": i} for i in range(10)], "b": [{"k": i} for i in range(9)]}
         assert auto_select_strategy(json.dumps(data), max_chars=10) == S.TRUNCATE
+
+    def test_dict_scalar_arrays_sum_at_20(self):
+        # Summed-array routing is length-only (mirrors the top-level scalar-array
+        # cutoff in test_array_of_scalars_at_20); scalar arrays count too.
+        data = {"a": list(range(12)), "b": list(range(8))}
+        assert auto_select_strategy(json.dumps(data), max_chars=10) == S.SCHEMA_PRUNING
 
 
 # ── B5: JSON dict nested count (3 threshold) ──────────────────────────


### PR DESCRIPTION
## Summary

`auto_select_strategy` only routed a JSON dict to `SCHEMA_PRUNING` when a **single** array value held ≥ 20 items. A dict holding several *smaller* arrays whose combined length is large (e.g. `{"a": [19 rows], "b": [15 rows]}`) fell through to lossy `TRUNCATE`, which drops whole arrays once the byte budget runs out — even though `SCHEMA_PRUNING` would preserve the shared row schema across every array.

## Change

Add a summed-array check **after** the existing `nested >= 3 → EXTRACT_FIELDS` clause, so the lossless config-dict path is untouched:

```python
list_values = [v for v in data.values() if isinstance(v, list)]
if list_values and sum(len(v) for v in list_values) >= 20:
    return CompressionStrategy.SCHEMA_PRUNING
```

- Fires only when **no single array reaches 20** and **nested < 3** (the case that previously sank to `TRUNCATE`).
- Cutoff mirrors the top-level `list >= 20` rule and is **length-only**, so scalar arrays count too (consistent with `test_array_of_scalars_at_20`).
- Ordering keeps `nested >= 3 → EXTRACT_FIELDS` first, so every existing `EXTRACT_FIELDS` assertion stays green.
- No recursion into nested dict values (the `{"data": {...}}` envelope shape is a deferred follow-up).

## Behavior change

`test_dict_multiple_arrays_all_under_20` previously asserted `TRUNCATE` for `{"a": [19], "b": [15]}` (sum 34). It now asserts `SCHEMA_PRUNING` — the intended fix. Added `sum == 20` / `sum == 19` boundary tests and a scalar-array case to pin the new cutoff.

## Tests

`uv run pytest -m "not ollama"` compression sweep: 332 passed. Ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
