### PR TITLE
fix(surfacing): hash secret-bearing queries on the proxy persist path

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -10,6 +10,7 @@ import uuid
 from typing import Any
 
 from memtomem_stm.observability.tracing import traced
+from memtomem_stm.proxy.privacy import contains_sensitive_content
 from memtomem_stm.surfacing.cache import SurfacingCache
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.context_extractor import ContextExtractor
@@ -162,9 +163,25 @@ class SurfacingEngine:
         comparison, dedup, formatter rendering, etc.) intentionally keeps
         the raw text — this knob only governs **what gets persisted to
         disk**, nothing about the in-process surface call.
+
+        Secret guard: regardless of ``persist_query_text``, a query whose
+        text matches a known secret pattern (API key, bearer token, JWT,
+        ``password=``/``api_key=`` assignment, private-key header) is
+        hashed before persistence, so an inline credential in a Bash
+        ``command`` argument or a tokenized URL never reaches disk verbatim
+        on the proxy path (the hook/daemon cold paths already disable
+        persistence). Only the persisted value is affected — the in-flight
+        ``query`` keeps its raw text as described above.
         """
-        if self._config.persist_query_text:
-            return query
+        if not self._config.persist_query_text:
+            return self._hashed_query(query)
+        if contains_sensitive_content(query):
+            return self._hashed_query(query)
+        return query
+
+    @staticmethod
+    def _hashed_query(query: str) -> str:
+        """Return the stable ``sha256:`` + 16-hex-char digest form of *query*."""
         digest = hashlib.sha256(query.encode("utf-8")).hexdigest()[:16]
         return f"{_QUERY_HASH_PREFIX}{digest}"
 

--- a/tests/test_surfacing_persist_query_text.py
+++ b/tests/test_surfacing_persist_query_text.py
@@ -197,10 +197,10 @@ class TestSecretGuard:
     _SECRETS = [
         "git clone repo then sk-ABCDEFGHIJKLMNOPQRSTUVWX",
         "fetch url with api_key=abc12345",
-        "token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        "token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36",
         "psql password=hunter2secret",
         "aws AKIAIOSFODNN7EXAMPLE",
-        "gh ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345",
+        "gh ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
         "-----BEGIN RSA PRIVATE KEY-----",
     ]
     _CLEAN = [

--- a/tests/test_surfacing_persist_query_text.py
+++ b/tests/test_surfacing_persist_query_text.py
@@ -184,6 +184,90 @@ class TestEngineHashesPersistedQuery:
         assert a == b
 
 
+class TestSecretGuard:
+    """A secret-bearing query is hashed even when ``persist_query_text=True``.
+
+    Closes the proxy-path gap (#352 covered the opt-in knob, not secrets):
+    a Bash ``command`` argument or a tokenized URL carrying an inline
+    credential must never reach ``surfacing_events.query`` verbatim. The
+    literals below are each verified to match ``proxy.privacy``'s default
+    patterns; the clean queries are verified not to.
+    """
+
+    _SECRETS = [
+        "git clone repo then sk-ABCDEFGHIJKLMNOPQRSTUVWX",
+        "fetch url with api_key=abc12345",
+        "token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        "psql password=hunter2secret",
+        "aws AKIAIOSFODNN7EXAMPLE",
+        "gh ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345",
+        "-----BEGIN RSA PRIVATE KEY-----",
+    ]
+    _CLEAN = [
+        "find the authentication bug in login",
+        "refactor the token parser module",
+        "reset the user password screen please",
+    ]
+
+    @pytest.mark.parametrize("secret", _SECRETS)
+    async def test_secret_query_hashed_when_persist_true(self, secret):
+        # Default config → persist_query_text=True; the secret guard must
+        # still hash it before it reaches record_surfacing.
+        tracker = _make_tracker()
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter([FakeSearchResult(FakeChunk(), 0.9)]),
+            feedback_tracker=tracker,
+        )
+        await engine.surface("s", "Bash", {"_context_query": secret}, LONG_RESPONSE)
+
+        tracker.record_surfacing.assert_called_once()
+        persisted = tracker.record_surfacing.call_args.kwargs["query"]
+        assert persisted.startswith(_QUERY_HASH_PREFIX)
+        assert secret not in persisted
+        expected = _QUERY_HASH_PREFIX + hashlib.sha256(secret.encode("utf-8")).hexdigest()[:16]
+        assert persisted == expected
+
+    @pytest.mark.parametrize("clean", _CLEAN)
+    async def test_clean_query_literal_when_persist_true(self, clean):
+        # A non-secret query is unaffected by the guard — persisted raw so
+        # feedback ratings keyed on (tool, query) keep correlating.
+        tracker = _make_tracker()
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter([FakeSearchResult(FakeChunk(), 0.9)]),
+            feedback_tracker=tracker,
+        )
+        await engine.surface("s", "read_file", {"_context_query": clean}, LONG_RESPONSE)
+
+        tracker.record_surfacing.assert_called_once()
+        assert tracker.record_surfacing.call_args.kwargs["query"] == clean
+
+    async def test_secret_guard_unit_level(self):
+        # Direct unit assertion on the chokepoint, independent of surface().
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter([]),
+            feedback_tracker=_make_tracker(),
+        )
+        out = engine._persistable_query("sk-ABCDEFGHIJKLMNOPQRSTUVWX")
+        assert out.startswith(_QUERY_HASH_PREFIX)
+        assert engine._persistable_query("ordinary search text") == "ordinary search text"
+
+
+class TestPersistSitesRouteThroughGuard:
+    """Both persistence sites must funnel through ``_persistable_query`` so
+    the guard cannot be bypassed by one path. The cache-hit
+    (``_render_cached``) and miss (``_do_surface_miss``) call sites are
+    shape-identical, so pin them by source inspection."""
+
+    def test_both_persist_sites_wrap_query(self):
+        import inspect
+
+        s = inspect.getsource(SurfacingEngine)
+        assert s.count("query=self._persistable_query(query)") >= 2
+
+
 # ── 2. Store stats query_preview ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

The proxy/server surfacing path builds `SurfacingEngine` with the default config, so `persist_query_text` defaults `True` and the raw query is written to `surfacing_events.query` verbatim. A Bash `command` argument — or a tokenized `WebFetch` URL — can therefore land an **inline secret** (API key, bearer token, password) on disk.

The hook cold path (`record_feedback_events=False`) and the daemon path (`persist_query_text=False`) already mitigate this. Only the proxy path was exposed. `#352` shipped an opt-in hashing knob, not a secret guard.

## Fix

Add the guard inside `SurfacingEngine._persistable_query` — the single chokepoint both persist sites (`_render_cached` cache-hit + `_do_surface_miss` miss) already route through:

```python
if not self._config.persist_query_text:
    return self._hashed_query(query)
if contains_sensitive_content(query):
    return self._hashed_query(query)
return query
```

- **Detect-then-hash, all tools.** Reuses `proxy.privacy.contains_sensitive_content` (api_key / secret_key / `password=` / bearer / private-key header / JWT / AWS / `sk-…` / `ghp_…`). Tool-agnostic — secrets can ride in `WebFetch`/`Write` too, not just Bash.
- **No new config.** privacy.py's module docstring already anticipates this reuse.
- **No import cycle.** privacy.py imports only stdlib.
- **Disk-only.** Only the *persisted* value changes; the in-flight query used for cooldown, cache keys, formatting, webhooks and session dedup is untouched.
- **Clean queries persist as-is**, so feedback ratings keyed on `(tool, query)` still correlate (the 16-hex `sha256:` digest is deterministic for secret-bearing ones too).
- The digest logic is factored into `_hashed_query`, shared by the existing `persist_query_text=False` branch and the new guard.

## Tests

`tests/test_surfacing_persist_query_text.py` — `TestSecretGuard` + `TestPersistSitesRouteThroughGuard`:
- Parametrized over all seven secret-pattern families (each verified to match the real detector) driven end-to-end through `engine.surface()` with **default config** → hashed.
- Clean queries (verified not to match) → persisted literal.
- Unit assertion directly on the chokepoint.
- Source-inspection pin: both persist sites wrap the query in `_persistable_query`.

`uv run pytest -m "not ollama"` surfacing+privacy sweep: 667 passed. Ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
