### PR TITLE
feat(surfacing): configurable + validated auto-tune bounds, purge pinned adjustments

### DIFF
--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from memtomem_stm.proxy.config import MODEL_CONTEXT_WINDOWS
 
@@ -72,6 +72,13 @@ class SurfacingConfig(BaseModel):
     auto_tune_enabled: bool = True
     auto_tune_min_samples: int = Field(default=20, gt=0)
     auto_tune_score_increment: float = Field(default=0.002, gt=0.0)
+    auto_tune_score_ceiling: float = Field(default=0.05, gt=0.0, le=1.0)
+    """Upper bound auto-tuning may raise a tool's min_score to. Left at its
+    default it widens to ``max(0.05, min_score)`` so a stricter min_score
+    never breaks construction; set it explicitly to cap below the default."""
+    auto_tune_score_floor: float = Field(default=0.005, ge=0.0, le=1.0)
+    """Lower bound auto-tuning may lower a tool's min_score to. Left at its
+    default it widens to ``min(0.005, min_score)``."""
     min_response_chars: int = Field(default=5000, ge=0)
     include_session_context: bool = True
     fire_webhook: bool = True
@@ -112,6 +119,47 @@ class SurfacingConfig(BaseModel):
     core format (``[rank] score | source``). ``structured`` selects the
     machine-parseable JSON format (``{"results": [...]}``) with automatic
     version negotiation — falls back to compact if core is too old."""
+
+    @model_validator(mode="after")
+    def _validate_auto_tune_bounds(self) -> SurfacingConfig:
+        """Keep floor <= min_score <= ceiling and the increment no larger
+        than the band it moves within.
+
+        The default ceiling/floor (0.05 / 0.005) bracket the default
+        min_score (0.03). When an operator raises or lowers min_score
+        without touching the bounds, the unset bound widens to include it so
+        a previously-valid config never fails. Explicitly setting a bound on
+        the wrong side of min_score is a real misconfiguration and is
+        rejected.
+
+        The increment guard rejects only a step bigger than the whole
+        [floor, ceiling] band — such a step would jump from one clamp to the
+        other in a single adjustment. Sub-band increments (the 0.002 default
+        crosses the band in ~22 steps) are accepted as-is; calibrating the
+        step further is a wait-for-signal concern, not a constructor
+        constraint.
+        """
+        set_fields = self.model_fields_set
+        if "auto_tune_score_ceiling" not in set_fields:
+            self.auto_tune_score_ceiling = max(self.auto_tune_score_ceiling, self.min_score)
+        if "auto_tune_score_floor" not in set_fields:
+            self.auto_tune_score_floor = min(self.auto_tune_score_floor, self.min_score)
+
+        if not (self.auto_tune_score_floor <= self.min_score <= self.auto_tune_score_ceiling):
+            raise ValueError(
+                "auto-tune bounds must satisfy floor <= min_score <= ceiling; got "
+                f"floor={self.auto_tune_score_floor}, min_score={self.min_score}, "
+                f"ceiling={self.auto_tune_score_ceiling}"
+            )
+        band = self.auto_tune_score_ceiling - self.auto_tune_score_floor
+        if band > 0 and self.auto_tune_score_increment > band:
+            raise ValueError(
+                f"auto_tune_score_increment={self.auto_tune_score_increment} exceeds the "
+                f"auto-tune band [{self.auto_tune_score_floor}, "
+                f"{self.auto_tune_score_ceiling}] (width {band}); a single step would "
+                "jump the entire range. Reduce the increment or widen the band."
+            )
+        return self
 
     def _context_tokens(self) -> int | None:
         if not self.consumer_model:

--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -108,8 +108,7 @@ class AutoTuner:
         # every restart silently throws away the AutoTuner's view.
         self._adjustments: dict[str, float] = dict(store.load_adjustments())
         logger.info(
-            "AutoTuner bounds: floor=%.4f, ceiling=%.4f, increment=%.4f, "
-            "base min_score=%.4f",
+            "AutoTuner bounds: floor=%.4f, ceiling=%.4f, increment=%.4f, base min_score=%.4f",
             config.auto_tune_score_floor,
             config.auto_tune_score_ceiling,
             config.auto_tune_score_increment,

--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -107,6 +107,40 @@ class AutoTuner:
         # Resume tunings persisted from a previous process — without this
         # every restart silently throws away the AutoTuner's view.
         self._adjustments: dict[str, float] = dict(store.load_adjustments())
+        logger.info(
+            "AutoTuner bounds: floor=%.4f, ceiling=%.4f, increment=%.4f, "
+            "base min_score=%.4f",
+            config.auto_tune_score_floor,
+            config.auto_tune_score_ceiling,
+            config.auto_tune_score_increment,
+            config.min_score,
+        )
+        self._purge_pinned_adjustments()
+
+    def _purge_pinned_adjustments(self) -> None:
+        """Suppress persisted adjustments for operator-pinned tools.
+
+        When a per-tool ``min_score`` override is set the engine always uses
+        the pin (it skips ``maybe_adjust`` for that tool), so a previously
+        learned adjustment is inert. Drop it from the in-memory map so
+        ``get_min_score_snapshot`` and the surfacing stats don't report a
+        stale value. The persisted row is left intact, so removing the pin
+        later restores the learned threshold.
+        """
+        pinned = {
+            tool
+            for tool, tool_cfg in self._config.context_tools.items()
+            if tool_cfg.min_score is not None
+        }
+        purged = [tool for tool in self._adjustments if tool in pinned]
+        for tool in purged:
+            del self._adjustments[tool]
+        if purged:
+            logger.info(
+                "AutoTuner: suppressed %d persisted adjustment(s) for pinned tools: %s",
+                len(purged),
+                sorted(purged),
+            )
 
     def maybe_adjust(self, tool: str) -> float | None:
         """Check feedback ratios and adjust min_score for a tool.
@@ -149,7 +183,7 @@ class AutoTuner:
         # Raise wins over lower when both fire — defensive: negative
         # feedback is the stronger signal to suppress.
         if neg_ratio is not None and neg_ratio > 0.6:
-            new_score = min(current + increment, 0.05)
+            new_score = min(current + increment, self._config.auto_tune_score_ceiling)
             if new_score != current:
                 self._adjustments[tool] = new_score
                 self._store.save_adjustment(tool, new_score)
@@ -162,7 +196,7 @@ class AutoTuner:
                 )
                 return new_score
         elif helpful_ratio is not None and helpful_ratio > 0.8:
-            new_score = max(current - increment, 0.005)
+            new_score = max(current - increment, self._config.auto_tune_score_floor)
             if new_score != current:
                 self._adjustments[tool] = new_score
                 self._store.save_adjustment(tool, new_score)

--- a/tests/test_surfacing_autotune_bounds.py
+++ b/tests/test_surfacing_autotune_bounds.py
@@ -1,0 +1,119 @@
+"""AutoTuner configurable bounds + pinned-adjustment purge tests.
+
+Companion to test_surfacing_autotune.py. Covers the work that made the
+0.05 ceiling / 0.005 floor configurable + validated and that suppresses
+persisted adjustments for operator-pinned tools.
+
+Self-contained on purpose: builds its own ``MagicMock`` store and
+``SurfacingConfig`` so it does not depend on the sibling file's fixtures.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from memtomem_stm.surfacing.config import SurfacingConfig, ToolSurfacingConfig
+from memtomem_stm.surfacing.feedback import AutoTuner
+
+
+def _store(*, neg=None, helpful=None, adjustments=None):
+    from unittest.mock import MagicMock
+
+    store = MagicMock()
+    store.get_tool_negative_ratio.return_value = neg
+    store.get_tool_helpful_ratio.return_value = helpful
+    store.load_adjustments.return_value = dict(adjustments or {})
+    return store
+
+
+class TestConfigurableBounds:
+    """The clamp values come from config, replacing the old hard-coded
+    0.05 / 0.005 literals."""
+
+    def test_ceiling_caps_the_raise(self):
+        # Custom ceiling 0.04 < the legacy 0.05 — a raising tool stops at
+        # 0.04, proving the literal is gone.
+        cfg = SurfacingConfig(
+            auto_tune_enabled=True,
+            min_score=0.03,
+            auto_tune_score_increment=0.005,
+            auto_tune_score_ceiling=0.04,
+        )
+        tuner = AutoTuner(cfg, _store(neg=0.9, helpful=0.0))
+        for _ in range(20):
+            tuner.maybe_adjust("read_file")
+        assert tuner.get_effective_min_score("read_file") == cfg.auto_tune_score_ceiling
+
+    def test_floor_caps_the_lower(self):
+        cfg = SurfacingConfig(
+            auto_tune_enabled=True,
+            min_score=0.03,
+            auto_tune_score_increment=0.005,
+            auto_tune_score_floor=0.02,
+        )
+        tuner = AutoTuner(cfg, _store(neg=0.0, helpful=0.95))
+        for _ in range(20):
+            tuner.maybe_adjust("read_file")
+        assert tuner.get_effective_min_score("read_file") == cfg.auto_tune_score_floor
+
+    def test_default_bounds_unchanged(self):
+        cfg = SurfacingConfig()
+        assert cfg.auto_tune_score_ceiling == 0.05
+        assert cfg.auto_tune_score_floor == 0.005
+
+
+class TestBoundsValidation:
+    def test_unset_bounds_widen_to_admit_raised_min_score(self):
+        cfg = SurfacingConfig(min_score=0.1)
+        assert cfg.auto_tune_score_ceiling == 0.1
+        assert cfg.auto_tune_score_floor == 0.005
+
+    def test_unset_floor_widens_to_admit_lowered_min_score(self):
+        cfg = SurfacingConfig(min_score=0.0)
+        assert cfg.auto_tune_score_floor == 0.0
+
+    def test_explicit_bound_on_wrong_side_rejected(self):
+        with pytest.raises(ValueError, match="floor <= min_score <= ceiling"):
+            SurfacingConfig(min_score=0.1, auto_tune_score_ceiling=0.05)
+
+    def test_increment_larger_than_band_rejected(self):
+        with pytest.raises(ValueError, match="exceeds the auto-tune band"):
+            SurfacingConfig(auto_tune_score_increment=0.1)
+
+    def test_increment_within_band_accepted(self):
+        # 0.04 fits inside the default 0.045 band — the guard only rejects a
+        # step bigger than the whole band, not the old 5-step rule.
+        cfg = SurfacingConfig(auto_tune_score_increment=0.04)
+        assert cfg.auto_tune_score_increment == 0.04
+
+
+class TestPinPurge:
+    """A persisted adjustment for a pinned tool is dropped from the
+    in-memory map on construction (inert at read-time; would otherwise
+    pollute snapshots/stats). The persisted row is left intact."""
+
+    def test_pinned_tool_adjustment_suppressed(self):
+        cfg = SurfacingConfig(context_tools={"read_file": ToolSurfacingConfig(min_score=0.2)})
+        tuner = AutoTuner(cfg, _store(adjustments={"read_file": 0.04, "grep": 0.02}))
+        assert "read_file" not in tuner.adjustments
+        assert tuner.adjustments.get("grep") == 0.02
+
+    def test_unpinned_tool_adjustment_kept(self):
+        cfg = SurfacingConfig(context_tools={"read_file": ToolSurfacingConfig()})
+        tuner = AutoTuner(cfg, _store(adjustments={"read_file": 0.04}))
+        assert tuner.adjustments.get("read_file") == 0.04
+
+    def test_purge_is_in_memory_only(self):
+        # No save/delete round-trip on the store — suppression is in-memory.
+        cfg = SurfacingConfig(context_tools={"read_file": ToolSurfacingConfig(min_score=0.2)})
+        store = _store(adjustments={"read_file": 0.04})
+        AutoTuner(cfg, store)
+        store.save_adjustment.assert_not_called()
+
+    def test_purge_logs_count(self, caplog):
+        cfg = SurfacingConfig(context_tools={"read_file": ToolSurfacingConfig(min_score=0.2)})
+        with caplog.at_level(logging.INFO, logger="memtomem_stm.surfacing.feedback"):
+            AutoTuner(cfg, _store(adjustments={"read_file": 0.04}))
+        assert any("suppressed 1 persisted adjustment" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

The AutoTuner had three gaps around its min_score bounds:

1. **Hard-coded literals.** `maybe_adjust` clamped to `0.05` (ceiling) and `0.005` (floor) inline — unvalidated, not configurable.
2. **No validation** tying the bounds to `min_score`, nor any guard against an increment large enough to jump the whole range in one step.
3. **Stale pinned adjustments.** When an operator pins a per-tool `min_score`, the engine already skips `maybe_adjust` for that tool — but `__init__` still resurrected the persisted adjustment, so `get_min_score_snapshot` / `stm_surfacing_stats` reported a value the engine never applies.

## Changes (one coupled `SurfacingConfig` + `AutoTuner` path)

**1. Configurable bounds.** New `SurfacingConfig.auto_tune_score_ceiling` (default `0.05`) and `auto_tune_score_floor` (default `0.005`); `feedback.py` clamps against these. Defaults are **unchanged** — prior calibration notes flag the ceiling as having no empirical basis, so this makes them tunable without re-tuning.

**2. `model_validator`.** Enforces `floor <= min_score <= ceiling`. A bound left at its default **widens** to admit a raised/lowered `min_score`, so no previously-valid config breaks on upgrade; an explicit bound on the wrong side of `min_score` is rejected. The increment guard rejects only a step **larger than the whole band** (a single jump across the entire range) — sub-band increments, including the existing `0.01` test default, stay valid.

**3. Pin purge.** `__init__` drops in-memory adjustments for pinned tools (**in-memory only** — the persisted row is left intact so unpinning restores the learned value) and logs the suppressed count. Bounds are logged once at construction.

## Tests

New `tests/test_surfacing_autotune_bounds.py` (self-contained):
- `TestConfigurableBounds`: ceiling/floor caps replace the literals, default bounds unchanged.
- `TestBoundsValidation`: adaptive widening (raised + lowered min_score), wrong-side bound rejected, over-band increment rejected, in-band increment accepted.
- `TestPinPurge`: pinned adjustment suppressed, unpinned kept, store left untouched (no save/delete round-trip), purge count logged.

The existing `test_surfacing_autotune.py` stays green. `uv run pytest -m "not ollama"` surfacing+feedback+config sweep: 658 passed. Ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
