### PR TITLE
fix(compression): inject the manager's relevance scorer into SelectiveCompressor

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -539,6 +539,16 @@ class ProxyManager:
                 store.initialize()
         if store is not None:
             kwargs["store"] = store
+        # Inject the manager's relevance scorer so SELECTIVE/HYBRID rank their
+        # TOC with the operator's configured scorer (e.g. embedding) instead of
+        # SelectiveCompressor's built-in BM25 default. With the default bm25
+        # scorer this is a no-op (passing a BM25Scorer == the class default).
+        # The scorer is read via the self-refreshing property, so a compressor
+        # built after a scorer change picks up the new scorer; a scorer-only
+        # hot-reload that does not also change the selective config keeps the
+        # cached compressor (and its scorer) until the next rebuild — an
+        # accepted edge case, tracked as a follow-up.
+        kwargs["scorer"] = self._relevance_scorer
         return SelectiveCompressor(**kwargs)
 
     def _resolve_tool_config(


### PR DESCRIPTION
## Problem

`ProxyManager` builds its relevance scorer from config (`bm25` or `embedding`) and already injects it into `TruncateCompressor` — but `_create_selective` constructed `SelectiveCompressor` with **no `scorer=` argument**. So SELECTIVE and HYBRID always ranked their TOC with `SelectiveCompressor`'s built-in BM25 default, silently ignoring an operator-configured embedding scorer.

## Fix

Pass `self._relevance_scorer` when constructing the `SelectiveCompressor` in `_create_selective`. This covers both the SELECTIVE branch and HYBRID (which reuses the same cached selective compressor).

```python
kwargs["scorer"] = self._relevance_scorer
return SelectiveCompressor(**kwargs)
```

- **No-op for the default.** With the `bm25` default, an injected `BM25Scorer` equals the class default, so existing behavior and the #386 query-aware ranking are unchanged. Only embedding-configured deployments newly get embedding-based TOC relevance.
- **Hot-reload.** The scorer is read through the self-refreshing `_relevance_scorer` property, so a compressor built after a scorer change picks up the new scorer. A scorer-only hot-reload that does not also change the selective config keeps the cached compressor (and its scorer) until the next rebuild — an accepted edge case, noted in a code comment.

## Tests (`tests/test_query_aware.py::TestSelectiveScorerInjection`)

- `_create_selective` injects the manager's **exact** scorer instance (BM25 by default — identity check, not a fresh default).
- An embedding-configured manager yields a `SelectiveCompressor` backed by an `EmbeddingScorer`.

`uv run pytest -m "not ollama" tests/test_query_aware.py`: 36 passed. Ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
