### PR TITLE
fix(compression): make SCHEMA_PRUNING + SKELETON query-aware

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1177,12 +1177,16 @@ class SchemaPruningCompressor:
         handling (which would duplicate the uniform path's truncation).
         """
         # (relevant_max_str, irrelevant_max_str, irrelevant_max_array)
+        # irrelevant_max_array stays >= 2: _prune samples "first 2 + last 1", so
+        # max_array=1 on a 2-item array duplicates the tail and emits a bogus
+        # "(-1 items omitted)" marker (oversized, not pruned). The value lever
+        # for irrelevant keys is max_string, not the array cap.
         tiers = (
             (self._max_string, self._max_string, self._max_array),
             (self._max_string, 40, 2),
-            (self._max_string, 20, 1),
-            (40, 12, 1),
-            (20, 10, 1),
+            (self._max_string, 20, 2),
+            (40, 12, 2),
+            (20, 10, 2),
         )
         for rel_str, irr_str, irr_arr in tiers:
             pruned = {
@@ -1324,7 +1328,13 @@ class SkeletonCompressor:
             return [base] * n
 
         scored = [(heading, "\n".join(body)) for heading, body in sections]
-        scores = self._scorer.score_sections(context_query, scored)
+        # Clamp to non-negative: BM25 scores are always >= 0 (no-op, preserves
+        # byte-identity), but an EmbeddingScorer returns cosine similarities that
+        # can be negative. Raw negatives would skew the proportional split into
+        # negative/huge per-section budgets, overfilling early sections so the
+        # final hard slice drops trailing headings — breaking the skeleton's
+        # every-heading-survives invariant.
+        scores = [max(0.0, s) for s in self._scorer.score_sections(context_query, scored)]
         total = sum(scores)
         if total <= 0:
             return [base] * n

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1122,13 +1122,17 @@ class SchemaPruningCompressor:
         # keys most relevant to the query — relevant subtrees keep longer
         # strings and more array items, irrelevant ones are pruned harder.
         # Every key is still emitted (the schema invariant) and key order is
-        # untouched. With no query, no BM25 signal, or a non-object root the
-        # uniform path below runs and the output is byte-for-byte identical to
-        # the pre-query behavior.
+        # untouched. With no query, no BM25 signal, a single-key dict, or a
+        # non-object root the uniform path below runs and the output is
+        # byte-for-byte identical to the pre-query behavior. When the budget is
+        # too tight even for the weighted tiers, _compress_weighted returns None
+        # and we likewise fall through to the uniform minimal/final tier.
         if context_query and context_query.strip() and isinstance(data, dict) and len(data) >= 2:
             relevant = self._relevant_keys(data, context_query)
             if relevant is not None:
-                return self._compress_weighted(data, max_chars, relevant)
+                weighted = self._compress_weighted(data, max_chars, relevant)
+                if weighted is not None:
+                    return weighted
 
         # Iteratively reduce detail until output fits budget
         for max_str in (self._max_string, 40, 20):
@@ -1156,7 +1160,7 @@ class SchemaPruningCompressor:
             return None
         return {k for (k, _), s in zip(sections, scores) if s > 0}
 
-    def _compress_weighted(self, data: dict, max_chars: int, relevant: set[str]) -> str:
+    def _compress_weighted(self, data: dict, max_chars: int, relevant: set[str]) -> str | None:
         """Prune relevant keys gently and irrelevant keys hard, tightening to fit.
 
         The first tier keeps full default detail everywhere — identical to the
@@ -1165,6 +1169,12 @@ class SchemaPruningCompressor:
         tiers cap irrelevant subtrees first (relevant keys stay at full detail),
         and finally trim relevant keys too. Every key survives and key order is
         preserved.
+
+        Returns ``None`` when even the tightest tier overflows ``max_chars`` — at
+        that point all detail is already minimal and there is no relevance
+        preference left to keep, so the caller falls through to the uniform
+        minimal/final tier rather than this method carrying its own overflow
+        handling (which would duplicate the uniform path's truncation).
         """
         # (relevant_max_str, irrelevant_max_str, irrelevant_max_array)
         tiers = (
@@ -1187,12 +1197,7 @@ class SchemaPruningCompressor:
             if len(result) <= max_chars:
                 return result
 
-        # Final: minimal detail everywhere (mirrors the uniform final tier).
-        pruned = {k: self._prune(v, max_str=10, max_array=2) for k, v in data.items()}
-        result = json.dumps(pruned, ensure_ascii=False, indent=2)
-        if len(result) > max_chars:
-            result = result[:max_chars] + "\n... (pruned)"
-        return result
+        return None
 
     def _prune(self, data: object, max_str: int = 80, max_array: int | None = None) -> object:
         ma = max_array if max_array is not None else self._max_array

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1098,17 +1098,37 @@ class SchemaPruningCompressor:
                  "servers": ["s1", "s2", "... (2 items omitted)", "s5"]}
     """
 
-    def __init__(self, max_string: int = 80, max_array_items: int = 3) -> None:
+    def __init__(
+        self,
+        max_string: int = 80,
+        max_array_items: int = 3,
+        scorer: RelevanceScorer | None = None,
+    ) -> None:
         self._max_string = max_string
         self._max_array = max_array_items
+        self._scorer = scorer or BM25Scorer()
 
-    def compress(self, text: str, *, max_chars: int) -> str:
+    def compress(self, text: str, *, max_chars: int, context_query: str | None = None) -> str:
         if not text or len(text) <= max_chars:
             return text
         try:
             data = json.loads(text)
         except (json.JSONDecodeError, ValueError):
-            return TruncateCompressor().compress(text, max_chars=max_chars)
+            return TruncateCompressor(scorer=self._scorer).compress(
+                text, max_chars=max_chars, context_query=context_query
+            )
+
+        # Query-aware: for a top-level object, spend the value budget on the
+        # keys most relevant to the query — relevant subtrees keep longer
+        # strings and more array items, irrelevant ones are pruned harder.
+        # Every key is still emitted (the schema invariant) and key order is
+        # untouched. With no query, no BM25 signal, or a non-object root the
+        # uniform path below runs and the output is byte-for-byte identical to
+        # the pre-query behavior.
+        if context_query and context_query.strip() and isinstance(data, dict) and len(data) >= 2:
+            relevant = self._relevant_keys(data, context_query)
+            if relevant is not None:
+                return self._compress_weighted(data, max_chars, relevant)
 
         # Iteratively reduce detail until output fits budget
         for max_str in (self._max_string, 40, 20):
@@ -1119,6 +1139,56 @@ class SchemaPruningCompressor:
 
         # Final: minimal detail
         pruned = self._prune(data, max_str=10, max_array=2)
+        result = json.dumps(pruned, ensure_ascii=False, indent=2)
+        if len(result) > max_chars:
+            result = result[:max_chars] + "\n... (pruned)"
+        return result
+
+    def _relevant_keys(self, data: dict, context_query: str) -> set[str] | None:
+        """Top-level keys whose subtree scores against the query.
+
+        Returns ``None`` when no key scores (no BM25 signal), which tells the
+        caller to fall back to the uniform path for byte-identical output.
+        """
+        sections = [(k, json.dumps(v, ensure_ascii=False)) for k, v in data.items()]
+        scores = self._scorer.score_sections(context_query, sections)
+        if not any(s > 0 for s in scores):
+            return None
+        return {k for (k, _), s in zip(sections, scores) if s > 0}
+
+    def _compress_weighted(self, data: dict, max_chars: int, relevant: set[str]) -> str:
+        """Prune relevant keys gently and irrelevant keys hard, tightening to fit.
+
+        The first tier keeps full default detail everywhere — identical to the
+        uniform path — so when the whole object fits there is no needless
+        pruning of irrelevant keys. Only under real budget pressure do later
+        tiers cap irrelevant subtrees first (relevant keys stay at full detail),
+        and finally trim relevant keys too. Every key survives and key order is
+        preserved.
+        """
+        # (relevant_max_str, irrelevant_max_str, irrelevant_max_array)
+        tiers = (
+            (self._max_string, self._max_string, self._max_array),
+            (self._max_string, 40, 2),
+            (self._max_string, 20, 1),
+            (40, 12, 1),
+            (20, 10, 1),
+        )
+        for rel_str, irr_str, irr_arr in tiers:
+            pruned = {
+                k: self._prune(
+                    v,
+                    max_str=(rel_str if k in relevant else irr_str),
+                    max_array=(self._max_array if k in relevant else irr_arr),
+                )
+                for k, v in data.items()
+            }
+            result = json.dumps(pruned, ensure_ascii=False, indent=2)
+            if len(result) <= max_chars:
+                return result
+
+        # Final: minimal detail everywhere (mirrors the uniform final tier).
+        pruned = {k: self._prune(v, max_str=10, max_array=2) for k, v in data.items()}
         result = json.dumps(pruned, ensure_ascii=False, indent=2)
         if len(result) > max_chars:
             result = result[:max_chars] + "\n... (pruned)"
@@ -1161,42 +1231,57 @@ class SkeletonCompressor:
 
     _HEADING_RE = re.compile(r"^(#{1,6}\s.+)$", re.MULTILINE)
 
-    def compress(self, text: str, *, max_chars: int) -> str:
-        """Keep all headings + first content line per section."""
+    def __init__(self, scorer: RelevanceScorer | None = None) -> None:
+        self._scorer = scorer or BM25Scorer()
+
+    def compress(self, text: str, *, max_chars: int, context_query: str | None = None) -> str:
+        """Keep all headings + first content line per section.
+
+        When a context query is supplied, the per-section content budget is
+        weighted toward the sections most relevant to the query so they retain
+        more body lines; every heading still survives and section order is
+        preserved. With no query (or no BM25 signal) the budget is split evenly
+        and the output is byte-for-byte identical to the pre-query behavior.
+        """
         if not text or len(text) <= max_chars:
             return text
 
         headings = list(self._HEADING_RE.finditer(text))
         if len(headings) < 2:
-            return TruncateCompressor().compress(text, max_chars=max_chars)
+            return TruncateCompressor(scorer=self._scorer).compress(
+                text, max_chars=max_chars, context_query=context_query
+            )
 
-        # Build sections: heading + first few meaningful content lines
-        parts: list[str] = []
-        total_body_trimmed = 0
-        budget_per_section = max(60, (max_chars - 80) // len(headings))
-
+        # Slice each section once into (heading_line, body_lines).
+        sections: list[tuple[str, list[str]]] = []
         for i, m in enumerate(headings):
             sec_start = m.start()
             sec_end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
-            section = text[sec_start:sec_end].rstrip()
-            lines = section.split("\n")
+            lines = text[sec_start:sec_end].rstrip().split("\n")
+            body_lines = [ln for ln in lines[1:] if ln.strip()]
+            sections.append((lines[0], body_lines))
 
+        budgets = self._section_budgets(sections, max_chars, context_query)
+
+        # Build sections: heading + first content lines up to the budget.
+        parts: list[str] = []
+        total_body_trimmed = 0
+        for (heading, body_lines), budget in zip(sections, budgets):
             # Always keep the heading
-            kept = [lines[0]]
-            kept_chars = len(lines[0])
+            kept = [heading]
+            kept_chars = len(heading)
 
             # Measure total body content (non-empty, non-heading lines)
-            body_lines = [ln for ln in lines[1:] if ln.strip()]
             section_body_chars = sum(len(ln) for ln in body_lines)
 
             # Add content lines until per-section budget
             for line in body_lines:
-                if kept_chars + len(line) + 1 > budget_per_section:
+                if kept_chars + len(line) + 1 > budget:
                     break
                 kept.append(line)
                 kept_chars += len(line) + 1
 
-            kept_body_chars = kept_chars - len(lines[0])
+            kept_body_chars = kept_chars - len(heading)
             total_body_trimmed += max(0, section_body_chars - kept_body_chars)
 
             parts.append("\n".join(kept))
@@ -1211,6 +1296,37 @@ class SkeletonCompressor:
         if len(result) > max_chars:
             result = result[:max_chars]
         return result
+
+    def _section_budgets(
+        self,
+        sections: list[tuple[str, list[str]]],
+        max_chars: int,
+        context_query: str | None,
+    ) -> list[int]:
+        """Per-section content budget: even split unless a query reweights it.
+
+        Without a query (or with no BM25 signal) every section gets the same
+        ``max(60, (max_chars - 80) // n)`` budget as before — byte-identical.
+        With a query, every section keeps the 60-char floor and the remaining
+        budget is handed out in proportion to BM25 relevance, so the most
+        relevant sections retain more body lines. The weighted total never
+        exceeds the even-split total, so query-awareness adds no overshoot.
+        """
+        n = len(sections)
+        content_budget = max_chars - 80
+        base = max(60, content_budget // n)
+        if not (context_query and context_query.strip()):
+            return [base] * n
+
+        scored = [(heading, "\n".join(body)) for heading, body in sections]
+        scores = self._scorer.score_sections(context_query, scored)
+        total = sum(scores)
+        if total <= 0:
+            return [base] * n
+
+        floor = 60
+        remainder = max(0, content_budget - floor * n)
+        return [floor + int(remainder * s / total) for s in scores]
 
 
 class LLMCompressor:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -28,7 +28,9 @@ from memtomem_stm.proxy.cleaning import DefaultContentCleaner
 from memtomem_stm.proxy.compression import (
     HybridCompressor,
     LLMCompressor,
+    SchemaPruningCompressor,
     SelectiveCompressor,
+    SkeletonCompressor,
     TruncateCompressor,
     auto_select_strategy,
     count_markdown_headings,
@@ -746,6 +748,27 @@ class ProxyManager:
         if compression == CompressionStrategy.TRUNCATE:
             return (
                 TruncateCompressor(scorer=self._relevance_scorer).compress(
+                    text, max_chars=max_chars, context_query=context_query
+                ),
+                None,
+            )
+
+        # SCHEMA_PRUNING / SKELETON are query-aware (the manager's relevance
+        # scorer is injected and context_query forwarded), so they get explicit
+        # branches rather than the query-blind generic dispatch below. The
+        # remaining strategies routed through get_compressor (NONE, PROGRESSIVE,
+        # EXTRACT_FIELDS) take neither a scorer nor a context_query.
+        if compression == CompressionStrategy.SCHEMA_PRUNING:
+            return (
+                SchemaPruningCompressor(scorer=self._relevance_scorer).compress(
+                    text, max_chars=max_chars, context_query=context_query
+                ),
+                None,
+            )
+
+        if compression == CompressionStrategy.SKELETON:
+            return (
+                SkeletonCompressor(scorer=self._relevance_scorer).compress(
                     text, max_chars=max_chars, context_query=context_query
                 ),
                 None,

--- a/tests/bench/harness.py
+++ b/tests/bench/harness.py
@@ -344,8 +344,17 @@ class BenchHarness:
             budget = self._apply_retention(len(cleaned), budget)
 
             t0 = _time.monotonic()
-            # Pass context_query to TruncateCompressor for query-aware allocation
-            if context_query and isinstance(comp, TruncateCompressor):
+            # Forward context_query to the query-aware compressors (truncate,
+            # schema-pruning, skeleton, and selective/hybrid). The rest take no
+            # context_query, so guard on the types that accept it.
+            query_aware = (
+                TruncateCompressor,
+                SchemaPruningCompressor,
+                SkeletonCompressor,
+                SelectiveCompressor,
+                HybridCompressor,
+            )
+            if context_query and isinstance(comp, query_aware):
                 compressed = comp.compress(cleaned, max_chars=budget, context_query=context_query)
             else:
                 compressed = comp.compress(cleaned, max_chars=budget)

--- a/tests/test_query_aware_structural.py
+++ b/tests/test_query_aware_structural.py
@@ -35,7 +35,25 @@ from memtomem_stm.proxy.config import (
 )
 from memtomem_stm.proxy.manager import ProxyManager
 from memtomem_stm.proxy.metrics import TokenTracker
-from memtomem_stm.proxy.relevance import EmbeddingScorer
+
+
+class _RecordingScorer:
+    """A RelevanceScorer stub that records calls and scores by token overlap.
+
+    Used to prove a compressor actually *consults* the injected scorer (not just
+    stores it), without any network dependency.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+
+    def score_sections(self, query: str, sections: list[tuple[str, str]]) -> list[float]:
+        self.calls.append((query, len(sections)))
+        terms = query.lower().split()
+        return [
+            float(sum(t in f"{title} {body}".lower() for t in terms)) for title, body in sections
+        ]
+
 
 # A dict-of-arrays payload (the dominant SCHEMA_PRUNING routing trigger): three
 # top-level keys, each an array of records, only one of which matches the query.
@@ -125,6 +143,25 @@ class TestSchemaPruningQueryAware:
         base = c.compress(list_payload, max_chars=300)
         assert c.compress(list_payload, max_chars=300, context_query="anything here") == base
 
+    def test_single_key_dict_is_byte_identical(self) -> None:
+        # A single-key object has nothing to weight (len < 2) — the query path is
+        # skipped and the output matches the no-query path exactly.
+        payload = json.dumps(
+            {"orders": [{"oid": i, "total": 12.5, "desc": "order text " * 6} for i in range(25)]}
+        )
+        c = SchemaPruningCompressor()
+        base = c.compress(payload, max_chars=400)
+        assert c.compress(payload, max_chars=400, context_query="orders total") == base
+
+    def test_tight_budget_delegates_to_uniform_path(self) -> None:
+        # When the budget is too tight for the weighted tiers, _compress_weighted
+        # returns None and the query path falls through to the uniform minimal
+        # tier instead of carrying a divergent copy of the overflow handling —
+        # so the output is identical to the no-query path.
+        c = SchemaPruningCompressor()
+        base = c.compress(_PRUNE_PAYLOAD, max_chars=100)
+        assert c.compress(_PRUNE_PAYLOAD, max_chars=100, context_query="orders total") == base
+
 
 class TestSkeletonQueryAware:
     def test_no_query_is_byte_identical(self) -> None:
@@ -182,16 +219,24 @@ class TestStructuralScorerInjection:
     def test_schema_pruning_defaults_to_bm25(self) -> None:
         assert isinstance(SchemaPruningCompressor()._scorer, BM25Scorer)
 
-    def test_schema_pruning_accepts_injected_scorer(self) -> None:
-        scorer = EmbeddingScorer.__new__(EmbeddingScorer)  # no network, identity only
-        assert SchemaPruningCompressor(scorer=scorer)._scorer is scorer
-
     def test_skeleton_defaults_to_bm25(self) -> None:
         assert isinstance(SkeletonCompressor()._scorer, BM25Scorer)
 
-    def test_skeleton_accepts_injected_scorer(self) -> None:
-        scorer = BM25Scorer()
-        assert SkeletonCompressor(scorer=scorer)._scorer is scorer
+    def test_schema_pruning_consults_injected_scorer(self) -> None:
+        # Inject a recording scorer and confirm it is both stored AND used when a
+        # query drives compression (not merely held as an attribute).
+        scorer = _RecordingScorer()
+        c = SchemaPruningCompressor(scorer=scorer)
+        assert c._scorer is scorer
+        c.compress(_PRUNE_PAYLOAD, max_chars=900, context_query="orders total")
+        assert scorer.calls, "injected scorer was never consulted"
+
+    def test_skeleton_consults_injected_scorer(self) -> None:
+        scorer = _RecordingScorer()
+        c = SkeletonCompressor(scorer=scorer)
+        assert c._scorer is scorer
+        c.compress(_skeleton_doc(), max_chars=400, context_query="invoice payment billing")
+        assert scorer.calls, "injected scorer was never consulted"
 
 
 @pytest.mark.asyncio

--- a/tests/test_query_aware_structural.py
+++ b/tests/test_query_aware_structural.py
@@ -162,6 +162,31 @@ class TestSchemaPruningQueryAware:
         base = c.compress(_PRUNE_PAYLOAD, max_chars=100)
         assert c.compress(_PRUNE_PAYLOAD, max_chars=100, context_query="orders total") == base
 
+    def test_irrelevant_small_array_not_corrupted(self) -> None:
+        # Regression: the weighted tiers used to pass max_array=1 to _prune, which
+        # samples "first 2 + last 1" — on a 2-item irrelevant array that
+        # duplicated the tail and emitted a bogus "(-1 items omitted)" marker
+        # (oversized, not pruned). The array cap must stay >= 2.
+        class _OnlyOrders:
+            def score_sections(self, q, sections):
+                return [1.0 if k == "orders" else 0.0 for k, _ in sections]
+
+        payload = json.dumps(
+            {
+                "orders": [{"oid": i, "desc": "order text " * 8} for i in range(40)],
+                "flags": ["alpha", "beta"],  # irrelevant 2-item array
+            }
+        )
+        c = SchemaPruningCompressor(scorer=_OnlyOrders())
+        for budget in range(300, 1600, 50):
+            out = c.compress(payload, max_chars=budget, context_query="orders")
+            assert "items omitted" not in out or "(-1" not in out
+            assert "-1 items omitted" not in out
+            if out.strip().startswith("{") and not out.endswith("(pruned)"):
+                flags = json.loads(out).get("flags")
+                if isinstance(flags, list):
+                    assert flags == ["alpha", "beta"], f"budget={budget}: {flags}"
+
 
 class TestSkeletonQueryAware:
     def test_no_query_is_byte_identical(self) -> None:
@@ -213,6 +238,22 @@ class TestSkeletonQueryAware:
         assert _block(bill_q, "## Billing").count("invoice") > _block(auth_q, "## Billing").count(
             "invoice"
         )
+
+    def test_negative_scores_do_not_drop_headings(self) -> None:
+        # Regression: an EmbeddingScorer returns cosine similarities that can be
+        # negative. Raw negatives used to skew the proportional budget so one
+        # section overfilled and the final hard slice dropped trailing headings.
+        # Scores are clamped to >= 0, so every heading must still survive.
+        class _NegScorer:
+            def score_sections(self, q, sections):
+                return [0.9, -0.8, 0.7, -0.7][: len(sections)]
+
+        doc = _skeleton_doc()
+        out = SkeletonCompressor(scorer=_NegScorer()).compress(
+            doc, max_chars=400, context_query="q"
+        )
+        assert all(h in out for h in ["## Auth", "## Billing", "## Logging", "## Metrics"])
+        assert len(out) <= 400
 
 
 class TestStructuralScorerInjection:

--- a/tests/test_query_aware_structural.py
+++ b/tests/test_query_aware_structural.py
@@ -1,0 +1,243 @@
+"""Query-aware wiring for SCHEMA_PRUNING / SKELETON structural compressors.
+
+Extends the #386 SELECTIVE / Hybrid-TOC query-awareness to the two structural
+compressors that previously ranked purely by position. Both now accept a
+``context_query`` and the manager's relevance scorer:
+
+* ``SchemaPruningCompressor`` keeps every key (the schema invariant) but spends
+  the value budget on the keys most relevant to the query — relevant subtrees
+  keep longer strings / more array items, irrelevant ones are pruned harder.
+* ``SkeletonCompressor`` keeps every heading but weights the per-section content
+  budget toward the most relevant sections so they retain more body lines.
+
+The load-bearing invariant is byte-for-byte identity when there is no query (or
+no BM25 signal): the compressors fall back to the exact pre-query behavior.
+``field_extract`` is intentionally left position-ranked (BM25 over short keys is
+a weak signal) — reopen if a user reports a dropped query-relevant key.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from memtomem_stm.proxy.compression import (
+    BM25Scorer,
+    SchemaPruningCompressor,
+    SkeletonCompressor,
+)
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ProxyConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager
+from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.relevance import EmbeddingScorer
+
+# A dict-of-arrays payload (the dominant SCHEMA_PRUNING routing trigger): three
+# top-level keys, each an array of records, only one of which matches the query.
+_PRUNE_PAYLOAD = json.dumps(
+    {
+        "users": [{"id": i, "name": "Alice", "bio": "long biography text " * 4} for i in range(22)],
+        "orders": [
+            {"oid": i, "total": 12.5, "desc": "order description text " * 4} for i in range(22)
+        ],
+        "logs": ["log line %d verbose detail text here and more" % i for i in range(22)],
+    }
+)
+
+
+# A multi-section markdown doc with multi-line bodies so the per-section budget
+# actually governs how many body lines survive.
+def _skeleton_doc() -> str:
+    def section(name: str, term: str) -> str:
+        lines = "\n".join(f"{term} detail line {i} explains more" for i in range(8))
+        return f"## {name}\n{lines}\n\n"
+
+    return (
+        section("Auth", "jwt oauth")
+        + section("Billing", "invoice payment")
+        + section("Logging", "log rotation")
+        + section("Metrics", "counter gauge")
+    )
+
+
+def _block(rendered: str, heading: str) -> str:
+    """Return the rendered text of a single section (heading → next heading)."""
+    return rendered.split(heading, 1)[1].split("##", 1)[0]
+
+
+class TestSchemaPruningQueryAware:
+    def test_no_query_is_byte_identical(self) -> None:
+        c = SchemaPruningCompressor()
+        base = c.compress(_PRUNE_PAYLOAD, max_chars=900)
+        assert c.compress(_PRUNE_PAYLOAD, max_chars=900, context_query=None) == base
+
+    def test_irrelevant_query_is_byte_identical(self) -> None:
+        # No top-level key scores → falls back to the uniform path verbatim.
+        c = SchemaPruningCompressor()
+        base = c.compress(_PRUNE_PAYLOAD, max_chars=900)
+        assert c.compress(_PRUNE_PAYLOAD, max_chars=900, context_query="zzzzz qqqqq") == base
+
+    def test_query_keeps_more_of_the_relevant_key(self) -> None:
+        c = SchemaPruningCompressor()
+        base = json.loads(c.compress(_PRUNE_PAYLOAD, max_chars=900))
+        out = json.loads(c.compress(_PRUNE_PAYLOAD, max_chars=900, context_query="orders total"))
+        # Under budget pressure the relevant subtree retains strictly more detail.
+        assert len(json.dumps(out["orders"])) > len(json.dumps(base["orders"]))
+
+    def test_all_keys_survive_with_query(self) -> None:
+        c = SchemaPruningCompressor()
+        out = json.loads(c.compress(_PRUNE_PAYLOAD, max_chars=900, context_query="orders total"))
+        assert set(out.keys()) == {"users", "orders", "logs"}
+
+    def test_output_respects_budget(self) -> None:
+        c = SchemaPruningCompressor()
+        assert len(c.compress(_PRUNE_PAYLOAD, max_chars=900, context_query="orders total")) <= 900
+
+    def test_full_payload_fits_means_no_needless_pruning(self) -> None:
+        # When the whole object fits at default detail, the query must not prune
+        # irrelevant keys harder than the uniform path — both are identical.
+        c = SchemaPruningCompressor()
+        base = c.compress(_PRUNE_PAYLOAD, max_chars=4000)
+        assert c.compress(_PRUNE_PAYLOAD, max_chars=4000, context_query="orders total") == base
+
+    def test_query_relevance_follows_the_query(self) -> None:
+        # A query for a different key shifts the retained detail to that key.
+        c = SchemaPruningCompressor()
+        users_q = json.loads(
+            c.compress(_PRUNE_PAYLOAD, max_chars=900, context_query="users name bio")
+        )
+        orders_q = json.loads(
+            c.compress(_PRUNE_PAYLOAD, max_chars=900, context_query="orders total desc")
+        )
+        assert len(json.dumps(users_q["users"])) > len(json.dumps(orders_q["users"]))
+        assert len(json.dumps(orders_q["orders"])) > len(json.dumps(users_q["orders"]))
+
+    def test_non_object_root_is_byte_identical(self) -> None:
+        # Top-level arrays have no keys to weight — query-awareness is deferred,
+        # so a query must not change the output.
+        list_payload = json.dumps([{"k": "v " * 20, "n": i} for i in range(30)])
+        c = SchemaPruningCompressor()
+        base = c.compress(list_payload, max_chars=300)
+        assert c.compress(list_payload, max_chars=300, context_query="anything here") == base
+
+
+class TestSkeletonQueryAware:
+    def test_no_query_is_byte_identical(self) -> None:
+        doc = _skeleton_doc()
+        c = SkeletonCompressor()
+        base = c.compress(doc, max_chars=400)
+        assert c.compress(doc, max_chars=400, context_query=None) == base
+
+    def test_irrelevant_query_is_byte_identical(self) -> None:
+        doc = _skeleton_doc()
+        c = SkeletonCompressor()
+        base = c.compress(doc, max_chars=400)
+        assert c.compress(doc, max_chars=400, context_query="zzzzz qqqqq") == base
+
+    def test_query_keeps_more_body_in_the_relevant_section(self) -> None:
+        doc = _skeleton_doc()
+        c = SkeletonCompressor()
+        base = c.compress(doc, max_chars=400)
+        out = c.compress(doc, max_chars=400, context_query="invoice payment billing")
+        assert _block(out, "## Billing").count("invoice") > _block(base, "## Billing").count(
+            "invoice"
+        )
+
+    def test_all_headings_survive_with_query(self) -> None:
+        doc = _skeleton_doc()
+        out = SkeletonCompressor().compress(
+            doc, max_chars=400, context_query="invoice payment billing"
+        )
+        assert all(h in out for h in ["## Auth", "## Billing", "## Logging", "## Metrics"])
+
+    def test_section_order_is_preserved(self) -> None:
+        doc = _skeleton_doc()
+        out = SkeletonCompressor().compress(doc, max_chars=400, context_query="invoice payment")
+        positions = [out.index(h) for h in ["## Auth", "## Billing", "## Logging", "## Metrics"]]
+        assert positions == sorted(positions)
+
+    def test_output_respects_budget(self) -> None:
+        doc = _skeleton_doc()
+        out = SkeletonCompressor().compress(doc, max_chars=400, context_query="invoice payment")
+        assert len(out) <= 400
+
+    def test_relevance_follows_the_query(self) -> None:
+        # Querying for Auth surfaces Auth's body instead of Billing's.
+        doc = _skeleton_doc()
+        c = SkeletonCompressor()
+        auth_q = c.compress(doc, max_chars=400, context_query="jwt oauth auth")
+        bill_q = c.compress(doc, max_chars=400, context_query="invoice payment billing")
+        assert _block(auth_q, "## Auth").count("jwt") > _block(bill_q, "## Auth").count("jwt")
+        assert _block(bill_q, "## Billing").count("invoice") > _block(auth_q, "## Billing").count(
+            "invoice"
+        )
+
+
+class TestStructuralScorerInjection:
+    def test_schema_pruning_defaults_to_bm25(self) -> None:
+        assert isinstance(SchemaPruningCompressor()._scorer, BM25Scorer)
+
+    def test_schema_pruning_accepts_injected_scorer(self) -> None:
+        scorer = EmbeddingScorer.__new__(EmbeddingScorer)  # no network, identity only
+        assert SchemaPruningCompressor(scorer=scorer)._scorer is scorer
+
+    def test_skeleton_defaults_to_bm25(self) -> None:
+        assert isinstance(SkeletonCompressor()._scorer, BM25Scorer)
+
+    def test_skeleton_accepts_injected_scorer(self) -> None:
+        scorer = BM25Scorer()
+        assert SkeletonCompressor(scorer=scorer)._scorer is scorer
+
+
+@pytest.mark.asyncio
+class TestManagerStructuralForwardsQuery:
+    @pytest.mark.parametrize(
+        "strategy, class_name",
+        [
+            (CompressionStrategy.SCHEMA_PRUNING, "SchemaPruningCompressor"),
+            (CompressionStrategy.SKELETON, "SkeletonCompressor"),
+        ],
+    )
+    async def test_forwards_query_and_injects_scorer(
+        self, tmp_path, monkeypatch, strategy, class_name
+    ) -> None:
+        proxy_cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={"srv": UpstreamServerConfig(prefix="test", compression=strategy)},
+        )
+        mgr = ProxyManager(proxy_cfg, TokenTracker(metrics_store=None))
+
+        captured: dict[str, object] = {}
+
+        def fake_factory(*, scorer=None):
+            captured["scorer"] = scorer
+
+            def compress(text, *, max_chars, context_query=None):
+                captured["context_query"] = context_query
+                return "OUT"
+
+            return SimpleNamespace(compress=compress)
+
+        monkeypatch.setattr(f"memtomem_stm.proxy.manager.{class_name}", fake_factory)
+
+        out, fallback = await mgr._apply_compression(
+            "x" * 500,
+            strategy,
+            100,
+            None,  # sel_cfg
+            None,  # llm_cfg
+            None,  # hybrid_cfg
+            "srv",
+            "tool",
+            context_query="orders total",
+        )
+        assert out == "OUT"
+        assert fallback is None
+        assert captured["context_query"] == "orders total"
+        # The manager injects its own (hot-reload-aware) relevance scorer.
+        assert captured["scorer"] is mgr._relevance_scorer


### PR DESCRIPTION
## What

Extends the #386 SELECTIVE / Hybrid-TOC query-awareness to the two structural compressors that still ranked purely by position. When a `context_query` is present, each one steers *what it keeps* toward the query; with no query (or no BM25 signal) both fall back to **byte-for-byte identical** output.

- **`SchemaPruningCompressor`** — for a top-level object whose keys score against the query, prune relevant subtrees gently and irrelevant ones hard (longer strings / more array items for the matching keys). The first tier keeps full default detail everywhere, so a payload that already fits is never pruned more than the uniform path. **Every key survives and key order is preserved** — mirrors `TruncateCompressor._json_key_truncate`.
- **`SkeletonCompressor`** — weight the per-section content budget by BM25 relevance (every section keeps a 60-char floor; the remainder is handed out by score) so relevant sections retain more body lines. **Section order and every heading are preserved** — mirrors `TruncateCompressor._section_aware_truncate`. The weighted total never exceeds the even-split total, so query-awareness adds no overshoot.
- **manager** — `SCHEMA_PRUNING` / `SKELETON` get explicit dispatch branches in `_apply_compression` that inject the manager's relevance scorer and forward `context_query`, exactly like `TRUNCATE` / `SELECTIVE`. The generic `get_compressor` fallback (NONE, PROGRESSIVE, EXTRACT_FIELDS) is unchanged — `NoopCompressor.compress` takes no `context_query`. This is the sole compression dispatch site (the main pipeline and the AUTO branch both route through it).

## Design notes

- **Load-bearing invariant:** with `context_query=None`, an empty/whitespace query, a no-signal query, a single-key object, or a non-object root, both compressors run the exact pre-query path. Pinned by `test_*_is_byte_identical` tests.
- **Reorder vs. reallocate:** these compressors emit a reduced *document* (not an index like the SELECTIVE TOC), so reordering content would corrupt document/key order. Instead we reallocate the keep-budget by relevance — the established in-repo pattern for these exact content types (`_section_aware_truncate`, `_json_key_truncate`).
- **`field_extract` is intentionally left position-ranked** — BM25 over short keys is a weak signal. Reopen if a user reports a dropped query-relevant key. Top-level arrays under schema-pruning are likewise deferred (no keys to weight).

## Out of scope (pre-existing, deferred)

`SchemaPruningCompressor`'s uniform final tier (`result[:max_chars] + "... (pruned)"`) both overshoots `max_chars` by the suffix length and can emit invalid JSON. This is a **pre-existing** gap (predates this change) that the manager retention guard mitigates in production; the proper fix for schema-pruning is non-trivial because it can't drop keys (the schema invariant). The query path here does **not** duplicate that handling — `_compress_weighted` returns `None` at a too-tight budget and delegates to the single uniform site, so at tight budgets the query output equals the no-query output.

## Tests

New `tests/test_query_aware_structural.py`: byte-identity (incl. single-key dict and tight-budget delegation), relevant-key/section enrichment, all-keys/all-headings survival, section-order preservation, no-waste-when-it-fits, non-object-root deferral, scorer **consultation** (recording stub), and manager forwarding + scorer injection for both strategies. The bench harness now forwards `context_query` to every query-aware compressor (no-op for current callers; removes a silent-drop trap).

Full suite: no new failures past the 2 known pre-existing py3.13 stdio-teardown flakes (`test_double_start_no_leak`, `test_search_returns_empty_when_no_session`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)