### PR TITLE
fix(compression): valid-JSON, within-budget final tier for SchemaPruning

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1240,7 +1240,12 @@ class SchemaPruningCompressor:
             omitted = n - min(2, n) - 1
             return head + [f"... ({omitted} items omitted)"] + tail
         if isinstance(data, str) and len(data) > max_str:
-            return data[:max_str] + "..."
+            # Never let the "..." ellipsis make the value LONGER than the
+            # original (e.g. a 2-char string at max_str=1). This keeps a very
+            # small max_str (used by the final tier to shrink values before
+            # dropping keys) from ever inflating short strings.
+            truncated = data[:max_str] + "..."
+            return truncated if len(truncated) < len(data) else data
         return data
 
     def _fit_minimal(self, data: object, max_chars: int) -> str:
@@ -1250,10 +1255,11 @@ class SchemaPruningCompressor:
         keeps every key and never drops whole items (the all-keys schema
         invariant). Degrades gracefully, validity and budget always held:
 
-        1. Keep EVERY top-level key, progressively collapsing the deepest nested
-           levels to compact shape stubs (``{N keys}`` / ``[N items]``) until the
-           object fits — so the agent still sees the full top-level schema, and
-           nested detail survives in proportion to the budget.
+        1. Keep EVERY top-level key, escalating value compression until it fits:
+           first collapse the deepest nested levels to shape stubs (``{N keys}``
+           / ``[N items]``), then shrink scalar strings — so the agent still sees
+           the full top-level schema, with nested/string detail surviving in
+           proportion to the budget.
         2. Only when the top-level keys *themselves* cannot fit (a wide object /
            array, where the key names alone exceed the budget) drop whole
            trailing keys/items into a valid marker.
@@ -1261,42 +1267,67 @@ class SchemaPruningCompressor:
            validity wins over the length cap (a budget the manager retention
            ladder never produces). Keys/items are dropped by position; at this
            tier all detail is uniform, so there is no relevance preference left.
+
+        Scalar roots have no keys to preserve, so they bypass the container
+        tiers and shrink the value directly (a string keeps a prefix; any other
+        scalar floors to ``null``).
         """
-        # Tier 1: all keys, shrinking nested depth (None == full depth, the old
-        # minimal tier). Deepest collapse keeps top-level keys with stub values.
-        for max_depth in (None, 3, 2, 1):
-            pruned = self._prune(data, max_str=10, max_array=2, max_depth=max_depth)
-            result = json.dumps(pruned, ensure_ascii=False, indent=2)
-            if len(result) <= max_chars:
-                return result
+        if isinstance(data, (dict, list)) and data:
+            # Tier 1: keep EVERY key/item, escalating value compression until it
+            # fits — collapse the deepest nesting to shape stubs, then shrink
+            # scalar strings (10 -> 4 -> 0 chars). Dropping a key is a last resort
+            # (Tier 2); a smaller stub value is always preferred. (max_str,
+            # max_depth); ``max_depth=None`` == full depth == byte-identical to
+            # the pre-final-tier behavior.
+            for max_str, max_depth in ((10, None), (10, 3), (10, 2), (10, 1), (4, 1), (0, 1)):
+                pruned = self._prune(data, max_str=max_str, max_array=2, max_depth=max_depth)
+                result = json.dumps(pruned, ensure_ascii=False, indent=2)
+                if len(result) <= max_chars:
+                    return result
 
-        # Tier 2: even the all-keys forms overflow — drop trailing keys/items.
-        if isinstance(data, dict) and data:
-            # Depth-1 form (stub values) so as many keys as possible survive.
-            items = list(self._prune(data, max_str=10, max_array=2, max_depth=1).items())
-            total = len(items)
-            # Collision-safe marker key: never clobber a real top-level "_pruned"
-            # field (that would lose its value AND skew the omitted count).
-            marker = "_pruned"
-            existing = {k for k, _ in items}
-            while marker in existing:
-                marker += "_"
-            for keep in range(total - 1, -1, -1):
-                kept = dict(items[:keep])
-                kept[marker] = f"{total - keep} of {total} keys omitted"
-                candidate = json.dumps(kept, ensure_ascii=False, indent=2)
-                if len(candidate) <= max_chars:
-                    return candidate
-            return "{}"
+            # Tier 2: even the most compact all-keys form overflows — the
+            # top-level keys themselves don't fit, so drop whole trailing ones.
+            if isinstance(data, dict):
+                # Most compact value form (stubbed nesting + minimal strings) so
+                # as many keys as possible survive before any are dropped.
+                items = list(self._prune(data, max_str=0, max_array=2, max_depth=1).items())
+                total = len(items)
+                # Collision-safe marker key: never clobber (or repurpose as the
+                # marker) a real top-level "_pruned" field, which would skew the
+                # omitted count and replace the user's key.
+                marker = "_pruned"
+                existing = {k for k, _ in items}
+                while marker in existing:
+                    marker += "_"
 
-        if isinstance(data, list) and data:
-            # Count against the ORIGINAL length: _prune already samples a long
-            # list, so counting the sampled form understates omissions by orders
-            # of magnitude. Show head elements (depth-1 stubs) + an exact marker.
+                def _candidate(keep: int) -> str:
+                    kept = dict(items[:keep])
+                    kept[marker] = f"{total - keep} of {total} keys omitted"
+                    return json.dumps(kept, ensure_ascii=False, indent=2)
+
+                # ``len(_candidate(keep))`` is monotonic in ``keep`` (each extra
+                # key adds far more than the marker's digit change), so
+                # binary-search the largest prefix that fits instead of dumping
+                # every prefix — O(log n) serializations, not O(n) (a wide object
+                # used to stall here).
+                lo, hi, best = 0, total - 1, None
+                while lo <= hi:
+                    mid = (lo + hi) // 2
+                    candidate = _candidate(mid)
+                    if len(candidate) <= max_chars:
+                        best, lo = candidate, mid + 1
+                    else:
+                        hi = mid - 1
+                return best if best is not None else "{}"
+
+            # list: count against the ORIGINAL length — _prune already samples a
+            # long list, so counting the sampled form understates omissions by
+            # orders of magnitude. Show head elements (most compact) + an exact
+            # marker.
             total = len(data)
             for keep in range(min(2, total), -1, -1):
                 shown: list[object] = [
-                    self._prune(data[i], max_str=10, max_array=2, max_depth=1) for i in range(keep)
+                    self._prune(data[i], max_str=0, max_array=2, max_depth=1) for i in range(keep)
                 ]
                 shown.append(f"... ({total - keep} of {total} items omitted)")
                 candidate = json.dumps(shown, ensure_ascii=False, indent=2)
@@ -1304,22 +1335,24 @@ class SchemaPruningCompressor:
                     return candidate
             return "[]"
 
-        # Scalar root or empty container: always emit a VALID token that fits.
-        # An empty object/array keeps its type ("{}"/"[]"); a string shrinks to a
-        # shorter valid JSON string (down to ``""``); any other scalar has no
-        # shorter same-type form, so emit a valid ``null`` rather than a
-        # mid-token slice — validity wins over the length cap (as for {}/[]/"").
-        pruned = self._prune(data, max_str=10, max_array=2)
+        # Scalar root or empty container: emit the shortest VALID token that
+        # fits. An empty object/array keeps its type; a string keeps a prefix
+        # (down to ``""``); any other scalar floors to a valid ``null`` rather
+        # than a mid-token slice — validity wins over the cap (as for {}/[]/"").
+        if isinstance(data, dict):
+            return "{}"
+        if isinstance(data, list):
+            return "[]"
+        pruned = self._prune(data, max_str=10)
         if isinstance(pruned, str):
+            result = json.dumps(pruned, ensure_ascii=False)
+            if len(result) <= max_chars:
+                return result
             for k in range(len(pruned), -1, -1):
                 candidate = json.dumps(pruned[:k], ensure_ascii=False)
                 if len(candidate) <= max_chars:
                     return candidate
             return '""'
-        if isinstance(pruned, dict):
-            return "{}"
-        if isinstance(pruned, list):
-            return "[]"
         return "null"
 
 

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1087,8 +1087,15 @@ class SchemaPruningCompressor:
 
     Strategy: recursively walk JSON tree, preserving the full key structure.
     Arrays are sampled (first 2 + last 1 + count), strings are capped.
-    This ensures every configuration field, every nested key, and every
-    data relationship is represented in the output.
+    At a normal budget this represents every configuration field, every nested
+    key, and every data relationship in the output.
+
+    When the budget physically cannot hold the full schema, the final tier
+    (``_fit_minimal``) degrades gracefully and always emits valid JSON within
+    budget: the deepest nesting collapses to shape stubs (``{N keys}`` /
+    ``[N items]``) first, and only if the top-level keys themselves overflow are
+    whole trailing keys/items dropped into a marker. So "all keys / every nested
+    key" is the normal-budget guarantee, not an unconditional one.
 
     Example — nested config with a long array (all keys preserved, array sampled)::
 
@@ -1141,12 +1148,10 @@ class SchemaPruningCompressor:
             if len(result) <= max_chars:
                 return result
 
-        # Final: minimal detail
-        pruned = self._prune(data, max_str=10, max_array=2)
-        result = json.dumps(pruned, ensure_ascii=False, indent=2)
-        if len(result) > max_chars:
-            result = result[:max_chars] + "\n... (pruned)"
-        return result
+        # Final tier: emit VALID JSON within the budget. The old
+        # ``result[:max_chars] + "... (pruned)"`` hard slice cut JSON mid-token
+        # (invalid output) and overshot the budget by the suffix length.
+        return self._fit_minimal(data, max_chars)
 
     def _relevant_keys(self, data: dict, context_query: str) -> set[str] | None:
         """Top-level keys whose subtree scores against the query.
@@ -1203,22 +1208,119 @@ class SchemaPruningCompressor:
 
         return None
 
-    def _prune(self, data: object, max_str: int = 80, max_array: int | None = None) -> object:
+    def _prune(
+        self,
+        data: object,
+        max_str: int = 80,
+        max_array: int | None = None,
+        max_depth: int | None = None,
+        _depth: int = 0,
+    ) -> object:
         ma = max_array if max_array is not None else self._max_array
+        # Depth cap (final-tier only): collapse a nested container to a compact
+        # shape stub so every shallower key still survives. ``max_depth=None``
+        # (the default for all earlier tiers) keeps full depth — byte-identical
+        # to the pre-depth behavior.
+        if max_depth is not None and _depth >= max_depth:
+            if isinstance(data, dict):
+                return f"{{{len(data)} keys}}"
+            if isinstance(data, list):
+                return f"[{len(data)} items]"
         if isinstance(data, dict):
-            return {k: self._prune(v, max_str, ma) for k, v in data.items()}
+            return {k: self._prune(v, max_str, ma, max_depth, _depth + 1) for k, v in data.items()}
         if isinstance(data, list):
             n = len(data)
             if n <= ma:
-                return [self._prune(item, max_str, ma) for item in data]
+                return [self._prune(item, max_str, ma, max_depth, _depth + 1) for item in data]
             # First 2 + last 1 + count (preserves head and tail anomalies)
-            head = [self._prune(data[i], max_str, ma) for i in range(min(2, n))]
-            tail = [self._prune(data[-1], max_str, ma)]
+            head = [
+                self._prune(data[i], max_str, ma, max_depth, _depth + 1) for i in range(min(2, n))
+            ]
+            tail = [self._prune(data[-1], max_str, ma, max_depth, _depth + 1)]
             omitted = n - min(2, n) - 1
             return head + [f"... ({omitted} items omitted)"] + tail
         if isinstance(data, str) and len(data) > max_str:
             return data[:max_str] + "..."
         return data
+
+    def _fit_minimal(self, data: object, max_chars: int) -> str:
+        """Fit ``data`` into ``max_chars`` as VALID JSON at the final tier.
+
+        Reached when even minimal per-value pruning overflows because ``_prune``
+        keeps every key and never drops whole items (the all-keys schema
+        invariant). Degrades gracefully, validity and budget always held:
+
+        1. Keep EVERY top-level key, progressively collapsing the deepest nested
+           levels to compact shape stubs (``{N keys}`` / ``[N items]``) until the
+           object fits — so the agent still sees the full top-level schema, and
+           nested detail survives in proportion to the budget.
+        2. Only when the top-level keys *themselves* cannot fit (a wide object /
+           array, where the key names alone exceed the budget) drop whole
+           trailing keys/items into a valid marker.
+        3. Floor: ``{}`` / ``[]`` / ``""`` / ``null`` — at a sub-token budget
+           validity wins over the length cap (a budget the manager retention
+           ladder never produces). Keys/items are dropped by position; at this
+           tier all detail is uniform, so there is no relevance preference left.
+        """
+        # Tier 1: all keys, shrinking nested depth (None == full depth, the old
+        # minimal tier). Deepest collapse keeps top-level keys with stub values.
+        for max_depth in (None, 3, 2, 1):
+            pruned = self._prune(data, max_str=10, max_array=2, max_depth=max_depth)
+            result = json.dumps(pruned, ensure_ascii=False, indent=2)
+            if len(result) <= max_chars:
+                return result
+
+        # Tier 2: even the all-keys forms overflow — drop trailing keys/items.
+        if isinstance(data, dict) and data:
+            # Depth-1 form (stub values) so as many keys as possible survive.
+            items = list(self._prune(data, max_str=10, max_array=2, max_depth=1).items())
+            total = len(items)
+            # Collision-safe marker key: never clobber a real top-level "_pruned"
+            # field (that would lose its value AND skew the omitted count).
+            marker = "_pruned"
+            existing = {k for k, _ in items}
+            while marker in existing:
+                marker += "_"
+            for keep in range(total - 1, -1, -1):
+                kept = dict(items[:keep])
+                kept[marker] = f"{total - keep} of {total} keys omitted"
+                candidate = json.dumps(kept, ensure_ascii=False, indent=2)
+                if len(candidate) <= max_chars:
+                    return candidate
+            return "{}"
+
+        if isinstance(data, list) and data:
+            # Count against the ORIGINAL length: _prune already samples a long
+            # list, so counting the sampled form understates omissions by orders
+            # of magnitude. Show head elements (depth-1 stubs) + an exact marker.
+            total = len(data)
+            for keep in range(min(2, total), -1, -1):
+                shown: list[object] = [
+                    self._prune(data[i], max_str=10, max_array=2, max_depth=1) for i in range(keep)
+                ]
+                shown.append(f"... ({total - keep} of {total} items omitted)")
+                candidate = json.dumps(shown, ensure_ascii=False, indent=2)
+                if len(candidate) <= max_chars:
+                    return candidate
+            return "[]"
+
+        # Scalar root or empty container: always emit a VALID token that fits.
+        # An empty object/array keeps its type ("{}"/"[]"); a string shrinks to a
+        # shorter valid JSON string (down to ``""``); any other scalar has no
+        # shorter same-type form, so emit a valid ``null`` rather than a
+        # mid-token slice — validity wins over the length cap (as for {}/[]/"").
+        pruned = self._prune(data, max_str=10, max_array=2)
+        if isinstance(pruned, str):
+            for k in range(len(pruned), -1, -1):
+                candidate = json.dumps(pruned[:k], ensure_ascii=False)
+                if len(candidate) <= max_chars:
+                    return candidate
+            return '""'
+        if isinstance(pruned, dict):
+            return "{}"
+        if isinstance(pruned, list):
+            return "[]"
+        return "null"
 
 
 class SkeletonCompressor:

--- a/tests/test_schema_pruning_output_invariants.py
+++ b/tests/test_schema_pruning_output_invariants.py
@@ -1,0 +1,366 @@
+"""Output-contract invariants for SchemaPruningCompressor's final tier.
+
+SchemaPruning's whole contract is "JSON schema-preserving": keep every key and
+emit valid JSON. But ``_prune`` keeps all keys and never drops whole array
+items, so a payload can still overflow the budget at the minimal-detail tier —
+a wide object (many top-level keys), a deeply nested object, or a heavy array.
+The pre-fix final tier handled that overflow with
+``result[:max_chars] + "\\n... (pruned)"``, which BOTH overshot the budget by
+the 13-char suffix AND cut the JSON mid-token, producing INVALID JSON. A 200-key
+dict at a routine 500-char budget already triggered it.
+
+This file is the regression net. At the final tier the output must always
+(a) parse as JSON and (b) stay within ``max(2, max_chars)`` (the ``{}`` / ``[]``
+/ ``""`` floor, the one edge where validity wins over the cap — a budget the
+manager retention ladder never produces). The graceful degradation is:
+
+1. keep EVERY top-level key, collapsing the deepest nested levels to compact
+   shape stubs (``{N keys}`` / ``[N items]``) so the schema shape survives;
+2. only when the top-level keys themselves cannot fit, drop whole trailing
+   keys/items into a valid marker.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memtomem_stm.proxy.compression import SchemaPruningCompressor
+
+
+def _wide_dict(n: int = 200) -> str:
+    """Many short top-level keys: the key *names* alone overflow a tight budget,
+    so even stubbed values cannot fit them all -> trailing keys are dropped."""
+    return json.dumps({f"key_{i:03d}": f"value_number_{i}" for i in range(n)})
+
+
+def _deep_single_key(subkeys: int = 300) -> str:
+    """One top-level key with a huge value: dropping the single key is the only
+    way to fit -> degrades to the marker / ``{}`` floor."""
+    return json.dumps({"big": {f"sub_{i}": f"data_{i}" * 3 for i in range(subkeys)}})
+
+
+def _heavy_list(rows: int = 20, fields: int = 40) -> str:
+    """Top-level array of wide dicts: even after first-2 + last-1 sampling the
+    elements overflow, so they collapse to stubs / items are dropped."""
+    return json.dumps([{f"f{j}": f"val_{i}_{j}" * 2 for j in range(fields)} for i in range(rows)])
+
+
+def _nested_config(services: int = 4) -> str:
+    """Few top-level keys, deep nesting, serialized with indent (like a real
+    config dump). Hits the depth-collapse path: top-level keys are kept while
+    the deepest levels become stubs in proportion to the budget."""
+    return json.dumps(
+        {
+            f"service_{s}": {
+                "host": f"svc{s}.internal.example.com",
+                "port": 8000 + s,
+                "pool": {
+                    "min": 2,
+                    "max": 20,
+                    "timeout_seconds": 30,
+                    "retry": {"count": 3, "backoff": "exp"},
+                },
+                "endpoints": [f"/api/v1/res{i}" for i in range(6)],
+                "flags": {"tls": True, "compression": False, "debug": False},
+            }
+            for s in range(services)
+        },
+        indent=2,
+    )
+
+
+_FINAL_TIER_FIXTURES = {
+    "wide_dict": _wide_dict(),
+    "deep_single_key": _deep_single_key(),
+    "heavy_list": _heavy_list(),
+    "nested_config": _nested_config(),
+}
+
+
+# ── A. Universal output invariants ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", sorted(_FINAL_TIER_FIXTURES))
+@pytest.mark.parametrize("budget", [500, 200, 80, 30, 10, 5, 2])
+def test_final_tier_emits_valid_json(name: str, budget: int) -> None:
+    """Invariant B (the core regression): the final tier always emits parseable
+    JSON. Pre-fix the mid-token slice raised ``JSONDecodeError`` for every
+    overflowing payload."""
+    out = SchemaPruningCompressor().compress(_FINAL_TIER_FIXTURES[name], max_chars=budget)
+    json.loads(out)  # raises if invalid — the bug that shipped
+
+
+@pytest.mark.parametrize("name", sorted(_FINAL_TIER_FIXTURES))
+@pytest.mark.parametrize("budget", [500, 200, 80, 30, 10])
+def test_final_tier_never_exceeds_budget(name: str, budget: int) -> None:
+    """Invariant A: len(output) <= max(2, budget). The pre-fix hard slice
+    appended a 13-char suffix *after* a budget-filling slice, overshooting."""
+    out = SchemaPruningCompressor().compress(_FINAL_TIER_FIXTURES[name], max_chars=budget)
+    assert len(out) <= max(2, budget), (
+        f"{name}@{budget}: produced {len(out)} chars (+{len(out) - budget})"
+    )
+
+
+# ── B. Depth-collapse keeps every top-level key ──────────────────────────────
+
+
+@pytest.mark.parametrize("budget", [1500, 900, 600, 400, 250, 150])
+def test_nested_config_keeps_all_top_level_keys(budget: int) -> None:
+    """A few-key, deeply-nested object keeps ALL top-level keys across the
+    final-tier budget range — the deepest levels collapse first, the schema
+    shape is never lost to a key drop until the keys themselves overflow."""
+    out = SchemaPruningCompressor().compress(_nested_config(4), max_chars=budget)
+    parsed = json.loads(out)
+    assert len(out) <= budget
+    assert "_pruned" not in parsed
+    for s in range(4):
+        assert f"service_{s}" in parsed, f"top-level key service_{s} dropped at budget {budget}"
+
+
+def test_nested_config_collapses_deep_levels_to_stubs() -> None:
+    """Under budget pressure the deepest nested containers become compact
+    ``{N keys}`` / ``[N items]`` stubs, while every top-level key survives and
+    the output stays valid JSON."""
+    out = SchemaPruningCompressor().compress(_nested_config(4), max_chars=600)
+    json.loads(out)
+    assert "keys}" in out or "items]" in out, "expected a collapsed nested stub"
+
+
+# ── C. Wide object: drop whole trailing keys into a marker ───────────────────
+
+
+def test_wide_dict_records_omitted_keys() -> None:
+    """When the top-level key names alone overflow, whole trailing keys are
+    dropped into a valid ``_pruned`` member with an internally-consistent
+    count, instead of vanishing behind an invalid mid-string cut."""
+    out = SchemaPruningCompressor().compress(_wide_dict(200), max_chars=400)
+    parsed = json.loads(out)
+    assert "_pruned" in parsed
+    assert parsed["_pruned"].endswith("of 200 keys omitted")
+    omitted = int(parsed["_pruned"].split(" of ")[0])
+    retained = len(parsed) - 1  # minus the _pruned marker itself
+    assert omitted + retained == 200
+    assert omitted > 0 and retained > 0
+
+
+def test_wide_dict_retained_keys_are_an_order_preserving_prefix() -> None:
+    """Kept keys are a prefix of the original order (trailing keys are dropped),
+    and the marker is the only synthetic member."""
+    out = SchemaPruningCompressor().compress(_wide_dict(200), max_chars=400)
+    parsed = json.loads(out)
+    kept = [k for k in parsed if k != "_pruned"]
+    assert kept == [f"key_{i:03d}" for i in range(len(kept))]
+
+
+# ── D. Array root ────────────────────────────────────────────────────────────
+
+
+def test_heavy_list_stays_valid_array_within_budget() -> None:
+    """A top-level array degrades to a valid JSON array within budget (elements
+    collapse to stubs; whole items drop only when even those overflow)."""
+    out = SchemaPruningCompressor().compress(_heavy_list(20, 40), max_chars=300)
+    parsed = json.loads(out)
+    assert isinstance(parsed, list)
+    assert len(out) <= 300
+
+
+# ── E. Pathological-budget floor ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("budget", [1, 2, 5])
+def test_pathological_budget_floor(budget: int) -> None:
+    """Contract floor: valid JSON cannot be shorter than ``{}`` (2 chars), so a
+    sub-2-char budget keeps validity over the length cap. This pins the one edge
+    where len > max_chars is allowed — a budget config and the manager retention
+    ladder never produce. Above the floor the cap holds."""
+    out = SchemaPruningCompressor().compress(_wide_dict(200), max_chars=budget)
+    json.loads(out)  # always parseable
+    assert len(out) <= max(2, budget)
+
+
+# ── F. Scalar root (defensive) ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("budget", [50, 13, 10, 4, 2])
+def test_scalar_root_stays_valid_json(budget: int) -> None:
+    """A top-level JSON string overflowing a sub-scalar budget shrinks to a
+    shorter valid JSON string rather than an unterminated slice."""
+    out = SchemaPruningCompressor().compress(json.dumps("x" * 5000), max_chars=budget)
+    assert isinstance(json.loads(out), str)
+    assert len(out) <= max(2, budget)
+
+
+# ── G. No change when the payload fits ───────────────────────────────────────
+
+
+def test_unchanged_when_input_fits() -> None:
+    """When the raw payload already fits, compress returns it verbatim — no
+    spurious marker and no pruning."""
+    text = json.dumps({"a": "short", "b": "also short", "c": 42})
+    out = SchemaPruningCompressor().compress(text, max_chars=10_000)
+    assert out == text
+    assert "_pruned" not in out
+
+
+# ── H. Non-string scalar & empty-container floor (sub-token budgets) ──────────
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        json.dumps(3.141592653589793),
+        json.dumps(1e300),
+        json.dumps(-12345678901234567890),
+        "true",
+        "false",
+        "null",
+        "{}",
+        "[]",
+    ],
+)
+@pytest.mark.parametrize("budget", [0, 1, 2, 3])
+def test_non_string_scalar_and_empty_roots_stay_valid(payload: str, budget: int) -> None:
+    """A non-string scalar or empty container root must stay VALID JSON even at a
+    sub-token budget — never a mid-token slice like ``'3.'`` / ``'tru'`` / ``'{'``.
+    The shortest valid token wins over the cap (``{}``/``[]`` -> 2 chars keep their
+    type; any other scalar -> ``null``, 4 chars), so the bound is ``max(4, budget)``."""
+    out = SchemaPruningCompressor().compress(payload, max_chars=budget)
+    json.loads(out)  # the core contract: always parseable
+    assert len(out) <= max(4, budget)
+    # Empty containers keep their JSON type rather than degrading to null.
+    if payload in ("{}", "[]"):
+        assert out == payload
+
+
+# ── I. Marker fidelity: collision-safe key, accurate counts ──────────────────
+
+
+def test_dict_marker_does_not_clobber_existing_pruned_key() -> None:
+    """A payload that legitimately has a top-level ``_pruned`` key keeps its real
+    value (the marker moves to a collision-free key) and the omitted count stays
+    internally consistent."""
+    data = {"_pruned": "REAL_VALUE", **{f"field_{i}": "x" * 40 for i in range(60)}}
+    out = SchemaPruningCompressor().compress(json.dumps(data), max_chars=400)
+    parsed = json.loads(out)
+    assert parsed["_pruned"] == "REAL_VALUE"  # user value preserved, not clobbered
+    marker_key = next(k for k in parsed if k != "_pruned" and "omitted" in str(parsed[k]))
+    omitted = int(parsed[marker_key].split(" of ")[0])
+    total = int(parsed[marker_key].split(" of ")[1].split()[0])
+    retained = len([k for k in parsed if k != marker_key])
+    assert total == 61  # 60 fields + the real _pruned key
+    assert omitted + retained == total  # count reconciles
+
+
+@pytest.mark.parametrize("n", [10, 100, 1000])
+def test_list_omitted_count_matches_original_length(n: int) -> None:
+    """The dropped-items marker counts against the ORIGINAL list length, not the
+    already-sampled (~4-element) intermediate form — pre-fix a 1000-item list
+    claimed only '3 items omitted'."""
+    out = SchemaPruningCompressor().compress(
+        json.dumps([{"a": i, "b": "x" * 20} for i in range(n)]), max_chars=50
+    )
+    parsed = json.loads(out)
+    assert isinstance(parsed, list)
+    marker = next(el for el in parsed if isinstance(el, str) and "omitted" in el)
+    assert f"of {n} items omitted" in marker  # true total, not the sampled count
+
+
+# ── J. Depth ladder: every rung reachable ────────────────────────────────────
+
+
+def test_depth_ladder_full_and_intermediate_tiers() -> None:
+    """Pin the two depth rungs the budget-range tests never land on: the
+    full-depth tier (deepest key survives) and the first intermediate collapse
+    (deepest key gone, the level above it retained)."""
+    comp = SchemaPruningCompressor()
+    # Full-depth tier wins in [1746, 1774): the deepest key 'backoff' survives.
+    full = comp.compress(_nested_config(4), max_chars=1750)
+    json.loads(full)
+    assert len(full) <= 1750
+    assert "backoff" in full and all(f"service_{s}" in full for s in range(4))
+    # First intermediate collapse wins in [1570, 1746): 'backoff' (deepest) is
+    # gone but 'retry' (the level above) and all top-level keys remain.
+    mid = comp.compress(_nested_config(4), max_chars=1600)
+    json.loads(mid)
+    assert len(mid) <= 1600
+    assert "retry" in mid and "backoff" not in mid
+    assert all(f"service_{s}" in mid for s in range(4))
+
+
+# ── K. Direct unit coverage of the fitter ────────────────────────────────────
+
+
+class TestFitMinimal:
+    def _comp(self) -> SchemaPruningCompressor:
+        return SchemaPruningCompressor()
+
+    def test_passthrough_when_minimal_fits(self) -> None:
+        out = self._comp()._fit_minimal({"a": 1, "b": 2}, 1000)
+        assert json.loads(out) == {"a": 1, "b": 2}
+
+    def test_keeps_all_top_level_keys_via_depth_collapse(self) -> None:
+        data = {"alpha": {"deep": {"x": "y" * 50}}, "beta": {"deep": {"x": "z" * 50}}}
+        out = self._comp()._fit_minimal(data, 80)
+        parsed = json.loads(out)
+        assert len(out) <= 80
+        assert set(parsed) == {"alpha", "beta"}  # both top-level keys survive
+        assert "keys}" in out  # the deep subtree collapsed to a stub
+
+    def test_wide_dict_drops_trailing_keys_into_marker(self) -> None:
+        pruned = {f"k{i}": "v" for i in range(50)}
+        out = self._comp()._fit_minimal(pruned, 120)
+        parsed = json.loads(out)
+        assert len(out) <= 120
+        assert "of 50 keys omitted" in parsed["_pruned"]
+
+    def test_dict_floor_is_empty_object(self) -> None:
+        out = self._comp()._fit_minimal({f"k{i}": "v" for i in range(50)}, 5)
+        assert out == "{}"
+
+    def test_list_drops_trailing_items(self) -> None:
+        out = self._comp()._fit_minimal([{"x": "y" * 30} for _ in range(30)], 100)
+        parsed = json.loads(out)
+        assert isinstance(parsed, list)
+        assert len(out) <= 100
+
+    def test_list_floor_is_empty_array(self) -> None:
+        out = self._comp()._fit_minimal([{"x": "y" * 50} for _ in range(30)], 5)
+        assert out == "[]"
+
+    def test_string_scalar_shrinks_to_fit(self) -> None:
+        # Budget below the max_str=10 capped form ("zzzzzzzzzz..." -> 15 JSON
+        # chars) forces the scalar shrink branch past the depth tiers.
+        out = self._comp()._fit_minimal("z" * 500, 8)
+        parsed = json.loads(out)
+        assert isinstance(parsed, str) and parsed.startswith("z")
+        assert len(out) <= 8
+
+    def test_string_floor_below_two_chars(self) -> None:
+        # Sub-2 budget: the shrink loop cannot fit even '""' (2 chars), so the
+        # explicit string floor returns a valid empty JSON string.
+        assert self._comp()._fit_minimal("hello", 1) == '""'
+        assert self._comp()._fit_minimal("hello", 0) == '""'
+
+    def test_non_string_scalar_floor_is_null(self) -> None:
+        # No shorter same-type valid form exists -> a valid `null`, never a slice.
+        assert self._comp()._fit_minimal(3.14159, 2) == "null"
+        assert self._comp()._fit_minimal(True, 1) == "null"
+        assert self._comp()._fit_minimal(123456789012345, 3) == "null"
+
+    def test_empty_container_passthrough(self) -> None:
+        assert self._comp()._fit_minimal({}, 100) == "{}"
+        assert self._comp()._fit_minimal([], 100) == "[]"
+
+    def test_empty_container_floor_below_two(self) -> None:
+        # Even below the 2-char floor an empty container keeps its type.
+        assert self._comp()._fit_minimal({}, 1) == "{}"
+        assert self._comp()._fit_minimal([], 0) == "[]"
+
+    def test_collision_safe_marker_preserves_real_pruned_key(self) -> None:
+        data = {"_pruned": "keep me", **{f"k{i}": "v" * 20 for i in range(40)}}
+        out = self._comp()._fit_minimal(data, 150)
+        parsed = json.loads(out)
+        assert parsed["_pruned"] == "keep me"
+        assert any(k.startswith("_pruned_") and "omitted" in parsed[k] for k in parsed)

--- a/tests/test_schema_pruning_output_invariants.py
+++ b/tests/test_schema_pruning_output_invariants.py
@@ -238,14 +238,17 @@ def test_non_string_scalar_and_empty_roots_stay_valid(payload: str, budget: int)
 
 
 def test_dict_marker_does_not_clobber_existing_pruned_key() -> None:
-    """A payload that legitimately has a top-level ``_pruned`` key keeps its real
-    value (the marker moves to a collision-free key) and the omitted count stays
-    internally consistent."""
+    """A payload that legitimately has a top-level ``_pruned`` key keeps that key
+    (the marker moves to a collision-free key rather than overwriting it) and the
+    omitted count stays internally consistent. The value itself is pruned like
+    every other value at this tier — the fix is about not corrupting the key/count,
+    not about exempting one field from compression."""
     data = {"_pruned": "REAL_VALUE", **{f"field_{i}": "x" * 40 for i in range(60)}}
     out = SchemaPruningCompressor().compress(json.dumps(data), max_chars=400)
     parsed = json.loads(out)
-    assert parsed["_pruned"] == "REAL_VALUE"  # user value preserved, not clobbered
+    assert "_pruned" in parsed  # real key survives, not repurposed as the marker
     marker_key = next(k for k in parsed if k != "_pruned" and "omitted" in str(parsed[k]))
+    assert marker_key.startswith("_pruned")  # collision-displaced, e.g. "_pruned_"
     omitted = int(parsed[marker_key].split(" of ")[0])
     total = int(parsed[marker_key].split(" of ")[1].split()[0])
     retained = len([k for k in parsed if k != marker_key])
@@ -358,9 +361,9 @@ class TestFitMinimal:
         assert self._comp()._fit_minimal({}, 1) == "{}"
         assert self._comp()._fit_minimal([], 0) == "[]"
 
-    def test_collision_safe_marker_preserves_real_pruned_key(self) -> None:
+    def test_collision_safe_marker_does_not_repurpose_real_pruned_key(self) -> None:
         data = {"_pruned": "keep me", **{f"k{i}": "v" * 20 for i in range(40)}}
         out = self._comp()._fit_minimal(data, 150)
         parsed = json.loads(out)
-        assert parsed["_pruned"] == "keep me"
+        assert "_pruned" in parsed  # real key retained, not overwritten by the marker
         assert any(k.startswith("_pruned_") and "omitted" in parsed[k] for k in parsed)


### PR DESCRIPTION
## Problem

`SchemaPruningCompressor`'s contract is *"JSON schema-preserving"*, but its
minimal final tier handled an overflow with `result[:max_chars] + "\n... (pruned)"`.
That **both overshot the budget by the 13-char suffix AND cut the JSON
mid-token, producing INVALID JSON**. It is not a corner case — a 200-key dict at
a routine 500-char budget already triggered it:

```
compress(<200-key dict>, max_chars=500)
-> len 513 (+13 over budget), tail: '..."key_016": "valu\n... (pruned)'  # JSONDecodeError
```

This is the same `result[:max_chars]+suffix` family `TruncateCompressor` fixed
in #384; the manager retention guard only masked it (it raises tiny budgets), so
direct/bench callers and tight final-tier budgets still hit it.

## Fix

Replace the hard slice with `_fit_minimal`, which **always emits valid JSON
within budget** and degrades gracefully instead of corrupting the output:

- **Tier 1** keeps EVERY top-level key, progressively collapsing the deepest
  nested levels to compact shape stubs (`{N keys}` / `[N items]`) so the agent
  still sees the full schema and nested detail survives in proportion to the
  budget. A new `max_depth` arg on `_prune` drives this — `None` (every existing
  caller) means full depth and is byte-identical to before.
- **Tier 2** drops whole trailing keys/items into a valid marker, only when the
  top-level keys *themselves* overflow (a wide object/array).
- **Floors** are type-preserving and always valid: `{}` / `[]` / `""` / `null`.

New contract: output is valid JSON **always**, and `len(out) <= max(4, max_chars)`
(`null` floor = 4; `{}`/`[]`/`""` = 2). Above a 4-char budget the cap always holds.

## Behavior change

At a budget too small to hold the full schema, the *all-keys* invariant now
**yields to validity + budget** (recording the loss in a marker), matching
`TruncateCompressor`'s `_truncated` precedent. Pre-fix, the output "kept" key
names only as substrings inside **invalid, over-budget** JSON — so this trades a
broken guarantee for an honest, parseable one. The existing
`test_information_loss` all-keys/nested-keys tests on `NESTED_CONFIG` pass
**unchanged** (depth-collapse keeps all top-level + nested keys at their budgets)
and now emit valid JSON where they previously relied on substrings in a corrupt
slice.

## Marker fidelity (caught in adversarial review, folded into this PR)

- the dropped-keys marker uses a **collision-safe key**, so a real top-level
  `_pruned` field is never clobbered and the omitted count stays consistent;
- the dropped-items marker counts against the **original** list length, not the
  already-sampled intermediate form (which understated it by ~30–300×);
- non-string scalar / empty-container roots at sub-token budgets now emit a
  **valid token** (`null`, or type-preserving `{}`/`[]`) instead of a mid-token slice.

## Out of scope (still deferred, distinct contracts)

`FieldExtract` / `Skeleton` / `Hybrid` share a surface-similar `result[:max_chars]`
pattern but with different contracts (looser-JSON / markdown-heading / non-JSON).
The `_fit_minimal` depth tiers are intentionally coarse — they can return under
budget at the floor; that is accepted floor behavior (valid + within budget), not
a regression.

## Test plan

New `tests/test_schema_pruning_output_invariants.py` (116 tests) pins: valid JSON
+ within `max(4, max_chars)` across object/array/scalar roots and budgets; the
keep-all-top-level-keys depth-collapse path; each depth rung; the marker-fidelity
guarantees; and the pathological-budget floors.

- `uv run pytest -m "not ollama"` → 2595 pass / 2 pre-existing py3.13 anyio
  stdio-teardown flakes (confirmed pre-existing on clean `main` via stash-test;
  unrelated to compression).
- `uv run ruff check src && uv run ruff format --check src` → clean.
- `uv run mypy src/memtomem_stm/proxy/compression.py` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)