### PR TITLE
fix(compression): valid-JSON, budget-filling final tier for FieldExtract

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -960,24 +960,37 @@ class FieldExtractCompressor:
 
     def _compress_json(self, data: object, max_chars: int) -> str:
         if isinstance(data, dict):
-            summary = self._extract_dict(data, max_chars)
-            result = json.dumps(summary, ensure_ascii=False, indent=2)
+            preview: object = self._extract_dict(data, max_chars)
         elif isinstance(data, list):
-            preview_n = min(5, len(data))
-            preview: list[object] = []
-            for item in data[:preview_n]:
-                if isinstance(item, dict):
-                    preview.append(self._preview_dict(item))
-                else:
-                    preview.append(item)
-            result = json.dumps(preview, ensure_ascii=False, indent=2)
-            if len(data) > preview_n:
-                result += f"\n... ({len(data)} items total, showing first {preview_n})"
+            preview = self._preview_list(data)
         else:
-            result = json.dumps(data, ensure_ascii=False)
-        if len(result) > max_chars:
-            result = result[:max_chars] + "\n... (truncated)"
-        return result
+            preview = data
+        indent = 2 if isinstance(data, (dict, list)) else None
+        result = json.dumps(preview, ensure_ascii=False, indent=indent)
+        if len(result) <= max_chars:
+            return result
+        # Final tier: emit VALID JSON within budget. The old
+        # ``result[:max_chars] + "\n... (truncated)"`` overshot the budget by the
+        # suffix length AND cut the JSON mid-token (invalid output); a top-level
+        # array additionally appended a non-JSON text marker. ``_fit_extracted``
+        # re-derives a valid, within-budget form from the original data.
+        return self._fit_extracted(data, max_chars)
+
+    def _preview_list(self, data: list) -> list[object]:
+        """Head preview of a top-level array as VALID JSON: the first items, then
+        an in-array omitted-count marker (an extra string element). The pre-fix
+        code appended ``"\\n... (N items total ...)"`` as text *after*
+        ``json.dumps``, which left the whole output unparseable for any array
+        over the 5-item preview."""
+        n = len(data)
+        preview_n = min(5, n)
+        preview: list[object] = [
+            self._preview_dict(item) if isinstance(item, dict) else item
+            for item in data[:preview_n]
+        ]
+        if n > preview_n:
+            preview.append(f"... ({n - preview_n} of {n} items omitted)")
+        return preview
 
     def _extract_dict(self, data: dict, budget: int) -> dict:
         """Budget-aware recursive dict extraction — preserves all keys with depth.
@@ -1066,10 +1079,179 @@ class FieldExtractCompressor:
             preview[f"...{remaining} more"] = "..."
         return preview
 
+    def _take(self, value: object, budget: int) -> object:
+        """Greedy prefix-fill: keep the leading, full-detail content of ``value``
+        whose serialized cost fits ``budget`` (COMPACT) chars, dropping the tail
+        into a valid omitted-count marker (an extra ``_truncated`` dict member or
+        an in-array string element, counted against the ORIGINAL length).
+
+        STRICT budget for containers: ``len(json.dumps(_take(value, b))) <= b``
+        always — every child (including the first) is gated, and a child is
+        accepted only if it still fits, so a caller can hand ``_take`` the hard
+        ``max_chars`` directly and trust the result. Leading full-length scalars
+        (names, ids, roles) survive untouched — only a boundary string is ever
+        truncated. A non-string scalar is returned whole (the parent's budget
+        check then drops it if it overflows).
+        """
+        if isinstance(value, str):
+            if len(value) + 2 <= budget:  # +2 for the surrounding quotes
+                return value
+            keep = budget - 5  # quotes (2) + "..." (3)
+            return value[:keep] + "..." if keep > 0 else ""
+        if not isinstance(value, (dict, list)):
+            return value  # int / float / bool / None: atomic; parent guards size
+
+        # Collision-safe marker key, checked against ALL original keys (a real
+        # "_truncated" key can be in the *dropped* tail, invisible to ``out``).
+        marker_key = "_truncated"
+        if isinstance(value, dict):
+            is_dict = True
+            items: list = list(value.items())
+            existing = set(value)
+            while marker_key in existing:
+                marker_key += "_"
+        else:
+            is_dict = False
+            items = list(enumerate(value))
+        n = len(items)
+
+        out_dict: dict = {}
+        out_list: list = []
+        used = 2  # "{}" / "[]"
+        for i, (k, v) in enumerate(items):
+            overhead = (len(json.dumps(k, ensure_ascii=False)) + 4) if is_dict else 2
+            child = self._take(v, max(0, budget - used - overhead))
+            cost = overhead + len(json.dumps(child, ensure_ascii=False))
+            # Stop when the child won't fit, or when the budget starved it down
+            # to an empty container while the source was non-empty (an empty
+            # stub adds noise, not signal — mark the tail instead).
+            starved = child in ({}, [], "") and v not in (None, {}, [], "", 0, False)
+            if used + cost > budget or starved:
+                if is_dict:
+                    mtext = f"{n - i} of {n} keys omitted"
+                    if (
+                        used + len(json.dumps({marker_key: mtext}, ensure_ascii=False)) - 1
+                        <= budget
+                    ):
+                        out_dict[marker_key] = mtext
+                else:
+                    mark = f"... ({n - i} of {n} items omitted)"
+                    if used + len(json.dumps(mark, ensure_ascii=False)) + 1 <= budget:
+                        out_list.append(mark)
+                break
+            if is_dict:
+                out_dict[k] = child
+            else:
+                out_list.append(child)
+            used += cost
+        return out_dict if is_dict else out_list
+
+    @staticmethod
+    def _stub_value(value: object) -> object:
+        """Smallest placeholder that keeps a key visible: a shape stub for a
+        container, an empty string for a string, the value itself for a small
+        scalar."""
+        if isinstance(value, dict):
+            return f"{{{len(value)} keys}}" if value else {}
+        if isinstance(value, list):
+            return f"[{len(value)} items]" if value else []
+        if isinstance(value, str):
+            return ""
+        return value  # int / float / bool / None
+
+    def _fit_extracted(self, data: object, max_chars: int) -> str:
+        """Re-derive a VALID, within-budget form from the ORIGINAL data, filling
+        the budget with as much leading full-detail content as fits.
+
+        Output is COMPACT JSON (no indent) so ``_take``'s compact cost
+        accounting matches the measured length exactly — the exact match makes
+        length monotonic in the soft budget, so the search fills ``max_chars``
+        instead of landing on a collapse cliff.
+
+        Top-level dict: first lay down a *skeleton* — every key with a minimal
+        stub value — so no top-level key vanishes while the budget allows it
+        (FieldExtract's "preserve key structure" contract). Then enrich keys in
+        document order, each grabbing as much full-detail content (via ``_take``)
+        as the remaining budget allows — leading values (names/ids/roles, what
+        QA reads) survive in full rather than every value being shrunk to a stub.
+        Only when the stubs themselves overflow are trailing keys dropped into a
+        valid collision-safe marker. List / scalar roots binary-search ``_take``
+        directly. Floors to ``{}`` / ``[]`` / ``""`` / ``null``.
+        """
+
+        def dump(obj: object) -> str:
+            return json.dumps(obj, ensure_ascii=False)
+
+        if isinstance(data, dict) and data:
+            items = list(data.items())
+            skeleton = {k: self._stub_value(v) for k, v in items}
+            if len(dump(skeleton)) <= max_chars:
+                # Enrich each key in order; leading keys grab budget first, all
+                # keys stay at least as their stub.
+                out = dict(skeleton)
+                for k, v in items:
+                    lo, hi, best_v = 0, len(dump(v)), out[k]
+                    while lo <= hi:
+                        mid = (lo + hi) // 2
+                        trial = dict(out)
+                        trial[k] = self._take(v, mid)
+                        if len(dump(trial)) <= max_chars:
+                            best_v, lo = trial[k], mid + 1
+                        else:
+                            hi = mid - 1
+                    out[k] = best_v
+                return dump(out)
+
+            # Even the all-stub skeleton overflows — keep the leading keys that
+            # fit + a valid marker. ``len`` is monotonic in ``keep``. The marker
+            # key is checked against ALL original keys, not just the kept prefix:
+            # a real "_truncated" key can sit in the *dropped* tail (invisible to
+            # ``kept``), and reusing its name would clobber/shadow it.
+            existing = set(data)
+            marker = "_truncated"
+            while marker in existing:
+                marker += "_"
+            lo, hi, best = 0, len(items) - 1, None
+            while lo <= hi:
+                keep = (lo + hi) // 2
+                kept = {k: skeleton[k] for k, _ in items[:keep]}
+                kept[marker] = f"{len(items) - keep} of {len(items)} keys omitted"
+                candidate = dump(kept)
+                if len(candidate) <= max_chars:
+                    best, lo = candidate, keep + 1
+                else:
+                    hi = keep - 1
+            return best if best is not None else "{}"
+
+        # List or scalar root: ``_take`` is strict (<= budget) for containers, so
+        # a single call at the hard budget fills it — no search, no cliff.
+        candidate = dump(self._take(data, max_chars))
+        if len(candidate) <= max_chars:
+            return candidate
+
+        # Even the most compact ``_take`` form overflows. Floor to the smallest
+        # valid JSON within budget.
+        if isinstance(data, dict):
+            return "{}"
+        if isinstance(data, list):
+            return "[]"
+        if isinstance(data, str):
+            for k in range(len(data), -1, -1):
+                candidate = json.dumps(data[:k], ensure_ascii=False)
+                if len(candidate) <= max_chars:
+                    return candidate
+            return '""'
+        # Non-string scalar root (number / bool / null): no shorter valid-JSON
+        # token preserves the value, so emit it verbatim rather than corrupt it
+        # to a within-budget literal (the old ``else "null"`` turned ``true`` /
+        # ``42`` into ``null``). The result is irreducible: it can exceed a
+        # sub-token budget the manager retention ladder never actually produces.
+        return json.dumps(data, ensure_ascii=False)
+
     def _compress_text(self, text: str, max_chars: int) -> str:
         lines = text.split("\n")
         if len(lines) <= 10:
-            return text[:max_chars] + "\n... (truncated)" if len(text) > max_chars else text
+            return self._fit_text(text, max_chars)
         head_count = max(3, len(lines) // 10)
         tail_count = max(3, len(lines) // 10)
         head = "\n".join(lines[:head_count])
@@ -1077,9 +1259,20 @@ class FieldExtractCompressor:
         omitted = len(lines) - head_count - tail_count
         summary = _content_summary(text)
         result = f"{head}\n... ({omitted} lines omitted){summary} ...\n{tail}"
-        if len(result) > max_chars:
-            result = result[:max_chars] + "\n... (truncated)"
-        return result
+        return self._fit_text(result, max_chars)
+
+    @staticmethod
+    def _fit_text(text: str, max_chars: int) -> str:
+        """Within-budget text fit. Text has no JSON contract, so a boundary cut
+        is acceptable — but reserve room for the suffix so the result never
+        exceeds ``max_chars`` (the old ``slice + suffix`` overshot by the suffix
+        length)."""
+        if len(text) <= max_chars:
+            return text
+        suffix = "\n... (truncated)"
+        if max_chars < len(suffix):
+            return text[:max_chars]
+        return text[: max_chars - len(suffix)] + suffix
 
 
 class SchemaPruningCompressor:

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1090,8 +1090,9 @@ class FieldExtractCompressor:
         accepted only if it still fits, so a caller can hand ``_take`` the hard
         ``max_chars`` directly and trust the result. Leading full-length scalars
         (names, ids, roles) survive untouched — only a boundary string is ever
-        truncated. A non-string scalar is returned whole (the parent's budget
-        check then drops it if it overflows).
+        truncated. A non-string scalar is returned whole when its literal fits,
+        otherwise it becomes the scalar stub ``""`` so sibling keys can still
+        survive.
         """
         if isinstance(value, str):
             if len(value) + 2 <= budget:  # +2 for the surrounding quotes
@@ -1099,7 +1100,11 @@ class FieldExtractCompressor:
             keep = budget - 5  # quotes (2) + "..." (3)
             return value[:keep] + "..." if keep > 0 else ""
         if not isinstance(value, (dict, list)):
-            return value  # int / float / bool / None: atomic; parent guards size
+            literal = json.dumps(value, ensure_ascii=False)
+            return value if len(literal) <= budget else ""
+
+        if len(json.dumps(value, ensure_ascii=False)) <= budget:
+            return value
 
         # Collision-safe marker key, checked against ALL original keys (a real
         # "_truncated" key can be in the *dropped* tail, invisible to ``out``).
@@ -1115,36 +1120,89 @@ class FieldExtractCompressor:
             items = list(enumerate(value))
         n = len(items)
 
-        out_dict: dict = {}
-        out_list: list = []
-        used = 2  # "{}" / "[]"
-        for i, (k, v) in enumerate(items):
-            overhead = (len(json.dumps(k, ensure_ascii=False)) + 4) if is_dict else 2
-            child = self._take(v, max(0, budget - used - overhead))
-            cost = overhead + len(json.dumps(child, ensure_ascii=False))
-            # Stop when the child won't fit, or when the budget starved it down
-            # to an empty container while the source was non-empty (an empty
-            # stub adds noise, not signal — mark the tail instead).
-            starved = child in ({}, [], "") and v not in (None, {}, [], "", 0, False)
-            if used + cost > budget or starved:
-                if is_dict:
-                    mtext = f"{n - i} of {n} keys omitted"
-                    if (
-                        used + len(json.dumps({marker_key: mtext}, ensure_ascii=False)) - 1
-                        <= budget
-                    ):
-                        out_dict[marker_key] = mtext
-                else:
-                    mark = f"... ({n - i} of {n} items omitted)"
-                    if used + len(json.dumps(mark, ensure_ascii=False)) + 1 <= budget:
-                        out_list.append(mark)
-                break
-            if is_dict:
-                out_dict[k] = child
-            else:
+        if not is_dict:
+            out_list: list = []
+
+            def list_fits(candidate: list) -> bool:
+                return len(json.dumps(candidate, ensure_ascii=False)) <= budget
+
+            def is_starved(child: object, source: object) -> bool:
+                if child == "" and not isinstance(source, (dict, list, str)):
+                    return False
+                return child in ({}, [], "") and source not in (None, {}, [], "", 0, False)
+
+            def best_child(source: object, suffix: list[str]) -> object | None:
+                lo, hi, best = 0, budget, None
+                while lo <= hi:
+                    mid = (lo + hi) // 2
+                    child = self._take(source, mid)
+                    if list_fits(out_list + [child] + suffix):
+                        best, lo = child, mid + 1
+                    else:
+                        hi = mid - 1
+                return best
+
+            for i, (_k, v) in enumerate(items):
+                marker_after = (
+                    f"... ({n - i - 1} of {n} items omitted)" if i < n - 1 else None
+                )
+                child = best_child(v, [marker_after] if marker_after else [])
+                if child is None or is_starved(child, v):
+                    marker = f"... ({n - i} of {n} items omitted)"
+                    if list_fits(out_list + [marker]):
+                        out_list.append(marker)
+                    else:
+                        child = best_child(v, [])
+                        if child is not None and not is_starved(child, v):
+                            out_list.append(child)
+                            continue
+                    break
                 out_list.append(child)
-            used += cost
-        return out_dict if is_dict else out_list
+            return out_list
+
+        out_dict: dict = {}
+
+        def dict_fits(candidate: dict) -> bool:
+            return len(json.dumps(candidate, ensure_ascii=False)) <= budget
+
+        def dict_starved(child: object, source: object) -> bool:
+            if child == "" and not isinstance(source, (dict, list, str)):
+                return False
+            return child in ({}, [], "") and source not in (None, {}, [], "", 0, False)
+
+        def best_value(key: object, source: object, suffix: dict[str, str]) -> object | None:
+            lo, hi, best = 0, budget, None
+            while lo <= hi:
+                mid = (lo + hi) // 2
+                child = self._take(source, mid)
+                candidate = dict(out_dict)
+                candidate[key] = child
+                candidate.update(suffix)
+                if dict_fits(candidate):
+                    best, lo = child, mid + 1
+                else:
+                    hi = mid - 1
+            return best
+
+        for i, (k, v) in enumerate(items):
+            marker_after = (
+                {marker_key: f"{n - i - 1} of {n} keys omitted"} if i < n - 1 else {}
+            )
+            child = best_value(k, v, marker_after)
+            if child is None or dict_starved(child, v):
+                marker = f"{n - i} of {n} keys omitted"
+                candidate = dict(out_dict)
+                candidate[marker_key] = marker
+                if dict_fits(candidate):
+                    out_dict[marker_key] = marker
+                else:
+                    child = best_value(k, v, {})
+                    if child is not None and not dict_starved(child, v):
+                        out_dict[k] = child
+                        continue
+                break
+            out_dict[k] = child
+        return out_dict
 
     @staticmethod
     def _stub_value(value: object) -> object:
@@ -1156,6 +1214,8 @@ class FieldExtractCompressor:
         if isinstance(value, list):
             return f"[{len(value)} items]" if value else []
         if isinstance(value, str):
+            return ""
+        if len(json.dumps(value, ensure_ascii=False)) > 80:
             return ""
         return value  # int / float / bool / None
 
@@ -1170,10 +1230,11 @@ class FieldExtractCompressor:
 
         Top-level dict: first lay down a *skeleton* — every key with a minimal
         stub value — so no top-level key vanishes while the budget allows it
-        (FieldExtract's "preserve key structure" contract). Then enrich keys in
-        document order, each grabbing as much full-detail content (via ``_take``)
-        as the remaining budget allows — leading values (names/ids/roles, what
-        QA reads) survive in full rather than every value being shrunk to a stub.
+        (FieldExtract's "preserve key structure" contract). Then restore short
+        scalar values first before enriching keys with as much full-detail
+        content (via ``_take``) as the remaining budget allows — values like
+        names/ids/roles survive in full rather than every value being shrunk to
+        a stub.
         Only when the stubs themselves overflow are trailing keys dropped into a
         valid collision-safe marker. List / scalar roots binary-search ``_take``
         directly. Floors to ``{}`` / ``[]`` / ``""`` / ``null``.
@@ -1195,7 +1256,15 @@ class FieldExtractCompressor:
                 out = dict(skeleton)
                 scalars = [(k, v) for k, v in items if not isinstance(v, (dict, list))]
                 collections = [(k, v) for k, v in items if isinstance(v, (dict, list))]
+                for k, v in sorted(scalars, key=lambda item: len(dump(item[1]))):
+                    trial = dict(out)
+                    trial[k] = v
+                    if len(dump(trial)) <= max_chars:
+                        out[k] = v
+
                 for k, v in scalars + collections:
+                    if out[k] == v:
+                        continue
                     lo, hi, best_v = 0, len(dump(v)), out[k]
                     while lo <= hi:
                         mid = (lo + hi) // 2
@@ -1229,7 +1298,22 @@ class FieldExtractCompressor:
                     hi = keep - 1
             return best if best is not None else "{}"
 
-        # List or scalar root: ``_take`` is strict (<= budget) for containers, so
+        if not isinstance(data, (dict, list, str)):
+            # Non-string scalar root (number / bool / null). Emit it verbatim
+            # when it fits; otherwise degrade to a truncated STRING of the
+            # literal. Nested oversized scalars use ``_take``'s empty-string stub,
+            # but root scalars should stay visibly truncated rather than
+            # disappearing behind an unlabelled empty value.
+            literal = json.dumps(data, ensure_ascii=False)
+            if len(literal) <= max_chars:
+                return literal
+            for k in range(len(literal), -1, -1):
+                candidate = json.dumps(literal[:k], ensure_ascii=False)
+                if len(candidate) <= max_chars:
+                    return candidate
+            return '""'
+
+        # List or string root: ``_take`` is strict (<= budget) for containers, so
         # a single call at the hard budget fills it — no search, no cliff.
         candidate = dump(self._take(data, max_chars))
         if len(candidate) <= max_chars:
@@ -1247,21 +1331,6 @@ class FieldExtractCompressor:
                 if len(candidate) <= max_chars:
                     return candidate
             return '""'
-        # Non-string scalar root (number / bool / null). Emit it verbatim when
-        # it fits — the old ``else "null"`` corrupted ``true`` / ``42`` to
-        # ``null`` even within budget. When the literal itself exceeds the budget
-        # (e.g. a 1000-digit number), no shorter literal PRESERVES the value, so
-        # degrade to a truncated STRING of the literal: valid JSON, WITHIN budget
-        # (max_chars is a hard token budget downstream relies on), and visibly
-        # truncated — never a silently-wrong number. (Sub-literal budgets like
-        # this are never produced by the manager retention ladder.)
-        literal = json.dumps(data, ensure_ascii=False)
-        if len(literal) <= max_chars:
-            return literal
-        for k in range(len(literal), -1, -1):
-            candidate = json.dumps(literal[:k], ensure_ascii=False)
-            if len(candidate) <= max_chars:
-                return candidate
         return '""'
 
     def _compress_text(self, text: str, max_chars: int) -> str:

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1143,9 +1143,7 @@ class FieldExtractCompressor:
                 return best
 
             for i, (_k, v) in enumerate(items):
-                marker_after = (
-                    f"... ({n - i - 1} of {n} items omitted)" if i < n - 1 else None
-                )
+                marker_after = f"... ({n - i - 1} of {n} items omitted)" if i < n - 1 else None
                 child = best_child(v, [marker_after] if marker_after else [])
                 if child is None or is_starved(child, v):
                     marker = f"... ({n - i} of {n} items omitted)"
@@ -1185,9 +1183,7 @@ class FieldExtractCompressor:
             return best
 
         for i, (k, v) in enumerate(items):
-            marker_after = (
-                {marker_key: f"{n - i - 1} of {n} keys omitted"} if i < n - 1 else {}
-            )
+            marker_after = {marker_key: f"{n - i - 1} of {n} keys omitted"} if i < n - 1 else {}
             child = best_value(k, v, marker_after)
             if child is None or dict_starved(child, v):
                 marker = f"{n - i} of {n} keys omitted"

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1186,10 +1186,16 @@ class FieldExtractCompressor:
             items = list(data.items())
             skeleton = {k: self._stub_value(v) for k, v in items}
             if len(dump(skeleton)) <= max_chars:
-                # Enrich each key in order; leading keys grab budget first, all
-                # keys stay at least as their stub.
+                # Enrich keys to fill the budget, but enrich SCALARS before
+                # collections (mirrors _extract_dict's scalar-first ordering):
+                # cheap, high-value scalar fields (ids, names, flags) must
+                # survive a tight budget even when large nested sections precede
+                # them in document order. The output dict keeps the original key
+                # order — only the enrichment *priority* is reordered.
                 out = dict(skeleton)
-                for k, v in items:
+                scalars = [(k, v) for k, v in items if not isinstance(v, (dict, list))]
+                collections = [(k, v) for k, v in items if isinstance(v, (dict, list))]
+                for k, v in scalars + collections:
                     lo, hi, best_v = 0, len(dump(v)), out[k]
                     while lo <= hi:
                         mid = (lo + hi) // 2
@@ -1241,12 +1247,22 @@ class FieldExtractCompressor:
                 if len(candidate) <= max_chars:
                     return candidate
             return '""'
-        # Non-string scalar root (number / bool / null): no shorter valid-JSON
-        # token preserves the value, so emit it verbatim rather than corrupt it
-        # to a within-budget literal (the old ``else "null"`` turned ``true`` /
-        # ``42`` into ``null``). The result is irreducible: it can exceed a
-        # sub-token budget the manager retention ladder never actually produces.
-        return json.dumps(data, ensure_ascii=False)
+        # Non-string scalar root (number / bool / null). Emit it verbatim when
+        # it fits — the old ``else "null"`` corrupted ``true`` / ``42`` to
+        # ``null`` even within budget. When the literal itself exceeds the budget
+        # (e.g. a 1000-digit number), no shorter literal PRESERVES the value, so
+        # degrade to a truncated STRING of the literal: valid JSON, WITHIN budget
+        # (max_chars is a hard token budget downstream relies on), and visibly
+        # truncated — never a silently-wrong number. (Sub-literal budgets like
+        # this are never produced by the manager retention ladder.)
+        literal = json.dumps(data, ensure_ascii=False)
+        if len(literal) <= max_chars:
+            return literal
+        for k in range(len(literal), -1, -1):
+            candidate = json.dumps(literal[:k], ensure_ascii=False)
+            if len(candidate) <= max_chars:
+                return candidate
+        return '""'
 
     def _compress_text(self, text: str, max_chars: int) -> str:
         lines = text.split("\n")

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -205,9 +205,13 @@ class TestFieldExtractCompressor:
         data = [{"name": f"item{i}", "value": "x" * 50} for i in range(10)]
         text = json.dumps(data)
         c = FieldExtractCompressor()
-        result = c.compress(text, max_chars=100)
-        # Shows preview of first items
+        # Budget large enough to keep the first preview readable as VALID JSON
+        # (a sub-100 budget can only fit the array by shrinking item0's values
+        # to "...", so the output is valid JSON but item0 is no longer literal).
+        result = c.compress(text, max_chars=400)
+        # Shows preview of first items, and the whole output parses as JSON.
         assert "item0" in result
+        json.loads(result)
 
     def test_plain_text_head_tail(self):
         lines = [f"Line {i}" for i in range(100)]

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -235,6 +235,146 @@ def test_marker_does_not_clobber_real_truncated_key_in_dropped_tail() -> None:
         assert "keys omitted" not in str(parsed["_truncated"])
 
 
+def test_list_fit_reserves_space_for_omission_marker() -> None:
+    """A tight list budget must prefer fewer leading items plus an omitted-count
+    marker over silently returning a longer prefix with no marker."""
+    payload = json.dumps([{"a": 1} for _ in range(1000)])
+    out = FieldExtractCompressor().compress(payload, max_chars=50)
+    parsed = json.loads(out)
+    marker = next(e for e in parsed if isinstance(e, str) and "items omitted" in e)
+    assert len(out) <= 50
+    assert parsed[0] == {"a": 1}
+    assert "999 of 1000 items omitted" in marker
+
+
+def test_list_fit_allows_exact_marker_fit() -> None:
+    """The marker budget check must use exact JSON length: marker-only output
+    can fit exactly when item-plus-marker cannot."""
+    payload = json.dumps([{"a": 1} for _ in range(1000)])
+    out = FieldExtractCompressor().compress(payload, max_chars=36)
+    parsed = json.loads(out)
+    assert len(out) == 36
+    assert parsed == ["... (1000 of 1000 items omitted)"]
+
+
+def test_list_fit_preserves_truncated_item_before_marker() -> None:
+    """If a smaller first item plus marker fits, keep that leading content
+    instead of dropping straight to marker-only output."""
+    payload = json.dumps(["x" * 1000 for _ in range(100)])
+    out = FieldExtractCompressor().compress(payload, max_chars=100)
+    parsed = json.loads(out)
+    assert len(out) <= 100
+    assert len(parsed) == 2
+    assert parsed[0].startswith("x")
+    assert parsed[0].endswith("...")
+    assert parsed[1] == "... (99 of 100 items omitted)"
+
+
+def test_list_fit_keeps_small_items_when_marker_is_too_large() -> None:
+    """A marker that cannot fit must not prevent later small items from being
+    considered when the list itself can still fit."""
+    assert FieldExtractCompressor()._take([1, 2], 6) == [1, 2]
+
+
+def test_take_keeps_full_container_when_it_fits() -> None:
+    """A fitting container must never be replaced by a longer omission marker."""
+    comp = FieldExtractCompressor()
+    cases = [
+        ([1, 2], 30),
+        ({"a": 1, "b": 2}, 40),
+        ([[1, 2]], 32),
+        ({"x": {"a": 1, "b": 2}}, 44),
+    ]
+    for value, budget in cases:
+        assert len(json.dumps(value, ensure_ascii=False)) <= budget
+        assert comp._take(value, budget) == value
+
+
+def test_dict_fit_reserves_space_for_omission_marker() -> None:
+    """Nested dict fitting must prefer an omitted-count marker over silently
+    returning a longer key prefix with no marker."""
+    payload = json.dumps(
+        {"outer": {f"k{i}": {"a": 1} for i in range(1000)}, "id": "abc"}
+    )
+    out = FieldExtractCompressor().compress(payload, max_chars=80)
+    parsed = json.loads(out)
+    outer = parsed["outer"]
+    marker = outer.get("_truncated", "")
+    retained = len([k for k in outer if k != "_truncated"])
+    omitted = int(marker.split(" of ")[0])
+    assert len(out) <= 80
+    assert parsed["id"] == "abc"
+    assert omitted + retained == 1000
+
+
+def test_dict_fit_allows_exact_marker_fit() -> None:
+    """Dict marker checks use exact JSON length, so marker-only output can fit
+    exactly when key-plus-marker cannot."""
+    data = {f"k{i}": {"a": 1} for i in range(1000)}
+    out = FieldExtractCompressor()._take(data, 43)
+    assert len(json.dumps(out, ensure_ascii=False)) == 43
+    assert out == {"_truncated": "1000 of 1000 keys omitted"}
+
+
+def test_later_short_scalars_survive_after_long_scalar() -> None:
+    """Long early scalar values must not consume the whole enrichment budget
+    before later short identifiers get restored from their stubs."""
+    payload = json.dumps({"description": "x" * 10_000, "id": "abc", "name": "Alice"})
+    out = FieldExtractCompressor().compress(payload, max_chars=100)
+    parsed = json.loads(out)
+    assert len(out) <= 100
+    assert parsed["id"] == "abc"
+    assert parsed["name"] == "Alice"
+    assert parsed["description"]
+
+
+def test_later_short_scalars_survive_after_medium_scalar() -> None:
+    """Even when an early scalar fits whole by itself, shorter later scalars get
+    first claim and the early value is trimmed if necessary."""
+    payload = json.dumps({"description": "x" * 55, "id": "abc", "name": "Alice"})
+    out = FieldExtractCompressor().compress(payload, max_chars=100)
+    parsed = json.loads(out)
+    assert len(out) <= 100
+    assert parsed["id"] == "abc"
+    assert parsed["name"] == "Alice"
+    assert parsed["description"].endswith("...")
+
+
+def test_oversized_non_string_scalar_stub_does_not_hide_later_keys() -> None:
+    """Huge numeric literals are bounded at the skeleton layer so other keys
+    can survive instead of collapsing the whole dict to a marker."""
+    payload = '{"huge": ' + ("1" * 1000) + ', "id": "abc"}'
+    out = FieldExtractCompressor().compress(payload, max_chars=80)
+    parsed = json.loads(out)
+    assert len(out) <= 80
+    assert "huge" in parsed
+    assert parsed["id"] == "abc"
+
+
+def test_nested_oversized_non_string_scalar_stub_preserves_later_keys() -> None:
+    """The same scalar bound applies inside recursive _take() paths, not just
+    top-level skeletons."""
+    payload = '{"outer": {"huge": ' + ("1" * 1000) + ', "id": "abc"}, "name": "foo"}'
+    out = FieldExtractCompressor().compress(payload, max_chars=80)
+    parsed = json.loads(out)
+    assert len(out) <= 80
+    assert parsed["outer"]["huge"] == ""
+    assert parsed["outer"]["id"] == "abc"
+    assert parsed["name"] == "foo"
+
+
+def test_nested_array_oversized_non_string_scalar_stub_preserves_later_keys() -> None:
+    """Objects inside arrays also keep short fields when a huge scalar is
+    bounded to a stub."""
+    payload = '{"items": [{"huge": ' + ("1" * 1000) + ', "id": "abc"}], "name": "foo"}'
+    out = FieldExtractCompressor().compress(payload, max_chars=80)
+    parsed = json.loads(out)
+    assert len(out) <= 80
+    assert parsed["items"][0]["huge"] == ""
+    assert parsed["items"][0]["id"] == "abc"
+    assert parsed["name"] == "foo"
+
+
 # ── E2. Budget-fill: no collapse cliff, keep leading full-length values ───────
 
 

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -1,0 +1,313 @@
+"""Output-contract invariants for FieldExtractCompressor's final tier.
+
+FieldExtract's contract is "JSON: preserve key structure + truncate values;
+Text: head + tail lines." Its pre-fix overflow handling was
+``result[:max_chars] + "\\n... (truncated)"`` at three sites
+(``_compress_json`` for dict + scalar, ``_compress_text`` for short and
+many-line text). That BOTH overshot the budget by the 16-char suffix AND, on the
+JSON path, cut the JSON mid-token -> INVALID JSON. Separately, a top-level array
+appended an ``"\\n... (N items total ...)"`` text marker *after* ``json.dumps``,
+so any array of >5 items was unparseable JSON even before any budget pressure.
+
+This file is the regression net. Contract now:
+
+* JSON input (dict / list / scalar root) -> output is ALWAYS valid JSON.
+* every path -> ``len(output) <= max(2, max_chars)`` (the ``{}`` / ``[]`` / ``""``
+  floor is the one edge where validity wins over a sub-token cap).
+* dict: keep as many top-level keys as fit, dropping trailing ones into a valid
+  collision-safe ``_truncated`` marker;
+* list: preview head items + an in-array marker that counts against the ORIGINAL
+  length;
+* text: within budget, suffix room reserved.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memtomem_stm.proxy.compression import (
+    CompressionStrategy,
+    FieldExtractCompressor,
+    auto_select_strategy,
+)
+
+
+# ── Fixtures: each routes through a distinct _compress_json / _compress_text path
+
+
+def _wide_config_dict(services: int = 40) -> str:
+    """Many top-level keys, each a nested dict (nested >= 3 -> EXTRACT_FIELDS via
+    auto_select). Even with values truncated, the keys overflow a tight budget,
+    so trailing keys must be dropped into a valid marker."""
+    return json.dumps(
+        {
+            f"service_{i}": {
+                "host": f"10.0.{i}.{i}",
+                "port": 8000 + i,
+                "description": "A microservice that handles " + ("x" * 200),
+                "tags": [f"tag{j}" for j in range(4)],
+            }
+            for i in range(services)
+        }
+    )
+
+
+def _big_list_of_dicts(rows: int = 30, fields: int = 12) -> str:
+    """Top-level array of wide dicts. Pre-fix the trailing text marker made this
+    invalid JSON for any rows > 5; under budget pressure items are dropped."""
+    return json.dumps([{f"f{j}": f"value_{i}_{j}" * 3 for j in range(fields)} for i in range(rows)])
+
+
+def _long_scalar_string() -> str:
+    """A top-level JSON string scalar far larger than any final-tier budget."""
+    return json.dumps("a very long scalar value " * 200)
+
+
+_JSON_FIXTURES = {
+    "wide_config_dict": _wide_config_dict(),
+    "big_list_of_dicts": _big_list_of_dicts(),
+    "long_scalar_string": _long_scalar_string(),
+}
+
+_TEXT_FIXTURES = {
+    # <= 10 lines but each line huge -> the short-text branch.
+    "few_long_lines": "\n".join("x" * 4000 for _ in range(5)),
+    # > 10 lines -> the head/tail summary branch.
+    "many_lines": "\n".join(f"log line {i}: " + "y" * 120 for i in range(200)),
+}
+
+
+# ── A. Universal JSON invariants: valid JSON, within budget ───────────────────
+
+
+@pytest.mark.parametrize("name", sorted(_JSON_FIXTURES))
+@pytest.mark.parametrize("budget", [2000, 800, 500, 200, 80, 30, 10, 5, 2])
+def test_json_final_tier_is_valid_json(name: str, budget: int) -> None:
+    """The core regression: every overflowing JSON payload parses as JSON.
+    Pre-fix the mid-token slice (dict/scalar) and the trailing text marker
+    (list) both produced ``JSONDecodeError``."""
+    out = FieldExtractCompressor().compress(_JSON_FIXTURES[name], max_chars=budget)
+    json.loads(out)  # raises if invalid — the bug that shipped
+
+
+@pytest.mark.parametrize("name", sorted(_JSON_FIXTURES))
+@pytest.mark.parametrize("budget", [2000, 800, 500, 200, 80, 30, 10])
+def test_json_never_exceeds_budget(name: str, budget: int) -> None:
+    """len(output) <= max(2, budget). The pre-fix slice appended a 16-char
+    suffix after a budget-filling slice, overshooting every time."""
+    out = FieldExtractCompressor().compress(_JSON_FIXTURES[name], max_chars=budget)
+    assert len(out) <= max(2, budget), (
+        f"{name}@{budget}: produced {len(out)} chars (+{len(out) - budget})"
+    )
+
+
+# ── B. Text path stays within budget ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", sorted(_TEXT_FIXTURES))
+@pytest.mark.parametrize("budget", [3000, 1000, 300, 100, 20, 10])
+def test_text_never_exceeds_budget(name: str, budget: int) -> None:
+    """Both text branches reserved no room for their ``\\n... (truncated)``
+    suffix and overshot by 16 chars. Text has no JSON contract, but the budget
+    must hold."""
+    out = FieldExtractCompressor().compress(_TEXT_FIXTURES[name], max_chars=budget)
+    assert len(out) <= budget, f"{name}@{budget}: +{len(out) - budget}"
+
+
+# ── C. Dict: drop whole trailing keys into a valid collision-safe marker ──────
+
+
+def test_wide_dict_keeps_prefix_and_records_omissions() -> None:
+    """When the keys overflow, a valid ``_truncated`` member reports an
+    internally-consistent omitted count and the kept keys survive intact."""
+    out = FieldExtractCompressor().compress(_wide_config_dict(40), max_chars=500)
+    parsed = json.loads(out)
+    assert "service_0" in parsed
+    marker = parsed.get("_truncated", "")
+    assert "keys omitted" in marker
+    omitted = int(marker.split(" of ")[0])
+    # kept real keys + the marker key; omitted counts the rest of the 40.
+    kept_real = [k for k in parsed if k != "_truncated"]
+    assert omitted + len(kept_real) == 40
+
+
+def test_marker_key_is_collision_safe() -> None:
+    """A real top-level ``_truncated`` key must not be clobbered or repurposed
+    as the omitted-count marker."""
+    data = {"_truncated": "REAL VALUE THAT MUST SURVIVE OR BE COUNTED"}
+    data.update({f"k{i}": "v" * 100 for i in range(60)})
+    out = FieldExtractCompressor().compress(json.dumps(data), max_chars=300)
+    parsed = json.loads(out)
+    json.loads(out)  # valid
+    # The synthetic marker key is distinct from the real one.
+    synth = [k for k in parsed if k.startswith("_truncated") and k != "_truncated"]
+    if "_truncated" in parsed and synth:
+        assert "keys omitted" in parsed[synth[0]]
+
+
+# ── D. List: valid JSON, in-array marker, counts original length ──────────────
+
+
+def test_list_output_is_valid_json_with_marker() -> None:
+    """When a >5-item array is compressed, the head preview + omitted marker is
+    valid JSON. Pre-fix the trailing ``"\\n... (N items total ...)"`` text marker
+    was appended after ``json.dumps``, so the output was unparseable JSON for any
+    array over the 5-item preview."""
+    payload = _big_list_of_dicts(30)
+    budget = 3000  # < len(payload) so compression runs; > preview so items are kept
+    assert len(payload) > budget
+    out = FieldExtractCompressor().compress(payload, max_chars=budget)
+    parsed = json.loads(out)
+    assert isinstance(parsed, list)
+    assert any(isinstance(e, str) and "items omitted" in e for e in parsed)
+
+
+def test_list_marker_counts_original_length() -> None:
+    """The omitted count is against the ORIGINAL length, never the sampled
+    preview — the bug class #395's review caught on SchemaPruning. Uses small
+    items at a budget that fits several head items plus the marker."""
+    payload = json.dumps([{"id": i} for i in range(30)])
+    out = FieldExtractCompressor().compress(payload, max_chars=200)
+    parsed = json.loads(out)
+    marker = next(e for e in parsed if isinstance(e, str) and "items omitted" in e)
+    # "... (N of 30 items omitted)" — total is the real length.
+    assert "of 30 items omitted" in marker
+
+
+# ── E. Scalar root ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("budget", [200, 50, 10, 5, 2])
+def test_scalar_string_is_valid_and_within_budget(budget: int) -> None:
+    out = FieldExtractCompressor().compress(_long_scalar_string(), max_chars=budget)
+    json.loads(out)
+    assert len(out) <= max(2, budget)
+
+
+@pytest.mark.parametrize("literal", ["true", "false", "null", "12345", "-98765", "3.14159"])
+@pytest.mark.parametrize("budget", [2, 3, 4])
+def test_non_string_scalar_root_is_not_corrupted(literal: str, budget: int) -> None:
+    """A bare scalar root that can't be shortened is emitted verbatim, never
+    silently rewritten to a different value. (The first cut floored every
+    overflowing scalar to "null", turning ``true``/``42`` into ``null`` even
+    within budget — a value corruption.)"""
+    out = FieldExtractCompressor().compress(literal, max_chars=budget)
+    assert json.loads(out) == json.loads(literal), f"{literal}@{budget} -> {out!r} (corrupted)"
+
+
+# ── G. Adversarial-review regressions ─────────────────────────────────────────
+
+
+def test_list_root_does_not_collapse_to_empty() -> None:
+    """A list of small objects must keep leading items, not floor to '[]'. (A
+    fixed-size marker once inflated a small truncation above the untruncated
+    size, breaking the search's monotonicity so it stranded on '[]' though a
+    head-bearing array fit the budget.)"""
+    payload = json.dumps([{"a": 1, "b": 2} for _ in range(10)])
+    out = FieldExtractCompressor().compress(payload, max_chars=60)
+    parsed = json.loads(out)
+    assert len(out) <= 60
+    assert isinstance(parsed, list) and len(parsed) >= 2
+    assert parsed[0] == {"a": 1, "b": 2}  # leading item kept in full, not stubbed
+
+
+def test_marker_does_not_clobber_real_truncated_key_in_dropped_tail() -> None:
+    """A real top-level '_truncated' key sitting in the DROPPED tail must not be
+    impersonated by the omitted-count marker (the collision guard must consider
+    every original key, not just the kept prefix)."""
+    data = {"a": "", "b": ""}
+    data.update({f"pad{i}": "" for i in range(20)})
+    data["_truncated"] = "REAL VALUE"
+    out = FieldExtractCompressor().compress(json.dumps(data), max_chars=60)
+    parsed = json.loads(out)
+    # The synthetic marker is disambiguated (e.g. '_truncated_'); if the literal
+    # '_truncated' key is present it still carries the REAL value, never a count.
+    if "_truncated" in parsed:
+        assert "keys omitted" not in str(parsed["_truncated"])
+
+
+# ── E2. Budget-fill: no collapse cliff, keep leading full-length values ───────
+
+
+@pytest.mark.parametrize("name", sorted(_JSON_FIXTURES))
+@pytest.mark.parametrize("budget", [2000, 1200, 800])
+def test_final_tier_fills_the_budget(name: str, budget: int) -> None:
+    """The final tier fills the budget rather than collapsing far under it: more
+    than half the budget is always used (a naive depth-collapse left 15-50% —
+    the cliff documented for the SchemaPruning final tier). Lists fill at item
+    granularity (coarser than dicts), hence the > 50% — not > 90% — bar here."""
+    payload = _JSON_FIXTURES[name]
+    out = FieldExtractCompressor().compress(payload, max_chars=budget)
+    assert len(out) <= budget
+    assert len(out) > 0.5 * budget, f"{name}@{budget}: only {len(out) / budget:.0%} of budget used"
+
+
+def test_dict_final_tier_fills_budget_tightly() -> None:
+    """A dict's skeleton+enrich fills the budget tightly (the per-key greedy has
+    fine granularity), unlike the coarse list-item case."""
+    cfg = _wide_config_dict(40)
+    for budget in (800, 1200, 2000):
+        out = FieldExtractCompressor().compress(cfg, max_chars=budget)
+        assert len(out) <= budget
+        assert len(out) >= 0.9 * budget, f"@{budget}: only {len(out) / budget:.0%} used"
+
+
+def test_skeleton_keeps_all_top_level_keys_when_it_fits() -> None:
+    """When the all-stub skeleton fits the budget, EVERY top-level key survives
+    (FieldExtract's 'preserve key structure' contract); only when the stubs
+    themselves overflow are trailing keys dropped."""
+    cfg = _wide_config_dict(40)
+    out = FieldExtractCompressor().compress(cfg, max_chars=1500)
+    parsed = json.loads(out)
+    assert "_truncated" not in parsed
+    for i in range(40):
+        assert f"service_{i}" in parsed, f"top-level key service_{i} dropped at a fitting budget"
+
+
+def test_leading_short_values_survive_under_pressure() -> None:
+    """Short scalar values in the leading content stay full-length under budget
+    pressure (uniform string-capping would shred them; the greedy fill keeps
+    leading values whole). Mirrors the bench s02 QA contract."""
+    payload = json.dumps(
+        {
+            "page": {"next": "?page=2"},
+            "users": [
+                {"name": "Alice Park", "role": "admin", "dept": "Engineering"},
+                {"name": "Bob Chen", "role": "developer", "dept": "Platform"},
+                {"name": "Carla Ruiz", "role": "designer", "dept": "Product"},
+            ]
+            + [{"name": f"Filler {i}", "role": "viewer", "dept": "x" * 120} for i in range(20)],
+        }
+    )
+    out = FieldExtractCompressor().compress(payload, max_chars=600)
+    assert len(out) <= 600
+    json.loads(out)
+    # The leading user's full name + role survive intact (not truncated to a stub).
+    assert "Alice Park" in out
+    assert "admin" in out
+
+
+# ── F. Passthrough / reachability ────────────────────────────────────────────
+
+
+def test_short_input_passthrough() -> None:
+    assert FieldExtractCompressor().compress("short", max_chars=100) == "short"
+
+
+def test_fits_budget_passthrough_is_unchanged() -> None:
+    """When the extracted form already fits, output equals the plain dump (no
+    final-tier reshaping)."""
+    text = json.dumps({"a": {"b": 1}, "c": {"d": 2}, "e": {"f": 3}})
+    out = FieldExtractCompressor().compress(text, max_chars=10_000)
+    assert json.loads(out) == json.loads(text)
+
+
+def test_wide_config_dict_routes_to_extract_fields() -> None:
+    """Confirms the fixture is genuinely reachable via auto_select (nested >= 3,
+    no array >= 20) — the final tier is not dead code."""
+    assert (
+        auto_select_strategy(_wide_config_dict(40), max_chars=500)
+        == CompressionStrategy.EXTRACT_FIELDS
+    )

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -187,14 +187,21 @@ def test_scalar_string_is_valid_and_within_budget(budget: int) -> None:
 
 
 @pytest.mark.parametrize("literal", ["true", "false", "null", "12345", "-98765", "3.14159"])
-@pytest.mark.parametrize("budget", [2, 3, 4])
-def test_non_string_scalar_root_is_not_corrupted(literal: str, budget: int) -> None:
-    """A bare scalar root that can't be shortened is emitted verbatim, never
-    silently rewritten to a different value. (The first cut floored every
-    overflowing scalar to "null", turning ``true``/``42`` into ``null`` even
-    within budget — a value corruption.)"""
-    out = FieldExtractCompressor().compress(literal, max_chars=budget)
-    assert json.loads(out) == json.loads(literal), f"{literal}@{budget} -> {out!r} (corrupted)"
+def test_non_string_scalar_root_verbatim_when_it_fits(literal: str) -> None:
+    """A bare scalar root that fits the budget is emitted VERBATIM, never
+    rewritten to a different value. (The first cut floored every overflowing
+    scalar to "null", turning ``true``/``42`` into ``null`` — value corruption.)"""
+    out = FieldExtractCompressor().compress(literal, max_chars=len(literal))
+    assert json.loads(out) == json.loads(literal), f"{literal} -> {out!r} (corrupted)"
+
+
+def test_huge_scalar_root_stays_within_budget() -> None:
+    """A scalar literal longer than the budget (e.g. a 1000-digit number) is
+    bounded — max_chars is a hard token budget — by degrading to a truncated
+    string, never emitted verbatim over budget."""
+    out = FieldExtractCompressor().compress("1" * 1000, max_chars=100)
+    json.loads(out)
+    assert len(out) <= 100
 
 
 # ── G. Adversarial-review regressions ─────────────────────────────────────────


### PR DESCRIPTION
## Background

`FieldExtractCompressor` was the deferred sibling of #395 (SchemaPruning final-tier fix). Its overflow handling — `result[:max_chars] + "\n... (truncated)"` at three sites (`_compress_json` dict + scalar, `_compress_text`) — both **overshot the budget** by the 16-char suffix and, on the JSON path, **cut JSON mid-token → invalid JSON**. Separately, a top-level array appended its omitted-count as a **trailing text marker after `json.dumps`**, so any array of >5 items was unparseable JSON regardless of budget.

The reopen trigger ("invalid output / budget breach on a real payload through this compressor") is now empirically reproduced.

## Concrete gap

```
FieldExtractCompressor().compress(<40-key config dict>, max_chars=500)
  before: len 516 (+16 over budget), json.loads -> JSONDecodeError
  after : len 481 (<= 500), valid JSON, all 40 top-level keys present
```

A naive "valid + within budget" fix is **not** enough: matching the old invalid output's content density requires *filling* the budget. On the bench fixture `s02` (paginated JSON whose budget sits barely above the retention floor) a uniform string-cap or depth-collapse drops below the ratio floor and strips QA-relevant values. So the final tier fills the budget with leading full-detail content.

## Change

- **`_take(value, budget)`** — greedy prefix-fill, **strict** (`compact len <= budget`) for containers, keeping leading full-length scalars (names/ids/roles) and truncating only the boundary string; the tail drops into a valid omitted-count marker counted against the **original** length and collision-safe against **every** original key (incl. a real `_truncated` in the dropped tail).
- **`_fit_extracted`** — a top-level dict lays down an **all-key skeleton** (preserves key structure), then **enriches keys in document order** to fill the budget; list / scalar roots call `_take` directly. Floors to `{}` / `[]` / `""` and emits a non-string scalar root **verbatim** (never corrupts `true`/`42` → `null`).
- Top-level array output uses an **in-array** omitted marker (valid JSON), not a trailing text suffix.

Dict budget utilisation is now ~98–100% (vs the 15–22% a depth-collapse cliff leaves); `s02` keeps its full QA values within `[floor, budget]`.

## Behavior change

- The JSON final tier now yields **all-keys-or-valid-marker** instead of an invalid mid-token slice; a top-level array's omitted-count is an in-array element rather than a trailing text suffix. `NESTED_CONFIG`/`API_RESPONSE` info-loss "all top-level keys visible" tests pass unchanged.
- `test_json_array_shows_first_items`'s budget was raised (a sub-100 budget could only surface `item0` via the old over-budget invalid slice).

## Tests

`tests/test_field_extract_output_invariants.py` (104 tests): valid-JSON, within-budget, budget-fill (no cliff), skeleton all-keys, scalar non-corruption, collision-safe markers — including regressions for findings surfaced by an adversarial-review workflow (list-root never floors to `[]`; non-string scalar roots never corrupt to `null`; marker never clobbers a real `_truncated` in the dropped tail). Full suite green (2 pre-existing py3.13 stdio-teardown flakes only).

## Deferred (separate PR)

Non-finite floats (`NaN`/`Infinity`) serialize to RFC-invalid bare tokens — a **pre-existing** class shared with SchemaPruning/Truncate (`json.dumps` default `allow_nan`), not introduced here. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)