### PR TITLE
feat(surfacing): support network LTM MCP transport

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,8 +116,14 @@ export MEMTOMEM_STM_SURFACING__DEDUP_TTL_SECONDS=604800    # 7 days; 0 to disabl
 export MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH=~/.memtomem/stm_feedback.db
 
 # LTM connection (defaults shown)
+export MEMTOMEM_STM_SURFACING__LTM_MCP_TRANSPORT=stdio
 export MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND=memtomem-server
 export MEMTOMEM_STM_SURFACING__LTM_MCP_ARGS='["--config","/etc/memtomem.json"]'
+
+# Network LTM service instead of stdio
+export MEMTOMEM_STM_SURFACING__LTM_MCP_TRANSPORT=streamable_http
+export MEMTOMEM_STM_SURFACING__LTM_MCP_URL=https://ltm.example/mcp
+export MEMTOMEM_STM_SURFACING__LTM_MCP_HEADERS='{"Authorization":"Bearer ..."}'
 ```
 
 See [Surfacing → Surfacing Controls](surfacing.md#surfacing-controls) for the complete table of fields and defaults.

--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -91,6 +91,11 @@ The injection mode is configurable: `append` (default), `prepend`, or `section`.
 | `preview_max_chars` | `300` | Max chars per result preview in the injected memory block |
 | `consumer_model` | `""` | Model name for auto-scaling `max_results` and `max_injection_chars` |
 | `feedback_db_path` | `~/.memtomem/stm_feedback.db` | SQLite store for events, feedback, and cross-session dedup |
+| `ltm_mcp_transport` | `stdio` | LTM MCP transport: `stdio`, `sse`, or `streamable_http` |
+| `ltm_mcp_command` | `memtomem-server` | Command used when `ltm_mcp_transport=stdio` |
+| `ltm_mcp_args` | `[]` | Args passed to the stdio LTM command |
+| `ltm_mcp_url` | `""` | Required endpoint when `ltm_mcp_transport` is `sse` or `streamable_http` |
+| `ltm_mcp_headers` | `null` | Optional static headers for network LTM transports |
 | `cache_ttl_seconds` | `60.0` | Internal surfacing result cache TTL |
 | `circuit_max_failures` | `3` | Consecutive failures before circuit breaker opens |
 | `circuit_reset_seconds` | `60.0` | Seconds before half-open probe after circuit opens |
@@ -186,10 +191,16 @@ STM connects to the LTM exclusively over the MCP protocol. The surfacing engine 
 
 ```bash
 # Default — spawns `memtomem-server` as a child process
+export MEMTOMEM_STM_SURFACING__LTM_MCP_TRANSPORT=stdio
 export MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND=memtomem-server
 
 # Pass extra arguments if needed (e.g. point at a custom config)
 export MEMTOMEM_STM_SURFACING__LTM_MCP_ARGS='["--config","/etc/memtomem.json"]'
+
+# Or connect to a long-running network MCP service
+export MEMTOMEM_STM_SURFACING__LTM_MCP_TRANSPORT=sse
+export MEMTOMEM_STM_SURFACING__LTM_MCP_URL=https://ltm.example/sse
+export MEMTOMEM_STM_SURFACING__LTM_MCP_HEADERS='{"Authorization":"Bearer ..."}'
 ```
 
 This makes memtomem reachable over the same MCP protocol boundary STM uses for other upstreams. Unlike a generic proxied upstream, LTM responses bypass the compression / cache pipeline — they are consumed by STM's surfacing engine (via `McpClientSearchAdapter`, see `src/memtomem_stm/surfacing/mcp_client.py`) to compose context for upstream calls, rather than being passed through to the caller. A memtomem crash never takes down STM's other upstream connections.

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import tomllib
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import AsyncExitStack, contextmanager
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -2200,13 +2200,16 @@ def _version_from_tool_result(result: Any) -> str | None:
     return str(version) if version else None
 
 
-async def _probe_ltm_mcp_command(
+async def _probe_ltm_mcp_server(
+    transport: str,
     command: str,
     args: list[str],
+    url: str,
+    headers: dict[str, str] | None,
     timeout: float,
     errlog: TextIO,
 ) -> dict[str, Any]:
-    """Probe the configured LTM stdio MCP server without starting the proxy.
+    """Probe the configured LTM MCP server without starting the proxy.
 
     *timeout* is an **end-to-end** budget shared across initialize +
     list_tools + the optional ``mem_do(action="version")`` probe — each
@@ -2230,7 +2233,9 @@ async def _probe_ltm_mcp_command(
     ``create_subprocess_exec(stderr=...)``, which requires ``fileno``).
     """
     from mcp import ClientSession
+    from mcp.client.sse import sse_client
     from mcp.client.stdio import StdioServerParameters, stdio_client
+    from mcp.client.streamable_http import streamablehttp_client
 
     deadline = asyncio.get_running_loop().time() + timeout
 
@@ -2240,8 +2245,27 @@ async def _probe_ltm_mcp_command(
         # returning a bogus result on a zero-budget call.
         return max(1e-3, deadline - asyncio.get_running_loop().time())
 
-    params = StdioServerParameters(command=command, args=args)
-    async with stdio_client(params, errlog=errlog) as streams:
+    sdk_timeout = remaining()
+    if transport == "sse":
+        ctx = sse_client(
+            url,
+            headers=headers,
+            timeout=sdk_timeout,
+            sse_read_timeout=sdk_timeout,
+        )
+    elif transport == "streamable_http":
+        ctx = streamablehttp_client(
+            url,
+            headers=headers,
+            timeout=sdk_timeout,
+            sse_read_timeout=sdk_timeout,
+        )
+    else:
+        params = StdioServerParameters(command=command, args=args)
+        ctx = stdio_client(params, errlog=errlog)
+
+    async with AsyncExitStack() as stack:
+        streams = await asyncio.wait_for(stack.enter_async_context(ctx), timeout=remaining())
         async with ClientSession(streams[0], streams[1]) as session:
             await asyncio.wait_for(session.initialize(), timeout=remaining())
             tools_result = await asyncio.wait_for(session.list_tools(), timeout=remaining())
@@ -2288,12 +2312,23 @@ def _ltm_mcp_status(surfacing: Any, timeout: float) -> dict[str, Any]:
     diagnostic past the user-requested ceiling. ``surfacing.timeout_seconds``
     (the runtime-call timeout) is not used here — it's a different SLA.
     """
+    transport = str(getattr(surfacing, "ltm_mcp_transport", "stdio") or "stdio")
     command = str(getattr(surfacing, "ltm_mcp_command", "") or "")
     args = [str(arg) for arg in (getattr(surfacing, "ltm_mcp_args", []) or [])]
-    display = _format_command_for_display(command, args) if command else "(empty command)"
+    url = str(getattr(surfacing, "ltm_mcp_url", "") or "")
+    headers = getattr(surfacing, "ltm_mcp_headers", None)
+    if not isinstance(headers, dict):
+        headers = None
+    display = (
+        _format_command_for_display(command, args)
+        if transport == "stdio" and command
+        else url or "(empty url)"
+    )
     status: dict[str, Any] = {
+        "transport": transport,
         "command": command,
         "args": args,
+        "url": url,
         "display": display,
         "connected": None,
         "version": None,
@@ -2303,11 +2338,15 @@ def _ltm_mcp_status(surfacing: Any, timeout: float) -> dict[str, Any]:
     if not getattr(surfacing, "enabled", False):
         status["skipped"] = "surfacing_disabled"
         return status
-    if not command:
+    if transport != "stdio" and not url:
+        status["connected"] = False
+        status["error"] = "ltm_mcp_url is required for network LTM transport"
+        return status
+    if transport == "stdio" and not command:
         status["connected"] = False
         status["error"] = "ltm_mcp_command is empty"
         return status
-    if shutil.which(command) is None:
+    if transport == "stdio" and shutil.which(command) is None:
         status["connected"] = False
         status["error"] = f"{command} not on PATH"
         return status
@@ -2320,7 +2359,17 @@ def _ltm_mcp_status(surfacing: Any, timeout: float) -> dict[str, Any]:
         # here. ``os.devnull`` gives us a fd-backed sink so server banners
         # and MCP-SDK stderr can't bleed into ``mms health`` output.
         with open(os.devnull, "w") as errnull, _silenced_mcp_sdk_logs():
-            probe = asyncio.run(_probe_ltm_mcp_command(command, args, probe_timeout, errnull))
+            probe = asyncio.run(
+                _probe_ltm_mcp_server(
+                    transport,
+                    command,
+                    args,
+                    url,
+                    headers,
+                    probe_timeout,
+                    errnull,
+                )
+            )
     except Exception as exc:
         # ``asyncio.wait_for`` inside the probe raises ``TimeoutError``, but
         # anyio's ``TaskGroup`` (wrapped by ``stdio_client``) re-raises it

--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -36,8 +36,14 @@ class SurfacingConfig(BaseModel):
     ``seen_memories`` cross-session dedup. Configurable so tests and
     notebooks can isolate state into a tempdir via
     ``MEMTOMEM_STM_SURFACING__FEEDBACK_DB_PATH``."""
+    ltm_mcp_transport: Literal["stdio", "sse", "streamable_http"] = "stdio"
+    """Transport used to connect to the LTM MCP server."""
     ltm_mcp_command: str = "memtomem-server"
     ltm_mcp_args: list[str] = []
+    ltm_mcp_url: str = ""
+    """Network endpoint for ``sse`` / ``streamable_http`` LTM transports."""
+    ltm_mcp_headers: dict[str, str] | None = None
+    """Optional static headers for network LTM transports."""
     min_score: float = Field(default=0.03, ge=0.0, le=1.0)
     max_results: int = Field(default=3, gt=0)
     min_query_tokens: int = Field(default=3, gt=0)
@@ -139,6 +145,11 @@ class SurfacingConfig(BaseModel):
         step further is a wait-for-signal concern, not a constructor
         constraint.
         """
+        if self.ltm_mcp_transport != "stdio" and not self.ltm_mcp_url:
+            raise ValueError(
+                f"ltm_mcp_url is required when ltm_mcp_transport is {self.ltm_mcp_transport!r}"
+            )
+
         set_fields = self.model_fields_set
         if "auto_tune_score_ceiling" not in set_fields:
             self.auto_tune_score_ceiling = max(self.auto_tune_score_ceiling, self.min_score)

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -352,7 +352,7 @@ class SurfacingEngine:
                             "chunk_count": len(target_ids),
                         },
                     ):
-                        await self._mcp_adapter.increment_access(target_ids)
+                        await self._increment_access_with_timeout(target_ids)
                     # Prune if exceeded cap — evict oldest (first-inserted) entries.
                     if len(self._boosted_event_ids) > self._boosted_event_ids_max:
                         excess = len(self._boosted_event_ids) - self._boosted_event_ids_max // 2
@@ -434,7 +434,7 @@ class SurfacingEngine:
                         "chunk_count": len(helpful_ids),
                     },
                 ):
-                    await self._mcp_adapter.increment_access(helpful_ids)
+                    await self._increment_access_with_timeout(helpful_ids)
                 if len(self._boosted_event_ids) > self._boosted_event_ids_max:
                     excess = len(self._boosted_event_ids) - self._boosted_event_ids_max // 2
                     for k in list(self._boosted_event_ids)[:excess]:
@@ -451,6 +451,18 @@ class SurfacingEngine:
         if errors:
             summary += " — " + "; ".join(errors)
         return summary
+
+    async def _increment_access_with_timeout(self, chunk_ids: list[str]) -> None:
+        """Best-effort LTM boost for helpful feedback.
+
+        Feedback recording must not block behind LTM startup or a stalled
+        network transport. Bound the whole adapter call, including lazy
+        connection setup, with the same surfacing timeout budget.
+        """
+        await asyncio.wait_for(
+            self._mcp_adapter.increment_access(chunk_ids),
+            timeout=self._config.timeout_seconds,
+        )
 
     def _invalidate_cache_for_feedback(self, surfacing_id: str, memory_id: str | None) -> None:
         """Populate ``_invalidated_ids`` from a surfacing event.
@@ -679,12 +691,17 @@ class SurfacingEngine:
         # empty-namespace case.
         if outcome in ("no_session", "transport_error"):
             if not self._warned_ltm_unavailable:
+                if self._config.ltm_mcp_transport == "stdio":
+                    ltm_target = self._config.ltm_mcp_command
+                else:
+                    ltm_target = self._config.ltm_mcp_url
                 logger.warning(
-                    "Surfacing skipped: LTM MCP command %r is not reachable "
+                    "Surfacing skipped: LTM MCP %s target %r is not reachable "
                     "(outcome=%s). Subsequent skips counted as 'ltm_unavailable' "
                     "in stm_surfacing_stats. Run `mms health` to diagnose or "
                     "set `surfacing.enabled=false` to silence.",
-                    self._config.ltm_mcp_command,
+                    self._config.ltm_mcp_transport,
+                    ltm_target,
                     outcome,
                 )
                 self._warned_ltm_unavailable = True

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from mcp import ClientSession
+from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import TextContent
 
 from memtomem_stm.surfacing.config import SurfacingConfig
@@ -219,7 +221,7 @@ _compact_parser = CompactResultParser()
 
 
 class McpClientSearchAdapter:
-    """Connects to a memtomem MCP server via stdio and calls mem_search.
+    """Connects to a memtomem MCP server and calls mem_search.
 
     Implements enough of the SearchPipeline interface for SurfacingEngine.
     """
@@ -253,18 +255,15 @@ class McpClientSearchAdapter:
         stack = AsyncExitStack()
         self._stack = stack
         try:
-            # #297: LTM transport is currently stdio-only. Adding SSE /
-            # streamable HTTP means giving SurfacingConfig a transport field
-            # and branching here, mirroring ``ProxyManager._open_transport``.
-            params = StdioServerParameters(
-                command=self._config.ltm_mcp_command,
-                args=self._config.ltm_mcp_args,
-            )
-            transport = stdio_client(params)
+            transport = self._open_transport()
             streams = await stack.enter_async_context(transport)
             self._session = await stack.enter_async_context(ClientSession(streams[0], streams[1]))
             await self._session.initialize()
-            logger.info("MCP client connected to memtomem server: %s", self._config.ltm_mcp_command)
+            logger.info(
+                "MCP client connected to memtomem server via %s: %s",
+                self._config.ltm_mcp_transport,
+                self._target_display(),
+            )
             await self._negotiate_format()
         except BaseException:
             # Roll back any contexts we entered (transport subprocess, session
@@ -277,6 +276,30 @@ class McpClientSearchAdapter:
             self._stack = None
             self._session = None
             raise
+
+    def _open_transport(self):  # noqa: ANN201
+        match self._config.ltm_mcp_transport:
+            case "sse":
+                return sse_client(
+                    self._config.ltm_mcp_url,
+                    headers=self._config.ltm_mcp_headers,
+                )
+            case "streamable_http":
+                return streamablehttp_client(
+                    self._config.ltm_mcp_url,
+                    headers=self._config.ltm_mcp_headers,
+                )
+            case _:
+                params = StdioServerParameters(
+                    command=self._config.ltm_mcp_command,
+                    args=self._config.ltm_mcp_args,
+                )
+                return stdio_client(params)
+
+    def _target_display(self) -> str:
+        if self._config.ltm_mcp_transport == "stdio":
+            return self._config.ltm_mcp_command
+        return self._config.ltm_mcp_url
 
     async def _negotiate_format(self) -> None:
         """Downgrade to compact if core doesn't advertise structured support.
@@ -317,7 +340,11 @@ class McpClientSearchAdapter:
 
     async def _reconnect(self) -> None:
         """Tear down and re-establish the MCP connection."""
-        logger.info("Attempting MCP adapter reconnect to %s", self._config.ltm_mcp_command)
+        logger.info(
+            "Attempting MCP adapter reconnect via %s to %s",
+            self._config.ltm_mcp_transport,
+            self._target_display(),
+        )
         try:
             await self.stop()
         except Exception:

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -14,10 +14,12 @@ home directory is touched.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
@@ -3813,6 +3815,90 @@ class TestHealth:
         assert result.exit_code == 0
         assert "ltm server: UNREACHABLE" in result.output
         assert "__missing_ltm__ not on PATH" in result.output
+
+    def test_ltm_network_health_uses_url_not_stdio_command(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        captured = {}
+
+        async def fake_probe(transport, command, args, url, headers, timeout, errlog):
+            captured.update(
+                {
+                    "transport": transport,
+                    "command": command,
+                    "args": args,
+                    "url": url,
+                    "headers": headers,
+                    "timeout": timeout,
+                    "errlog": errlog,
+                }
+            )
+            return {"connected": True, "version": "0.3.0-net", "error": None}
+
+        monkeypatch.setattr(proxy_mod, "_probe_ltm_mcp_server", fake_probe)
+
+        status = proxy_mod._ltm_mcp_status(
+            SimpleNamespace(
+                enabled=True,
+                ltm_mcp_transport="sse",
+                ltm_mcp_command="__missing_ltm__",
+                ltm_mcp_args=[],
+                ltm_mcp_url="https://ltm.example/sse",
+                ltm_mcp_headers={"Authorization": "Bearer token"},
+            ),
+            timeout=2,
+        )
+
+        assert status["connected"] is True
+        assert status["transport"] == "sse"
+        assert status["display"] == "https://ltm.example/sse"
+        assert captured["transport"] == "sse"
+        assert captured["command"] == "__missing_ltm__"
+        assert captured["url"] == "https://ltm.example/sse"
+        assert captured["headers"] == {"Authorization": "Bearer token"}
+
+    def test_sse_ltm_probe_timeout_bounds_transport_enter(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        captured = {}
+
+        class HangingTransport:
+            async def __aenter__(self):
+                await asyncio.sleep(60)
+
+            async def __aexit__(self, *_args):
+                return None
+
+        def fake_sse_client(url, *, headers=None, timeout=None, sse_read_timeout=None):
+            captured.update(
+                {
+                    "url": url,
+                    "headers": headers,
+                    "timeout": timeout,
+                    "sse_read_timeout": sse_read_timeout,
+                }
+            )
+            return HangingTransport()
+
+        monkeypatch.setattr("mcp.client.sse.sse_client", fake_sse_client)
+
+        with pytest.raises(TimeoutError):
+            asyncio.run(
+                proxy_mod._probe_ltm_mcp_server(
+                    "sse",
+                    "",
+                    [],
+                    "https://ltm.example/sse",
+                    {"Authorization": "Bearer token"},
+                    0.1,
+                    sys.stderr,
+                )
+            )
+
+        assert captured["url"] == "https://ltm.example/sse"
+        assert captured["headers"] == {"Authorization": "Bearer token"}
+        assert captured["timeout"] == pytest.approx(0.1, rel=0.1)
+        assert captured["sse_read_timeout"] == pytest.approx(0.1, rel=0.1)
 
     def test_health_reports_connectable_ltm_server(self, config, monkeypatch):
         """Probe a live MCP child via real subprocess.

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -80,6 +80,33 @@ class TestProxyNumericConstraints:
         assert cfg.reconnect_delay_seconds == 5
 
 
+class TestSurfacingLtmTransportConfig:
+    def test_stdio_transport_keeps_existing_defaults(self) -> None:
+        cfg = SurfacingConfig()
+
+        assert cfg.ltm_mcp_transport == "stdio"
+        assert cfg.ltm_mcp_command == "memtomem-server"
+        assert cfg.ltm_mcp_url == ""
+        assert cfg.ltm_mcp_headers is None
+
+    def test_network_transport_requires_url(self) -> None:
+        with pytest.raises(ValidationError, match="ltm_mcp_url is required"):
+            SurfacingConfig(ltm_mcp_transport="sse")
+
+        with pytest.raises(ValidationError, match="ltm_mcp_url is required"):
+            SurfacingConfig(ltm_mcp_transport="streamable_http")
+
+    def test_network_transport_accepts_url_and_headers(self) -> None:
+        cfg = SurfacingConfig(
+            ltm_mcp_transport="streamable_http",
+            ltm_mcp_url="https://ltm.example/mcp",
+            ltm_mcp_headers={"Authorization": "Bearer token"},
+        )
+
+        assert cfg.ltm_mcp_url == "https://ltm.example/mcp"
+        assert cfg.ltm_mcp_headers == {"Authorization": "Bearer token"}
+
+
 class TestLLMCompressorApiKey:
     """``provider=openai|anthropic`` with empty ``api_key`` used to send a
     malformed ``Bearer `` header and silently fall back to truncate; validate

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -43,6 +43,85 @@ def _result_with_text(text: str):
     return r
 
 
+# ── LTM transport selection (#297) ───────────────────────────────────────
+
+
+class TestLtmTransportSelection:
+    def test_stdio_transport_uses_command_and_args(self, monkeypatch):
+        from memtomem_stm.surfacing import mcp_client as mod
+
+        captured = {}
+        sentinel = object()
+
+        def fake_stdio_client(params):
+            captured["command"] = params.command
+            captured["args"] = params.args
+            return sentinel
+
+        monkeypatch.setattr(mod, "stdio_client", fake_stdio_client)
+
+        adapter = McpClientSearchAdapter(
+            SurfacingConfig(ltm_mcp_command="memtomem-dev", ltm_mcp_args=["--debug"])
+        )
+
+        assert adapter._open_transport() is sentinel
+        assert captured == {"command": "memtomem-dev", "args": ["--debug"]}
+
+    def test_sse_transport_uses_url_and_headers(self, monkeypatch):
+        from memtomem_stm.surfacing import mcp_client as mod
+
+        captured = {}
+        sentinel = object()
+
+        def fake_sse_client(url, *, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return sentinel
+
+        monkeypatch.setattr(mod, "sse_client", fake_sse_client)
+
+        adapter = McpClientSearchAdapter(
+            SurfacingConfig(
+                ltm_mcp_transport="sse",
+                ltm_mcp_url="https://ltm.example/sse",
+                ltm_mcp_headers={"Authorization": "Bearer token"},
+            )
+        )
+
+        assert adapter._open_transport() is sentinel
+        assert captured == {
+            "url": "https://ltm.example/sse",
+            "headers": {"Authorization": "Bearer token"},
+        }
+
+    def test_streamable_http_transport_uses_url_and_headers(self, monkeypatch):
+        from memtomem_stm.surfacing import mcp_client as mod
+
+        captured = {}
+        sentinel = object()
+
+        def fake_streamablehttp_client(url, *, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return sentinel
+
+        monkeypatch.setattr(mod, "streamablehttp_client", fake_streamablehttp_client)
+
+        adapter = McpClientSearchAdapter(
+            SurfacingConfig(
+                ltm_mcp_transport="streamable_http",
+                ltm_mcp_url="https://ltm.example/mcp",
+                ltm_mcp_headers={"X-Project": "stm"},
+            )
+        )
+
+        assert adapter._open_transport() is sentinel
+        assert captured == {
+            "url": "https://ltm.example/mcp",
+            "headers": {"X-Project": "stm"},
+        }
+
+
 # ── Reconnect retry paths ────────────────────────────────────────────────
 
 

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -726,6 +726,29 @@ class TestFeedbackBoost:
         # so a future call can retry the boost.
         assert "sid-5" not in engine._boosted_event_ids
 
+    async def test_boost_timeout_does_not_break_feedback(self):
+        """A stalled LTM boost must not stall feedback recording indefinitely."""
+        adapter = _make_mcp_adapter([])
+
+        async def stalled_increment(_ids):
+            await asyncio.sleep(60)
+
+        adapter.increment_access = AsyncMock(side_effect=stalled_increment)
+        tracker = self._make_tracker(["mid-A"])
+        engine = SurfacingEngine(
+            config=_make_config(timeout_seconds=0.01),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        result = await engine.handle_feedback("sid-timeout", "helpful", memory_id="mid-A")
+
+        assert "Feedback recorded" in result
+        adapter.increment_access.assert_awaited_once_with(["mid-A"])
+        # Timeout is treated like any other failed best-effort boost: release
+        # the guard so a later feedback call can retry.
+        assert "sid-timeout" not in engine._boosted_event_ids
+
     async def test_no_boost_when_event_has_no_memories(self):
         """When the surfacing event has no memories, skip the call entirely."""
         adapter = _make_mcp_adapter([])
@@ -887,6 +910,32 @@ class TestHandleFeedbackBatch:
         )
 
         adapter.increment_access.assert_awaited_once_with(["mid-A", "mid-B"])
+
+    async def test_batched_boost_timeout_does_not_break_feedback(self):
+        adapter = _make_mcp_adapter([])
+
+        async def stalled_increment(_ids):
+            await asyncio.sleep(60)
+
+        adapter.increment_access = AsyncMock(side_effect=stalled_increment)
+        tracker = self._make_tracker(memory_ids=["mid-A", "mid-B"])
+        engine = SurfacingEngine(
+            config=_make_config(timeout_seconds=0.01),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+
+        result = await engine.handle_feedback_batch(
+            "sid-batch-timeout",
+            [
+                {"memory_id": "mid-A", "rating": "helpful"},
+                {"memory_id": "mid-B", "rating": "helpful"},
+            ],
+        )
+
+        assert "2/2 entries" in result
+        adapter.increment_access.assert_awaited_once_with(["mid-A", "mid-B"])
+        assert "sid-batch-timeout" not in engine._boosted_event_ids
 
     async def test_per_event_boost_guard_blocks_batched_after_single(self):
         """A single-call ``helpful`` first claims the guard; a subsequent


### PR DESCRIPTION
## Summary
- add surfacing LTM MCP transport config for stdio, SSE, and streamable HTTP
- route McpClientSearchAdapter and mms health through the selected transport, including URL and headers for network LTM services
- document the new environment variables and cover config, adapter, and health behavior with tests

Fixes #297

## Verification
- uv run pytest tests/test_config_constraints.py tests/test_mcp_client_reconnect.py tests/test_surfacing_engine.py::TestSurfacingLtmOutcomeDispatch tests/cli/test_proxy_cli.py::TestHealth tests/test_remote_ltm_integration.py -q
- uv run ruff check src/memtomem_stm/surfacing/config.py src/memtomem_stm/surfacing/mcp_client.py src/memtomem_stm/surfacing/engine.py src/memtomem_stm/cli/proxy.py tests/test_config_constraints.py tests/test_mcp_client_reconnect.py tests/cli/test_proxy_cli.py
- git diff --check