### PR TITLE
Fix surfacing feedback demotion

### DIFF
--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -105,6 +105,8 @@ The injection mode is configurable: `append` (default), `prepend`, or `section`.
 | `auto_tune_min_samples` | `20` | Minimum feedback entries before adjusting per-tool score |
 | `auto_tune_score_increment` | `0.002` | Step size for `min_score` adjustments |
 | `feedback_enabled` | `true` | Enable the feedback recording and `stm_surfacing_feedback` tool |
+| `feedback_demotion_enabled` | `true` | Locally filter memories that accumulated repeated negative feedback (`not_relevant` or `already_known`) before cache/injection |
+| `feedback_demotion_negative_threshold` | `3` | Distinct negative surfacing events required before local STM demotion applies to a memory |
 | `fire_webhook` | `true` | Fire surfacing event webhooks |
 
 ## Per-tool Templates
@@ -218,6 +220,7 @@ Surfacing tracks which memory IDs have already been shown so the same content do
 | In-memory `_surfaced_ids` | Insertion-ordered `dict` on the `SurfacingEngine` | Skip IDs already surfaced in this process | Bulk prune to ~5,000 entries when size exceeds **10,000** (FIFO — oldest insertions go first) |
 | In-memory `_boosted_event_ids` | Insertion-ordered `dict` on the `SurfacingEngine` | Ensure each surfacing event's `access_count` boost fires exactly once, even across repeated `helpful` ratings | Bulk prune to ~5,000 when size exceeds **10,000** (same FIFO as `_surfaced_ids`) |
 | Persistent `seen_memories` | SQLite row in `stm_feedback.db` | Skip IDs surfaced in a prior session within `dedup_ttl_seconds` | TTL-based (default 7 days; `0` disables) |
+| Persistent negative feedback | SQLite rows in `surfacing_feedback` | Locally demote IDs with at least `feedback_demotion_negative_threshold` distinct negative surfacing events | Kept with feedback history; set `feedback_demotion_enabled=false` to disable filtering |
 
 The in-memory set is **seeded from `seen_memories`** on startup so dedup survives restarts within the TTL, and every new surfacing writes to both layers via `FeedbackStore.mark_surfaced(ids)`.
 

--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -71,6 +71,13 @@ class SurfacingConfig(BaseModel):
     ]
     context_tools: dict[str, ToolSurfacingConfig] = {}
     feedback_enabled: bool = True
+    feedback_demotion_enabled: bool = True
+    """When enabled, memories with repeated negative feedback are locally
+    filtered from future STM surfacing results. This is an STM-side shadow
+    demotion; the LTM rank itself is not mutated."""
+    feedback_demotion_negative_threshold: int = Field(default=3, gt=0)
+    """Distinct negative surfacing events required before a memory is locally
+    demoted. Negative feedback is ``not_relevant`` or ``already_known``."""
     max_surfacings_per_minute: int = Field(default=15, gt=0)
     cache_ttl_seconds: float = Field(default=60.0, ge=0.0)
     circuit_max_failures: int = Field(default=3, ge=0)

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -506,6 +506,30 @@ class SurfacingEngine:
             for k in list(self._invalidated_ids)[:excess]:
                 del self._invalidated_ids[k]
 
+    def _feedback_demoted_ids(self, memory_ids: list[str]) -> set[str]:
+        """Return IDs that accumulated enough durable negative feedback.
+
+        This is STM-side shadow demotion for memories the LTM still ranks
+        above ``min_score`` after repeated ``not_relevant`` / ``already_known``
+        ratings. It deliberately filters only the current candidate set and
+        leaves the LTM rank untouched until core grows a symmetric demotion
+        action.
+        """
+        if (
+            self._feedback_tracker is None
+            or not self._record_feedback_events
+            or not self._config.feedback_demotion_enabled
+            or not memory_ids
+        ):
+            return set()
+        try:
+            counts = self._feedback_tracker.store.get_negative_feedback_counts(memory_ids)
+        except Exception:
+            logger.debug("Failed to load negative feedback counts", exc_info=True)
+            return set()
+        threshold = self._config.feedback_demotion_negative_threshold
+        return {mid for mid, count in counts.items() if count >= threshold}
+
     def _claim_surfaced_ids(self, ids: list[str]) -> None:
         """Record memory IDs as surfaced this session, FIFO-pruning to
         ``_surfaced_ids_max``. Shared by the miss path and the cache-hit path so
@@ -734,11 +758,24 @@ class SurfacingEngine:
                 except Exception:
                     logger.debug("token_tracker.record_hints failed", exc_info=True)
 
-        # Filter by score, then exclude already-surfaced memories in this session
+        # Filter by score, then locally demote memories with repeated durable
+        # negative feedback, then exclude already-surfaced memories in this
+        # session. Demotion sits before cache write so a rejected memory does
+        # not keep reappearing from a cached query after process restart.
         scored = [r for r in results if r.score >= min_score]
+        demoted_ids = self._feedback_demoted_ids([str(r.chunk.id) for r in scored])
+        if demoted_ids:
+            logger.debug(
+                "Surfacing demotion filter: %s/%s skipped %d memory IDs",
+                server,
+                tool,
+                len(demoted_ids),
+            )
         relevant = []
         for r in scored:
             mid = str(r.chunk.id)
+            if mid in demoted_ids:
+                continue
             if mid not in self._surfaced_ids:
                 relevant.append(r)
                 if len(relevant) >= max_results:
@@ -752,7 +789,9 @@ class SurfacingEngine:
             # passed but session-dedup killed everything" so an operator can
             # tell whether to lower min_score (former) or whether the dedup
             # is over-aggressive on long sessions (latter).
-            if scored:
+            if demoted_ids and all(str(r.chunk.id) in demoted_ids for r in scored):
+                self._observability.record_skip(tool, "no_results_demoted")
+            elif scored:
                 self._observability.record_skip(tool, "no_results_dedup")
             else:
                 self._observability.record_skip(tool, "no_results_score")

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS auto_tune_adjustments (
 );
 
 CREATE INDEX IF NOT EXISTS idx_feedback_surfacing ON surfacing_feedback(surfacing_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_memory_rating ON surfacing_feedback(memory_id, rating);
 CREATE INDEX IF NOT EXISTS idx_events_tool ON surfacing_events(tool);
 CREATE INDEX IF NOT EXISTS idx_seen_last ON seen_memories(last_seen_at);
 """
@@ -245,6 +246,55 @@ class FeedbackStore:
             return json.loads(row[0])
         except (json.JSONDecodeError, TypeError):
             return []
+
+    def get_negative_feedback_counts(self, memory_ids: list[str]) -> dict[str, int]:
+        """Return durable negative-feedback event counts for memory IDs.
+
+        Counts distinct ``surfacing_id`` values, not raw feedback rows, so
+        repeated submissions for the same surfacing event cannot trigger
+        demotion by themselves. Explicit per-memory feedback is counted
+        directly from ``surfacing_feedback.memory_id``. Legacy blanket
+        negatives (``memory_id IS NULL``) are expanded from the parent
+        event's ``memory_ids`` JSON without relying on SQLite JSON1.
+        """
+        if self._db is None or not memory_ids:
+            return {}
+
+        target_ids = list(dict.fromkeys(str(mid) for mid in memory_ids))
+        event_ids_by_memory = {mid: set() for mid in target_ids}
+        target_set = set(target_ids)
+
+        placeholders = ", ".join("?" for _ in target_ids)
+        rating_placeholders = ", ".join("?" for _ in _NEGATIVE_FEEDBACK_RATINGS)
+        explicit_rows = self._db.execute(
+            "SELECT DISTINCT memory_id, surfacing_id FROM surfacing_feedback "
+            f"WHERE memory_id IN ({placeholders}) "
+            f"AND rating IN ({rating_placeholders})",
+            (*target_ids, *_NEGATIVE_FEEDBACK_RATINGS),
+        ).fetchall()
+        for memory_id, surfacing_id in explicit_rows:
+            event_ids_by_memory[str(memory_id)].add(str(surfacing_id))
+
+        blanket_rows = self._db.execute(
+            "SELECT DISTINCT f.surfacing_id, e.memory_ids FROM surfacing_feedback f "
+            "JOIN surfacing_events e ON f.surfacing_id = e.id "
+            "WHERE f.memory_id IS NULL "
+            f"AND f.rating IN ({rating_placeholders})",
+            _NEGATIVE_FEEDBACK_RATINGS,
+        ).fetchall()
+        for surfacing_id, event_memory_ids_json in blanket_rows:
+            try:
+                event_memory_ids = json.loads(event_memory_ids_json)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(event_memory_ids, list):
+                continue
+            for memory_id in event_memory_ids:
+                mid = str(memory_id)
+                if mid in target_set:
+                    event_ids_by_memory[mid].add(str(surfacing_id))
+
+        return {mid: len(event_ids) for mid, event_ids in event_ids_by_memory.items()}
 
     def get_surfacing_event(self, surfacing_id: str) -> dict | None:
         """Return ``{server, tool, memory_ids}`` for a surfacing event.

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -190,6 +190,8 @@ class TestSurfacingNumericConstraints:
             SurfacingConfig(max_injection_chars=0)
         with pytest.raises(ValidationError):
             SurfacingConfig(min_query_tokens=0)
+        with pytest.raises(ValidationError):
+            SurfacingConfig(feedback_demotion_negative_threshold=0)
 
     def test_surfacing_context_window_nonnegative(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -277,6 +277,46 @@ class TestFeedbackStore:
         assert ratio is not None
         assert abs(ratio - 0.6) < 0.01
 
+    def test_negative_feedback_counts_distinct_surfacing_events(
+        self, feedback_store: FeedbackStore
+    ):
+        feedback_store.record_surfacing("s1", "sv", "t", "q", ["m1"], [0.5])
+        feedback_store.record_surfacing("s2", "sv", "t", "q", ["m1"], [0.5])
+        feedback_store.record_feedback("s1", "not_relevant", "m1")
+        feedback_store.record_feedback("s1", "not_relevant", "m1")
+        feedback_store.record_feedback("s1", "helpful", "m1")
+        feedback_store.record_feedback("s2", "already_known", "m1")
+
+        counts = feedback_store.get_negative_feedback_counts(["m1", "missing"])
+
+        assert counts == {"m1": 2, "missing": 0}
+
+    def test_negative_feedback_counts_expand_blanket_feedback(
+        self, feedback_store: FeedbackStore
+    ):
+        feedback_store.record_surfacing("s1", "sv", "t", "q", ["m1", "m2"], [0.5, 0.4])
+        feedback_store.record_surfacing("s2", "sv", "t", "q", ["m2"], [0.4])
+        feedback_store.record_feedback("s1", "not_relevant")
+        feedback_store.record_feedback("s1", "already_known")
+        feedback_store.record_feedback("s2", "helpful")
+
+        counts = feedback_store.get_negative_feedback_counts(["m1", "m2"])
+
+        assert counts == {"m1": 1, "m2": 1}
+
+    def test_negative_feedback_counts_dedupes_blanket_and_explicit_same_event(
+        self, feedback_store: FeedbackStore
+    ):
+        feedback_store.record_surfacing("s1", "sv", "t", "q", ["m1", "m2"], [0.5, 0.4])
+        feedback_store.record_surfacing("s2", "sv", "t", "q", ["m1"], [0.5])
+        feedback_store.record_feedback("s1", "not_relevant")
+        feedback_store.record_feedback("s1", "already_known", "m1")
+        feedback_store.record_feedback("s2", "not_relevant", "m1")
+
+        counts = feedback_store.get_negative_feedback_counts(["m1", "m2"])
+
+        assert counts == {"m1": 2, "m2": 1}
+
     def test_per_tool_breakdown_includes_feedback_counts(self, feedback_store: FeedbackStore):
         """Per-tool breakdown exposes total, not_relevant, and negative counts."""
         feedback_store.record_surfacing("s_a1", "sv", "tool_a", "q", ["m1"], [0.9])

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -830,6 +830,110 @@ class TestFeedbackBoost:
         adapter.increment_access.assert_not_called()
 
 
+class TestFeedbackDemotion:
+    async def test_repeated_negative_feedback_filters_future_surfacing(self, tmp_path: Path):
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+
+        tracker = FeedbackTracker(
+            config=_make_config(),
+            db_path=tmp_path / "fb.db",
+        )
+        try:
+            for i in range(3):
+                sid = f"sid-neg-{i}"
+                tracker.record_surfacing(sid, "gh", "read_file", "q", ["demoted"], [0.9])
+                tracker.record_feedback(sid, "not_relevant", "demoted")
+
+            results = [
+                FakeSearchResult(
+                    chunk=FakeChunk(id="demoted", content="memory that should be hidden"),
+                    score=0.9,
+                ),
+                FakeSearchResult(
+                    chunk=FakeChunk(id="fresh", content="memory that should remain"),
+                    score=0.8,
+                ),
+            ]
+            engine = SurfacingEngine(
+                config=_make_config(feedback_demotion_negative_threshold=3),
+                mcp_adapter=_make_mcp_adapter(results),
+                feedback_tracker=tracker,
+            )
+
+            output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+
+            assert "memory that should be hidden" not in output
+            assert "memory that should remain" in output
+        finally:
+            tracker.close()
+
+    async def test_feedback_demotion_can_be_disabled(self, tmp_path: Path):
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+
+        tracker = FeedbackTracker(
+            config=_make_config(),
+            db_path=tmp_path / "fb.db",
+        )
+        try:
+            for i in range(3):
+                sid = f"sid-neg-{i}"
+                tracker.record_surfacing(sid, "gh", "read_file", "q", ["demoted"], [0.9])
+                tracker.record_feedback(sid, "already_known", "demoted")
+
+            results = [
+                FakeSearchResult(
+                    chunk=FakeChunk(id="demoted", content="memory that should still show"),
+                    score=0.9,
+                )
+            ]
+            engine = SurfacingEngine(
+                config=_make_config(feedback_demotion_enabled=False),
+                mcp_adapter=_make_mcp_adapter(results),
+                feedback_tracker=tracker,
+            )
+
+            output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+
+            assert "memory that should still show" in output
+        finally:
+            tracker.close()
+
+    async def test_feedback_demotion_skipped_for_dedup_only_engine(self, tmp_path: Path):
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+
+        tracker = FeedbackTracker(
+            config=_make_config(),
+            db_path=tmp_path / "fb.db",
+        )
+        try:
+            for i in range(3):
+                sid = f"sid-neg-{i}"
+                tracker.record_surfacing(sid, "gh", "read_file", "q", ["demoted"], [0.9])
+                tracker.record_feedback(sid, "not_relevant", "demoted")
+
+            results = [
+                FakeSearchResult(
+                    chunk=FakeChunk(
+                        id="demoted",
+                        content="memory that should show in dedup-only mode",
+                    ),
+                    score=0.9,
+                )
+            ]
+            engine = SurfacingEngine(
+                config=_make_config(feedback_demotion_negative_threshold=3),
+                mcp_adapter=_make_mcp_adapter(results),
+                feedback_tracker=tracker,
+                record_feedback_events=False,
+            )
+
+            output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+
+            assert "memory that should show in dedup-only mode" in output
+        finally:
+            tracker.close()
+
+
 class TestHandleFeedbackBatch:
     """Batched per-memory ratings (#353 part 1).
 


### PR DESCRIPTION
## Summary
- add STM-side shadow demotion for memories with repeated negative surfacing feedback
- count distinct negative surfacing events per memory, including legacy blanket negative ratings
- document the demotion knobs and cover the behavior with regression tests

Closes #372

## Tests
- uv run pytest tests/test_feedback.py tests/test_surfacing_engine.py tests/test_config_constraints.py -q
- uv run ruff check src/memtomem_stm/surfacing/config.py src/memtomem_stm/surfacing/feedback_store.py src/memtomem_stm/surfacing/engine.py tests/test_feedback.py tests/test_surfacing_engine.py tests/test_config_constraints.py
- git diff --check