### PR TITLE
fix(compression): monotone list-root final tier for FieldExtract

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1402,25 +1402,194 @@ class FieldExtractCompressor:
                     return candidate
             return '""'
 
-        # List or string root: ``_take`` is strict (<= budget) for containers, so
-        # a single call at the hard budget fills it — no search, no cliff.
-        candidate = dump(self._take(data, max_chars))
-        if len(candidate) <= max_chars:
-            return candidate
-
-        # Even the most compact ``_take`` form overflows. Floor to the smallest
-        # valid JSON within budget.
-        if isinstance(data, dict):
-            return "{}"
         if isinstance(data, list):
-            return "[]"
+            # ``_take`` content is NON-monotone in its budget: a larger child
+            # budget can flip a value into a longer-but-emptier omitted marker
+            # (e.g. ``_take({"a": 1, "b": {...}}, 37)`` -> ``{"_truncated": ...}``),
+            # so a search that maximizes the budget handed to ``_take`` can show
+            # LESS content at a LARGER ``max_chars``. ``_fit_monotone`` is the
+            # monotone analog (breadth-preserving, shared-cap depth fill), leaving
+            # ``_take`` — which the dict-enrich search at the top relies on —
+            # untouched.
+            return dump(self._fit_monotone(data, max(2, max_chars)))
+
         if isinstance(data, str):
+            # ``_take`` string truncation is already monotone in the budget.
+            candidate = dump(self._take(data, max_chars))
+            if len(candidate) <= max_chars:
+                return candidate
             for k in range(len(data), -1, -1):
                 candidate = json.dumps(data[:k], ensure_ascii=False)
                 if len(candidate) <= max_chars:
                     return candidate
             return '""'
-        return '""'
+
+        # Defensive: any other container type.
+        candidate = dump(self._take(data, max_chars))
+        if len(candidate) <= max_chars:
+            return candidate
+        return "{}" if isinstance(data, dict) else '""'
+
+    def _fit_monotone(self, value: object, budget: int) -> object:
+        """Monotone analog of ``_take``: the preserved-leaf content of the result
+        is NON-DECREASING in ``budget``, so a larger budget never shows less.
+        Returns a compact-JSON-serializable object whose ``json.dumps`` length is
+        ``<= budget`` (callers pass ``max(2, max_chars)``).
+
+        ``_take`` hands each child the largest budget that fits and assumes more
+        budget means more content — false, because ``_take`` itself flips a value
+        into a longer-but-emptier omitted marker as its own budget grows (e.g.
+        ``_take({"a": 1, "b": {...}}, 37)`` -> ``{"_truncated": "..."}``). A search
+        that maximizes the per-child budget inherits that regression, so a LARGER
+        ``max_chars`` can show LESS content.
+
+        The fix keeps ``_take``'s prefix shape — leading items in FULL detail, a
+        single truncated boundary item, then an omitted-count marker — but makes
+        every degree of freedom monotone:
+
+        - **Full prefix**: keep item ``k`` in FULL only while ``[full 0..k] + marker``
+          fits. A full item is full at every larger budget, so the prefix length
+          only grows; growing it replaces the old (partial) boundary with a FULL
+          element, which never has less content.
+        - **Boundary**: the first item that does not fit full is filled by RECURSING
+          (``_fit_monotone``), whose content is monotone in its own budget — unlike
+          ``_take``, it never collapses to an emptier marker as the budget grows.
+        - **Marker**: counts the items AFTER the boundary; a dropped tail is
+          content-free, so the prefix/boundary/marker split is monotone overall.
+
+        The boundary's budget is derived by EXACT frame arithmetic (one recursion,
+        no per-cap scan), so a deeply nested or huge boundary item costs O(depth),
+        not O(budget**depth).
+        """
+
+        def dump(obj: object) -> str:
+            return json.dumps(obj, ensure_ascii=False)
+
+        if isinstance(value, str):
+            if len(dump(value)) <= budget:  # dump() counts the quotes AND escaping
+                return value
+            # Truncate to the largest prefix whose DUMPED length (escaping makes it
+            # non-linear in the prefix length) plus the "..." marker fits. Dumped
+            # length is monotone in the prefix length, so binary-search it; budgeting
+            # by raw len() would under-count escaped chars and overflow the budget.
+            lo, hi, best = 0, len(value), ""
+            while lo <= hi:
+                mid = (lo + hi) // 2
+                cand = value[:mid] + "..."
+                if len(dump(cand)) <= budget:
+                    best, lo = cand, mid + 1
+                else:
+                    hi = mid - 1
+            return best
+        if not isinstance(value, (dict, list)):
+            literal = dump(value)
+            return value if len(literal) <= budget else ""
+        if len(dump(value)) <= budget:
+            return value  # whole value fits in full
+
+        # Narrow ``value`` for both the type checker and key/index handling, and
+        # pick a collision-safe marker key checked against ALL original keys (a
+        # real "_truncated" may sit in the dropped tail) — mirroring ``_take``.
+        marker_key = "_truncated"
+        if isinstance(value, dict):
+            is_dict = True
+            items: list = list(value.items())
+            existing = set(value)
+            while marker_key in existing:
+                marker_key += "_"
+        else:
+            is_dict = False
+            items = list(enumerate(value))
+        n = len(items)
+
+        _MISSING = object()  # "no boundary item" sentinel (``None`` is a valid value)
+
+        def frame(full_count: int, boundary: object, omitted: int) -> object:
+            """Leading ``full_count`` items in FULL + an optional truncated boundary
+            at index ``full_count`` + an omitted-count marker."""
+            if is_dict:
+                out: dict = {items[i][0]: items[i][1] for i in range(full_count)}
+                if boundary is not _MISSING:
+                    out[items[full_count][0]] = boundary
+                if omitted > 0:
+                    out[marker_key] = f"{omitted} of {n} keys omitted"
+                return out
+            lst: list = [items[i][1] for i in range(full_count)]
+            if boundary is not _MISSING:
+                lst.append(boundary)
+            if omitted > 0:
+                lst.append(f"... ({omitted} of {n} items omitted)")
+            return lst
+
+        def starved(child: object, source: object) -> bool:
+            # An empty container/string standing in for a non-empty source carries
+            # no content; a scalar legitimately stubbed to "" is not starved.
+            if child == "" and not isinstance(source, (dict, list, str)):
+                return False
+            return child in ({}, [], "") and source not in (None, {}, [], "", 0, False)
+
+        # Full prefix: keep item ``k`` in FULL while ``[full 0..k] + marker`` fits.
+        # Adding a full item strictly grows the frame (a marker's digit width
+        # shrinks by at most a couple of chars), so the first overflow ends it.
+        full_k = 0
+        for k in range(1, n + 1):
+            if len(dump(frame(k, _MISSING, n - k))) <= budget:
+                full_k = k
+            else:
+                break
+        if full_k >= n:
+            return value  # defensive — the whole value already fit above
+
+        # Boundary: fill the leftover with a truncated form of item ``full_k`` via
+        # the monotone recursion, keeping a marker for the items AFTER it. Fit it in
+        # ONE recursion (``_fit_monotone`` guarantees its dump <= its budget) rather
+        # than scanning every cap — a scan re-serializes a large nested boundary
+        # once per cap (O(budget * boundary_size)) and binary search is unsafe
+        # because the candidate's length is not monotone in the cap. The room is
+        # ``budget`` minus the marker-bearing frame minus the EXACT framing an
+        # inserted item adds (a ", " separator, plus a "<key>: " for a dict), so the
+        # assembled frame lands at or under ``budget`` by construction and the room
+        # — hence the boundary's content — is monotone in ``budget``.
+        boundary_item = items[full_k][1]
+        omitted_after = n - full_k - 1
+        base = frame(full_k, _MISSING, omitted_after)
+        base_empty = full_k == 0 and omitted_after == 0  # leading "["/"{" with no element
+        if is_dict:
+            framing = len(dump(items[full_k][0])) + (2 if base_empty else 4)
+        else:
+            framing = 0 if base_empty else 2
+        room = budget - len(dump(base)) - framing
+        cand = self._fit_monotone(boundary_item, room) if room >= 0 else _MISSING
+        if (
+            cand is not _MISSING
+            and not starved(cand, boundary_item)
+            and len(dump(frame(full_k, cand, omitted_after))) <= budget
+        ):
+            return frame(full_k, cand, omitted_after)
+
+        # No room for a content-bearing boundary: keep the full prefix + a marker
+        # for every remaining item.
+        if full_k > 0:
+            return frame(full_k, _MISSING, n - full_k)
+        # full_k == 0: emit the marker alone if it fits. Below the marker's width,
+        # keep a MARKERLESS prefix when the whole value is cheaper than the marker
+        # — then the value's FULL form (never a marker tier) is what appears as the
+        # budget grows, so dropping the marker keeps the result monotone. For a
+        # large value (marker cheaper than full) a markerless prefix would regress
+        # against the marker-only tier just above it, so floor to an empty container.
+        marker_only = frame(0, _MISSING, n)
+        if len(dump(marker_only)) <= budget:
+            return marker_only
+        if len(dump(value)) <= len(dump(marker_only)):
+            markerless_k = 0
+            for k in range(1, n + 1):
+                if len(dump(frame(k, _MISSING, 0))) <= budget:
+                    markerless_k = k
+                else:
+                    break
+            if markerless_k > 0:
+                return frame(markerless_k, _MISSING, 0)
+        return {} if is_dict else []
 
     def _compress_text(self, text: str, max_chars: int) -> str:
         lines = text.split("\n")

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -293,9 +293,7 @@ def test_take_keeps_full_container_when_it_fits() -> None:
 def test_dict_fit_reserves_space_for_omission_marker() -> None:
     """Nested dict fitting must prefer an omitted-count marker over silently
     returning a longer key prefix with no marker."""
-    payload = json.dumps(
-        {"outer": {f"k{i}": {"a": 1} for i in range(1000)}, "id": "abc"}
-    )
+    payload = json.dumps({"outer": {f"k{i}": {"a": 1} for i in range(1000)}, "id": "abc"})
     out = FieldExtractCompressor().compress(payload, max_chars=80)
     parsed = json.loads(out)
     outer = parsed["outer"]
@@ -458,3 +456,111 @@ def test_wide_config_dict_routes_to_extract_fields() -> None:
         auto_select_strategy(_wide_config_dict(40), max_chars=500)
         == CompressionStrategy.EXTRACT_FIELDS
     )
+
+
+# ── E3. Monotonicity: a larger budget never shows less content (the 4B fix) ───
+
+
+def _preserved_leaves(obj: object) -> int:
+    """Count preserved original scalar leaves, EXCLUDING omitted-count markers
+    (the dict ``_truncated`` member and the in-array ``... items omitted`` string)."""
+    if isinstance(obj, dict):
+        return sum(
+            _preserved_leaves(v)
+            for k, v in obj.items()
+            if not str(k).startswith("_truncated") and not (isinstance(v, str) and "omitted" in v)
+        )
+    if isinstance(obj, list):
+        return sum(_preserved_leaves(e) for e in obj if not (isinstance(e, str) and "omitted" in e))
+    return 1
+
+
+_LIST_MONO_FIXTURES: dict[str, object] = {
+    # The canonical regression: a bulky nested field on the FIRST element. The
+    # old `_take`-based enrichment flipped element 0 into a longer-but-emptier
+    # marker as the budget grew (content 4 @ 62 -> 2 @ 63).
+    "bulky_first": [{"a": 1, "b": {"c": "deep", "d": [10, 20]}}, {"a": 2}, {"a": 3}],
+    "wide_records": [{"id": i, "v": "x" * (i % 7)} for i in range(40)],
+    "nested_lists": [[1, 2, 3], [4, 5], [6]],
+    "strings": ["x" * 30, "y" * 20, "z" * 10, "short"],
+    "mixed": [{"x": "hello world", "y": [1, 2, 3]}, {"x": "hi"}, {"z": 9}],
+    "big_dicts": _big_list_of_dicts(8, 6),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_LIST_MONO_FIXTURES))
+def test_list_root_content_is_monotone_in_budget(name: str) -> None:
+    """For a list root, a LARGER budget must never preserve FEWER original leaves
+    in the final tier.
+
+    ``_take``'s content is non-monotone in its budget (a larger child budget can
+    flip a value into a longer-but-emptier ``_truncated`` marker), so any search
+    that maximizes the per-child budget regresses. ``_fit_monotone`` keeps the
+    prefix shape but makes every degree of freedom monotone. Budgets are swept
+    CONTIGUOUSLY so a one-char cliff cannot hide between sampled points; output
+    is asserted valid + within budget at every step too.
+
+    Exercises ``_fit_extracted`` (the final tier this PR rewrites) directly, the
+    same surface the design probe swept. The ``_compress_json`` *router* in front
+    of it has a SEPARATE, pre-existing non-monotonicity — it prefers a fixed
+    5-item ``indent=2`` ``_preview_list`` whenever that pretty form fits, which
+    carries less content than the budget-filling compact final tier — and is
+    out of scope here.
+    """
+    fixture = _LIST_MONO_FIXTURES[name]
+    data = json.loads(fixture) if isinstance(fixture, str) else fixture
+    compressor = FieldExtractCompressor()
+    prev: int | None = None
+    for budget in range(2, len(json.dumps(data)) + 5):
+        out = compressor._fit_extracted(data, budget)
+        parsed = json.loads(out)  # always valid JSON
+        assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
+        leaves = _preserved_leaves(parsed)
+        if prev is not None:
+            assert leaves >= prev, f"{name}@{budget}: content regressed {prev} -> {leaves}"
+        prev = leaves
+
+
+def test_small_list_keeps_markerless_prefix_below_marker_width() -> None:
+    """Below the omission-marker's width, a SMALL list keeps a markerless leading
+    prefix instead of collapsing to ``[]``. The marker tier is unreachable for such
+    a value (its full form is cheaper than the marker), so dropping the marker
+    stays monotone. ``_fit_extracted([1, 2, 3], 8)`` regressed to ``[]`` mid-review.
+    """
+    c = FieldExtractCompressor()
+    assert c._fit_extracted([1, 2, 3], 8) == "[1, 2]"
+    assert c._fit_extracted([1, 2, 3], 5) == "[1]"
+    assert json.loads(c._fit_extracted([1, 2, 3], 2)) == []  # the true floor
+
+
+def test_huge_boundary_item_does_not_scan_quadratically() -> None:
+    """A huge leading item under a tight budget must bound the boundary cap by the
+    budget, not the item's full size — otherwise the scan is quadratic and hangs.
+    The fixed path is sub-millisecond; the generous bound only catches a regression
+    back to O(item_size**2)."""
+    import time
+
+    c = FieldExtractCompressor()
+    start = time.perf_counter()
+    out = c._fit_extracted(["x" * 100_000, "y"], 100)
+    elapsed = time.perf_counter() - start
+    assert len(out) <= 100
+    json.loads(out)  # valid JSON
+    assert elapsed < 1.0, f"boundary scan took {elapsed:.2f}s (quadratic regression?)"
+
+
+def test_list_string_element_budgeted_by_serialized_length() -> None:
+    """A list string element that needs JSON escaping must be budgeted by its
+    SERIALIZED length, not raw char count. Otherwise _fit_monotone returns an
+    over-budget candidate, the frame rejects it, and fitting content (a truncated
+    string, then the cheap tail item) is wrongly dropped to a marker. (`['"'*20,
+    'ok']` at max_chars=45 emitted only the omission marker mid-review.)"""
+    c = FieldExtractCompressor()
+    out45 = c._fit_extracted(['"' * 20, "ok"], 45)
+    parsed45 = json.loads(out45)
+    assert len(out45) <= 45
+    # A truncated escaped-string element survives instead of marker-only output.
+    assert isinstance(parsed45[0], str) and parsed45[0].startswith('"')
+    out50 = c._fit_extracted(['"' * 20, "ok"], 50)
+    assert len(out50) <= 50
+    assert "ok" in json.loads(out50)  # the cheap tail survives once there is room


### PR DESCRIPTION
## What

`FieldExtractCompressor`'s final tier for a **list root** (`_fit_extracted`) was content **non-monotone in the budget** — a larger `max_chars` could preserve **fewer** original leaves (content 4 @ budget 62 → 2 @ 63 on a bulky-first list).

**Root cause:** `_take`'s content is non-monotone in its own budget — a larger child budget can flip a value into a longer-but-emptier `_truncated` marker (e.g. `_take({"a": 1, "b": {...}}, 37) -> {"_truncated": "..."}`). Any search that maximizes the per-child budget inherits that regression.

## Fix

Replace the list path with `_fit_monotone`, a monotone analog of `_take` that keeps the same **prefix shape** (leading items in FULL detail, one truncated boundary item, an omitted-count marker) but makes every degree of freedom monotone:

- the full prefix only grows (a full item is full at every larger budget, and growing it replaces the old partial boundary with a full element);
- the boundary is filled by **recursing** (`_fit_monotone`), whose content is monotone in its own budget, so it never collapses to an emptier marker;
- the marker counts the content-free dropped tail.

The boundary's budget is derived by **exact frame arithmetic** (one recursion, no per-cap scan and no binary search — a candidate's serialized length is not monotone in its cap), so a huge or deeply nested leading item costs `O(depth)`, not `O(budget)` or `O(budget**depth)`. `_take` is left untouched (the dict-root enrich path still uses it).

## Verification

- All **105 existing** FieldExtract output-invariant tests pass unchanged (valid JSON, within budget, prefix+marker shape, item-granularity fill).
- New tests: a contiguous budget sweep over six list shapes (preserved-leaf count never regresses), the markerless-prefix floor, the huge-boundary perf bound, and JSON-escaped-string budgeting.
- Reviewed across **5 `codex review` passes**; four found edge issues (markerless collapse, nested-input blow-up, large-boundary re-serialization, escaped-string under-counting) — all folded in; the final pass is clean.
- Perf back in the `_take` ballpark (200-dict list @5000 ≈ 1 ms; 2000-element list @10000 ≈ 6 ms; 5000-int nested boundary @2000 ≈ 5 ms).
- Full suite `-m "not ollama"`: no new failures (2 pre-existing py3.13 stdio flakes).

## Out of scope

The `_compress_json` router in front of the final tier has a **separate, pre-existing** non-monotonicity — it prefers a fixed 5-item `indent=2` `_preview_list` whenever that pretty form fits, which carries less content than the budget-filling compact final tier. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
