### PR TITLE
fix(compression): monotone _compress_json router for FieldExtract

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1052,125 +1052,28 @@ class FieldExtractCompressor:
         return self._compress_text(text, max_chars)
 
     def _compress_json(self, data: object, max_chars: int) -> str:
-        if isinstance(data, dict):
-            preview: object = self._extract_dict(data, max_chars)
-        elif isinstance(data, list):
-            preview = self._preview_list(data)
-        else:
-            preview = data
+        # If the WHOLE value fits, emit it losslessly — pretty (indent=2) for
+        # containers, compact for scalars. ``json.dumps(data)`` always round-trips
+        # ``data`` exactly, so this tier carries the maximum possible content and
+        # can never regress as the budget grows.
         indent = 2 if isinstance(data, (dict, list)) else None
-        result = json.dumps(preview, ensure_ascii=False, indent=indent)
+        result = json.dumps(data, ensure_ascii=False, indent=indent)
         if len(result) <= max_chars:
             return result
-        # Final tier: emit VALID JSON within budget. The old
-        # ``result[:max_chars] + "\n... (truncated)"`` overshot the budget by the
-        # suffix length AND cut the JSON mid-token (invalid output); a top-level
-        # array additionally appended a non-JSON text marker. ``_fit_extracted``
-        # re-derives a valid, within-budget form from the original data.
+
+        # The value overflows: hand off to the budget-filling final tier. It emits
+        # VALID JSON within budget and — for a list root — fills it MONOTONICALLY
+        # (a larger budget never shows less; see ``_fit_monotone``).
+        #
+        # The old router instead returned a FIXED 5-item ``indent=2`` head preview
+        # whenever that pretty form fit. That preview was content-NON-monotone
+        # against this tier: at a budget where the bulky pretty preview just fits it
+        # carries fewer leaves than the compact final tier carries at a SMALLER
+        # budget, so a larger ``max_chars`` could show LESS content. Preferring this
+        # tier for every overflow removes that cliff. (The dict final tier still
+        # inherits ``_take``'s own non-monotonicity — tracked separately, the dict
+        # analog of the list fix.)
         return self._fit_extracted(data, max_chars)
-
-    def _preview_list(self, data: list) -> list[object]:
-        """Head preview of a top-level array as VALID JSON: the first items, then
-        an in-array omitted-count marker (an extra string element). The pre-fix
-        code appended ``"\\n... (N items total ...)"`` as text *after*
-        ``json.dumps``, which left the whole output unparseable for any array
-        over the 5-item preview."""
-        n = len(data)
-        preview_n = min(5, n)
-        preview: list[object] = [
-            self._preview_dict(item) if isinstance(item, dict) else item
-            for item in data[:preview_n]
-        ]
-        if n > preview_n:
-            preview.append(f"... ({n - preview_n} of {n} items omitted)")
-        return preview
-
-    def _extract_dict(self, data: dict, budget: int) -> dict:
-        """Budget-aware recursive dict extraction — preserves all keys with depth.
-
-        Scalar/small values are placed first so they survive truncation.
-        Large arrays/dicts are placed after, allowing them to be cut if needed.
-        """
-        # Separate scalar (small) values from large collections
-        scalar_keys: list[str] = []
-        collection_keys: list[str] = []
-        for key, value in data.items():
-            if isinstance(value, (list, dict)):
-                collection_keys.append(key)
-            else:
-                scalar_keys.append(key)
-
-        # Process scalars first (survive truncation), then collections
-        summary: dict = {}
-        for key in scalar_keys + collection_keys:
-            value = data[key]
-            if isinstance(value, str) and len(value) > 80:
-                if "```" in value:
-                    limit = min(len(value), 500)
-                    fence_end = value.rfind("```", 0, limit)
-                    summary[key] = (
-                        value[: fence_end + 3] if fence_end > 80 else value[:limit] + "..."
-                    )
-                else:
-                    summary[key] = value[:80] + "..."
-            elif isinstance(value, list):
-                preview_n = min(5, len(value))
-                items: list[object] = []
-                for item in value[:preview_n]:
-                    if isinstance(item, str) and len(item) > 80:
-                        items.append(item[:80] + "...")
-                    elif isinstance(item, dict):
-                        items.append(self._preview_dict(item))
-                    elif isinstance(item, list):
-                        items.append(f"[{len(item)} items]")
-                    else:
-                        items.append(item)
-                remaining = len(value) - preview_n
-                if remaining > 0:
-                    items.append(f"... ({remaining} more)")
-                summary[key] = items
-            elif isinstance(value, dict):
-                # Recurse one level — preserve all keys of nested dicts
-                summary[key] = self._preview_dict(value)
-            else:
-                summary[key] = value
-        return summary
-
-    @staticmethod
-    def _preview_dict(d: dict, max_keys: int = 6, max_value_len: int = 80) -> dict:
-        """Show first N key-value pairs with truncated values, hint at rest."""
-        preview: dict = {}
-        keys = list(d.keys())
-        for k in keys[:max_keys]:
-            v = d[k]
-            if isinstance(v, str) and len(v) > max_value_len:
-                preview[k] = v[:max_value_len] + "..."
-            elif isinstance(v, dict):
-                # One more level of preview for nested dicts
-                inner: dict = {}
-                inner_keys = list(v.keys())
-                for ik in inner_keys[:4]:
-                    iv = v[ik]
-                    if isinstance(iv, str) and len(iv) > 40:
-                        inner[ik] = iv[:40] + "..."
-                    elif isinstance(iv, (dict, list)):
-                        inner[ik] = f"({type(iv).__name__}, {len(iv)})"
-                    else:
-                        inner[ik] = iv
-                if len(inner_keys) > 4:
-                    inner[f"...{len(inner_keys) - 4} more"] = "..."
-                preview[k] = inner
-            elif isinstance(v, list):
-                if len(v) <= 3:
-                    preview[k] = v
-                else:
-                    preview[k] = v[:3] + [f"... ({len(v) - 3} more)"]
-            else:
-                preview[k] = v
-        remaining = len(keys) - max_keys
-        if remaining > 0:
-            preview[f"...{remaining} more"] = "..."
-        return preview
 
     def _take(self, value: object, budget: int) -> object:
         """Greedy prefix-fill: keep the leading, full-detail content of ``value``
@@ -1325,8 +1228,9 @@ class FieldExtractCompressor:
         names/ids/roles survive in full rather than every value being shrunk to
         a stub.
         Only when the stubs themselves overflow are trailing keys dropped into a
-        valid collision-safe marker. List / scalar roots binary-search ``_take``
-        directly. Floors to ``{}`` / ``[]`` / ``""`` / ``null``.
+        valid collision-safe marker. A list root fills the budget MONOTONICALLY
+        via ``_fit_monotone``; string / scalar roots truncate directly. Floors to
+        ``{}`` / ``[]`` / ``""`` / ``null``.
         """
 
         def dump(obj: object) -> str:
@@ -1337,11 +1241,10 @@ class FieldExtractCompressor:
             skeleton = {k: self._stub_value(v) for k, v in items}
             if len(dump(skeleton)) <= max_chars:
                 # Enrich keys to fill the budget, but enrich SCALARS before
-                # collections (mirrors _extract_dict's scalar-first ordering):
-                # cheap, high-value scalar fields (ids, names, flags) must
-                # survive a tight budget even when large nested sections precede
-                # them in document order. The output dict keeps the original key
-                # order — only the enrichment *priority* is reordered.
+                # collections: cheap, high-value scalar fields (ids, names, flags)
+                # must survive a tight budget even when large nested sections
+                # precede them in document order. The output dict keeps the original
+                # key order — only the enrichment *priority* is reordered.
                 out = dict(skeleton)
                 scalars = [(k, v) for k, v in items if not isinstance(v, (dict, list))]
                 collections = [(k, v) for k, v in items if isinstance(v, (dict, list))]

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -500,12 +500,11 @@ def test_list_root_content_is_monotone_in_budget(name: str) -> None:
     CONTIGUOUSLY so a one-char cliff cannot hide between sampled points; output
     is asserted valid + within budget at every step too.
 
-    Exercises ``_fit_extracted`` (the final tier this PR rewrites) directly, the
-    same surface the design probe swept. The ``_compress_json`` *router* in front
-    of it has a SEPARATE, pre-existing non-monotonicity — it prefers a fixed
-    5-item ``indent=2`` ``_preview_list`` whenever that pretty form fits, which
-    carries less content than the budget-filling compact final tier — and is
-    out of scope here.
+    Exercises ``_fit_extracted`` (the final tier the 4B fix rewrites) directly,
+    the same surface the design probe swept. The ``_compress_json`` *router* in
+    front of it had a SEPARATE non-monotonicity — it preferred a fixed 5-item
+    ``indent=2`` head preview over the budget-filling compact final tier — now
+    fixed and covered by the E4 router tests below.
     """
     fixture = _LIST_MONO_FIXTURES[name]
     data = json.loads(fixture) if isinstance(fixture, str) else fixture
@@ -564,3 +563,124 @@ def test_list_string_element_budgeted_by_serialized_length() -> None:
     out50 = c._fit_extracted(['"' * 20, "ok"], 50)
     assert len(out50) <= 50
     assert "ok" in json.loads(out50)  # the cheap tail survives once there is room
+
+
+# ── E4. Router monotonicity: the _compress_json head-preview cliff is gone ─────
+#
+# These exercise ``_compress_json`` DIRECTLY (like E3 hits ``_fit_extracted``):
+# the public ``compress`` short-circuits and returns the input verbatim once it
+# fits the budget, which masks the router at the very budgets where the cliff
+# lived. The router now emits the WHOLE value as ``indent=2`` pretty JSON when it
+# fits (lossless, max content) and otherwise hands every overflow to the
+# budget-filling final tier — instead of preferring a fixed 5-item pretty head
+# preview that carried fewer leaves than the compact tier did at a smaller budget.
+
+
+_ROUTER_LIST_FIXTURES: dict[str, object] = {
+    # Each hit the old router cliff: at the budget where the fixed 5-item
+    # ``indent=2`` head preview just fit, the router returned it (few leaves) even
+    # though the compact final tier carried MORE leaves one char below.
+    "ints_50": list(range(50)),  # leaves 9 @ 60 -> 5 @ 61 pre-fix
+    "small_dicts_100": [{"id": i, "name": f"item{i}"} for i in range(100)],  # 15 @ 246 -> 10 @ 247
+    "short_strings": [f"val-{i}" for i in range(40)],
+    "nested_lists": [[i, i + 1, i + 2] for i in range(20)],
+}
+
+
+@pytest.mark.parametrize("name", sorted(_ROUTER_LIST_FIXTURES))
+def test_list_root_monotone_through_router(name: str) -> None:
+    """For a LIST root, a larger budget never preserves fewer leaves through the
+    full router. Pre-fix the fixed ``indent=2`` head preview undercut the compact
+    final tier; routing every overflow through ``_fit_extracted`` (itself monotone
+    for lists, the 4B fix) removes the cliff. Budgets swept CONTIGUOUSLY."""
+    data = _ROUTER_LIST_FIXTURES[name]
+    c = FieldExtractCompressor()
+    prev: int | None = None
+    for budget in range(2, len(json.dumps(data, indent=2)) + 5):
+        out = c._compress_json(data, budget)
+        parsed = json.loads(out)  # always valid JSON
+        assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
+        leaves = _preserved_leaves(parsed)
+        if prev is not None:
+            assert leaves >= prev, f"{name}@{budget}: content regressed {prev} -> {leaves}"
+        prev = leaves
+
+
+_FLAT_DICT_FIXTURES: dict[str, object] = {
+    # Scalar-only dicts: the dict final tier (skeleton + scalar enrich) is itself
+    # monotone, so end-to-end monotonicity holds once the router preview cliff is
+    # gone. Dicts with NESTED collections also lose the router cliff, but their
+    # final tier still inherits ``_take``'s non-monotonicity (the dict analog of
+    # the list 4B fix, tracked as a follow-up) — so they are asserted only via the
+    # weaker pretty-is-lossless invariant below, not full monotonicity.
+    "string_values_30": {f"k{i}": f"value-{i}" for i in range(30)},
+    "mixed_scalars": {f"f{i}": (i if i % 2 else f"s{i}") for i in range(25)},
+}
+
+
+@pytest.mark.parametrize("name", sorted(_FLAT_DICT_FIXTURES))
+def test_flat_dict_monotone_through_router(name: str) -> None:
+    """A scalar-only DICT root is monotone end-to-end once the router no longer
+    prefers the lossy ``indent=2`` preview (its final tier carries no nested
+    collection that ``_take`` could flip into an emptier marker)."""
+    data = _FLAT_DICT_FIXTURES[name]
+    c = FieldExtractCompressor()
+    prev: int | None = None
+    for budget in range(2, len(json.dumps(data, indent=2)) + 5):
+        out = c._compress_json(data, budget)
+        parsed = json.loads(out)
+        assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
+        leaves = _preserved_leaves(parsed)
+        if prev is not None:
+            assert leaves >= prev, f"{name}@{budget}: content regressed {prev} -> {leaves}"
+        prev = leaves
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        list(range(50)),
+        [{"id": i, "name": f"item{i}"} for i in range(30)],
+        {"a": 1, "b": 2, "items": [{"x": i, "y": f"v{i}"} for i in range(20)], "tail": "end"},
+        {f"k{i}": "x" * 50 for i in range(10)},
+    ],
+)
+def test_router_pretty_output_is_always_lossless(data: object) -> None:
+    """The router emits ``indent=2`` pretty JSON ONLY for the WHOLE value (the
+    lossless tier); every overflow is the compact final tier. So whenever the
+    output is pretty (contains a newline) it must round-trip to the original data
+    EXACTLY — never a lossy head preview. Holds for list AND dict roots,
+    independent of the dict final tier's separate residual non-monotonicity."""
+    c = FieldExtractCompressor()
+    for budget in range(2, len(json.dumps(data, indent=2)) + 5):
+        out = c._compress_json(data, budget)
+        if "\n" in out:  # pretty (indent=2) => must be the full, lossless value
+            assert json.loads(out) == data, f"@{budget}: pretty output is lossy"
+
+
+def test_router_no_longer_prefers_lossy_preview() -> None:
+    """Pin the canonical pre-fix regressions: a larger budget returned the bulky
+    5-item ``indent=2`` preview (fewer leaves) than the compact tier carried one
+    char below. After the fix the leaf count is non-decreasing across the
+    boundary, for both a list-of-ints and a list-of-dicts root."""
+    c = FieldExtractCompressor()
+    ints: list[object] = list(range(50))
+    assert _preserved_leaves(json.loads(c._compress_json(ints, 61))) >= _preserved_leaves(
+        json.loads(c._compress_json(ints, 60))
+    )
+    dicts: list[object] = [{"id": i, "name": f"item{i}"} for i in range(100)]
+    assert _preserved_leaves(json.loads(c._compress_json(dicts, 247))) >= _preserved_leaves(
+        json.loads(c._compress_json(dicts, 246))
+    )
+
+
+def test_router_emits_whole_value_pretty_when_it_fits() -> None:
+    """A value that fits in full is emitted losslessly as ``indent=2`` pretty JSON
+    for containers — the readable tier the router still keeps."""
+    c = FieldExtractCompressor()
+    d = {"name": "svc", "port": 8080, "tags": ["a", "b"]}
+    out = c._compress_json(d, 500)
+    assert "\n" in out and json.loads(out) == d  # pretty + lossless
+    lst = [1, 2, 3]
+    out2 = c._compress_json(lst, 100)
+    assert "\n" in out2 and json.loads(out2) == lst


### PR DESCRIPTION
## What

The `_compress_json` router was content **non-monotone in the budget** — the separate, pre-existing issue scoped out of #405. On overflow it returned a FIXED 5-item `indent=2` head preview (`_preview_list` / `_extract_dict`) whenever that pretty form fit, and only fell through to the budget-filling compact final tier when it did not. The pretty preview carries **fewer** original leaves than the compact tier, so a **larger** `max_chars` could show **less** content:

| root | smaller budget | larger budget |
|---|---|---|
| `list(range(50))` | 60 → **9** leaves (compact) | 61 → **5** (pretty preview) |
| `[{"id","name"} ×100]` | 246 → **15** | 247 → **10** |
| nested dict | — | regressed at two budgets |

## Fix

Route every overflow through `_fit_extracted`. The router now:
- emits the **whole value** as lossless `indent=2` pretty JSON only when it fits (max content — can never regress as the budget grows);
- hands all overflow to the final tier, which for a **list root** fills the budget **monotonically** (`_fit_monotone`, #405).

This makes **list roots fully monotone end-to-end**. The **dict** final tier still inherits `_take`'s own non-monotonicity (the dict analog of #405) — tracked as a follow-up; this PR removes only the router-level cliff for dicts (verified via the pretty-is-lossless invariant).

The lossy head-preview machinery (`_preview_list`, `_extract_dict`, `_preview_dict`) is now unreachable and removed as a **consequent cleanup**; two comments/docstrings that named it are updated. Net **−128 / +151** (mostly deletions + tests).

## Behavior changes

- Overflowing dict/list output is the **compact final tier** rather than a pretty reduced preview (more content, fewer tokens; the `indent=2` form is kept only for the whole-value lossless case).
- The preview tier's **markdown code-fence-aware** string truncation (`_extract_dict`'s ` ``` ` handling) goes away with it; oversized string values now truncate plainly via `_take`. No test/consumer depended on it; flagged here for visibility.

## Verification

- New **E4** test section sweeps budgets **contiguously** through `_compress_json` for list and flat-dict roots (no leaf regression at any step, output valid + within budget), pins the canonical pre-fix boundaries (60/61, 246/247), and asserts pretty output is **always** the full lossless value.
- All **existing** FieldExtract/compression invariants pass unchanged (`126` in the FieldExtract file).
- Full suite `-m "not ollama"`: **2908 passed**, 2 pre-existing py3.13 local stdio flakes (fail identically on `main`, green on CI), no new failures.
- `ruff check src` + `ruff format --check src` clean.

## Out of scope

The **dict** final tier's `_take`-inherited non-monotonicity (the dict analog of #405's list fix) remains — surfaces as compact-output regressions on dict roots with nested collections. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)