### PR TITLE
fix(compression): monotone dict final tier for FieldExtract

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1212,13 +1212,24 @@ class FieldExtractCompressor:
         return value  # int / float / bool / None
 
     @staticmethod
+    def _is_shape_stub(s: str) -> bool:
+        """True for a placeholder emitted by ``_stub_value`` for a dropped value —
+        ``{N keys}`` / ``[N items]`` / ``""`` — none of which preserves any
+        ORIGINAL scalar content."""
+        return s == "" or (
+            (s.startswith("{") and s.endswith(" keys}"))
+            or (s.startswith("[") and s.endswith(" items]"))
+        )
+
+    @staticmethod
     def _content_leaves(obj: object) -> int:
         """Count preserved ORIGINAL scalar leaves — the metric the monotonicity
-        contract is stated in. Omitted-count markers carry no original content and
-        are excluded: a ``_truncated`` dict member and an ``... omitted`` in-array
-        string. A shape stub (``{N keys}`` / ``[N items]`` / ``""``) is a plain
-        scalar here and counts as one, so trading it for an emptier or marker-only
-        container is correctly seen as a loss."""
+        contract is stated in. PLACEHOLDERS carry no original content and count 0:
+        omitted-count markers (a ``_truncated`` dict member, an ``... omitted``
+        in-array string), shape stubs (``{N keys}`` / ``[N items]`` / ``""``), and
+        empty containers. So showing the COMPLETE value of a key (even an
+        empty-nested one) is never scored below its stub — the stub stands for zero
+        preserved scalars, exactly what an empty-nested full value also preserves."""
         if isinstance(obj, dict):
             return sum(
                 FieldExtractCompressor._content_leaves(v)
@@ -1232,6 +1243,8 @@ class FieldExtractCompressor:
                 for e in obj
                 if not (isinstance(e, str) and "omitted" in e)
             )
+        if isinstance(obj, str) and FieldExtractCompressor._is_shape_stub(obj):
+            return 0
         return 1
 
     def _enrich_dict_monotone(self, data: dict, max_chars: int) -> str:
@@ -1308,9 +1321,16 @@ class FieldExtractCompressor:
         # monotone in it; the assembled frame is re-checked against the budget.
         room = max_chars - len(dump(base)) + len(dump(stub[bkey]))
         filled = self._fit_monotone(bval, room) if room >= 2 else None
+        # Take the boundary fill only when it carries REAL content, OR the source
+        # itself has none (then the truthful empty-nested value is fine). A
+        # content-free fill of a NON-empty source ({} / [] / a marker-only
+        # container) is dropped in favor of the cheaper, equally-informative
+        # ``{N keys}`` stub — keeping it would just spend budget without adding a
+        # leaf. (The stub counts 0 too, so this is a quality choice, not needed for
+        # monotonicity: a full prefix value is never scored below its stub.)
         if (
             filled is not None
-            and self._content_leaves(filled) >= self._content_leaves(stub[bkey])
+            and (self._content_leaves(filled) > 0 or self._content_leaves(bval) == 0)
             and len(dump(frame(n_full, b_idx, filled))) <= max_chars
         ):
             return dump(frame(n_full, b_idx, filled))

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1231,8 +1231,10 @@ class FieldExtractCompressor:
         """True if ``filled`` (a ``_fit_monotone`` rendering of ``source``) preserves
         at least one ORIGINAL scalar of ``source`` — judged by PROVENANCE, never by
         string pattern. A scalar of ``filled`` is preserved when it equals a source
-        scalar or is a ``"…"``-truncated prefix of one; generated markers, stubs and
-        empty fills are absent from the source pool and so add nothing. A source with
+        scalar or is a NON-EMPTY ``"…"``-truncated prefix of one; generated markers,
+        stubs and empty fills add nothing — including a bare ``"..."`` boundary fill,
+        whose empty prefix preserves zero source characters (an exact source value of
+        ``"..."`` is still matched by the equality check above). A source with
         no scalars at all (empty-nested) is vacuously preserved — the truthful empty
         fill is fine.
 
@@ -1250,7 +1252,8 @@ class FieldExtractCompressor:
             if (
                 isinstance(f, str)
                 and f.endswith("...")
-                and any(o.startswith(f[:-3]) for o in src_strs)
+                and (prefix := f[:-3])  # bare "..." has an empty prefix → not a match
+                and any(o.startswith(prefix) for o in src_strs)
             ):
                 return True
         return False

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1278,15 +1278,23 @@ class FieldExtractCompressor:
                     out[k] = stub[k]
             return out
 
-        # Largest FULL-value prefix (in priority order) that fits; the rest stay
-        # stubs. ``frame`` length is non-decreasing in ``n_full`` (a full value is
-        # never shorter than its stub), so the first overflow ends the prefix.
+        # Largest FULL-value prefix (in priority order) that fits. ``frame`` length
+        # is NOT monotone in the prefix count: a small container's full form is
+        # SHORTER than its ``{N items}`` / ``{N keys}`` stub, so a longer prefix can
+        # fit after a shorter one overflows — we must take the MAX fitting prefix,
+        # not stop at the first overflow. ``frame(n)`` only swaps a value's stub for
+        # its full form (key + framing unchanged), so its length is the skeleton's
+        # length plus the running (full - stub) deltas; track that in O(n) instead of
+        # re-serializing each candidate. (No fitting prefix is missed: if a prefix
+        # longer than the max fit, the max would not be the max.)
+        skeleton_len = len(dump(stub))
+        running = skeleton_len
         n_full = 0
         for n in range(1, len(items) + 1):
-            if len(dump(frame(n, None, None))) <= max_chars:
+            k, v = items[order[n - 1]]
+            running += len(dump(v)) - len(dump(stub[k]))
+            if running <= max_chars:
                 n_full = n
-            else:
-                break
         if n_full >= len(items):
             return dump(frame(n_full, None, None))  # every value full
 

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1212,40 +1212,28 @@ class FieldExtractCompressor:
         return value  # int / float / bool / None
 
     @staticmethod
-    def _is_shape_stub(s: str) -> bool:
-        """True for a placeholder emitted by ``_stub_value`` for a dropped value —
-        ``{N keys}`` / ``[N items]`` / ``""`` — none of which preserves any
-        ORIGINAL scalar content."""
-        return s == "" or (
-            (s.startswith("{") and s.endswith(" keys}"))
-            or (s.startswith("[") and s.endswith(" items]"))
-        )
+    def _is_contentless(obj: object) -> bool:
+        """True if ``obj`` — a ``_fit_monotone`` rendering — preserves NO original
+        scalar: an empty container, the empty-string scalar stub ``""``, or a
+        container holding only omitted-count markers and other contentless values.
 
-    @staticmethod
-    def _content_leaves(obj: object) -> int:
-        """Count preserved ORIGINAL scalar leaves — the metric the monotonicity
-        contract is stated in. PLACEHOLDERS carry no original content and count 0:
-        omitted-count markers (a ``_truncated`` dict member, an ``... omitted``
-        in-array string), shape stubs (``{N keys}`` / ``[N items]`` / ``""``), and
-        empty containers. So showing the COMPLETE value of a key (even an
-        empty-nested one) is never scored below its stub — the stub stands for zero
-        preserved scalars, exactly what an empty-nested full value also preserves."""
+        Provenance-correct by construction: ``_fit_monotone`` only ever emits
+        original values, truncated original strings, ``""`` for an oversized scalar,
+        and omitted-count markers — it NEVER fabricates a ``{N keys}`` / ``[N items]``
+        shape stub (those come only from ``_stub_value``). So a string that merely
+        looks like ``"[2 items]"`` here is a genuine original value and is correctly
+        treated as content — no pattern-matching, no false positives."""
         if isinstance(obj, dict):
-            return sum(
-                FieldExtractCompressor._content_leaves(v)
+            return all(
+                str(k).startswith("_truncated") or FieldExtractCompressor._is_contentless(v)
                 for k, v in obj.items()
-                if not str(k).startswith("_truncated")
-                and not (isinstance(v, str) and "omitted" in v)
             )
         if isinstance(obj, list):
-            return sum(
-                FieldExtractCompressor._content_leaves(e)
+            return all(
+                (isinstance(e, str) and "omitted" in e) or FieldExtractCompressor._is_contentless(e)
                 for e in obj
-                if not (isinstance(e, str) and "omitted" in e)
             )
-        if isinstance(obj, str) and FieldExtractCompressor._is_shape_stub(obj):
-            return 0
-        return 1
+        return obj == ""
 
     def _enrich_dict_monotone(self, data: dict, max_chars: int) -> str:
         """Fill a dict root's budget MONOTONICALLY while keeping EVERY top-level
@@ -1321,16 +1309,15 @@ class FieldExtractCompressor:
         # monotone in it; the assembled frame is re-checked against the budget.
         room = max_chars - len(dump(base)) + len(dump(stub[bkey]))
         filled = self._fit_monotone(bval, room) if room >= 2 else None
-        # Take the boundary fill only when it carries REAL content, OR the source
-        # itself has none (then the truthful empty-nested value is fine). A
-        # content-free fill of a NON-empty source ({} / [] / a marker-only
-        # container) is dropped in favor of the cheaper, equally-informative
-        # ``{N keys}`` stub — keeping it would just spend budget without adding a
-        # leaf. (The stub counts 0 too, so this is a quality choice, not needed for
-        # monotonicity: a full prefix value is never scored below its stub.)
+        # Take the boundary fill unless it is a content-free rendering ({} / [] / a
+        # marker-only container) of a source that DID have content — then the
+        # cheaper, equally-informative ``{N keys}`` stub is kept instead of spending
+        # budget on an empty-looking shell. (Both score zero preserved leaves, so
+        # this is a quality choice, not needed for monotonicity.) When the source
+        # itself is contentless, the truthful empty-nested fill is fine.
         if (
             filled is not None
-            and (self._content_leaves(filled) > 0 or self._content_leaves(bval) == 0)
+            and not (self._is_contentless(filled) and not self._is_contentless(bval))
             and len(dump(frame(n_full, b_idx, filled))) <= max_chars
         ):
             return dump(frame(n_full, b_idx, filled))

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1212,28 +1212,48 @@ class FieldExtractCompressor:
         return value  # int / float / bool / None
 
     @staticmethod
-    def _is_contentless(obj: object) -> bool:
-        """True if ``obj`` — a ``_fit_monotone`` rendering — preserves NO original
-        scalar: an empty container, the empty-string scalar stub ``""``, or a
-        container holding only omitted-count markers and other contentless values.
+    def _scalar_pool(obj: object) -> list:
+        """Every scalar leaf of ``obj``, flattened depth-first."""
+        pool: list = []
+        stack = [obj]
+        while stack:
+            o = stack.pop()
+            if isinstance(o, dict):
+                stack.extend(o.values())
+            elif isinstance(o, list):
+                stack.extend(o)
+            else:
+                pool.append(o)
+        return pool
 
-        Provenance-correct by construction: ``_fit_monotone`` only ever emits
-        original values, truncated original strings, ``""`` for an oversized scalar,
-        and omitted-count markers — it NEVER fabricates a ``{N keys}`` / ``[N items]``
-        shape stub (those come only from ``_stub_value``). So a string that merely
-        looks like ``"[2 items]"`` here is a genuine original value and is correctly
-        treated as content — no pattern-matching, no false positives."""
-        if isinstance(obj, dict):
-            return all(
-                str(k).startswith("_truncated") or FieldExtractCompressor._is_contentless(v)
-                for k, v in obj.items()
-            )
-        if isinstance(obj, list):
-            return all(
-                (isinstance(e, str) and "omitted" in e) or FieldExtractCompressor._is_contentless(e)
-                for e in obj
-            )
-        return obj == ""
+    @staticmethod
+    def _fill_preserves_source(filled: object, source: object) -> bool:
+        """True if ``filled`` (a ``_fit_monotone`` rendering of ``source``) preserves
+        at least one ORIGINAL scalar of ``source`` — judged by PROVENANCE, never by
+        string pattern. A scalar of ``filled`` is preserved when it equals a source
+        scalar or is a ``"…"``-truncated prefix of one; generated markers, stubs and
+        empty fills are absent from the source pool and so add nothing. A source with
+        no scalars at all (empty-nested) is vacuously preserved — the truthful empty
+        fill is fine.
+
+        Pattern-based detection (a ``_truncated`` key prefix, an ``"omitted"``
+        substring) would misclassify real keys/values that happen to look like the
+        generated markers; comparing against the source avoids that entirely."""
+        src = FieldExtractCompressor._scalar_pool(source)
+        if not src:
+            return True
+        src_set = set(src)
+        src_strs = [s for s in src if isinstance(s, str)]
+        for f in FieldExtractCompressor._scalar_pool(filled):
+            if f in src_set:
+                return True
+            if (
+                isinstance(f, str)
+                and f.endswith("...")
+                and any(o.startswith(f[:-3]) for o in src_strs)
+            ):
+                return True
+        return False
 
     def _enrich_dict_monotone(self, data: dict, max_chars: int) -> str:
         """Fill a dict root's budget MONOTONICALLY while keeping EVERY top-level
@@ -1309,15 +1329,16 @@ class FieldExtractCompressor:
         # monotone in it; the assembled frame is re-checked against the budget.
         room = max_chars - len(dump(base)) + len(dump(stub[bkey]))
         filled = self._fit_monotone(bval, room) if room >= 2 else None
-        # Take the boundary fill unless it is a content-free rendering ({} / [] / a
-        # marker-only container) of a source that DID have content — then the
-        # cheaper, equally-informative ``{N keys}`` stub is kept instead of spending
-        # budget on an empty-looking shell. (Both score zero preserved leaves, so
-        # this is a quality choice, not needed for monotonicity.) When the source
-        # itself is contentless, the truthful empty-nested fill is fine.
+        # Take the boundary fill unless it preserves NONE of the source's original
+        # scalars (a content-free shell — {} / [] / a marker-only container) while
+        # the source DID have scalars; then the cheaper, equally-informative
+        # ``{N keys}`` stub is kept instead of spending budget on an empty-looking
+        # shell. Both preserve zero original scalars, so this is a quality choice,
+        # not needed for monotonicity. Provenance, not pattern: a real value that
+        # looks like a marker still counts as preserved.
         if (
             filled is not None
-            and not (self._is_contentless(filled) and not self._is_contentless(bval))
+            and self._fill_preserves_source(filled, bval)
             and len(dump(frame(n_full, b_idx, filled))) <= max_chars
         ):
             return dump(frame(n_full, b_idx, filled))

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -1211,6 +1211,103 @@ class FieldExtractCompressor:
             return ""
         return value  # int / float / bool / None
 
+    @staticmethod
+    def _content_leaves(obj: object) -> int:
+        """Count preserved ORIGINAL scalar leaves — the metric the monotonicity
+        contract is stated in. Omitted-count markers carry no original content and
+        are excluded: a ``_truncated`` dict member and an ``... omitted`` in-array
+        string. A shape stub (``{N keys}`` / ``[N items]`` / ``""``) is a plain
+        scalar here and counts as one, so trading it for an emptier or marker-only
+        container is correctly seen as a loss."""
+        if isinstance(obj, dict):
+            return sum(
+                FieldExtractCompressor._content_leaves(v)
+                for k, v in obj.items()
+                if not str(k).startswith("_truncated")
+                and not (isinstance(v, str) and "omitted" in v)
+            )
+        if isinstance(obj, list):
+            return sum(
+                FieldExtractCompressor._content_leaves(e)
+                for e in obj
+                if not (isinstance(e, str) and "omitted" in e)
+            )
+        return 1
+
+    def _enrich_dict_monotone(self, data: dict, max_chars: int) -> str:
+        """Fill a dict root's budget MONOTONICALLY while keeping EVERY top-level
+        key (the all-stub skeleton, which the caller verified fits).
+
+        Mirrors ``_fit_monotone``'s discipline — a growing FULL prefix plus ONE
+        partial boundary — but the tail is STUBS, not a marker, so no top-level
+        key vanishes (FieldExtract's "preserve key structure" contract). Each key's
+        value is filled by ``_fit_monotone`` (sibling-preserving + monotone). Keys
+        are prioritized oversized-scalar-LAST so a huge value cannot crowd out
+        short, high-value siblings; otherwise document order. Only ONE key is ever
+        partial, so a growing budget never displaces another key — the source of
+        the old per-key greedy's non-monotonicity. Output keeps the ORIGINAL key
+        order; only the fill *priority* is reordered.
+        """
+
+        def dump(obj: object) -> str:
+            return json.dumps(obj, ensure_ascii=False)
+
+        items = list(data.items())
+        stub = {k: self._stub_value(v) for k, v in items}
+
+        def rank(i: int) -> tuple:
+            v = items[i][1]
+            if isinstance(v, (dict, list)):
+                return (1, 0, i)  # collections: after short scalars, document order
+            size = len(dump(v))
+            if size > 80:
+                return (2, size, i)  # oversized scalars LAST (a huge blob is low value)
+            return (0, size, i)  # short scalars FIRST, smallest first (ids/names/flags win)
+
+        order = sorted(range(len(items)), key=rank)
+
+        def frame(n_full: int, b_idx: int | None, b_val: object) -> dict:
+            full = {order[i] for i in range(n_full)}
+            out: dict = {}
+            for i, (k, v) in enumerate(items):  # ORIGINAL key order
+                if i in full:
+                    out[k] = v
+                elif b_idx is not None and i == b_idx:
+                    out[k] = b_val
+                else:
+                    out[k] = stub[k]
+            return out
+
+        # Largest FULL-value prefix (in priority order) that fits; the rest stay
+        # stubs. ``frame`` length is non-decreasing in ``n_full`` (a full value is
+        # never shorter than its stub), so the first overflow ends the prefix.
+        n_full = 0
+        for n in range(1, len(items) + 1):
+            if len(dump(frame(n, None, None))) <= max_chars:
+                n_full = n
+            else:
+                break
+        if n_full >= len(items):
+            return dump(frame(n_full, None, None))  # every value full
+
+        base = frame(n_full, None, None)
+        b_idx = order[n_full]
+        bkey = items[b_idx][0]
+        bval = items[b_idx][1]
+        # The boundary REPLACES bkey's stub already counted in ``base`` (the key and
+        # ``": "`` stay), so the room for the filled value is the leftover plus the
+        # stub it displaces. ``_fit_monotone`` keeps its dump within that room and is
+        # monotone in it; the assembled frame is re-checked against the budget.
+        room = max_chars - len(dump(base)) + len(dump(stub[bkey]))
+        filled = self._fit_monotone(bval, room) if room >= 2 else None
+        if (
+            filled is not None
+            and self._content_leaves(filled) >= self._content_leaves(stub[bkey])
+            and len(dump(frame(n_full, b_idx, filled))) <= max_chars
+        ):
+            return dump(frame(n_full, b_idx, filled))
+        return dump(base)
+
     def _fit_extracted(self, data: object, max_chars: int) -> str:
         """Re-derive a VALID, within-budget form from the ORIGINAL data, filling
         the budget with as much leading full-detail content as fits.
@@ -1222,11 +1319,11 @@ class FieldExtractCompressor:
 
         Top-level dict: first lay down a *skeleton* — every key with a minimal
         stub value — so no top-level key vanishes while the budget allows it
-        (FieldExtract's "preserve key structure" contract). Then restore short
-        scalar values first before enriching keys with as much full-detail
-        content (via ``_take``) as the remaining budget allows — values like
-        names/ids/roles survive in full rather than every value being shrunk to
-        a stub.
+        (FieldExtract's "preserve key structure" contract). When the skeleton
+        fits, ``_enrich_dict_monotone`` fills the budget MONOTONICALLY: a growing
+        FULL-value prefix (oversized scalars ranked last so short, high-value
+        siblings survive) plus ONE partial boundary value, every other key kept
+        as its stub.
         Only when the stubs themselves overflow are trailing keys dropped into a
         valid collision-safe marker. A list root fills the budget MONOTONICALLY
         via ``_fit_monotone``; string / scalar roots truncate directly. Floors to
@@ -1240,34 +1337,7 @@ class FieldExtractCompressor:
             items = list(data.items())
             skeleton = {k: self._stub_value(v) for k, v in items}
             if len(dump(skeleton)) <= max_chars:
-                # Enrich keys to fill the budget, but enrich SCALARS before
-                # collections: cheap, high-value scalar fields (ids, names, flags)
-                # must survive a tight budget even when large nested sections
-                # precede them in document order. The output dict keeps the original
-                # key order — only the enrichment *priority* is reordered.
-                out = dict(skeleton)
-                scalars = [(k, v) for k, v in items if not isinstance(v, (dict, list))]
-                collections = [(k, v) for k, v in items if isinstance(v, (dict, list))]
-                for k, v in sorted(scalars, key=lambda item: len(dump(item[1]))):
-                    trial = dict(out)
-                    trial[k] = v
-                    if len(dump(trial)) <= max_chars:
-                        out[k] = v
-
-                for k, v in scalars + collections:
-                    if out[k] == v:
-                        continue
-                    lo, hi, best_v = 0, len(dump(v)), out[k]
-                    while lo <= hi:
-                        mid = (lo + hi) // 2
-                        trial = dict(out)
-                        trial[k] = self._take(v, mid)
-                        if len(dump(trial)) <= max_chars:
-                            best_v, lo = trial[k], mid + 1
-                        else:
-                            hi = mid - 1
-                    out[k] = best_v
-                return dump(out)
+                return self._enrich_dict_monotone(data, max_chars)
 
             # Even the all-stub skeleton overflows — keep the leading keys that
             # fit + a valid marker. ``len`` is monotonic in ``keep``. The marker
@@ -1396,7 +1466,17 @@ class FieldExtractCompressor:
         marker_key = "_truncated"
         if isinstance(value, dict):
             is_dict = True
-            items: list = list(value.items())
+            # Rank oversized SCALAR values LAST: a huge id/number/string would
+            # otherwise become the boundary (or full prefix) and crowd its often
+            # short, high-value siblings into the marker. Pushing it to the tail
+            # keeps the cheap siblings in the FULL prefix; the oversized scalar then
+            # degrades cheaply as the boundary or marker. Stable, so non-oversized
+            # keys keep document order. (A container value is never "oversized" here
+            # — it can absorb the boundary budget meaningfully via recursion.)
+            items: list = sorted(
+                value.items(),
+                key=lambda kv: not isinstance(kv[1], (dict, list)) and len(dump(kv[1])) > 80,
+            )
             existing = set(value)
             while marker_key in existing:
                 marker_key += "_"

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -291,18 +291,37 @@ def test_take_keeps_full_container_when_it_fits() -> None:
 
 
 def test_dict_fit_reserves_space_for_omission_marker() -> None:
-    """Nested dict fitting must prefer an omitted-count marker over silently
-    returning a longer key prefix with no marker."""
+    """A partially-shown nested dict keeps retained keys + an omitted-count marker
+    (never a silent prefix). The budget must leave room to retain >= 1 key: when
+    NONE fit, the monotone fill instead collapses the whole nested dict to the
+    compact ``{N keys}`` stub (a smaller, still-explicit omission indicator that —
+    unlike a marker-only dict — never regresses against the stub as the budget
+    grows; see test_dict_fully_omitted_nested_collapses_to_stub)."""
     payload = json.dumps({"outer": {f"k{i}": {"a": 1} for i in range(1000)}, "id": "abc"})
-    out = FieldExtractCompressor().compress(payload, max_chars=80)
+    out = FieldExtractCompressor().compress(payload, max_chars=120)
     parsed = json.loads(out)
     outer = parsed["outer"]
     marker = outer.get("_truncated", "")
     retained = len([k for k in outer if k != "_truncated"])
     omitted = int(marker.split(" of ")[0])
+    assert len(out) <= 120
+    assert parsed["id"] == "abc"
+    assert retained >= 1  # at this budget at least the leading key survives
+    assert omitted + retained == 1000
+
+
+def test_dict_fully_omitted_nested_collapses_to_stub() -> None:
+    """When a nested dict is too big to retain even ONE key, it collapses to the
+    compact ``{N keys}`` stub rather than a marker-only ``{"_truncated": ...}``
+    dict. The stub is smaller AND carries a content leaf, so the fill never
+    regresses from the stub to a larger-but-emptier marker as the budget grows
+    (the monotonicity contract). The sibling ``id`` still survives."""
+    payload = json.dumps({"outer": {f"k{i}": {"a": 1} for i in range(1000)}, "id": "abc"})
+    out = FieldExtractCompressor().compress(payload, max_chars=80)
+    parsed = json.loads(out)
     assert len(out) <= 80
     assert parsed["id"] == "abc"
-    assert omitted + retained == 1000
+    assert parsed["outer"] == "{1000 keys}"  # compact omission indicator, not a marker dict
 
 
 def test_dict_fit_allows_exact_marker_fit() -> None:
@@ -684,3 +703,94 @@ def test_router_emits_whole_value_pretty_when_it_fits() -> None:
     lst = [1, 2, 3]
     out2 = c._compress_json(lst, 100)
     assert "\n" in out2 and json.loads(out2) == lst
+
+
+# ── E5. Monotonicity: the DICT final tier (the dict analog of the 4B list fix) ─
+#
+# The old dict enrich filled the budget with a per-key greedy ``_take`` search.
+# That was non-monotone two ways: (1) ``_take``'s own content flips to a
+# longer-but-emptier marker as its budget grows (the 4B root cause), and (2) the
+# per-key greedy let a growing budget hand an EARLIER key more budget, displacing
+# a LATER key. ``_enrich_dict_monotone`` replaces it with ``_fit_monotone``'s
+# discipline — a growing full-value prefix plus ONE partial boundary, every other
+# key kept as its stub — so only one key is ever partial and a larger budget never
+# shows fewer leaves on a dict root.
+
+
+_DICT_MONO_FIXTURES: dict[str, object] = {
+    # cfg (a nested dict) used to enrich to a marker-only form that displaced the
+    # trailing ``tags`` content as the budget grew.
+    "displacing_coll": {
+        "name": "app",
+        "cfg": {f"o{i}": i for i in range(15)},
+        "tags": list(range(20)),
+    },
+    # An early bulky collection used to steal budget from a later collection.
+    "early_big_late": {
+        "A": [{"p": i, "q": f"v{i}"} for i in range(15)],
+        "B": {"x": 1, "y": 2, "z": 3},
+    },
+    # A huge leading scalar must not crowd out short later identifiers.
+    "oversized_first": {"blob": "x" * 300, "id": "abc", "name": "Alice", "cfg": {"a": 1, "b": 2}},
+    # Wide config: every value a nested dict; fill must stay tight AND monotone.
+    "wide_config": _wide_config_dict(20),
+    "nested_lists": {
+        "a": 1,
+        "b": 2,
+        "items": [{"x": i, "y": f"v{i}"} for i in range(20)],
+        "tail": "end",
+    },
+    "flat_scalars": {f"k{i}": f"value-{i}" for i in range(25)},
+    "deep": {"l1": {"l2": {"l3": {"l4": [1, 2, 3], "id": "x"}, "k": "v"}, "m": 5}, "n": 9},
+}
+
+
+@pytest.mark.parametrize("name", sorted(_DICT_MONO_FIXTURES))
+def test_dict_root_content_is_monotone_in_budget(name: str) -> None:
+    """For a dict root, a LARGER budget must never preserve FEWER original leaves
+    in the final tier. Budgets are swept CONTIGUOUSLY so a one-char cliff cannot
+    hide between sampled points; output is asserted valid + within budget too."""
+    fixture = _DICT_MONO_FIXTURES[name]
+    data = json.loads(fixture) if isinstance(fixture, str) else fixture
+    c = FieldExtractCompressor()
+    prev: int | None = None
+    for budget in range(2, len(json.dumps(data)) + 5):
+        out = c._fit_extracted(data, budget)
+        parsed = json.loads(out)  # always valid JSON
+        assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
+        leaves = _preserved_leaves(parsed)
+        if prev is not None:
+            assert leaves >= prev, f"{name}@{budget}: content regressed {prev} -> {leaves}"
+        prev = leaves
+
+
+def test_dict_single_partial_boundary_no_cross_key_displacement() -> None:
+    """The canonical pre-fix cross-key regression: as the budget grows one char,
+    an early collection used to grab more budget and an emptier-marker form
+    displaced a later key (content dropped). With a single partial boundary the
+    leaf count is non-decreasing across that exact boundary."""
+    c = FieldExtractCompressor()
+    data = {
+        "A": [{"p": i, "q": f"v{i}", "r": [i, i + 1]} for i in range(15)],
+        "B": {"x": 1, "y": 2, "z": 3, "w": 4},
+    }
+    prev = -1
+    for budget in range(2, 200):
+        leaves = _preserved_leaves(json.loads(c._fit_extracted(data, budget)))
+        assert leaves >= prev, f"@{budget}: regressed {prev} -> {leaves}"
+        prev = leaves
+
+
+def test_dict_oversized_scalar_ranked_last_preserves_short_siblings() -> None:
+    """A huge scalar value is ranked LAST, so short, high-value siblings land in
+    the full prefix instead of being crowded into the boundary/marker. Mirrors the
+    contract behind test_later_short_scalars_* but through the new enrich path."""
+    c = FieldExtractCompressor()
+    data = {"blob": "x" * 500, "id": "abc", "name": "Alice", "flag": True}
+    out = c._fit_extracted(data, 120)
+    parsed = json.loads(out)
+    assert len(out) <= 120
+    assert parsed["id"] == "abc"
+    assert parsed["name"] == "Alice"
+    assert parsed["flag"] is True
+    assert parsed["blob"] != "x" * 500  # the huge value is the one that degrades

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -482,16 +482,17 @@ def test_wide_config_dict_routes_to_extract_fields() -> None:
 
 def _preserved_leaves(obj: object, original: object) -> int:
     """Count preserved ORIGINAL scalar leaves — the true monotonicity metric, scored
-    by PROVENANCE against ``original`` (not by string pattern, which can't tell a
-    real ``"[2 items]"`` value from a generated ``{N items}`` stub).
+    purely by PROVENANCE against ``original`` (NO string-pattern filters, which can't
+    tell a real ``"[2 items]"`` / ``"... omitted"`` value or a real ``_truncated_x``
+    key from a generated marker or stub).
 
     An output scalar counts 1 iff it derives from an original scalar — an exact
     original value, or a ``"…"``-truncated prefix of one. Generated placeholders
-    therefore count 0: omitted-count markers, the empty-string / shape stubs from
-    ``_stub_value`` (none of which appear in ``original``), and empty containers.
-    Mirrors the intent of ``FieldExtractCompressor._is_contentless``."""
+    therefore count 0 automatically (they are absent from ``original``): omitted-count
+    markers, the empty-string / shape stubs from ``_stub_value``, and empty
+    containers. No key/value is skipped by name, so a real key like ``_truncated_x``
+    or a real value containing ``omitted`` is still scored on its own provenance."""
     strings: set[str] = set()
-    others: set = set()
 
     def collect(o: object) -> None:
         if isinstance(o, dict):
@@ -502,8 +503,6 @@ def _preserved_leaves(obj: object, original: object) -> int:
                 collect(e)
         elif isinstance(o, str):
             strings.add(o)
-        else:
-            others.add(o)
 
     collect(original)
 
@@ -514,17 +513,12 @@ def _preserved_leaves(obj: object, original: object) -> int:
 
     def count(o: object) -> int:
         if isinstance(o, dict):
-            return sum(
-                count(v)
-                for k, v in o.items()
-                if not str(k).startswith("_truncated")
-                and not (isinstance(v, str) and "omitted" in v)
-            )
+            return sum(count(v) for v in o.values())
         if isinstance(o, list):
-            return sum(count(e) for e in o if not (isinstance(e, str) and "omitted" in e))
+            return sum(count(e) for e in o)
         if isinstance(o, str):
             return 1 if derives(o) else 0
-        return 1  # numbers / bools / None are emitted verbatim or stubbed away
+        return 1  # numbers / bools / None are emitted verbatim, never fabricated
 
     return count(obj)
 
@@ -861,5 +855,33 @@ def test_dict_empty_nested_value_is_monotone_against_its_stub() -> None:
     prev = -1
     for budget in range(2, len(json.dumps(data)) + 5):
         leaves = _preserved_leaves(json.loads(c._fit_extracted(data, budget)), data)
+        assert leaves >= prev, f"@{budget}: regressed {prev} -> {leaves}"
+        prev = leaves
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # A real list value containing the word "omitted" must not be mistaken for a
+        # generated omitted-count marker by the boundary guard.
+        {"a": ["a real omitted note", "tail"], "b": "x" * 40, "c": [1, 2, 3]},
+        # A real string value that reads like the in-array marker.
+        {"a": {"label": "... (2 of 2 items omitted)", "note": "hello"}, "b": "x" * 40},
+        # A real key whose name starts with the collision-safe marker prefix.
+        {"outer": {"_truncated_real": "keep me", "z": "tail"}, "id": "abc", "pad": "y" * 40},
+        # A real top-level _truncated* key.
+        {"_truncated_x": "keep", "data": [{"v": i} for i in range(15)], "id": "z"},
+    ],
+)
+def test_dict_provenance_not_pattern_for_markers(data: object) -> None:
+    """Marker/placeholder detection is by PROVENANCE, not string pattern: a real
+    value containing ``omitted`` or a real ``_truncated*`` key is genuine content,
+    so the boundary guard must not drop it and the budget must stay monotone."""
+    c = FieldExtractCompressor()
+    prev = -1
+    for budget in range(2, len(json.dumps(data)) + 5):
+        out = c._fit_extracted(data, budget)
+        assert len(out) <= max(2, budget), f"@{budget}: over budget"
+        leaves = _preserved_leaves(json.loads(out), data)
         assert leaves >= prev, f"@{budget}: regressed {prev} -> {leaves}"
         prev = leaves

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -794,3 +794,18 @@ def test_dict_oversized_scalar_ranked_last_preserves_short_siblings() -> None:
     assert parsed["name"] == "Alice"
     assert parsed["flag"] is True
     assert parsed["blob"] != "x" * 500  # the huge value is the one that degrades
+
+
+def test_dict_small_container_full_fits_after_larger_prefix_overflows() -> None:
+    """The full-prefix search must take the MAX fitting prefix, not stop at the
+    first overflow: a small container's FULL form is SHORTER than its ``{N items}``
+    stub, so a longer prefix can fit after a shorter one overflows. Here both ``a``
+    and ``b`` fit fully at a budget where the (b-stub) prefix-of-1 overflows — the
+    early-break search wrongly stubbed ``b``."""
+    c = FieldExtractCompressor()
+    data = {"a": [0, 1, 2, 3], "b": [0], "blob": "x" * 100}
+    out = c._fit_extracted(data, 48)
+    parsed = json.loads(out)
+    assert len(out) <= 48
+    assert parsed["a"] == [0, 1, 2, 3]
+    assert parsed["b"] == [0]  # the small container survives FULL, not "[1 items]"

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -481,8 +481,20 @@ def test_wide_config_dict_routes_to_extract_fields() -> None:
 
 
 def _preserved_leaves(obj: object) -> int:
-    """Count preserved original scalar leaves, EXCLUDING omitted-count markers
-    (the dict ``_truncated`` member and the in-array ``... items omitted`` string)."""
+    """Count preserved ORIGINAL scalar leaves — the true monotonicity metric.
+    PLACEHOLDERS count 0 (they preserve no original content): omitted-count markers
+    (the dict ``_truncated`` member, the in-array ``... omitted`` string), shape
+    stubs (``{N keys}`` / ``[N items]`` / ``""``), and empty containers. Counting a
+    stub as a leaf would falsely score the COMPLETE value of an empty-nested key
+    below its stub. Mirrors ``FieldExtractCompressor._content_leaves``."""
+
+    def _is_stub(s: str) -> bool:
+        return (
+            s == ""
+            or (s.startswith("{") and s.endswith(" keys}"))
+            or (s.startswith("[") and s.endswith(" items]"))
+        )
+
     if isinstance(obj, dict):
         return sum(
             _preserved_leaves(v)
@@ -491,6 +503,8 @@ def _preserved_leaves(obj: object) -> int:
         )
     if isinstance(obj, list):
         return sum(_preserved_leaves(e) for e in obj if not (isinstance(e, str) and "omitted" in e))
+    if isinstance(obj, str) and _is_stub(obj):
+        return 0
     return 1
 
 
@@ -742,6 +756,9 @@ _DICT_MONO_FIXTURES: dict[str, object] = {
     },
     "flat_scalars": {f"k{i}": f"value-{i}" for i in range(25)},
     "deep": {"l1": {"l2": {"l3": {"l4": [1, 2, 3], "id": "x"}, "k": "v"}, "m": 5}, "n": 9},
+    # Empty-nested values (0 original scalars): a full ``{"x": []}`` must not score
+    # below its ``{1 keys}`` stub — the metric counts both as 0 preserved content.
+    "empty_nested": {"a": {"x": []}, "b": "tail", "c": [[], {}], "d": 5},
 }
 
 
@@ -809,3 +826,19 @@ def test_dict_small_container_full_fits_after_larger_prefix_overflows() -> None:
     assert len(out) <= 48
     assert parsed["a"] == [0, 1, 2, 3]
     assert parsed["b"] == [0]  # the small container survives FULL, not "[1 items]"
+
+
+def test_dict_empty_nested_value_is_monotone_against_its_stub() -> None:
+    """A key whose whole value is empty-nested (``{"x": []}`` — zero original
+    scalars) must not score below its ``{1 keys}`` stub as the budget grows. The
+    stub preserves no original scalar (counts 0); so does the full empty-nested
+    value, so promoting it to full is monotone. Pre-metric-fix this regressed from
+    2 -> 1 'leaves' at the budget where the full value first fit, because the stub
+    string was wrongly counted as a preserved leaf."""
+    c = FieldExtractCompressor()
+    data = {"a": {"x": []}, "b": "tail"}
+    prev = -1
+    for budget in range(2, len(json.dumps(data)) + 5):
+        leaves = _preserved_leaves(json.loads(c._fit_extracted(data, budget)))
+        assert leaves >= prev, f"@{budget}: regressed {prev} -> {leaves}"
+        prev = leaves

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -509,7 +509,10 @@ def _preserved_leaves(obj: object, original: object) -> int:
     def derives(s: str) -> bool:
         if s in strings:
             return True
-        return s.endswith("...") and any(o.startswith(s[:-3]) for o in strings)
+        if not s.endswith("..."):
+            return False
+        prefix = s[:-3]  # a bare "..." has an empty prefix → preserves no source char
+        return bool(prefix) and any(o.startswith(prefix) for o in strings)
 
     def count(o: object) -> int:
         if isinstance(o, dict):
@@ -521,6 +524,38 @@ def _preserved_leaves(obj: object, original: object) -> int:
         return 1  # numbers / bools / None are emitted verbatim, never fabricated
 
     return count(obj)
+
+
+def test_bare_ellipsis_does_not_count_as_preserved_content() -> None:
+    """A content-free ``"..."`` boundary fill preserves ZERO original characters, so
+    neither the provenance metric nor the runtime guard may treat it as preserved.
+
+    Regression for the empty-prefix bug: ``"..."[:-3] == ""`` and every string
+    ``.startswith("")``, so a bare ``"..."`` was falsely read as a truncated prefix of
+    any source string. An ORIGINAL value that is literally ``"..."`` is still matched
+    by equality and scores 1.
+    """
+    # Metric: a generated bare "..." against a real source scalar -> 0.
+    assert _preserved_leaves({"payload": "..."}, {"payload": "secret"}) == 0
+    # Metric: a genuine "..."-truncated prefix of the source -> 1.
+    assert _preserved_leaves({"payload": "sec..."}, {"payload": "secret"}) == 1
+    # Metric: an original value that is literally "..." -> matched by equality -> 1.
+    assert _preserved_leaves({"payload": "..."}, {"payload": "..."}) == 1
+
+    comp = FieldExtractCompressor()
+    # Runtime guard mirrors the metric on the same cases.
+    assert comp._fill_preserves_source({"payload": "..."}, {"payload": "secret"}) is False
+    assert comp._fill_preserves_source({"payload": "sec..."}, {"payload": "secret"}) is True
+    assert comp._fill_preserves_source({"payload": "..."}, {"payload": "..."}) is True
+
+    # End-to-end (codex's repro): at a tight budget the bulky payload would truncate to
+    # a content-free "..."; the fixed guard rejects that shell in favor of the cheaper
+    # empty stub, so the surviving "id" is the ONLY preserved leaf — never the "...".
+    source = {"id": "abc", "payload": "x" * 100}
+    out = json.loads(comp._fit_extracted(source, 31))
+    assert out["id"] == "abc"
+    assert out["payload"] == ""  # content-free fill dropped to the empty stub
+    assert _preserved_leaves(out, source) == 1  # only "id":"abc", NOT the "..."
 
 
 _LIST_MONO_FIXTURES: dict[str, object] = {

--- a/tests/test_field_extract_output_invariants.py
+++ b/tests/test_field_extract_output_invariants.py
@@ -480,32 +480,53 @@ def test_wide_config_dict_routes_to_extract_fields() -> None:
 # ── E3. Monotonicity: a larger budget never shows less content (the 4B fix) ───
 
 
-def _preserved_leaves(obj: object) -> int:
-    """Count preserved ORIGINAL scalar leaves — the true monotonicity metric.
-    PLACEHOLDERS count 0 (they preserve no original content): omitted-count markers
-    (the dict ``_truncated`` member, the in-array ``... omitted`` string), shape
-    stubs (``{N keys}`` / ``[N items]`` / ``""``), and empty containers. Counting a
-    stub as a leaf would falsely score the COMPLETE value of an empty-nested key
-    below its stub. Mirrors ``FieldExtractCompressor._content_leaves``."""
+def _preserved_leaves(obj: object, original: object) -> int:
+    """Count preserved ORIGINAL scalar leaves — the true monotonicity metric, scored
+    by PROVENANCE against ``original`` (not by string pattern, which can't tell a
+    real ``"[2 items]"`` value from a generated ``{N items}`` stub).
 
-    def _is_stub(s: str) -> bool:
-        return (
-            s == ""
-            or (s.startswith("{") and s.endswith(" keys}"))
-            or (s.startswith("[") and s.endswith(" items]"))
-        )
+    An output scalar counts 1 iff it derives from an original scalar — an exact
+    original value, or a ``"…"``-truncated prefix of one. Generated placeholders
+    therefore count 0: omitted-count markers, the empty-string / shape stubs from
+    ``_stub_value`` (none of which appear in ``original``), and empty containers.
+    Mirrors the intent of ``FieldExtractCompressor._is_contentless``."""
+    strings: set[str] = set()
+    others: set = set()
 
-    if isinstance(obj, dict):
-        return sum(
-            _preserved_leaves(v)
-            for k, v in obj.items()
-            if not str(k).startswith("_truncated") and not (isinstance(v, str) and "omitted" in v)
-        )
-    if isinstance(obj, list):
-        return sum(_preserved_leaves(e) for e in obj if not (isinstance(e, str) and "omitted" in e))
-    if isinstance(obj, str) and _is_stub(obj):
-        return 0
-    return 1
+    def collect(o: object) -> None:
+        if isinstance(o, dict):
+            for v in o.values():
+                collect(v)
+        elif isinstance(o, list):
+            for e in o:
+                collect(e)
+        elif isinstance(o, str):
+            strings.add(o)
+        else:
+            others.add(o)
+
+    collect(original)
+
+    def derives(s: str) -> bool:
+        if s in strings:
+            return True
+        return s.endswith("...") and any(o.startswith(s[:-3]) for o in strings)
+
+    def count(o: object) -> int:
+        if isinstance(o, dict):
+            return sum(
+                count(v)
+                for k, v in o.items()
+                if not str(k).startswith("_truncated")
+                and not (isinstance(v, str) and "omitted" in v)
+            )
+        if isinstance(o, list):
+            return sum(count(e) for e in o if not (isinstance(e, str) and "omitted" in e))
+        if isinstance(o, str):
+            return 1 if derives(o) else 0
+        return 1  # numbers / bools / None are emitted verbatim or stubbed away
+
+    return count(obj)
 
 
 _LIST_MONO_FIXTURES: dict[str, object] = {
@@ -547,7 +568,7 @@ def test_list_root_content_is_monotone_in_budget(name: str) -> None:
         out = compressor._fit_extracted(data, budget)
         parsed = json.loads(out)  # always valid JSON
         assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
-        leaves = _preserved_leaves(parsed)
+        leaves = _preserved_leaves(parsed, data)
         if prev is not None:
             assert leaves >= prev, f"{name}@{budget}: content regressed {prev} -> {leaves}"
         prev = leaves
@@ -633,7 +654,7 @@ def test_list_root_monotone_through_router(name: str) -> None:
         out = c._compress_json(data, budget)
         parsed = json.loads(out)  # always valid JSON
         assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
-        leaves = _preserved_leaves(parsed)
+        leaves = _preserved_leaves(parsed, data)
         if prev is not None:
             assert leaves >= prev, f"{name}@{budget}: content regressed {prev} -> {leaves}"
         prev = leaves
@@ -663,7 +684,7 @@ def test_flat_dict_monotone_through_router(name: str) -> None:
         out = c._compress_json(data, budget)
         parsed = json.loads(out)
         assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
-        leaves = _preserved_leaves(parsed)
+        leaves = _preserved_leaves(parsed, data)
         if prev is not None:
             assert leaves >= prev, f"{name}@{budget}: content regressed {prev} -> {leaves}"
         prev = leaves
@@ -698,12 +719,12 @@ def test_router_no_longer_prefers_lossy_preview() -> None:
     boundary, for both a list-of-ints and a list-of-dicts root."""
     c = FieldExtractCompressor()
     ints: list[object] = list(range(50))
-    assert _preserved_leaves(json.loads(c._compress_json(ints, 61))) >= _preserved_leaves(
-        json.loads(c._compress_json(ints, 60))
+    assert _preserved_leaves(json.loads(c._compress_json(ints, 61)), ints) >= _preserved_leaves(
+        json.loads(c._compress_json(ints, 60)), ints
     )
     dicts: list[object] = [{"id": i, "name": f"item{i}"} for i in range(100)]
-    assert _preserved_leaves(json.loads(c._compress_json(dicts, 247))) >= _preserved_leaves(
-        json.loads(c._compress_json(dicts, 246))
+    assert _preserved_leaves(json.loads(c._compress_json(dicts, 247)), dicts) >= _preserved_leaves(
+        json.loads(c._compress_json(dicts, 246)), dicts
     )
 
 
@@ -775,7 +796,7 @@ def test_dict_root_content_is_monotone_in_budget(name: str) -> None:
         out = c._fit_extracted(data, budget)
         parsed = json.loads(out)  # always valid JSON
         assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
-        leaves = _preserved_leaves(parsed)
+        leaves = _preserved_leaves(parsed, data)
         if prev is not None:
             assert leaves >= prev, f"{name}@{budget}: content regressed {prev} -> {leaves}"
         prev = leaves
@@ -793,7 +814,7 @@ def test_dict_single_partial_boundary_no_cross_key_displacement() -> None:
     }
     prev = -1
     for budget in range(2, 200):
-        leaves = _preserved_leaves(json.loads(c._fit_extracted(data, budget)))
+        leaves = _preserved_leaves(json.loads(c._fit_extracted(data, budget)), data)
         assert leaves >= prev, f"@{budget}: regressed {prev} -> {leaves}"
         prev = leaves
 
@@ -839,6 +860,6 @@ def test_dict_empty_nested_value_is_monotone_against_its_stub() -> None:
     data = {"a": {"x": []}, "b": "tail"}
     prev = -1
     for budget in range(2, len(json.dumps(data)) + 5):
-        leaves = _preserved_leaves(json.loads(c._fit_extracted(data, budget)))
+        leaves = _preserved_leaves(json.loads(c._fit_extracted(data, budget)), data)
         assert leaves >= prev, f"@{budget}: regressed {prev} -> {leaves}"
         prev = leaves


### PR DESCRIPTION
## What

The dict final tier (`_fit_extracted`'s skeleton+enrich path) was content **non-monotone in the budget** — the dict analog of the list fix in #405, scoped out there and in #406. Completing it makes **list AND dict roots fully content-monotone end-to-end**.

The old enrich filled the budget with a per-key greedy `_take` search, non-monotone two ways:
1. `_take`'s own content flips to a longer-but-emptier `_truncated` marker as its per-child budget grows (the #405 root cause);
2. the per-key greedy let a growing budget hand an **earlier** key more budget, **displacing a later** key.

| root | regression (preserved leaves) |
|---|---|
| `{name, cfg:{…15}, tags:[…20]}` | cfg → marker-only form displaced `tags` |
| `{A:[…15 dicts], B:{…}}` | A stole budget from B (5 → 2 at one step) |
| wide nested dicts | regressed at multiple budgets |

## Fix

`_enrich_dict_monotone` applies `_fit_monotone`'s discipline to the dict root — a growing **FULL-value prefix** plus **ONE partial boundary**, every other key kept as its stub (tail = stubs, not a marker, so the "preserve key structure" contract holds). Each value is filled by `_fit_monotone`; **only one key is ever partial**, so a larger budget never displaces another key.

- **Priority:** scalars by size first (short ids/names/flags win a tight budget), then collections in document order, then **oversized scalars last** (a huge blob is low value).
- A `_content_leaves` guard keeps a key's stub rather than trading it for an emptier/marker-only enrichment.
- `_fit_monotone`'s dict branch now ranks **oversized scalar values last**, so a huge field collapses to a stub while its siblings survive — required for the recursive nested-dict case. Re-verified clean against all #405 list invariants.

## Behavior changes

- A **fully-omitted nested dict/list collapses to the compact `{N keys}` / `[N items]` stub** instead of a marker-only `{"_truncated": …}` dict. The stub is smaller AND carries a content leaf, so the fill never regresses from stub → larger-but-emptier marker as the budget grows (monotonicity). Siblings still survive. `test_dict_fit_reserves_space_for_omission_marker` moves to a budget where ≥1 key is retainable (the retained+marker path it intends); `test_dict_fully_omitted_nested_collapses_to_stub` pins the stub behavior.
- Nested dict key order may change (oversized-scalar keys rendered last).

## Verification

- New **E5** section sweeps budgets **contiguously** through `_fit_extracted` for dict roots (no leaf regression, valid + within budget at every step), pins the cross-key no-displacement boundary and oversized-scalar-ranked-last preservation.
- Broad adversarial sweep (13 dict + list shapes, contiguous budgets): **0 regressions**; fill stays tight (≥ ~90% on wide configs).
- All existing FieldExtract/compression invariants pass (incl. #405 list E3 + #406 router E4).
- Full suite `-m "not ollama"`: **2909 passed**, 2 pre-existing py3.13 local stdio flakes only (fail identically on `main`, green on CI).
- `ruff check src` + `ruff format --check src` clean; mypy error count unchanged (7, all pre-existing).

## Closes the series

This completes the FieldExtract final-tier monotonicity work: #405 (list final tier) → #406 (`_compress_json` router) → this (dict final tier). No known FieldExtract non-monotonicity remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)