### PR TITLE
Handle AnyIO cancel scope shutdown cleanly

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -31,6 +31,11 @@ from memtomem_stm.surfacing.feedback import FeedbackTracker
 
 logger = logging.getLogger(__name__)
 
+_ANYIO_CANCEL_SCOPE_SHUTDOWN_MARKERS = (
+    "Attempted to exit a cancel scope",
+    "current cancel scope",
+)
+
 _HASHED_QUERY_PREVIEW_RE = re.compile(r"sha256:[0-9a-f]{16}")
 """Exact shape of the opaque ID `FeedbackStore.get_stats` passes through
 verbatim for rows persisted under ``persist_query_text=False`` (#352
@@ -1414,6 +1419,13 @@ async def stm_tuning_recommendations(
 # ---------------------------------------------------------------------------
 
 
+def _is_anyio_cancel_scope_shutdown_error(exc: RuntimeError) -> bool:
+    """Return true for the AnyIO shutdown cleanup error seen on stdio EOF."""
+
+    message = str(exc)
+    return all(marker in message for marker in _ANYIO_CANCEL_SCOPE_SHUTDOWN_MARKERS)
+
+
 def main() -> None:
     """Run the STM MCP server."""
     level = os.environ.get("MEMTOMEM_STM_LOG_LEVEL", "WARNING").upper()
@@ -1428,6 +1440,14 @@ def main() -> None:
     # after logging so the process still terminates; we only add observability.
     try:
         mcp.run()
+    except RuntimeError as e:
+        if _is_anyio_cancel_scope_shutdown_error(e):
+            logger.warning(
+                "STM MCP server shut down with AnyIO cancel scope warning (ignored): %s", e
+            )
+            return
+        logger.exception("STM MCP server terminated with an unhandled exception")
+        raise
     except Exception:
         logger.exception("STM MCP server terminated with an unhandled exception")
         raise

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -31,9 +31,9 @@ from memtomem_stm.surfacing.feedback import FeedbackTracker
 
 logger = logging.getLogger(__name__)
 
-_ANYIO_CANCEL_SCOPE_SHUTDOWN_MARKERS = (
-    "Attempted to exit a cancel scope",
-    "current cancel scope",
+_ANYIO_CANCEL_SCOPE_SHUTDOWN_MESSAGES = (
+    "Attempted to exit a cancel scope that isn't the current tasks's current cancel scope",
+    "Attempted to exit cancel scope in a different task than it was entered in",
 )
 
 _HASHED_QUERY_PREVIEW_RE = re.compile(r"sha256:[0-9a-f]{16}")
@@ -1423,7 +1423,7 @@ def _is_anyio_cancel_scope_shutdown_error(exc: RuntimeError) -> bool:
     """Return true for the AnyIO shutdown cleanup error seen on stdio EOF."""
 
     message = str(exc)
-    return all(marker in message for marker in _ANYIO_CANCEL_SCOPE_SHUTDOWN_MARKERS)
+    return any(marker in message for marker in _ANYIO_CANCEL_SCOPE_SHUTDOWN_MESSAGES)
 
 
 def main() -> None:

--- a/tests/test_qa_round3.py
+++ b/tests/test_qa_round3.py
@@ -162,19 +162,20 @@ class TestParseResultsRegex:
 
 
 class TestDocsToolCount:
-    def test_cli_md_has_11_tools(self):
+    def test_cli_md_has_current_tool_counts(self):
         cli_md = Path(__file__).parent.parent / "docs" / "cli.md"
         content = cli_md.read_text(encoding="utf-8")
-        assert "11 + proxied" in content
+        assert "4 default + 8 opt-in + proxied" in content
         assert "stm_proxy_health" in content
         assert "stm_compression_feedback" in content
         assert "stm_progressive_stats" in content
         assert "stm_tuning_recommendations" in content
 
-    def test_readme_has_11_tools(self):
+    def test_readme_has_current_tool_counts(self):
         readme = Path(__file__).parent.parent / "README.md"
         content = readme.read_text(encoding="utf-8")
-        assert "11 MCP tools" in content
+        assert "four model-facing MCP tools by default" in content
+        assert "Eight observability and" in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1503,18 +1503,25 @@ class TestMainExceptionBarrier:
 
         from memtomem_stm import server
 
-        err = RuntimeError(
-            "Attempted to exit a cancel scope that isn't the current tasks's current cancel scope"
+        errors = (
+            RuntimeError(
+                "Attempted to exit a cancel scope that isn't the current tasks's "
+                "current cancel scope"
+            ),
+            RuntimeError(
+                "Attempted to exit cancel scope in a different task than it was entered in"
+            ),
         )
 
-        caplog.clear()
-        with (
-            caplog.at_level(logging.WARNING, logger="memtomem_stm.server"),
-            patch.object(server.mcp, "run", side_effect=err),
-        ):
-            server.main()
+        for err in errors:
+            caplog.clear()
+            with (
+                caplog.at_level(logging.WARNING, logger="memtomem_stm.server"),
+                patch.object(server.mcp, "run", side_effect=err),
+            ):
+                server.main()
 
-        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
-        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert not error_records
-        assert any("AnyIO cancel scope warning" in r.getMessage() for r in warning_records)
+            error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert not error_records
+            assert any("AnyIO cancel scope warning" in r.getMessage() for r in warning_records)

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1497,3 +1497,24 @@ class TestMainExceptionBarrier:
         assert not error_records, (
             f"clean exit should not emit ERROR logs; got: {[r.getMessage() for r in error_records]}"
         )
+
+    def test_anyio_cancel_scope_shutdown_error_exits_cleanly(self, caplog):
+        import logging
+
+        from memtomem_stm import server
+
+        err = RuntimeError(
+            "Attempted to exit a cancel scope that isn't the current tasks's current cancel scope"
+        )
+
+        caplog.clear()
+        with (
+            caplog.at_level(logging.WARNING, logger="memtomem_stm.server"),
+            patch.object(server.mcp, "run", side_effect=err),
+        ):
+            server.main()
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert not error_records
+        assert any("AnyIO cancel scope warning" in r.getMessage() for r in warning_records)


### PR DESCRIPTION
## Summary
- Treat the AnyIO cancel-scope RuntimeError seen during MCP stdio shutdown as a clean shutdown path
- Keep all other RuntimeError failures logged and re-raised through the existing main exception barrier
- Add regression coverage for the shutdown-only warning path

## Tests
- uv run pytest tests/test_server_tools.py -q
- uv run ruff format --check src/memtomem_stm/server.py tests/test_server_tools.py
- git diff --check