### PR TITLE
fix(proxy): don't cache responses that embed a transient retrieval key

### DIFF
--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -50,6 +50,38 @@ def _make_key(server: str, tool: str, args: dict[str, Any]) -> str:
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
+# Substrings that flag a response embedding a TRANSIENT retrieval key pointing
+# into a process-local pending store. Such payloads must never be cached/served:
+# the key outlives neither a process restart nor the (shorter) pending-store TTL,
+# so a cache hit would hand the agent a dead ``stm_proxy_read_more`` /
+# ``stm_proxy_select_chunks`` key with the response tail unrecoverable.
+#   - progressive first-chunks carry ``progressive.PROGRESSIVE_FOOTER_TOKEN``.
+#   - SELECTIVE / HYBRID chunk TOCs are JSON objects carrying BOTH a
+#     ``"selection_key"`` field and a ``"ttl_seconds_remaining"`` field
+#     (``SelectiveCompressor`` in compression.py). We require the PAIR — not
+#     ``"selection_key"`` alone — so an arbitrary upstream JSON that merely
+#     contains a ``selection_key`` field is not misclassified as transient. The
+#     pair is spacing-invariant, matching both the spaced selective dump and the
+#     compact ``HybridCompressor._fit_toc_tail`` dump (whose abbreviated call
+#     hint drops ``stm_proxy_select_chunks(``, which is why we key on fields).
+# Kept here (the persistence layer) so the store-side guard and the startup
+# legacy purge below can never diverge.
+_PROGRESSIVE_MARKER = "\n---\n[progressive: chars="
+_SELECTION_KEY_MARKER = '"selection_key"'
+_TOC_SHAPE_MARKER = '"ttl_seconds_remaining"'
+
+
+def response_carries_transient_key(text: str) -> bool:
+    """True if ``text`` embeds a transient pending-store retrieval key.
+
+    Used by ``ProxyManager`` to skip caching such responses and by
+    :meth:`ProxyCache.initialize` to purge any that pre-date the guard.
+    """
+    if _PROGRESSIVE_MARKER in text:
+        return True
+    return _SELECTION_KEY_MARKER in text and _TOC_SHAPE_MARKER in text
+
+
 class ProxyCache:
     def __init__(self, db_path: Path, max_entries: int = 10000) -> None:
         self._db_path = db_path
@@ -76,6 +108,19 @@ class ProxyCache:
                 "DELETE FROM proxy_cache WHERE ttl_seconds IS NOT NULL "
                 "AND created_at + ttl_seconds <= ?",
                 (time.time(),),
+            )
+            # One-time purge of legacy rows whose cached result embeds a
+            # transient retrieval key (progressive/SELECTIVE/HYBRID TOC). These
+            # pre-date the store-side guard and would otherwise serve a dead key
+            # after restart/TTL skew until they expire (or forever for no-TTL
+            # caches). ``instr`` is a case-sensitive literal substring match, so
+            # the predicate mirrors ``response_carries_transient_key`` exactly
+            # (progressive footer OR the selection_key + ttl_seconds_remaining
+            # pair) — no LIKE wildcard/case-folding divergence.
+            db.execute(
+                "DELETE FROM proxy_cache WHERE instr(result, ?) > 0 "
+                "OR (instr(result, ?) > 0 AND instr(result, ?) > 0)",
+                (_PROGRESSIVE_MARKER, _SELECTION_KEY_MARKER, _TOC_SHAPE_MARKER),
             )
             db.commit()
         except Exception:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -24,6 +24,7 @@ from mcp.client.streamable_http import streamablehttp_client
 
 from memtomem_stm.proxy import tool_name_budget
 from memtomem_stm.proxy.cache import _make_key as _cache_key
+from memtomem_stm.proxy.cache import response_carries_transient_key
 from memtomem_stm.proxy.cleaning import DefaultContentCleaner
 from memtomem_stm.proxy.compression import (
     HybridCompressor,
@@ -1990,22 +1991,41 @@ class ProxyManager:
         # Cache writes are an optional fast-path: a SQLite lock timeout, disk
         # full, or any other store error must NOT propagate to the agent and
         # discard a successful upstream response. Log and continue.
+        #
+        # Never cache a response that embeds a TRANSIENT retrieval key
+        # (progressive first-chunk, SELECTIVE/HYBRID TOC): ``compressed`` is a
+        # pointer into the process-local pending store, whose key dies on
+        # restart/eviction or its shorter TTL (progressive 1800s / selective
+        # 300s) well before the cache TTL (3600s). A later cache hit would hand
+        # back a dead ``stm_proxy_read_more`` / ``stm_proxy_select_chunks`` key.
+        # Skipping the store makes the next identical call re-run the pipeline
+        # and mint a fresh, live key. Detection is marker-based (shared with the
+        # startup legacy purge in ``ProxyCache.initialize``); a false positive
+        # only costs one un-cached response, never correctness.
         if self._cache is not None and not non_text_content:
-            try:
-                self._cache.set(
+            if response_carries_transient_key(compressed):
+                logger.debug(
+                    "Skipping cache store for %s/%s: response carries a transient "
+                    "retrieval key (progressive/selective TOC)",
                     server,
                     tool,
-                    cache_args,
-                    compressed,
-                    ttl_seconds=cfg_snap.cache.default_ttl_seconds,
                 )
-            except Exception:
-                logger.warning(
-                    "Cache store failed for %s/%s — response unaffected",
-                    server,
-                    tool,
-                    exc_info=True,
-                )
+            else:
+                try:
+                    self._cache.set(
+                        server,
+                        tool,
+                        cache_args,
+                        compressed,
+                        ttl_seconds=cfg_snap.cache.default_ttl_seconds,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Cache store failed for %s/%s — response unaffected",
+                        server,
+                        tool,
+                        exc_info=True,
+                    )
 
         # Combine compressed text with preserved non-text content
         if non_text_content:

--- a/tests/test_proxy_cache.py
+++ b/tests/test_proxy_cache.py
@@ -4,7 +4,20 @@ from __future__ import annotations
 
 import time
 
-from memtomem_stm.proxy.cache import ProxyCache, _make_key
+from memtomem_stm.proxy.cache import (
+    ProxyCache,
+    _make_key,
+    response_carries_transient_key,
+)
+from memtomem_stm.proxy.compression import HybridCompressor, SelectiveCompressor
+from memtomem_stm.proxy.progressive import PROGRESSIVE_FOOTER_TOKEN
+
+# Markdown with enough sections that SELECTIVE/HYBRID emit a chunk TOC (which
+# embeds a transient ``selection_key``) instead of falling back to truncation.
+_TOC_TEXT = "# Doc\n\n" + "\n\n".join(
+    f"## Section {i} heading text\n" + ("alpha beta gamma delta epsilon zeta " * 12)
+    for i in range(12)
+)
 
 
 class TestProxyCacheBasic:
@@ -90,6 +103,121 @@ class TestProxyCacheStats:
         stats = proxy_cache.stats()
         assert stats["total_entries"] == 1
         assert stats["expired_entries"] == 0
+
+
+class TestTransientKeyDetector:
+    """``response_carries_transient_key`` must flag any response embedding a
+    transient pending-store key (progressive first-chunk, SELECTIVE/HYBRID TOC)
+    and leave key-free responses (plain text, truncate fallbacks) alone."""
+
+    def test_plain_text_is_not_transient(self):
+        assert not response_carries_transient_key("just a normal tool response")
+
+    def test_progressive_footer_is_transient(self):
+        text = f"chunk body{PROGRESSIVE_FOOTER_TOKEN}0-100/500] use stm_proxy_read_more"
+        assert response_carries_transient_key(text)
+
+    def test_selective_toc_is_transient(self):
+        out = SelectiveCompressor().compress(_TOC_TEXT, max_chars=600)
+        assert '"selection_key"' in out  # precondition: a key was minted
+        assert response_carries_transient_key(out)
+
+    def test_hybrid_fitted_toc_is_transient(self):
+        # max_chars=550 drives HybridCompressor into _fit_toc_tail, which
+        # abbreviates the call hint to ``select_chunks key=`` (dropping
+        # ``stm_proxy_select_chunks(key=``) while keeping ``"selection_key"`` —
+        # the regression that forced keying on the field, not the hint.
+        out = HybridCompressor().compress(_TOC_TEXT, max_chars=550)
+        assert '"selection_key"' in out
+        assert "stm_proxy_select_chunks(key=" not in out
+        assert response_carries_transient_key(out)
+
+    def test_truncate_fallback_is_not_transient(self):
+        # Tiny budget on unstructured text → plain truncation, no key minted.
+        out = SelectiveCompressor().compress("x" * 5000, max_chars=200)
+        assert '"selection_key"' not in out
+        assert not response_carries_transient_key(out)
+
+    def test_selection_key_field_without_toc_shape_is_not_transient(self):
+        # A legit upstream JSON merely containing a ``selection_key`` field (but
+        # not the SELECTIVE/HYBRID TOC shape) must NOT be misclassified — the
+        # detector requires the ``selection_key`` + ``ttl_seconds_remaining`` pair.
+        assert not response_carries_transient_key('{"selection_key": "abc", "data": 1}')
+
+    def test_uppercase_markers_are_not_transient(self):
+        # Detection is case-sensitive (matches the SQL ``instr`` purge, not LIKE).
+        assert not response_carries_transient_key(
+            '{"SELECTION_KEY": "x", "TTL_SECONDS_REMAINING": 1}'
+        )
+
+
+class TestLegacyTransientPurge:
+    """``initialize`` purges pre-existing rows whose result embeds a transient
+    key (they pre-date the store-side guard) while keeping normal rows."""
+
+    def test_initialize_purges_legacy_transient_rows(self, tmp_path):
+        db = tmp_path / "legacy.db"
+        seed = ProxyCache(db, max_entries=100)
+        seed.initialize()
+        try:
+            seed.set("s", "plain", {}, "ordinary cached response", ttl_seconds=None)
+            seed.set(
+                "s",
+                "prog",
+                {},
+                f"chunk{PROGRESSIVE_FOOTER_TOKEN}0-9/99] more",
+                ttl_seconds=None,
+            )
+            seed.set(
+                "s",
+                "sel",
+                {},
+                SelectiveCompressor().compress(_TOC_TEXT, max_chars=600),
+                ttl_seconds=None,
+            )
+            seed.set(
+                "s",
+                "hyb",
+                {},
+                HybridCompressor().compress(_TOC_TEXT, max_chars=550),
+                ttl_seconds=None,
+            )
+        finally:
+            seed.close()
+
+        # Re-open the SAME db: the startup purge runs in initialize().
+        reopened = ProxyCache(db, max_entries=100)
+        reopened.initialize()
+        try:
+            assert reopened.get("s", "plain", {}) == "ordinary cached response"
+            assert reopened.get("s", "prog", {}) is None
+            assert reopened.get("s", "sel", {}) is None
+            assert reopened.get("s", "hyb", {}) is None
+        finally:
+            reopened.close()
+
+    def test_initialize_keeps_non_toc_rows(self, tmp_path):
+        # Precision + case-sensitivity guard: a legit response carrying a
+        # ``selection_key`` field but NOT the TOC shape, and a case-variant, must
+        # survive — the purge mirrors the case-sensitive, pair-requiring detector
+        # (no over-broad LIKE / ASCII case-folding).
+        db = tmp_path / "precision.db"
+        seed = ProxyCache(db, max_entries=100)
+        seed.initialize()
+        field_row = '{"selection_key": "x", "data": 1}'
+        upper_row = '{"SELECTION_KEY": "x", "TTL_SECONDS_REMAINING": 1}'
+        try:
+            seed.set("s", "field", {}, field_row, ttl_seconds=None)
+            seed.set("s", "upper", {}, upper_row, ttl_seconds=None)
+        finally:
+            seed.close()
+        reopened = ProxyCache(db, max_entries=100)
+        reopened.initialize()
+        try:
+            assert reopened.get("s", "field", {}) == field_row
+            assert reopened.get("s", "upper", {}) == upper_row
+        finally:
+            reopened.close()
 
 
 class TestMakeKey:

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -1040,3 +1040,72 @@ class TestCallTimeout:
             f"second attempt used {captured_timeouts[1]:.4f}s but remaining "
             "deadline was smaller; shrink logic not applied"
         )
+
+
+class TestTransientKeyResponsesNotCached:
+    """Responses embedding a TRANSIENT pending-store retrieval key (progressive
+    first-chunk, SELECTIVE/HYBRID TOC) must NOT be cached: the key dies on
+    process restart / pending-store eviction / its shorter TTL, so a cache hit
+    would hand back a dead ``stm_proxy_read_more`` / ``stm_proxy_select_chunks``
+    key with the response tail unrecoverable. Skipping the store makes the next
+    identical call re-run the pipeline and mint a fresh, live key."""
+
+    # Enough markdown sections that SELECTIVE emits a chunk TOC (with a
+    # transient ``selection_key``) rather than falling back to truncation.
+    _TOC_TEXT = "# Doc\n\n" + "\n\n".join(
+        f"## Section {i} heading text\n" + ("alpha beta gamma delta epsilon zeta " * 12)
+        for i in range(12)
+    )
+
+    async def test_selective_toc_response_is_not_cached(self, tmp_path):
+        from memtomem_stm.proxy.cache import ProxyCache
+
+        mgr = _make_manager(
+            compression=CompressionStrategy.SELECTIVE,
+            max_result_chars=400,
+            tmp_path=tmp_path,
+        )
+        session = _get_session(mgr)
+        session.call_tool.side_effect = [
+            _make_result(self._TOC_TEXT),
+            _make_result(self._TOC_TEXT),
+        ]
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=10)
+        cache.initialize()
+        mgr._cache = cache
+        try:
+            r1 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert '"selection_key"' in r1, (
+                "precondition: SELECTIVE must emit a TOC carrying a transient key"
+            )
+            # Identical second call must re-run upstream — the TOC was NOT cached.
+            r2 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert '"selection_key"' in r2
+            assert session.call_tool.call_count == 2, (
+                "transient-key TOC must not be cached; the second identical call "
+                f"should re-run upstream (saw {session.call_tool.call_count})"
+            )
+            assert cache.get("srv", "tool", {"x": 1}) is None
+        finally:
+            cache.close()
+
+    async def test_plain_response_is_still_cached(self, tmp_path):
+        """Over-suppression guard: a key-free response must still be cached."""
+        from memtomem_stm.proxy.cache import ProxyCache
+
+        mgr = _make_manager(tmp_path=tmp_path)  # compression NONE
+        session = _get_session(mgr)
+        session.call_tool.side_effect = [_make_result("plain upstream payload")]
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=10)
+        cache.initialize()
+        mgr._cache = cache
+        try:
+            r1 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert "plain upstream payload" in r1
+            r2 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert "plain upstream payload" in r2
+            assert session.call_tool.call_count == 1, (
+                "non-transient response should be cached; second call must hit cache"
+            )
+        finally:
+            cache.close()


### PR DESCRIPTION
## Problem

A progressive first-chunk and a SELECTIVE/HYBRID chunk TOC each embed a key into a **process-local** pending store, but the proxy cache stored that pre-surfacing `compressed` payload under the cache TTL (3600s). That TTL is longer than the pending store's (progressive 1800s, selective 300s) and the in-memory store does not survive a restart. So a later cache hit could return a TOC / first-chunk whose `stm_proxy_read_more` / `stm_proxy_select_chunks` key was already dead — the agent loses the response tail with no way to recover it.

(Surfaced by a codex design review of `proxy/*` + `surfacing/*`; this is the High-severity finding of that review.)

## Fix

- **Don't cache transient-key responses.** A shared `response_carries_transient_key()` detector (in `cache.py`, the persistence layer) flags a response that embeds a transient retrieval key:
  - progressive first-chunks → `PROGRESSIVE_FOOTER_TOKEN`
  - SELECTIVE/HYBRID TOCs → the **pair** `"selection_key"` **and** `"ttl_seconds_remaining"` (requiring the pair avoids misclassifying an arbitrary upstream JSON that merely has a `selection_key` field; the pair is spacing-invariant, so it matches both the spaced selective dump and the compact `HybridCompressor._fit_toc_tail` dump — whose abbreviated hint drops `stm_proxy_select_chunks(`, which is why we key on fields, not the hint).
  The single `cache.set` site in `ProxyManager` skips the store (and logs at debug) when the detector fires. The next identical call re-runs the pipeline and mints a fresh, live key.
- **Purge legacy rows once.** `ProxyCache.initialize()` deletes any pre-existing rows whose `result` embeds a transient key, using `instr(...)` (case-sensitive literal match) so the SQL predicate mirrors the Python detector exactly — no LIKE wildcard/case-folding divergence.

A false positive only costs one un-cached response (re-fetched next call), never correctness. Progressive passthroughs (`content <= chunk_size`) and truncate fallbacks mint no key, carry no marker, and stay cacheable.

## Tests

- `tests/test_proxy_cache.py`: detector unit tests (progressive footer, real SELECTIVE TOC, real **HYBRID fitted-tail** TOC, truncate fallback, plain text, `selection_key`-field-without-TOC-shape, uppercase/case-sensitivity); legacy-purge tests (transient rows purged, non-TOC/case-variant rows kept).
- `tests/test_proxy_error_paths.py::TestTransientKeyResponsesNotCached`: end-to-end — a SELECTIVE TOC response is not cached (second identical call re-runs upstream), a plain response still is.
- Full suite `pytest -m "not ollama"`: 2929 passed (the 2 unrelated local hermeticity failures are addressed in a separate PR). ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)