### PR TITLE
fix(surfacing): expose per-memory id for batched feedback (EN-2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Surfaced memories expose a per-memory `memory_id` for feedback** (EN-2/3) — each injected bullet now renders its `chunk.id` as a backticked token, and the feedback preamble adds a batched `stm_surfacing_feedback(ratings=[{"memory_id": ..., "rating": ...}])` example alongside the single-call one, so an agent can rate (and invalidate) individual memories rather than the whole surfacing event. **Behavior change**: the injected bullet format gains a `` `id` `` segment between the namespace badge and the `[bucket]` label; parsers keying on the exact `**source**{ns} [bucket]:` shape must account for it (the preview still follows `[bucket]: `). Injection-size truncation now pins the whole feedback preamble and drops body bullets on whole-line boundaries so a `memory_id` token is never severed mid-string. Under the default `result_format="compact"` the rendered id is a content-derived surrogate (`sha256(content)[:16]`), which drives STM-side invalidation but not the LTM `increment_access` boost; set `result_format="structured"` for the real `chunk_id` end to end.
+
 ## [0.1.25] — 2026-06-02
 
 A small maintenance release: the standalone `mms` MCP stdio server now exits

--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -56,13 +56,16 @@ When memories are found, they're wrapped in `<surfaced-memories>` XML tags and i
 ## Relevant Memories
 _surfacing_id: abc123def456_
 > Rate (one of "helpful" | "partially_helpful" | "not_relevant" | "already_known"): `stm_surfacing_feedback(surfacing_id="abc123def456", rating="helpful")`
+> Or rate specific memories: `stm_surfacing_feedback(surfacing_id="abc123def456", ratings=[{"memory_id": "<id from a bullet below>", "rating": "helpful"}])`
 
-- **notes/auth_notes.md** [code-notes] [strong]: OAuth2 implementation uses PKCE flow...
-- **design/api_design.md** [default] [related]: Rate limiting is handled by middleware in...
+- **notes/auth_notes.md** [code-notes] `a1b2c3d4e5f6a7b8` [strong]: OAuth2 implementation uses PKCE flow...
+- **design/api_design.md** [default] `9f8e7d6c5b4a3210` [related]: Rate limiting is handled by middleware in...
 </surfaced-memories>
 ```
 
 Each result line shows a relevance bucket (`[weak]`, `[related]`, or `[strong]`) instead of the raw search score. Buckets are computed across the active `[min_score, 1.0]` range, so changing `min_score` also shifts the bucket boundaries. Exact raw-score distributions remain available through `stm_surfacing_stats`.
+
+Each bullet also carries its memory's id as a backticked token (e.g. `` `a1b2c3d4e5f6a7b8` ``). Pass it as a `memory_id` in the batched `stm_surfacing_feedback(ratings=[...])` call to rate individual memories — `not_relevant` / `already_known` then invalidate exactly those memories on the next cache hit. Under the default `result_format="compact"` this id is a content-derived surrogate (`sha256(content)[:16]`): it drives STM-side cache invalidation but not the LTM `increment_access` boost, and two memories with identical content collide on one id. Set `result_format="structured"` to carry the real `chunk_id` end to end.
 
 The injection mode is configurable: `append` (default), `prepend`, or `section`. `prepend` is skipped on the progressive-delivery path because it would shift character offsets and break `stm_proxy_read_more` — the skip is counted as `progressive_mode_conflict` in `stm_surfacing_stats`.
 

--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -131,7 +131,20 @@ class SurfacingConfig(BaseModel):
     """Parser format for mem_search output. ``compact`` is the legacy
     core format (``[rank] score | source``). ``structured`` selects the
     machine-parseable JSON format (``{"results": [...]}``) with automatic
-    version negotiation — falls back to compact if core is too old."""
+    version negotiation — falls back to compact if core is too old.
+
+    Per-memory feedback fidelity (EN-2/3): the formatter renders each
+    memory's ``chunk.id`` so the agent can rate memories individually via
+    ``stm_surfacing_feedback(ratings=[{"memory_id": ..., "rating": ...}])``.
+    Under ``compact`` that id is a content-derived surrogate
+    (``sha256(content)[:16]``, see ``mcp_client.py``) rather than the real
+    LTM chunk id, with two consequences: a ``helpful`` boost cannot reach
+    the underlying chunk (``increment_access`` no-ops), and two memories
+    with identical content collide on one id. STM-side cache invalidation
+    (``not_relevant`` / ``already_known``) still works because it keys on
+    the same surrogate within the process. Select ``structured`` when
+    reliable per-memory boost / dedup matters — it carries the real
+    ``chunk_id`` end to end."""
 
     @model_validator(mode="after")
     def _validate_auto_tune_bounds(self) -> SurfacingConfig:

--- a/src/memtomem_stm/surfacing/formatter.py
+++ b/src/memtomem_stm/surfacing/formatter.py
@@ -7,6 +7,10 @@ from typing import Any
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.feedback import VALID_RATINGS
 
+# Header for the optional scratch / working-memory section. Shared between the
+# render site and the truncation orphan-trim so the two cannot drift.
+_WORKING_MEMORY_HEADER = "**Working Memory:**"
+
 
 class SurfacingFormatter:
     """Inject surfaced memories into a tool response."""
@@ -90,7 +94,23 @@ class SurfacingFormatter:
                 f"`stm_surfacing_feedback(surfacing_id={surfacing_id!r}, "
                 f"rating={example_rating!r})`"
             )
+            # EN-2/3: per-memory feedback. Every bullet below carries its
+            # ``memory_id`` (the backticked token after the namespace badge);
+            # the batched form rates them individually so ``not_relevant`` /
+            # ``already_known`` invalidate exactly those memories on the next
+            # cache hit instead of the whole event. The single-call line above
+            # stays first so the AST-scraped rating example keeps exactly one
+            # literal ``rating=`` (the batched call uses ``ratings=`` instead).
+            lines.append(
+                f"> Or rate specific memories: "
+                f"`stm_surfacing_feedback(surfacing_id={surfacing_id!r}, "
+                f'ratings=[{{"memory_id": "<id from a bullet below>", '
+                f'"rating": "{example_rating}"}}])`'
+            )
         lines.append("")
+        # Everything appended above is the preamble (header + feedback spec);
+        # it is pinned through truncation below. Bullets/scratch are the body.
+        body_start = len(lines)
 
         for r in results:
             chunk = r.chunk
@@ -117,11 +137,22 @@ class SurfacingFormatter:
                     preview = preview + " | " + snippet + "..."
 
             bucket = self._relevance_bucket(float(r.score), score_floor)
-            lines.append(f"- **{source}**{ns_badge} [{bucket}]: {preview}")
+            # The backticked ``chunk.id`` is the agent-copyable ``memory_id``
+            # for ``stm_surfacing_feedback(ratings=...)`` (EN-2/3). It sits
+            # before the ``[bucket]: `` marker so the preview parse (and the
+            # ``preview_max_chars`` cap) is unaffected, and it matches the
+            # ``str(r.chunk.id)`` key the engine invalidation filters on.
+            # Rendered only when present — every production chunk carries an id
+            # (a content surrogate under compact, the real chunk_id under
+            # structured), but a chunk without one degrades to the id-less
+            # bullet rather than crashing the whole injection.
+            cid = getattr(chunk, "id", None)
+            id_token = f" `{cid}`" if cid else ""
+            lines.append(f"- **{source}**{ns_badge}{id_token} [{bucket}]: {preview}")
 
         if scratch_items:
             lines.append("")
-            lines.append("**Working Memory:**")
+            lines.append(_WORKING_MEMORY_HEADER)
             for item in scratch_items[:3]:
                 key = item.get("key", "")
                 value = str(item.get("value", ""))[:200].replace("\n", " ")
@@ -129,10 +160,34 @@ class SurfacingFormatter:
 
         memory_block = "\n".join(lines)
 
-        # Enforce injection size limit to prevent context bloat
+        # Enforce injection size limit to prevent context bloat. The preamble
+        # (``lines[:body_start]`` — header + surfacing_id + rating spec) is
+        # pinned so the feedback loop survives truncation on the largest, most
+        # expensive surfacings (#350); the body (bullets + scratch) is dropped
+        # on whole-line boundaries so a per-memory ``memory_id`` token is never
+        # severed mid-string — a half-copied id silently no-ops batched
+        # feedback invalidation (EN-2/3). A flat ``[:max_chars]`` slice broke
+        # both. The preamble may overrun ``max_chars`` by a bounded amount,
+        # which only happens at the tiny caps tests use; production caps
+        # (default 3000) dwarf the ~300-char preamble.
         max_chars = self._config.effective_max_injection_chars()
         if max_chars and len(memory_block) > max_chars:
-            memory_block = memory_block[:max_chars] + "\n... (memory block truncated)"
+            marker = "\n... (memory block truncated)"
+            kept = lines[:body_start]
+            used = len("\n".join(kept))
+            for line in lines[body_start:]:
+                # +1 accounts for the newline that joins this line on.
+                if used + len(line) + len(marker) + 1 > max_chars:
+                    break
+                kept.append(line)
+                used += len(line) + 1
+            # A whole-line drop can stop right after the working-memory header
+            # (or a section's blank separator), leaving an orphan header with no
+            # items beneath it. Trim trailing structural-only lines so the
+            # truncated block stays well-formed.
+            while len(kept) > body_start and kept[-1] in ("", _WORKING_MEMORY_HEADER):
+                kept.pop()
+            memory_block = "\n".join(kept) + marker
 
         match self._config.injection_mode:
             case "prepend":

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -52,6 +52,12 @@ class RemoteSearchResult:
         def __init__(self, content: str, source: str, namespace: str):
             self.content = content
             self.metadata = RemoteSearchResult._FakeMeta(source, namespace)
+            # Compact parser has no real chunk id, so derive a stable surrogate
+            # from the content. The formatter renders this as the agent-facing
+            # ``memory_id`` (EN-2/3); the structured parser overwrites it with
+            # the real ``chunk_id`` from core (see ResultParser). The surrogate
+            # is good enough for STM-side invalidation but cannot drive the LTM
+            # ``increment_access`` boost — see ``SurfacingConfig.result_format``.
             self.id = hashlib.sha256(content.encode()).hexdigest()[:16]
 
     def __init__(self, content: str, score: float, source: str = "", namespace: str = "default"):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -85,14 +85,14 @@ class TestFormatterInjection:
     def test_relevance_bucket_labels_replace_raw_scores(self):
         fmt = SurfacingFormatter(SurfacingConfig())
         results = [
-            FakeResult(FakeChunk(content="near floor"), 0.04),
-            FakeResult(FakeChunk(content="middle band"), 0.50),
-            FakeResult(FakeChunk(content="top band"), 0.95),
+            FakeResult(FakeChunk(content="near floor", id="m-weak"), 0.04),
+            FakeResult(FakeChunk(content="middle band", id="m-related"), 0.50),
+            FakeResult(FakeChunk(content="top band", id="m-strong"), 0.95),
         ]
         output = fmt.inject("response", results, "query")
-        assert "- **notes/test.md** [default] [weak]: near floor" in output
-        assert "- **notes/test.md** [default] [related]: middle band" in output
-        assert "- **notes/test.md** [default] [strong]: top band" in output
+        assert "- **notes/test.md** [default] `m-weak` [weak]: near floor" in output
+        assert "- **notes/test.md** [default] `m-related` [related]: middle band" in output
+        assert "- **notes/test.md** [default] `m-strong` [strong]: top band" in output
         assert "score=" not in output
         assert "0.04" not in output
         assert "0.50" not in output
@@ -101,22 +101,22 @@ class TestFormatterInjection:
     def test_relevance_bucket_boundaries_follow_min_score(self):
         fmt = SurfacingFormatter(SurfacingConfig(min_score=0.4))
         results = [
-            FakeResult(FakeChunk(content="custom weak"), 0.55),
-            FakeResult(FakeChunk(content="custom related"), 0.70),
-            FakeResult(FakeChunk(content="custom strong"), 0.90),
+            FakeResult(FakeChunk(content="custom weak", id="b-weak"), 0.55),
+            FakeResult(FakeChunk(content="custom related", id="b-related"), 0.70),
+            FakeResult(FakeChunk(content="custom strong", id="b-strong"), 0.90),
         ]
         output = fmt.inject("response", results, "query")
-        assert "- **notes/test.md** [default] [weak]: custom weak" in output
-        assert "- **notes/test.md** [default] [related]: custom related" in output
-        assert "- **notes/test.md** [default] [strong]: custom strong" in output
+        assert "- **notes/test.md** [default] `b-weak` [weak]: custom weak" in output
+        assert "- **notes/test.md** [default] `b-related` [related]: custom related" in output
+        assert "- **notes/test.md** [default] `b-strong` [strong]: custom strong" in output
 
     def test_relevance_bucket_uses_active_score_floor_when_provided(self):
         fmt = SurfacingFormatter(SurfacingConfig(min_score=0.03))
-        results = [FakeResult(FakeChunk(content="near active floor"), 0.70)]
+        results = [FakeResult(FakeChunk(content="near active floor", id="f-weak"), 0.70)]
 
         output = fmt.inject("response", results, "query", score_floor=0.6)
 
-        assert "- **notes/test.md** [default] [weak]: near active floor" in output
+        assert "- **notes/test.md** [default] `f-weak` [weak]: near active floor" in output
         assert "[strong]" not in output
 
     def test_source_renders_parent_and_basename(self):
@@ -287,6 +287,130 @@ class TestFormatterInjection:
         output = fmt.inject("response", results, "query", surfacing_id=None)
         assert "stm_surfacing_feedback" not in output
         assert "surfacing_id" not in output
+        assert "ratings=[" not in output  # batched example is gated too
+
+    def test_bullet_renders_memory_id_for_feedback(self):
+        """EN-2/3: each bullet carries its ``chunk.id`` as a backticked token
+        so the agent can pass it as ``memory_id`` to the batched feedback
+        call. The id must render before the ``[bucket]: `` marker so it never
+        bleeds into the preview slice (and ``preview_max_chars`` is measured
+        on the preview alone)."""
+        fmt = SurfacingFormatter(SurfacingConfig())
+        results = [FakeResult(FakeChunk(content="rememberable", id="chunk-id-42"), 0.5)]
+        output = fmt.inject("response", results, "query", surfacing_id="sid-1")
+
+        assert "`chunk-id-42`" in output
+        preview_line = _preview_line_after_bucket(output)
+        assert "chunk-id-42" not in preview_line
+        assert preview_line == "rememberable"
+
+    def test_batched_feedback_example_rendered_with_surfacing_id(self):
+        """EN-2/3: when feedback is trackable the injection offers a batched
+        ``ratings=[...]`` example so the per-bullet memory ids are actionable,
+        not just decorative. The legacy single-call example stays present and
+        first (the AST scrape relies on it)."""
+        fmt = SurfacingFormatter(SurfacingConfig())
+        results = [FakeResult(FakeChunk(), 0.5)]
+        output = fmt.inject("response", results, "query", surfacing_id="sid-1")
+
+        assert 'ratings=[{"memory_id": "<id from a bullet below>", "rating": "helpful"}]' in output
+        # Single-call example unchanged and still present.
+        assert "stm_surfacing_feedback(surfacing_id='sid-1', rating='helpful')" in output
+        # The single-call example precedes the batched one (AST scrape order).
+        assert output.index("rating='helpful')") < output.index("ratings=[")
+
+    def test_truncation_pins_preamble_and_keeps_ids_whole(self):
+        """EN-2/3: truncation pins the whole feedback preamble (header +
+        surfacing_id + both rating examples) and drops body bullets on
+        whole-line boundaries, so a per-memory ``memory_id`` token is never
+        sliced mid-string — a half-copied id silently no-ops batched feedback
+        invalidation. The old flat ``[:max_chars]`` slice could cut a bullet
+        (and its id) at an arbitrary offset."""
+        import re
+
+        config = SurfacingConfig(max_injection_chars=550)
+        fmt = SurfacingFormatter(config)
+        results = [
+            FakeResult(FakeChunk(content="keep this", id="id-keepme-0001"), 0.5),
+            FakeResult(FakeChunk(content="x" * 5000, id="id-dropme-0002"), 0.5),
+        ]
+        output = fmt.inject("response", results, "query", surfacing_id="sid-xyz")
+        block = output.split("<surfaced-memories>\n", 1)[1].rsplit("\n</surfaced-memories>", 1)[0]
+
+        assert "truncated" in block, "precondition: the block must be truncated"
+        # Whole feedback preamble survives.
+        assert "## Relevant Memories" in block
+        assert "_surfacing_id: sid-xyz_" in block
+        assert "stm_surfacing_feedback(surfacing_id='sid-xyz', rating='helpful')" in block
+        assert 'ratings=[{"memory_id": "<id from a bullet below>", "rating": "helpful"}]' in block
+        # Body cut on a line boundary: the marker is its own final line.
+        assert block.splitlines()[-1] == "... (memory block truncated)"
+        # Short bullet's id survives intact; dropped bullet's id is fully
+        # absent — and no ``id-*`` token appears half-sliced.
+        assert "`id-keepme-0001`" in block
+        assert "id-dropme-0002" not in block
+        for frag in re.findall(r"`([^`]+)`", block):
+            if frag.startswith("id-"):
+                assert frag == "id-keepme-0001", f"partial id token leaked: {frag!r}"
+
+    def test_bullet_without_id_degrades_without_crashing(self):
+        """The id token renders only when the chunk has a truthy id. A chunk
+        without one (the defensive guard — every production chunk does carry an
+        id) must degrade to the legacy id-less bullet, not raise in the hot
+        injection path."""
+        from dataclasses import dataclass
+
+        @dataclass
+        class _NoIdChunk:
+            content: str
+            metadata: FakeChunkMeta
+
+        chunk = _NoIdChunk(content="no id here", metadata=FakeChunkMeta())
+        fmt = SurfacingFormatter(SurfacingConfig())
+        output = fmt.inject("response", [FakeResult(chunk, 0.5)], "query", surfacing_id="sid-1")
+
+        # Legacy id-less bullet: no backticked id segment, no doubled space.
+        assert "- **notes/test.md** [default] [related]: no id here" in output
+        assert "[default]  [related]" not in output
+        assert "[default] `" not in output
+
+    def test_truncation_preamble_overrun_drops_all_bullets(self):
+        """When the pinned preamble alone exceeds the cap, the whole body is
+        dropped (zero bullets) but the entire feedback preamble — both rating
+        examples — survives, with the marker on its own final line. This is the
+        bounded-overrun boundary the preamble-pin design relies on."""
+        config = SurfacingConfig(max_injection_chars=120)  # well below ~380-char preamble
+        fmt = SurfacingFormatter(config)
+        results = [FakeResult(FakeChunk(content="x" * 400, id="id-body"), 0.5)]
+        output = fmt.inject("response", results, "query", surfacing_id="sid-over")
+        block = output.split("<surfaced-memories>\n", 1)[1].rsplit("\n</surfaced-memories>", 1)[0]
+
+        # Whole feedback preamble survives even though it overruns the cap.
+        assert "## Relevant Memories" in block
+        assert "_surfacing_id: sid-over_" in block
+        assert "stm_surfacing_feedback(surfacing_id='sid-over', rating='helpful')" in block
+        assert 'ratings=[{"memory_id": "<id from a bullet below>", "rating": "helpful"}]' in block
+        # Zero body bullets; marker on its own final line.
+        assert "- **" not in block
+        assert "id-body" not in block
+        assert block.splitlines()[-1] == "... (memory block truncated)"
+
+    def test_truncation_trims_orphan_working_memory_header(self):
+        """Scratch lines participate in whole-line truncation. If the cut lands
+        right after the working-memory header, the orphan header (and any
+        dangling blank separator) is trimmed so the truncated block stays
+        well-formed rather than leaving a header with no items beneath it."""
+        config = SurfacingConfig(max_injection_chars=120)
+        fmt = SurfacingFormatter(config)
+        # No surfacing_id → tiny preamble, so the cap lands inside the scratch
+        # section (not the preamble).
+        scratch = [{"key": "current_task", "value": "x" * 300}]
+        output = fmt.inject("response", [], "query", scratch_items=scratch)
+        block = output.split("<surfaced-memories>\n", 1)[1].rsplit("\n</surfaced-memories>", 1)[0]
+
+        assert "truncated" in block
+        assert "**Working Memory:**" not in block  # orphan header trimmed
+        assert block.splitlines()[-1] == "... (memory block truncated)"
 
     def test_scratch_items_included(self):
         fmt = SurfacingFormatter(SurfacingConfig())

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -994,6 +994,67 @@ class TestHandleFeedbackBatch:
         # The helpful entry did NOT land in the invalidation set.
         assert ("gh", "read_file", "mid-A") not in engine._invalidated_ids
 
+    async def test_rendered_bullet_id_roundtrips_through_batch_feedback(self, tmp_path: Path):
+        """EN-2/3 end-to-end: the ``memory_id`` the formatter renders in a
+        bullet is exactly the token ``handle_feedback_batch`` needs to
+        invalidate that memory. Surface → read the backticked id out of the
+        injected block (as an agent would) → batch-rate it ``not_relevant``
+        → the next cache hit drops it. Proves the rendered id is actionable
+        via the batched path; the single-call path is covered by
+        ``TestCacheInvalidationOnNegativeFeedback``."""
+        import re
+
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+
+        chunk_a = FakeChunk(id="mid-A", content="apple memory")
+        chunk_b = FakeChunk(id="mid-B", content="banana memory")
+        adapter = _make_mcp_adapter(
+            [
+                FakeSearchResult(chunk=chunk_a, score=0.5),
+                FakeSearchResult(chunk=chunk_b, score=0.4),
+            ]
+        )
+
+        tracker = FeedbackTracker(config=_make_config(), db_path=tmp_path / "fb.db")
+        engine = SurfacingEngine(
+            config=_make_config(cooldown_seconds=0),
+            mcp_adapter=adapter,
+            feedback_tracker=tracker,
+        )
+        try:
+            out1 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            # The formatter renders each memory id as a backticked token the
+            # agent can lift straight into the batched ``ratings`` shape.
+            assert "`mid-A`" in out1
+            assert "`mid-B`" in out1
+
+            sid_match = re.search(r"surfacing_id[:=]\s*\"?([a-f0-9]{16})", out1)
+            assert sid_match, "surfacing_id not found in first output"
+            sid = sid_match.group(1)
+
+            # Close the loop: lift the id off the "apple memory" bullet itself
+            # (as an agent would) and feed THAT back. A formatter that ever
+            # rendered a token other than the ``str(chunk.id)`` invalidation key
+            # would fail here, rather than passing on a shared hardcoded literal.
+            apple_line = next(ln for ln in out1.splitlines() if "apple memory" in ln)
+            apple_id_match = re.search(r"`([^`]+)`", apple_line)
+            assert apple_id_match, f"no backticked id on the apple bullet: {apple_line!r}"
+            apple_id = apple_id_match.group(1)
+            assert apple_id == "mid-A"
+
+            result = await engine.handle_feedback_batch(
+                sid, [{"memory_id": apple_id, "rating": "not_relevant"}]
+            )
+            assert "1/1 entries" in result
+
+            # Next cache hit drops mid-A, keeps mid-B.
+            out2 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            assert "apple memory" not in out2
+            assert "banana memory" in out2
+            assert "`mid-A`" not in out2
+        finally:
+            tracker.close()
+
     async def test_multiple_helpful_collapse_to_single_boost_with_set(self):
         adapter = _make_mcp_adapter([])
         adapter.increment_access = AsyncMock()


### PR DESCRIPTION
## Summary

Surfaced memories gave an agent no way to rate (or invalidate) an **individual** memory. The injected bullet showed only `source` / `[bucket]` / preview, and the lone feedback example was the single-call `surfacing_id`+`rating` form — so `stm_surfacing_feedback(ratings=[{memory_id, rating}])`'s `memory_id`, and the engine's per-memory cache invalidation keyed on `str(chunk.id)`, were effectively unreachable from the rendered block (EN-2/3 from the dev-trio review).

This is PR B of the STM-review series (PR A = #412). Branched from `main`.

## Changes

- **Render the `memory_id` in each bullet** — `chunk.id` is emitted as a backticked token *before* the `[bucket]:` marker, so the preview parse and `preview_max_chars` cap are unaffected, and the token matches the `str(r.chunk.id)` key the engine filters invalidated memories on.
- **Batched feedback example** — a second `stm_surfacing_feedback(..., ratings=[{"memory_id": ..., "rating": ...}])` line is added after the single-call example (gated on `surfacing_id`; the single-call line stays first so the AST-scrape contract for the one-literal `rating=` example holds).
- **Preamble-pinned, whole-line truncation** — replaces the flat `[:max_chars]` slice. The feedback preamble (header + surfacing_id + both rating examples) is always kept; the body is dropped on whole-line boundaries so a `memory_id` token is never severed mid-string (a half-copied id silently no-ops invalidation). An orphan `**Working Memory:**` header that a whole-line cut could leave behind is trimmed.
- **Defensive id rendering** — `getattr(chunk, "id", None)`; a chunk without an id degrades to the legacy id-less bullet instead of raising in the hot injection path. (Every production chunk has an id — surrogate under compact, real `chunk_id` under structured — so this only guards a degenerate case.)
- **Documented the compact surrogate-id limitation** — under the default `result_format="compact"` the id is `sha256(content)[:16]`: it drives STM-side cache invalidation but not the LTM `increment_access` boost, and identical-content memories collide on one id. `structured` carries the real `chunk_id` end to end. (config docstring, `mcp_client.py` comment, `CHANGELOG.md`, `docs/surfacing.md` sample.)

### Behavior change

The injected bullet gains a `` `id` `` segment between the namespace badge and `[bucket]:`. Parsers keying on the exact `**source**{ns} [bucket]:` shape must account for it (the preview still follows `[bucket]: `).

## Tests

- Bullet id render + placement (not in the preview slice), batched-example present/absent, id-less degradation.
- Preamble-pin + whole-line truncation, plus the preamble-overrun (zero-bullet) and orphan scratch-header boundaries.
- Engine roundtrip: lifts the rendered id off the `apple memory` bullet and feeds it through `handle_feedback_batch` → next cache hit drops that memory (proves the rendered token equals the invalidation key).
- Updated 3 relevance-bucket assertions for the new bullet shape.

Gate: `ruff check`/`format` ✅, `pytest -m "not ollama"` ✅ (the 2 unrelated `test_double_start_no_leak` / `test_search_returns_empty_when_no_session` failures are pre-existing local-only — a live LTM server on the dev box — and pass in CI; tracked for PR E), `mypy` ✅.

A 13-agent adversarial review of the diff surfaced 6 findings (3 rejected); all 6 are folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)