### PR TITLE
fix(surfacing): pad short tool-call queries with the tool name (KR-4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - **Surfaced memories expose a per-memory `memory_id` for feedback** (EN-2/3) — each injected bullet now renders its `chunk.id` as a backticked token, and the feedback preamble adds a batched `stm_surfacing_feedback(ratings=[{"memory_id": ..., "rating": ...}])` example alongside the single-call one, so an agent can rate (and invalidate) individual memories rather than the whole surfacing event. **Behavior change**: the injected bullet format gains a `` `id` `` segment between the namespace badge and the `[bucket]` label; parsers keying on the exact `**source**{ns} [bucket]:` shape must account for it (the preview still follows `[bucket]: `). Injection-size truncation now pins the whole feedback preamble and drops body bullets on whole-line boundaries so a `memory_id` token is never severed mid-string. Under the default `result_format="compact"` the rendered id is a content-derived surrogate (`sha256(content)[:16]`), which drives STM-side invalidation but not the LTM `increment_access` boost; set `result_format="structured"` for the real `chunk_id` end to end.
 
+### Fixed
+
+- **Short tool-call queries surface instead of silently dropping** (KR-4.2) — `ContextExtractor` appended the tool name to clear `min_query_tokens` only when argument extraction yielded *nothing*. A short-but-non-empty extraction — e.g. `read_file {"path": "/etc/hosts"}` tokenizing to `"etc hosts"` (2 tokens, below the default floor of 3) — produced no query, so surfacing never fired for it. The fallback now also fires when the extracted tokens alone fall below `min_query_tokens`, appending the tool-name token(s) after the deterministic argument scan. Queries that already clear the floor are untouched, and a query still too short even with the tool name (e.g. a one-token tool) is still rejected. Trade-off: a marginal query now consumes a surfacing rate-limit / cooldown slot.
+
 ## [0.1.25] — 2026-06-02
 
 A small maintenance release: the standalone `mms` MCP stdio server now exits

--- a/src/memtomem_stm/surfacing/context_extractor.py
+++ b/src/memtomem_stm/surfacing/context_extractor.py
@@ -74,8 +74,18 @@ class ContextExtractor:
                 # query (inconsistent and a poor search term).
                 parts.append(str(value))
 
-        # Fall back to tool name only if no semantic args found
-        if not parts:
+        # Fall back to the tool name when the extracted args alone do not clear
+        # ``min_query_tokens`` — not only when ``parts`` is empty. KR-4.2: a
+        # short-but-non-empty extraction (e.g. ``/etc/hosts`` → "etc hosts",
+        # 2 tokens < 3) otherwise returned None below and surfacing never fired,
+        # even though appending the tool-name token(s) would clear the floor.
+        # The empty-parts case is subsumed (``"".split()`` → 0 tokens, always
+        # below ``min_query_tokens`` which is validated ``gt=0``), and the
+        # append runs after the deterministic sorted loop so ordering is stable.
+        # Not strictly free: a marginal query now consumes a rate-limit /
+        # cooldown slot, and a large ``min_query_tokens`` widens how often the
+        # tool name dilutes the args — tune it there if this gets noisy.
+        if len(" ".join(parts).split()) < config.min_query_tokens:
             parts.append(tool.replace("_", " "))
 
         query = " ".join(parts).strip()

--- a/tests/test_context_extractor.py
+++ b/tests/test_context_extractor.py
@@ -157,6 +157,44 @@ class TestHeuristicExtraction:
         assert result is None
 
 
+class TestShortNonEmptyQueryPadsWithToolName:
+    """KR-4.2: the tool-name fallback fires whenever the extracted args alone
+    fall below ``min_query_tokens``, not only when extraction yields nothing.
+    A short-but-non-empty extraction (e.g. ``/etc/hosts`` → "etc hosts",
+    2 tokens) previously returned None and surfacing never fired for it."""
+
+    def test_short_path_pads_with_tool_name(self):
+        # /etc/hosts → "etc hosts" (2 tokens) < 3; pre-fix returned None.
+        result = _extract("read_file", {"path": "/etc/hosts"}, min_query_tokens=3)
+        assert result is not None
+        assert "etc" in result and "hosts" in result
+        # The tool-name token(s) were appended to clear the floor.
+        assert "read" in result and "file" in result
+        assert len(result.split()) >= 3
+
+    def test_pad_is_appended_after_args_deterministically(self):
+        # The tool name comes after the extracted arg tokens (stable order
+        # keeps the surfacing cache key deterministic).
+        result = _extract("read_file", {"path": "/etc/hosts"}, min_query_tokens=3)
+        assert result == "etc hosts read file"
+
+    def test_still_none_when_args_plus_tool_name_below_floor(self):
+        # Non-empty short extraction + short tool name still below the floor
+        # → None (the final threshold re-check is unchanged). "etc hosts" (2)
+        # + "io" (1) = 3 tokens < 5.
+        result = _extract("io", {"path": "/etc/hosts"}, min_query_tokens=5)
+        assert result is None
+
+    def test_strong_query_not_diluted_by_tool_name(self):
+        # A query that already clears the floor must not get the tool name
+        # appended — no dilution of an already-good query.
+        result = _extract(
+            "read_file", {"query": "authentication token refresh flow"}, min_query_tokens=3
+        )
+        assert result == "authentication token refresh flow"
+        assert "read" not in result and "file" not in result
+
+
 class TestEdgeCases:
     """Edge cases for extract_query — inputs realistic from LLM tool calls."""
 


### PR DESCRIPTION
## Summary

`ContextExtractor.extract_query` appended the tool name to clear `min_query_tokens` **only when argument extraction produced nothing**. A short-but-non-empty extraction — e.g. `read_file {"path": "/etc/hosts"}` tokenizing to `"etc hosts"` (2 tokens, below the default floor of 3) — returned no query, so surfacing silently never fired for it, even though the tool-name token would have cleared the floor (KR-4.2 from the dev-trio review).

This is PR C of the STM-review series (PR A = #412, PR B = #413, both merged). Branched from `main`.

## Change

The fallback now fires whenever the **extracted tokens alone** fall below `min_query_tokens`, not only when `parts` is empty:

```python
if len(" ".join(parts).split()) < config.min_query_tokens:
    parts.append(tool.replace("_", " "))
```

- The empty-parts case is subsumed (`"".split()` → 0 tokens, and `min_query_tokens` is validated `gt=0`).
- The append runs **after** the deterministic `sorted(arguments.items())` scan, so the query string — the surfacing cache / cooldown / dedup key — stays stable.
- The unchanged final threshold check still returns `None` when the combined query is still too short even with the tool name (e.g. a one-token tool).

**Trade-off** (in the commit body): a marginal query now consumes a surfacing rate-limit / cooldown slot, and a large `min_query_tokens` widens how often the tool name dilutes the args — tune it there if noisy.

## Tests

New `TestShortNonEmptyQueryPadsWithToolName`:
- `/etc/hosts` → non-`None`, contains both the arg tokens and the appended tool-name tokens.
- Deterministic append order (`"etc hosts read file"`).
- Still `None` when args + tool name remain below the floor (`io` + `/etc/hosts`, floor 5).
- A strong query (≥ floor) is **not** diluted by an appended tool name.

Existing regressions stay green: `test_returns_none_for_short_query`, `test_falls_back_to_tool_name` / `_only_short_values` / `_all_underscore`, and the uuid/hex→`None` filters in `test_surfacing_query_extraction.py`. Note `test_short_query_rejected` and `test_no_query_records_skip` were already written to anticipate this padding behavior.

Gate: `ruff check`/`format` ✅, `pytest -m "not ollama"` ✅ (the 2 unrelated `test_double_start_no_leak` / `test_search_returns_empty_when_no_session` failures are pre-existing local-only — a live LTM server on the dev box — and pass in CI; tracked for PR E), `mypy` ✅. A 3-agent adversarial review of the diff (correctness / regression-scope / tests+plan) returned **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)