### PR TITLE
test: make double-start and no-session adapter tests hermetic (EN-4)

### DIFF
--- a/tests/test_qa_round3.py
+++ b/tests/test_qa_round3.py
@@ -357,12 +357,18 @@ class TestCJKSentenceBoundary:
 
 class TestDoubleStartGuard:
     @pytest.mark.asyncio
-    async def test_double_start_no_leak(self):
+    async def test_double_start_no_leak(self, tmp_path):
         from memtomem_stm.proxy.config import ProxyConfig
         from memtomem_stm.proxy.manager import ProxyManager
         from memtomem_stm.proxy.metrics import TokenTracker
 
-        pm = ProxyManager(ProxyConfig(), TokenTracker())
+        # Point config_path at a non-existent file so start()'s load_from_file
+        # falls back to an empty ProxyConfig (no upstream_servers) instead of
+        # the dev box's real ~/.memtomem/stm_proxy.json. A real config spawns
+        # stdio children whose anyio cancel scopes raise "exit cancel scope in
+        # a different task" on stop() — the production stop() fix (#410) does
+        # not cover test-spawned subprocesses.
+        pm = ProxyManager(ProxyConfig(config_path=tmp_path / "stm_proxy.json"), TokenTracker())
 
         # First start (no servers configured, just creates stack)
         await pm.start()

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -388,6 +388,11 @@ class TestMcpClientSearchAdapter:
         from memtomem_stm.surfacing.config import SurfacingConfig
 
         adapter = McpClientSearchAdapter(SurfacingConfig())
+        # Mark the lazy-start as already attempted so _heal_if_needed
+        # short-circuits to False without spawning a real memtomem-server
+        # (which lazy-starts on this dev box and would yield 'ok'/'empty_results'
+        # instead of the asserted 'no_session').
+        adapter._start_attempted = True
         results, hints, outcome = await adapter.search("test query")
         assert results == []
         assert hints == []


### PR DESCRIPTION
## What

Makes the two tests that fail on a dev box with a live LTM server hermetic. These were the **only two full-suite failures** locally; they pass in CI only because CI has neither a live `memtomem-server` nor a real `~/.memtomem/stm_proxy.json`.

## Why each failed (against `origin/main`)

- **`test_qa_round3.py::TestDoubleStartGuard::test_double_start_no_leak`** — `start()` loads `upstream_servers` from the default `config_path` when none are configured (`manager.py:213-216`), spawning real stdio children. `stop()` then raised anyio `"exit cancel scope in a different task"` — the production `stop()` fix in #410 does not cover test-spawned subprocesses.
- **`test_stm_remaining.py::TestMcpClientSearchAdapter::test_search_returns_empty_when_no_session`** — the adapter lazy-started a real `memtomem-server` via `_heal_if_needed`, so `outcome` was `'ok'`/`'empty_results'` instead of the asserted `'no_session'`.

## Fix (test-only)

- Point `config_path` at a non-existent `tmp_path` file → `load_from_file` returns an empty `ProxyConfig` (`config.py:588-597`) → `upstream_servers={}` → the only spawn path (`stdio_client`, `manager.py:284-293`) is never reached → `stop()` closes an empty stack. The double-start no-leak invariant is gated only on `_stack` (`manager.py:196-211`), so it is unaffected.
- Set `adapter._start_attempted = True` → `_heal_if_needed` short-circuits to `False` before `start()` (`mcp_client.py:383-384`) → `search` returns `no_session`. Both heal-`False` routes (sticky-flag and start-failure) return the identical `([], [], "no_session")` contract.

No production behavior change. Sibling tests in both files were verified already hermetic (pre-set `_connections`/`_session` or mocked `start`/`_reconnect`) and are untouched.

## Verification

- Both target tests: PASS (was 11s → 0.15s, no subprocess spawned).
- Full suite `uv run pytest -m "not ollama"`: **2944 passed, 10 skipped, 0 failed** — fully green locally for the first time.
- `ruff check src` / `ruff format --check src`: pass.
- 3-lens adversarial review (hermeticity / assertion-value / completeness) of the diff: **0 findings**, each lens source-traced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)