### PR TITLE
fix(cli): `mms stats` must mirror the server's env-enabled config bypass

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -681,25 +681,40 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
     path = Path(config_path)
     resolved = path.expanduser().resolve()
 
-    # Mirror the server's env > file > defaults precedence so the resolved DB
-    # paths honor MEMTOMEM_STM_* overrides (server.py app_lifespan).
-    proxy_cfg = ProxyConfig.load_from_file(path, env_overrides=collect_proxy_env_overrides())
-    if proxy_cfg is None:
-        # Parse/validation error — fall back to defaults purely to locate the
-        # DB paths to probe, but flag the config as invalid.
-        config_status = "invalid"
-        proxy_cfg = ProxyConfig()
-    elif not resolved.exists():
-        config_status = "missing"
-    else:
-        config_status = "ok"
-
-    # Surfacing config lives outside the proxy JSON file; read it (env-aware)
-    # the same way ``mms health`` does (_surfacing_bootstrap_status).
+    # Resolve config + DB paths exactly as the server does (server.app_lifespan).
+    # ``STMConfig()`` pulls proxy + surfacing from ``MEMTOMEM_STM_*`` env. When
+    # the proxy is enabled via env, the server uses that env-only config and
+    # SKIPS the JSON file entirely (server.py), so honoring a file-level
+    # ``metrics.db_path`` here would point ``mms stats`` at a different
+    # ``proxy_metrics.db`` than the one the server actually writes to.
+    env_enabled = bool(os.environ.get("MEMTOMEM_STM_PROXY__ENABLED"))
     try:
-        feedback_path = STMConfig().surfacing.feedback_db_path
+        stm_config: STMConfig | None = STMConfig()
     except Exception:
-        feedback_path = Path("~/.memtomem/stm_feedback.db")
+        stm_config = None
+    feedback_path = (
+        stm_config.surfacing.feedback_db_path
+        if stm_config is not None
+        else Path("~/.memtomem/stm_feedback.db")
+    )
+
+    if env_enabled and stm_config is not None:
+        # Env-only mode — the JSON file is bypassed, matching the server.
+        proxy_cfg = stm_config.proxy
+        config_status = "env"
+    else:
+        loaded = ProxyConfig.load_from_file(path, env_overrides=collect_proxy_env_overrides())
+        if loaded is None:
+            # Parse/validation error — fall back to defaults purely to locate the
+            # DB paths to probe, but flag the config as invalid.
+            config_status = "invalid"
+            proxy_cfg = ProxyConfig()
+        elif not resolved.exists():
+            config_status = "missing"
+            proxy_cfg = loaded
+        else:
+            config_status = "ok"
+            proxy_cfg = loaded
 
     compression = read_compression_summary(proxy_cfg.metrics.db_path, tool=tool_filter)
     surfacing = read_surfacing_summary(feedback_path, tool=tool_filter)
@@ -722,7 +737,10 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
         )
         return
 
-    click.echo(f"Config : {resolved} ({config_status})")
+    if config_status == "env":
+        click.echo("Config : MEMTOMEM_STM_PROXY__ENABLED set — env config (JSON file bypassed)")
+    else:
+        click.echo(f"Config : {resolved} ({config_status})")
     click.echo(f"Enabled: {'yes' if proxy_cfg.enabled else 'no'}")
     click.echo(f"Servers: {len(proxy_cfg.upstream_servers)}")
     if tool_filter:

--- a/tests/cli/test_mms_stats.py
+++ b/tests/cli/test_mms_stats.py
@@ -102,3 +102,35 @@ class TestMmsStats:
         data = json.loads(result.output)
         assert data["tool_filter"] == "query-docs"
         assert data["compression"]["total_calls"] == 2
+
+    def test_env_enabled_bypasses_file_metrics_path(self, runner, tmp_path, monkeypatch):
+        """When ``MEMTOMEM_STM_PROXY__ENABLED`` is set the server uses its
+        env-only proxy config and ignores the JSON file (server.app_lifespan),
+        so ``mms stats`` must too — otherwise it would probe a different
+        ``proxy_metrics.db`` than the one the server writes to."""
+        set_home(monkeypatch, tmp_path)
+        monkeypatch.setenv("MEMTOMEM_STM_PROXY__ENABLED", "1")
+
+        # A config file points metrics at a SEEDED db that the env-enabled
+        # server would ignore.
+        file_db = tmp_path / "file_metrics.db"
+        store = MetricsStore(file_db)
+        store.initialize()
+        try:
+            store.record(
+                CallMetrics(server="c7", tool="query-docs", original_chars=100, compressed_chars=40)
+            )
+        finally:
+            store.close()
+        config = tmp_path / "stm_proxy.json"
+        config.write_text(json.dumps({"enabled": True, "metrics": {"db_path": str(file_db)}}))
+
+        result = runner.invoke(cli, ["stats", "--config", str(config), "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["config_status"] == "env"
+        # The env path (default ~/.memtomem/proxy_metrics.db, unseeded under the
+        # patched HOME) is used — NOT the file's seeded db — so its row must not
+        # leak in.
+        assert data["compression"]["total_calls"] == 0


### PR DESCRIPTION
## Context

Follow-up to #419, surfaced by a dev-trio **codex** review of the merged `mms
stats` code (verdict NEEDS-FIX, one Major).

`mms stats` always called `ProxyConfig.load_from_file(...)` to locate
`proxy_metrics.db`. But the server bootstrap (`server.app_lifespan`) **skips the
JSON file entirely** when `MEMTOMEM_STM_PROXY__ENABLED` is set and uses the
env-only proxy config:

```python
# server.py
if not os.environ.get("MEMTOMEM_STM_PROXY__ENABLED"):
    file_cfg = ProxyConfig.load_from_file(config.proxy.config_path, ...)
    if file_cfg is not None:
        config.proxy = file_cfg
```

So in env-enabled mode a file-level `metrics.db_path` is ignored by the server
but was still honored by `mms stats` → the CLI could report a **different (often
empty) `proxy_metrics.db`** than the one the server actually writes to.

## Fix

Mirror the server's branch:

- `MEMTOMEM_STM_PROXY__ENABLED` set → use `STMConfig().proxy` (env-only), bypass
  the JSON file, report `config_status: "env"` (and a clear "JSON file bypassed"
  line in the human output).
- otherwise → unchanged `env > file > defaults` via `load_from_file`
  (ok/missing/invalid).

The surfacing path now reuses the same `STMConfig()` instance instead of a
second construction.

## Tests

New `test_env_enabled_bypasses_file_metrics_path`: with
`MEMTOMEM_STM_PROXY__ENABLED=1` and a config file pointing `metrics.db_path` at a
**seeded** DB, asserts the CLI reports `config_status: "env"` and `total_calls:
0` (i.e. it reads the env/default path, not the bypassed file's seeded DB).

## Verification

- `uv run pytest -m "not ollama" tests/cli/` → **408 passed** (+ the new case);
  stats suites green.
- `ruff check src` + `ruff format --check src` clean; `mypy src/.../cli/proxy.py`
  clean (the type-narrowing was tidied so `proxy_cfg` is never `… | None`).
- Manual smoke: `MEMTOMEM_STM_PROXY__ENABLED=1 mms stats` now prints
  "MEMTOMEM_STM_PROXY__ENABLED set — env config (JSON file bypassed)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)