### PR TITLE
feat(surfacing): per-upstream surfacing toggle (surfacing_enabled + `mms surfacing`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Per-upstream surfacing toggle** — `UpstreamServerConfig` gains a `surfacing_enabled` flag (default `true`), and `mms surfacing <server> [on|off]` toggles it in `stm_proxy.json` (`mms status` renders it per server). Disabling an upstream short-circuits proactive surfacing for every tool on that server *before* the LTM search runs. It is enforced in `ProxyManager`, which reads the hot-reloaded proxy config — not the `SurfacingEngine` relevance gate, which is built once at startup from the top-level `SurfacingConfig` and never sees per-upstream config — and is counted as a new healthy `upstream_disabled` reason in `stm_surfacing_stats`. Because the flag lives in the shared proxy config rather than per-client `env`, every MCP client proxying through the same `mms` sees one consistent scope, unlike the existing `MEMTOMEM_STM_SURFACING__EXCLUDE_TOOLS` glob (which also matches `server__tool` but must be carried in each client's env). `docs/surfacing.md` now documents both the per-upstream toggle and the server-qualified `exclude_tools` glob, and corrects the circuit-breaker ordering in the surfacing sequence diagram.
+
 ## [0.1.26] — 2026-06-03
 
 A correctness and surfacing-quality maintenance release completing the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -238,6 +238,9 @@ mms status
 # Remove a server
 mms remove github
 
+# Toggle proactive surfacing for an upstream (persisted in stm_proxy.json)
+mms surfacing context7 off  # `on` to re-enable; omit the state to show it
+
 # Check upstream connectivity (probes each server)
 mms health
 mms health --json          # machine-readable output
@@ -260,6 +263,17 @@ Options:
 Removes direct registrations for STM upstreams that are still registered in a source MCP client (`~/.claude.json`, `.mcp.json`, Claude Desktop). Use this to collapse the dual-path state that `mms init` and `mms add --import` leave behind when you didn't opt into pruning at import time — the tools then route through STM only, picking up compression, caching, and LTM surfacing.
 
 Scope selection is explicit by design: pass `--all` to act on every dual-registered upstream, or pass one or more `NAMES` to limit the action. Running `mms prune` with no arguments is a usage error rather than defaulting to "everything" — this is a destructive operation against external config files and the default should be visible.
+
+### `surfacing`
+
+```
+Usage: mms surfacing NAME [on|off]
+
+Options:
+  --config TEXT  [default: ~/.memtomem/stm_proxy.json]
+```
+
+Toggles `surfacing_enabled` on an upstream in `stm_proxy.json` (default `on`). With no state it prints the current value; `mms status` shows it per server. A running proxy hot-reloads the change without a restart. Because the flag lives in the shared proxy config — not per-client `env` — every MCP client that proxies through this `mms` sees the same scope. When off, surfacing is skipped before the LTM search for every tool on that server (counted as `upstream_disabled` in `stm_surfacing_stats`). For tool-grained or cross-server glob scope, use the `MEMTOMEM_STM_SURFACING__EXCLUDE_TOOLS` env glob instead (matches `server__tool`). See [surfacing.md](surfacing.md#scoping-surfacing-per-upstream).
 
 "Dual-registered" requires both the name **and** the identity to match: the source-client entry must share the STM upstream's `(transport, command, args)` or `(transport, url)` signature. If you've edited either side to point at a different server that happens to share a name, `mms prune` skips it rather than clobbering the unrelated entry.
 

--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -85,7 +85,7 @@ The injection mode is configurable: `append` (default), `prepend`, or `section`.
 | `injection_mode` | `append` | Where to inject: `prepend`, `append`, `section`. `prepend` is skipped on the progressive-delivery path (would break `stm_proxy_read_more` offsets) — counted as `progressive_mode_conflict` in `stm_surfacing_stats`. |
 | `section_header` | `## Relevant Memories` | Header text for injected section |
 | `default_namespace` | `null` | Restrict search to a specific namespace |
-| `exclude_tools` | `[]` | fnmatch patterns to never surface (e.g. `["*debug*"]`) |
+| `exclude_tools` | `[]` | fnmatch patterns to never surface, matched against **both** the bare tool name and `server__tool` — so a server-qualified glob like `["context7__*"]` disables a whole upstream (e.g. `["*debug*", "langfuse-docs__*"]`). See [Scoping surfacing per upstream](#scoping-surfacing-per-upstream). |
 | `write_tool_patterns` | `*write*`, `*create*`, `*delete*`, `*push*`, `*send*`, `*remove*` | Auto-skip write/mutation operations |
 | `include_session_context` | `true` | Include working memory (scratch) items |
 | `dedup_ttl_seconds` | `604800` (7d) | Cross-session dedup window; `0` to disable |
@@ -111,6 +111,41 @@ The injection mode is configurable: `append` (default), `prepend`, or `section`.
 | `feedback_demotion_enabled` | `true` | Locally filter memories that accumulated repeated negative feedback (`not_relevant` or `already_known`) before cache/injection |
 | `feedback_demotion_negative_threshold` | `3` | Distinct negative surfacing events required before local STM demotion applies to a memory |
 | `fire_webhook` | `true` | Fire surfacing event webhooks |
+
+### Scoping surfacing per upstream
+
+`exclude_tools` is global config (top-level `SurfacingConfig`), set via env.
+Because its patterns match `server__tool` as well as the bare tool name, a
+server-qualified glob turns surfacing off for a whole upstream:
+
+```bash
+# Per-client env: skip surfacing for every tool on these upstreams
+export MEMTOMEM_STM_SURFACING__EXCLUDE_TOOLS='["context7__*","langfuse-docs__*"]'
+```
+
+For a **persistent, client-independent** toggle, set `surfacing_enabled` on the
+upstream itself in `stm_proxy.json` (`UpstreamServerConfig`, default `true`).
+Unlike the env glob — which each MCP client must carry in its own `env` block,
+and which can drift between clients — this lives in the shared proxy config that
+every client reads, hot-reloads without a restart, and shows up in `mms status`:
+
+```bash
+mms surfacing context7 off    # disable surfacing for this upstream
+mms surfacing context7        # show current state
+mms surfacing context7 on     # re-enable
+```
+
+When an upstream is disabled this way the skip happens *before* the LTM search
+(saving the round-trip) and is enforced in `ProxyManager` — not the
+`RelevanceGate` — because the engine is built once at startup from the top-level
+`SurfacingConfig` and never sees per-upstream config. It is counted as
+`upstream_disabled` (a healthy skip) in `stm_surfacing_stats`.
+
+Reach for the env glob for cross-server / tool-grained scope or quick
+experiments; reach for `surfacing_enabled` to durably opt one upstream out —
+e.g. a third-party server whose calls never match your LTM (so the per-call
+search is pure wasted latency), or a sensitive upstream whose request context
+should never become an LTM query.
 
 ### Tuning `min_response_chars`
 
@@ -190,17 +225,17 @@ sequenceDiagram
     participant Core as memtomem core
 
     Agent->>STM: tool response (≥ min_response_chars)
-    STM->>Ext: extract_query(server, tool, args)
-    Ext-->>STM: query
-    STM->>Gate: should_surface(server, tool, query)
-    Gate-->>STM: pass / skip
-    alt skip (write tool / cooldown / rate limit)
+    STM->>CB: check
+    alt circuit open
         STM-->>Agent: original response
-    else pass
-        STM->>CB: check
-        alt circuit open
+    else closed / half-open
+        STM->>Ext: extract_query(server, tool, args)
+        Ext-->>STM: query
+        STM->>Gate: should_surface(server, tool, query)
+        Gate-->>STM: pass / skip
+        alt skip (write tool / cooldown / rate limit)
             STM-->>Agent: original response
-        else closed / half-open
+        else pass
             STM->>MCP: search(query, top_k, namespace)
             MCP->>Core: mem_search (via configured MCP transport)
             Core-->>MCP: results
@@ -435,6 +470,10 @@ hit:
 - `gate_write_tool` / `gate_excluded_tool` / `gate_tool_disabled`
   / `gate_rate_limit` / `gate_cooldown` — a `RelevanceGate`
   reject; check the gate config for the offending bucket.
+- `upstream_disabled` — the upstream's `surfacing_enabled=False`
+  (set via `mms surfacing <server> off`) opted every tool on that
+  server out of surfacing, short-circuited in `ProxyManager` before
+  the LTM search.
 - `circuit_open` — repeated upstream failures opened the circuit
   breaker. Surfacing pauses for `circuit_reset_seconds` (default
   60s) before retrying.

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -553,8 +553,12 @@ def status(config_path: str, *, as_json: bool = False) -> None:
                 detail = cfg.get("url", "")
             compression = cfg.get("compression", "auto")
             max_chars = cfg.get("max_result_chars", 8000)
+            surfacing_on = cfg.get("surfacing_enabled", True)
             click.echo(f"  {name:<20} prefix={prefix}  [{transport}] {detail}")
-            click.echo(f"  {'':<20} compression={compression}  max_chars={max_chars}")
+            click.echo(
+                f"  {'':<20} compression={compression}  max_chars={max_chars}  "
+                f"surfacing={'on' if surfacing_on else 'off'}"
+            )
 
 
 @cli.command(name="list")
@@ -2110,6 +2114,46 @@ def remove(name: str, config_path: str, yes: bool) -> None:
     del servers[name]
     _save(path, data)
     click.echo(f"{_ok('Removed')} server '{name}'.")
+
+
+@cli.command()
+@click.argument("name")
+@click.argument("state", type=click.Choice(["on", "off"]), required=False)
+@click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
+def surfacing(name: str, state: str | None, config_path: str) -> None:
+    """Toggle proactive memory surfacing for an upstream server.
+
+    \b
+    mms surfacing <server>          # show current state
+    mms surfacing <server> off      # disable surfacing for this upstream
+    mms surfacing <server> on       # re-enable
+
+    Writes ``surfacing_enabled`` into the upstream's entry in the proxy config
+    (``stm_proxy.json``); a running proxy hot-reloads it without a restart, and
+    `mms status` shows the effective state. Because the flag lives in the shared
+    config file rather than per-client env, every MCP client that proxies
+    through this `mms` sees the same scope.
+
+    For tool-grained or cross-server glob scope instead, set
+    ``MEMTOMEM_STM_SURFACING__EXCLUDE_TOOLS`` (matches ``server__tool``).
+    """
+    path = Path(config_path)
+    data = _load(path)
+    servers: dict[str, Any] = data.get("upstream_servers", {})
+
+    if name not in servers:
+        click.echo(f"{_err('Error:')} server '{name}' not found.", err=True)
+        sys.exit(1)
+
+    current = bool(servers[name].get("surfacing_enabled", True))
+    if state is None:
+        click.echo(f"surfacing for '{name}': {'on' if current else 'off'}")
+        return
+
+    desired = state == "on"
+    servers[name]["surfacing_enabled"] = desired
+    _save(path, data)
+    click.echo(f"{_ok('Surfacing ' + state)} for '{name}'.")
 
 
 # ── prune command ──────────────────────────────────────────────────────

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -292,6 +292,20 @@ class UpstreamServerConfig(BaseModel):
     tool_overrides: dict[str, ToolOverrideConfig] = {}
     auto_index: bool | None = None
     extraction: bool | None = None
+    surfacing_enabled: bool = True
+    """Opt this upstream's proxied tool responses in/out of the SURFACE stage
+    (proactive memory surfacing). Default ``True`` preserves existing behavior;
+    ``False`` suppresses surfacing for every tool on this server.
+
+    Useful for third-party upstreams whose calls never match the user's LTM
+    (so the per-call LTM search is pure wasted latency), or to keep a sensitive
+    upstream's request context out of LTM queries entirely.
+
+    Enforced in ``ProxyManager``, which reads this from ``stm_proxy.json`` via
+    the hot-reloaded config — *not* in the ``SurfacingEngine`` relevance gate,
+    which is built once at startup from the top-level ``SurfacingConfig`` and
+    never sees per-upstream config. For tool-grained or glob scope instead, see
+    ``SurfacingConfig.exclude_tools`` (matches ``server__tool``)."""
     max_retries: int = Field(default=3, ge=0)
     reconnect_delay_seconds: float = Field(default=1.0, ge=0.0)
     max_reconnect_delay_seconds: float = Field(default=30.0, ge=0.0)

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from memtomem_stm.proxy.protocols import FileIndexer
     from memtomem_stm.proxy.relevance import RelevanceScorer
     from memtomem_stm.surfacing.engine import SurfacingEngine
+    from memtomem_stm.surfacing.observability import SkipReason
 
 from mcp import ClientSession
 from mcp.client.sse import sse_client
@@ -777,6 +778,28 @@ class ProxyManager:
 
         return get_compressor(compression).compress(text, max_chars=max_chars), None
 
+    def _surfacing_enabled_for(self, server: str) -> bool:
+        """Whether this upstream opts into surfacing.
+
+        Read from the hot-reloaded ``stm_proxy.json`` (``self._config``) so a
+        ``mms surfacing <server> off`` takes effect without a restart. This is
+        the per-upstream enforcement point the ``SurfacingEngine`` gate cannot
+        be: the engine is built once at startup from the top-level
+        ``SurfacingConfig`` and never sees per-upstream config. Unknown servers
+        fail open (``True``) — surfacing stays best-effort.
+        """
+        cfg = self._config.upstream_servers.get(server)
+        return cfg.surfacing_enabled if cfg is not None else True
+
+    def _record_surfacing_skip(self, tool: str, reason: SkipReason) -> None:
+        """Record a pre-engine surfacing skip so ``stm_surfacing_stats`` shows
+        it (the engine cannot, since we short-circuit before calling it)."""
+        if self._surfacing_engine is None:
+            return
+        obs = self._surfacing_engine.observability
+        if obs is not None:
+            obs.record_skip(tool, reason)
+
     async def _apply_surfacing(
         self,
         server: str,
@@ -789,6 +812,9 @@ class ProxyManager:
     ) -> str:
         """Apply proactive memory surfacing if eligible."""
         if self._surfacing_engine is None:
+            return text
+        if not self._surfacing_enabled_for(server):
+            self._record_surfacing_skip(tool, "upstream_disabled")
             return text
         try:
             return await self._surfacing_engine.surface(
@@ -836,6 +862,9 @@ class ProxyManager:
         which modes are safe.
         """
         if self._surfacing_engine is None:
+            return text, None, None
+        if not self._surfacing_enabled_for(server):
+            self._record_surfacing_skip(tool, "upstream_disabled")
             return text, None, None
         if self._surfacing_engine.injection_mode == "prepend":
             if not self._warned_prepend_on_progressive:

--- a/src/memtomem_stm/surfacing/observability.py
+++ b/src/memtomem_stm/surfacing/observability.py
@@ -57,6 +57,12 @@ SkipReason = Literal[
     # label is mode-agnostic so a future per-mode constraint can reuse it
     # without a new enum value.
     "progressive_mode_conflict",
+    # Per-upstream opt-out: ``UpstreamServerConfig.surfacing_enabled=False``
+    # short-circuits surfacing for every tool on that server. Recorded by
+    # ``ProxyManager`` before the engine runs (the engine is built once from
+    # the top-level ``SurfacingConfig`` and never sees per-upstream config),
+    # so it lands here rather than as a ``gate_*`` reason.
+    "upstream_disabled",
 ]
 
 # Operator-facing categorization for ``stm_surfacing_stats`` (#362, #351 part 2).
@@ -89,6 +95,7 @@ HEALTHY_SKIP_REASONS: frozenset[str] = frozenset(
         "no_results_invalidated",
         "no_results_empty_cache",
         "progressive_mode_conflict",
+        "upstream_disabled",
     }
 )
 FAULT_SKIP_REASONS: frozenset[str] = frozenset(

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -4448,3 +4449,61 @@ class TestRootCauseMessage:
         inner = BaseExceptionGroup("inner", [leaf])
         outer = BaseExceptionGroup("outer", [inner])
         assert _root_cause_message(outer) == "network down"
+
+
+class TestSurfacingCommand:
+    """`mms surfacing <server> [on|off]` toggles per-upstream surfacing in
+    stm_proxy.json; `mms status` renders the effective state."""
+
+    @staticmethod
+    def _seed(config: Path, *, surfacing_enabled: bool | None = None) -> None:
+        entry: dict = {"prefix": "c7", "command": "echo", "args": []}
+        if surfacing_enabled is not None:
+            entry["surfacing_enabled"] = surfacing_enabled
+        config.write_text(
+            json.dumps({"enabled": True, "upstream_servers": {"context7": entry}}),
+            encoding="utf-8",
+        )
+
+    def test_show_defaults_to_on(self, runner, config):
+        self._seed(config)
+        result = runner.invoke(cli, ["surfacing", "context7", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "surfacing for 'context7': on" in result.output
+
+    def test_off_persists_flag(self, runner, config):
+        self._seed(config)
+        result = runner.invoke(cli, ["surfacing", "context7", "off", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(config.read_text())
+        assert data["upstream_servers"]["context7"]["surfacing_enabled"] is False
+
+    def test_on_re_enables(self, runner, config):
+        self._seed(config, surfacing_enabled=False)
+        result = runner.invoke(cli, ["surfacing", "context7", "on", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(config.read_text())
+        assert data["upstream_servers"]["context7"]["surfacing_enabled"] is True
+
+    def test_unknown_server_errors(self, runner, config):
+        self._seed(config)
+        result = runner.invoke(cli, ["surfacing", "ghost", "off", *_cfg_args(config)])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_invalid_state_rejected(self, runner, config):
+        self._seed(config)
+        result = runner.invoke(cli, ["surfacing", "context7", "maybe", *_cfg_args(config)])
+        assert result.exit_code != 0
+
+    def test_status_renders_surfacing_off(self, runner, config):
+        self._seed(config, surfacing_enabled=False)
+        result = runner.invoke(cli, ["status", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "surfacing=off" in result.output
+
+    def test_status_renders_surfacing_on_by_default(self, runner, config):
+        self._seed(config)
+        result = runner.invoke(cli, ["status", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "surfacing=on" in result.output

--- a/tests/test_per_upstream_surfacing.py
+++ b/tests/test_per_upstream_surfacing.py
@@ -1,0 +1,100 @@
+"""Per-upstream surfacing toggle (``UpstreamServerConfig.surfacing_enabled``).
+
+The flag lives in ``stm_proxy.json`` (ProxyConfig) and is enforced in
+``ProxyManager`` — *not* in the ``SurfacingEngine`` relevance gate, which is
+built once at startup from the top-level ``SurfacingConfig`` and never sees
+per-upstream config. These tests pin both the config default/round-trip and the
+manager short-circuit on every surfacing entry point (normal + progressive),
+including the fail-open behavior for an unknown server.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from memtomem_stm.proxy.config import ProxyConfig, UpstreamServerConfig
+from memtomem_stm.proxy.manager import ProxyManager
+from memtomem_stm.proxy.metrics import TokenTracker
+
+_LONG = "x" * 50  # comfortably over any min_response_chars the engine would gate on
+
+
+def _manager(tmp_path: Path, *, surfacing_enabled: bool) -> ProxyManager:
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "stm_proxy.json",
+        upstream_servers={
+            "svc": UpstreamServerConfig(prefix="svc", surfacing_enabled=surfacing_enabled),
+        },
+    )
+    engine = MagicMock()
+    engine.surface = AsyncMock(return_value="SURFACED")
+    engine.observability = MagicMock()
+    engine.injection_mode = "append"
+    return ProxyManager(proxy_cfg, TokenTracker(), surfacing_engine=engine)
+
+
+# ── config field ─────────────────────────────────────────────────────────
+
+
+class TestConfigField:
+    def test_default_is_enabled(self) -> None:
+        assert UpstreamServerConfig(prefix="c7").surfacing_enabled is True
+
+    def test_round_trips_through_model_dump(self) -> None:
+        cfg = UpstreamServerConfig(prefix="c7", surfacing_enabled=False)
+        dumped = cfg.model_dump()
+        assert dumped["surfacing_enabled"] is False
+        assert UpstreamServerConfig(**dumped).surfacing_enabled is False
+
+
+# ── _surfacing_enabled_for ───────────────────────────────────────────────
+
+
+class TestEnabledLookup:
+    def test_reads_per_upstream_flag(self, tmp_path: Path) -> None:
+        assert _manager(tmp_path, surfacing_enabled=False)._surfacing_enabled_for("svc") is False
+        assert _manager(tmp_path, surfacing_enabled=True)._surfacing_enabled_for("svc") is True
+
+    def test_unknown_server_fails_open(self, tmp_path: Path) -> None:
+        # An unconfigured server must not silently lose surfacing — best-effort.
+        assert _manager(tmp_path, surfacing_enabled=False)._surfacing_enabled_for("ghost") is True
+
+
+# ── ProxyManager enforcement ─────────────────────────────────────────────
+
+
+class TestApplySurfacing:
+    async def test_disabled_upstream_short_circuits(self, tmp_path: Path) -> None:
+        mgr = _manager(tmp_path, surfacing_enabled=False)
+        out = await mgr._apply_surfacing("svc", "lookup", {}, _LONG)
+        assert out == _LONG
+        mgr._surfacing_engine.surface.assert_not_called()
+        mgr._surfacing_engine.observability.record_skip.assert_called_once_with(
+            "lookup", "upstream_disabled"
+        )
+
+    async def test_enabled_upstream_surfaces(self, tmp_path: Path) -> None:
+        mgr = _manager(tmp_path, surfacing_enabled=True)
+        out = await mgr._apply_surfacing("svc", "lookup", {}, _LONG)
+        assert out == "SURFACED"
+        mgr._surfacing_engine.surface.assert_awaited_once()
+        mgr._surfacing_engine.observability.record_skip.assert_not_called()
+
+
+class TestApplySurfacingProgressive:
+    async def test_disabled_upstream_short_circuits(self, tmp_path: Path) -> None:
+        mgr = _manager(tmp_path, surfacing_enabled=False)
+        text, ok, err = await mgr._apply_surfacing_on_progressive("svc", "lookup", {}, _LONG)
+        assert (text, ok, err) == (_LONG, None, None)
+        mgr._surfacing_engine.surface.assert_not_called()
+        mgr._surfacing_engine.observability.record_skip.assert_called_once_with(
+            "lookup", "upstream_disabled"
+        )
+
+    async def test_enabled_upstream_surfaces(self, tmp_path: Path) -> None:
+        mgr = _manager(tmp_path, surfacing_enabled=True)
+        text, ok, err = await mgr._apply_surfacing_on_progressive("svc", "lookup", {}, _LONG)
+        assert text == "SURFACED"
+        assert ok is True
+        mgr._surfacing_engine.surface.assert_awaited_once()


### PR DESCRIPTION
## Why

Surfacing scope was controllable only **globally** (`surfacing.enabled`) or **per-tool** (`context_tools`). The one per-server lever — `exclude_tools` glob, which already matches `server__tool` — lives in the **top-level env config** (`MEMTOMEM_STM_SURFACING__EXCLUDE_TOOLS`). That means every MCP client must carry it in its own `env` block, and the setting **drifts across clients**: Claude Code / Codex / Antigravity all launch the same `mms` and share one `~/.memtomem/stm_proxy.json`, but **not** one env. For an upstream whose calls never match the user's LTM (e.g. third-party doc servers), surfacing also runs a **wasted LTM search on every call**.

This adds a per-upstream toggle that lives in the **shared** proxy config: set once, hot-reloaded, visible in `mms status`, consistent across every client.

## What

- **`UpstreamServerConfig.surfacing_enabled: bool = True`** — persisted in `stm_proxy.json`.
- **`mms surfacing <server> [on|off]`** — toggle it (omit the state to print current); `mms status` now renders `surfacing=on/off` per server.
- **Enforced in `ProxyManager`** on both surfacing entry points (`_apply_surfacing` and `_apply_surfacing_on_progressive`), reading the **hot-reloaded** config via `self._config.upstream_servers` — *not* the `SurfacingEngine` relevance gate, which is built once at startup from the top-level `SurfacingConfig` and never sees per-upstream config. When disabled, surfacing is skipped **before the LTM search** (saving the round-trip) and recorded as a new **healthy** `upstream_disabled` reason in `stm_surfacing_stats`. Unknown servers fail open (surfacing stays best-effort).

## Why this enforcement point

Two independent reviews converged on it: the `SurfacingEngine` can't honor a `stm_proxy.json` field because it's instantiated once at startup; the `ProxyManager` reads the proxy config live, so it's the only place a hot-reloadable per-upstream flag can take effect.

## Docs

- `docs/surfacing.md`: new **Scoping surfacing per upstream** section (per-upstream toggle + server-qualified `exclude_tools` glob + env recipe), enriched `exclude_tools` table row, `upstream_disabled` skip-reason legend, and a **fix** to the surfacing sequence diagram — the circuit breaker is checked *before* query extraction and the gate, not after.
- `docs/cli.md`: `mms surfacing` command reference.
- `CHANGELOG.md`: Unreleased → Added.

## Testing

- New `tests/test_per_upstream_surfacing.py` (config default/round-trip; `_surfacing_enabled_for` incl. fail-open; ProxyManager short-circuit + `record_skip` on both normal and progressive paths; enabled path still surfaces).
- New `TestSurfacingCommand` in `tests/cli/test_proxy_cli.py` (on/off/show, persistence, unknown-server error, invalid-state rejection, `mms status` rendering).
- Full CI-filtered suite: **2973 passed, 3 skipped**. `ruff check`/`format` clean, `mypy` clean. CLI smoke-tested end to end.

## Notes for reviewers

- `exclude_tools` (env, glob, tool-grained / cross-server) and `surfacing_enabled` (shared config, per-upstream, persistent) are complementary; the docs steer between them.
- No behavior change at the default (`surfacing_enabled=True` everywhere).