### PR TITLE
docs: decline third-party automated promotional/badge PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,9 @@ The LTM core lives in a separate repository: [memtomem/memtomem](https://github.
 7. Write a clear commit message describing the "why"
 8. Sign the CLA on your first pull request (see below)
 
+We do not accept third-party automated promotional or badge PRs (for example,
+vendor security-scan badges); these will be closed.
+
 ## Adding a bench_qa scenario
 
 `bench_qa` is an end-to-end pytest sub-suite that drives the proxy


### PR DESCRIPTION
## What

Adds one line to `CONTRIBUTING.md` (Pull Request Guidelines) stating that
third-party automated promotional/badge PRs are not accepted.

## Why

Vendor security-scan badge PRs (e.g. #421, now closed) drop an external
promotional badge into the README that links to a commercial service we
don't control, carrying a self-asserted "score" that can drift from the
badge text. Stating the policy explicitly lets us close such PRs by
reference instead of re-explaining the rationale each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)