### PR TITLE
fix(proxy): PROGRESSIVE-strategy calls crash with UnboundLocalError at the metrics record

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1589,6 +1589,11 @@ class ProxyManager:
                 )
             _compress_ms = 0.0
             compressed_chars_for_metrics = len(cleaned)
+            # The metrics record at the bottom reads ``metrics_strategy`` on
+            # every path; mirror the assignment at the top of the compression
+            # branch (pre-fix this branch left it unbound and every
+            # PROGRESSIVE-strategy call died with UnboundLocalError).
+            metrics_strategy = effective_compression.value
             # F6: surface on progressive when ``injection_mode`` is append/section.
             # ``prepend`` stays skipped (offset-shift); helper returns ``ok=None``
             # in that case and logs a one-time WARNING.

--- a/tests/test_compression_ratio_guard.py
+++ b/tests/test_compression_ratio_guard.py
@@ -20,6 +20,7 @@ import pytest
 
 from memtomem_stm.proxy.config import (
     CompressionStrategy,
+    ProgressiveConfig,
     ProxyConfig,
     UpstreamServerConfig,
 )
@@ -155,6 +156,7 @@ def _make_manager_with_store(
     min_retention: float = 0.65,
     compression: CompressionStrategy = CompressionStrategy.TRUNCATE,
     max_result_chars: int = 50000,
+    progressive: ProgressiveConfig | None = None,
 ) -> tuple[ProxyManager, MetricsStore]:
     """Build a ProxyManager wired to a real MetricsStore so tests can read
     persisted rows directly — closer to production than summary dicts."""
@@ -166,6 +168,7 @@ def _make_manager_with_store(
         max_result_chars=max_result_chars,
         max_retries=0,
         reconnect_delay_seconds=0.0,
+        progressive=progressive,
     )
     proxy_cfg = ProxyConfig(
         config_path=tmp_path / "proxy.json",
@@ -209,6 +212,31 @@ class TestProxyManagerRatioGuard:
         await mgr.call_tool("srv", "tool", {})
         row = _latest_row(store)
         assert row["compression_strategy"] == "truncate"
+        assert row["ratio_violation"] == 0
+        store.close()
+
+    async def test_progressive_strategy_call_completes_and_records_metric(self, tmp_path):
+        """End-to-end PROGRESSIVE-strategy call returns a first chunk and
+        records ``"progressive"`` in the metrics row.
+
+        Pre-fix the PROGRESSIVE branch never assigned ``metrics_strategy``,
+        so every call configured with this strategy died with
+        UnboundLocalError at the metrics record — no end-to-end test drove
+        the branch until now.
+        """
+        mgr, store = _make_manager_with_store(
+            tmp_path,
+            compression=CompressionStrategy.PROGRESSIVE,
+            progressive=ProgressiveConfig(chunk_size=500),
+        )
+        large_text = "content paragraph. " * 200  # > chunk_size → chunked
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(large_text)
+
+        result = await mgr.call_tool("srv", "tool", {})
+
+        assert "stm_proxy_read_more" in result
+        row = _latest_row(store)
+        assert row["compression_strategy"] == "progressive"
         assert row["ratio_violation"] == 0
         store.close()
 

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,6 +12,7 @@ import pytest
 
 from memtomem_stm.proxy.config import (
     CompressionStrategy,
+    ProgressiveConfig,
     ProxyConfig,
     UpstreamServerConfig,
 )
@@ -40,6 +42,7 @@ def _make_manager(
     tmp_path: Path | None = None,
     call_timeout: float = 90.0,
     overall_deadline: float = 180.0,
+    progressive: ProgressiveConfig | None = None,
 ) -> ProxyManager:
     """Create a ProxyManager with a mocked upstream connection."""
     server_cfg = UpstreamServerConfig(
@@ -51,6 +54,7 @@ def _make_manager(
         max_reconnect_delay_seconds=max_reconnect_delay,
         call_timeout_seconds=call_timeout,
         overall_deadline_seconds=overall_deadline,
+        progressive=progressive,
     )
     config_path = (tmp_path / "proxy.json") if tmp_path else Path("/tmp/proxy.json")
     proxy_cfg = ProxyConfig(
@@ -1106,6 +1110,106 @@ class TestTransientKeyResponsesNotCached:
             assert "plain upstream payload" in r2
             assert session.call_tool.call_count == 1, (
                 "non-transient response should be cached; second call must hit cache"
+            )
+        finally:
+            cache.close()
+
+    _READ_MORE_RE = re.compile(r'stm_proxy_read_more\(key="([0-9a-f]+)", offset=(\d+)\)')
+
+    async def test_progressive_first_chunk_is_not_cached(self, tmp_path):
+        """Same invariant on the PROGRESSIVE-strategy branch, end to end.
+
+        Until the ``metrics_strategy`` fix this branch could not be driven
+        through ``call_tool`` at all (UnboundLocalError at the metrics
+        record), so only the detector unit tests covered the progressive
+        marker — not the store guard on a real PROGRESSIVE call."""
+        from memtomem_stm.proxy.cache import ProxyCache
+
+        mgr = _make_manager(
+            compression=CompressionStrategy.PROGRESSIVE,
+            progressive=ProgressiveConfig(chunk_size=500),
+            tmp_path=tmp_path,
+        )
+        session = _get_session(mgr)
+        large = "paragraph sentence here. " * 200  # 5000 chars > chunk_size
+        session.call_tool.side_effect = [_make_result(large), _make_result(large)]
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=10)
+        cache.initialize()
+        mgr._cache = cache
+        try:
+            r1 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert "stm_proxy_read_more" in r1
+            r2 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert "stm_proxy_read_more" in r2
+            assert session.call_tool.call_count == 2, (
+                "progressive first-chunk must not be cached; the second identical "
+                f"call should re-run upstream (saw {session.call_tool.call_count})"
+            )
+            assert cache.get("srv", "tool", {"x": 1}) is None
+        finally:
+            cache.close()
+
+    async def test_progressive_repeat_call_mints_live_key_after_store_eviction(self, tmp_path):
+        """The original data-loss shape: progressive-store entry evicted
+        between two identical calls. The second call must mint a fresh key
+        whose tail is readable — not re-serve a chunk pointing at the dead
+        one."""
+        from memtomem_stm.proxy.cache import ProxyCache
+
+        mgr = _make_manager(
+            compression=CompressionStrategy.PROGRESSIVE,
+            progressive=ProgressiveConfig(chunk_size=500),
+            tmp_path=tmp_path,
+        )
+        session = _get_session(mgr)
+        large = "alpha bravo charlie delta. " * 200
+        session.call_tool.side_effect = [_make_result(large), _make_result(large)]
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=10)
+        cache.initialize()
+        mgr._cache = cache
+        try:
+            first = await mgr.call_tool("srv", "tool", {"x": 1})
+            m1 = self._READ_MORE_RE.search(first)
+            assert m1 is not None
+            key1 = m1.group(1)
+
+            # Simulate TTL / max_stored eviction between the two calls.
+            mgr._get_progressive_store().delete(key1)
+
+            second = await mgr.call_tool("srv", "tool", {"x": 1})
+            m2 = self._READ_MORE_RE.search(second)
+            assert m2 is not None, "second call must be re-chunked, not served from cache"
+            key2, offset2 = m2.group(1), int(m2.group(2))
+            assert key2 != key1
+
+            follow_up = mgr.read_more(key2, offset2)
+            assert "not found or expired" not in follow_up
+            assert follow_up.strip(), "tail content must be reachable via the new key"
+        finally:
+            cache.close()
+
+    async def test_progressive_passthrough_is_still_cached(self, tmp_path):
+        """Content that fits one chunk passes through without a read_more
+        key — the exclusion must stay narrow and keep caching it."""
+        from memtomem_stm.proxy.cache import ProxyCache
+
+        mgr = _make_manager(
+            compression=CompressionStrategy.PROGRESSIVE,
+            progressive=ProgressiveConfig(chunk_size=4000),
+            tmp_path=tmp_path,
+        )
+        session = _get_session(mgr)
+        session.call_tool.side_effect = [_make_result("short response body")]
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=10)
+        cache.initialize()
+        mgr._cache = cache
+        try:
+            r1 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert "stm_proxy_read_more" not in r1
+            r2 = await mgr.call_tool("srv", "tool", {"x": 1})
+            assert "short response body" in r2
+            assert session.call_tool.call_count == 1, (
+                "single-chunk passthrough carries no key and should be cached"
             )
         finally:
             cache.close()


### PR DESCRIPTION
## Summary

Any tool configured with `compression: progressive` crashed on every call: the Stage-2 PROGRESSIVE branch in `_call_tool_inner` never assigned `metrics_strategy`, so the `CallMetrics` record at the end of the pipeline raised `UnboundLocalError` — after the upstream call had already succeeded. The agent got an internal error instead of a response; the strategy was unusable end to end.

## Why nothing caught it

- The F6 progressive tests exercise `_apply_surfacing_on_progressive` in isolation, never `call_tool` with the strategy configured.
- The ratio-guard tests drive the progressive *fallback* tier, which lives in the compression branch where `metrics_strategy` is assigned.
- #412's transient-key integration tests cover the SELECTIVE path plus per-marker detection units; a PROGRESSIVE-strategy integration test would have hit this crash.

Found while writing regression tests for the cache/`read_more` interaction #412 fixed — the test could not even drive the branch.

## Fix

One line: mirror `metrics_strategy = effective_compression.value` at the point the PROGRESSIVE branch sets its other metrics fields, matching the assignment at the top of the compression branch.

## Behavior change

- Tools configured with PROGRESSIVE now return responses instead of erroring (the bugfix itself).
- Their metrics rows now record `compression_strategy = "progressive"` — a value that previously never appeared via this branch, so dashboards/queries grouping by strategy will start seeing it.

## Tests

- `test_progressive_strategy_call_completes_and_records_metric` — end-to-end PROGRESSIVE call returns a keyed first chunk and records `"progressive"` in the metrics row (fails with `UnboundLocalError` pre-fix).
- Extended #412's `TestTransientKeyResponsesNotCached` to the now-reachable progressive path: the first chunk is not cached and a second identical call re-runs upstream; a repeat call after progressive-store eviction mints a fresh, live `read_more` key (the original data-loss shape); single-chunk passthrough carries no key and stays cacheable.
- Full suite: 2987 passed, 3 skipped (`-m "not ollama"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)