### PR TITLE
fix(surfacing): classify httpx errors as transport errors so network LTM reconnects

### DIFF
--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
 
+import httpx
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters, stdio_client
@@ -20,16 +21,6 @@ from mcp.types import TextContent
 
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.utils.numeric import safe_float
-
-# httpx ships as a dependency of the mcp SDK (its sse/streamable_http
-# clients are built on it), but guard the import so a trimmed stdio-only
-# environment still loads this module.
-try:
-    import httpx
-
-    _HTTPX_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (httpx.TransportError,)
-except ImportError:  # pragma: no cover — httpx comes with mcp
-    _HTTPX_TRANSPORT_ERRORS = ()
 
 logger = logging.getLogger(__name__)
 
@@ -361,13 +352,13 @@ class McpClientSearchAdapter:
     # which never reconnects, leaving surfacing dead until restart.
     # httpx.HTTPStatusError / DecodingError stay OUT: the server answered,
     # so the transport is healthy and reconnecting would mask real errors.
-    _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    _TRANSPORT_ERRORS = (
         OSError,
         ConnectionError,
         EOFError,
         BrokenPipeError,
         asyncio.TimeoutError,
-        *_HTTPX_TRANSPORT_ERRORS,
+        httpx.TransportError,
     )
 
     async def _reconnect(self) -> None:

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -21,6 +21,16 @@ from mcp.types import TextContent
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.utils.numeric import safe_float
 
+# httpx ships as a dependency of the mcp SDK (its sse/streamable_http
+# clients are built on it), but guard the import so a trimmed stdio-only
+# environment still loads this module.
+try:
+    import httpx
+
+    _HTTPX_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (httpx.TransportError,)
+except ImportError:  # pragma: no cover — httpx comes with mcp
+    _HTTPX_TRANSPORT_ERRORS = ()
+
 logger = logging.getLogger(__name__)
 
 # #295: outcome typing for ``McpClientSearchAdapter.search`` — five
@@ -342,7 +352,23 @@ class McpClientSearchAdapter:
             self._stack = None
             self._session = None
 
-    _TRANSPORT_ERRORS = (OSError, ConnectionError, EOFError, BrokenPipeError, asyncio.TimeoutError)
+    # Transient failure modes that warrant tearing down and rebuilding the
+    # connection. stdio pipe failures surface as OSError / EOFError /
+    # BrokenPipeError; the sse and streamable_http clients (#398) raise
+    # httpx.TransportError subclasses (ConnectError, ReadTimeout,
+    # RemoteProtocolError, ...) whose MRO has no OSError ancestor — without
+    # the httpx entry a network blip fell through to the generic handler,
+    # which never reconnects, leaving surfacing dead until restart.
+    # httpx.HTTPStatusError / DecodingError stay OUT: the server answered,
+    # so the transport is healthy and reconnecting would mask real errors.
+    _TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+        OSError,
+        ConnectionError,
+        EOFError,
+        BrokenPipeError,
+        asyncio.TimeoutError,
+        *_HTTPX_TRANSPORT_ERRORS,
+    )
 
     async def _reconnect(self) -> None:
         """Tear down and re-establish the MCP connection."""

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -20,6 +20,7 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from memtomem_stm.surfacing.config import SurfacingConfig
@@ -237,6 +238,86 @@ class TestNonTransportErrorsDoNotReconnect:
         await adapter.search("q")
 
         adapter._reconnect.assert_awaited_once()
+
+
+# ── Network transports (#398): httpx errors are transport errors ─────────
+
+
+class TestNetworkTransportErrorsReconnect:
+    """The sse / streamable_http clients raise httpx errors whose MRO has no
+    OSError ancestor. They must be classified as transport errors (reconnect +
+    retry, outcome ``transport_error``) — pre-fix they fell into the generic
+    handler (outcome ``call_error``), the adapter never healed, and surfacing
+    stayed dead over the network path after the first blip."""
+
+    @staticmethod
+    def _network_adapter(transport: str = "sse") -> McpClientSearchAdapter:
+        return McpClientSearchAdapter(
+            SurfacingConfig(ltm_mcp_transport=transport, ltm_mcp_url="http://127.0.0.1:9/mcp")
+        )
+
+    @pytest.mark.parametrize("transport", ["sse", "streamable_http"])
+    @pytest.mark.parametrize(
+        "exc_type",
+        [httpx.ConnectError, httpx.ReadTimeout, httpx.RemoteProtocolError],
+        ids=["ConnectError", "ReadTimeout", "RemoteProtocolError"],
+    )
+    @pytest.mark.asyncio
+    async def test_httpx_error_triggers_reconnect_and_retry(self, exc_type, transport):
+        adapter = self._network_adapter(transport)
+
+        good_result = _result_with_text("[1] 0.95 | [default] src/app.py\nRecovered fine.\n")
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(side_effect=[exc_type("network blip"), good_result])
+        adapter._session = mock_session
+        adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
+
+        results, hints, outcome = await adapter.search("q")
+
+        adapter._reconnect.assert_awaited_once()
+        assert mock_session.call_tool.await_count == 2
+        assert outcome == "ok"
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_httpx_error_with_failed_reconnect_is_transport_error(self):
+        """Outcome must be ``transport_error`` (reconnect path), not
+        ``call_error`` (generic handler — the pre-fix misclassification)."""
+        adapter = self._network_adapter("streamable_http")
+
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        adapter._session = mock_session
+        adapter._reconnect = AsyncMock(  # type: ignore[method-assign]
+            side_effect=httpx.ConnectError("still refused")
+        )
+
+        results, hints, outcome = await adapter.search("q")
+
+        assert results == []
+        assert hints == []
+        assert outcome == "transport_error"
+        adapter._reconnect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_httpx_status_error_does_not_reconnect(self):
+        """An HTTP status error means the server answered — application-level,
+        not a transport failure; reconnecting would mask real errors."""
+        adapter = self._network_adapter()
+
+        request = httpx.Request("POST", "http://127.0.0.1:9/mcp")
+        response = httpx.Response(500, request=request)
+        exc = httpx.HTTPStatusError("server error", request=request, response=response)
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(side_effect=exc)
+        adapter._session = mock_session
+        adapter._reconnect = AsyncMock()  # type: ignore[method-assign]
+
+        results, hints, outcome = await adapter.search("q")
+
+        assert results == []
+        assert outcome == "call_error"
+        adapter._reconnect.assert_not_awaited()
 
 
 # ── Version negotiation fallback paths ───────────────────────────────────


### PR DESCRIPTION
## Summary

After the first transient network error, surfacing over the #398 `sse` / `streamable_http` LTM transports is permanently dead until process restart.

`_TRANSPORT_ERRORS = (OSError, ConnectionError, EOFError, BrokenPipeError, asyncio.TimeoutError)` covers only stdio failure modes. The mcp network clients raise `httpx` errors (`ConnectError`, `ReadTimeout`, `RemoteProtocolError`, `ConnectTimeout`, ...) whose MRO — `httpx.* → TransportError → RequestError → HTTPError → Exception` — has no `OSError` ancestor (verified empirically against this repo's venv). So a network blip falls through `except self._TRANSPORT_ERRORS` into the generic `except Exception` in `search()` / `increment_access()` / `scratch_list()`: outcome `"call_error"`, no `_reconnect()`, no `_needs_reconnect`. The dead `ClientSession` is reused forever. stdio self-heals only because pipe failures *are* `OSError`/`BrokenPipeError`.

## Fix

Add `httpx.TransportError` to `_TRANSPORT_ERRORS`:

- `TransportError` is the exact transient-failure base (timeouts, network errors, protocol violations). `HTTPStatusError` / `DecodingError` are deliberately excluded — the server answered, the transport is healthy, and reconnecting would mask real application errors. Pinned by a no-reconnect test.
- httpx is imported plainly: it is a declared direct dependency (`httpx>=0.28`) and this module already imports the mcp sse/streamable_http clients unconditionally, which themselves require httpx. (An earlier revision wrapped the import in a dead try/except guard — codex R1 caught that the trimmed-env claim was unsatisfiable; dropped in `5d771ea`.)
- All three call sites share the class-level tuple, so they heal uniformly.

## Why nothing caught it

The reconnect/heal suite constructed every adapter with the default stdio config and injected `ConnectionError`/`OSError` — types that happen to be in the tuple. The network transports' only coverage was transport *selection* (`_open_transport` returns the right client), never error classification.

## Tests

New `TestNetworkTransportErrorsReconnect` in `tests/test_mcp_client_reconnect.py`:

- `test_httpx_error_triggers_reconnect_and_retry` — parametrized over `{ConnectError, ReadTimeout, RemoteProtocolError} × {sse, streamable_http}`: reconnect fires once, the retry's results are returned, outcome `"ok"`.
- `test_httpx_error_with_failed_reconnect_is_transport_error` — outcome is `"transport_error"` (reconnect path), not `"call_error"` (the pre-fix misclassification).
- `test_httpx_status_error_does_not_reconnect` — HTTP 500 stays application-level: outcome `"call_error"`, no reconnect.

Pre-fix these fail 7/8 (only the status-error guard passes); post-fix 8/8. Full suite: 2991 passed, 3 skipped (`-m "not ollama"`). `ruff` and `mypy` clean (with the plain import the tuple is a literal of exception types, so no annotation is needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
