### PR TITLE
fix(server): recognize ExceptionGroup-wrapped cancel-scope errors on shutdown

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -1426,6 +1426,22 @@ def _is_anyio_cancel_scope_shutdown_error(exc: RuntimeError) -> bool:
     return any(marker in message for marker in _ANYIO_CANCEL_SCOPE_SHUTDOWN_MESSAGES)
 
 
+def _is_clean_cancel_scope_shutdown(exc: BaseException) -> bool:
+    """True when *exc* consists only of AnyIO cancel-scope shutdown errors.
+
+    ``mcp.run()`` executes the server inside ``anyio.create_task_group()``,
+    and anyio >= 4 (strict task groups) wraps anything escaping a task group
+    in an ``ExceptionGroup`` — on stdio EOF the cancel-scope RuntimeError
+    reaches ``main()`` in that wrapped shape, not bare. Walk groups
+    recursively and treat the tree as a clean shutdown only when EVERY leaf
+    is the cancel-scope error; any other leaf is a real failure that must
+    hit the exception barrier.
+    """
+    if isinstance(exc, BaseExceptionGroup):
+        return all(_is_clean_cancel_scope_shutdown(sub) for sub in exc.exceptions)
+    return isinstance(exc, RuntimeError) and _is_anyio_cancel_scope_shutdown_error(exc)
+
+
 def main() -> None:
     """Run the STM MCP server."""
     level = os.environ.get("MEMTOMEM_STM_LOG_LEVEL", "WARNING").upper()
@@ -1440,8 +1456,11 @@ def main() -> None:
     # after logging so the process still terminates; we only add observability.
     try:
         mcp.run()
-    except RuntimeError as e:
-        if _is_anyio_cancel_scope_shutdown_error(e):
+    except (RuntimeError, ExceptionGroup) as e:
+        # The bare RuntimeError occurs when the cancel-scope error escapes
+        # outside any task group; the ExceptionGroup shape is what anyio's
+        # strict task groups actually deliver on stdio EOF (#410 follow-up).
+        if _is_clean_cancel_scope_shutdown(e):
             logger.warning(
                 "STM MCP server shut down with AnyIO cancel scope warning (ignored): %s", e
             )

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1525,3 +1525,74 @@ class TestMainExceptionBarrier:
             warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
             assert not error_records
             assert any("AnyIO cancel scope warning" in r.getMessage() for r in warning_records)
+
+    def test_exception_group_wrapped_cancel_scope_error_exits_cleanly(self, caplog):
+        """anyio >= 4 strict task groups wrap the cancel-scope RuntimeError in
+        an ``ExceptionGroup`` before it reaches ``main()`` — the bare shape
+        the test above injects never occurs through ``mcp.run()`` in
+        production. Both the single-wrap and the nested-group shape must be
+        treated as a clean shutdown."""
+        import logging
+
+        from memtomem_stm import server
+
+        cancel_err = RuntimeError(
+            "Attempted to exit cancel scope in a different task than it was entered in"
+        )
+        shapes = (
+            ExceptionGroup("unhandled errors in a TaskGroup", [cancel_err]),
+            ExceptionGroup(
+                "unhandled errors in a TaskGroup",
+                [ExceptionGroup("unhandled errors in a TaskGroup", [cancel_err])],
+            ),
+        )
+
+        for group in shapes:
+            caplog.clear()
+            with (
+                caplog.at_level(logging.WARNING, logger="memtomem_stm.server"),
+                patch.object(server.mcp, "run", side_effect=group),
+            ):
+                server.main()
+
+            error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+            warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert not error_records, (
+                f"wrapped cancel-scope shutdown must not hit the barrier; "
+                f"got: {[r.getMessage() for r in error_records]}"
+            )
+            assert any("AnyIO cancel scope warning" in r.getMessage() for r in warning_records)
+
+    def test_exception_group_with_real_failure_hits_barrier(self, caplog):
+        """A group mixing the cancel-scope error with any other failure is NOT
+        a clean shutdown — the real failure must be logged and re-raised."""
+        import logging
+
+        from memtomem_stm import server
+
+        group = ExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [
+                RuntimeError(
+                    "Attempted to exit cancel scope in a different task than it was entered in"
+                ),
+                ValueError("real bug"),
+            ],
+        )
+
+        caplog.clear()
+        with (
+            caplog.at_level(logging.ERROR, logger="memtomem_stm.server"),
+            patch.object(server.mcp, "run", side_effect=group),
+        ):
+            try:
+                server.main()
+            except ExceptionGroup:
+                pass
+            else:
+                import pytest as _pytest
+
+                _pytest.fail("main() must re-raise a group containing a real failure")
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("unhandled exception" in r.getMessage() for r in error_records)


### PR DESCRIPTION
## Summary

#410 (`6b906be`) taught `main()` to swallow the AnyIO cancel-scope RuntimeError on stdio EOF, but the guard is `except RuntimeError` — and `mcp.run()` executes the server inside `anyio.create_task_group()`, whose strict mode (anyio ≥ 4, this repo pins 4.13) wraps anything escaping the group in an `ExceptionGroup`. Verified empirically against this repo's venv: an error raised under `anyio.run()`'s task group surfaces as `ExceptionGroup`, not `RuntimeError`.

So the production shape sails past the #410 guard into the generic barrier: ERROR log + re-raise + non-zero exit on every clean shutdown — exactly the noise #410 set out to remove. The #410 test passes only because it injects a *bare* `RuntimeError` as `mcp.run`'s `side_effect`, bypassing the real task-group wrapping.

## Fix

New `_is_clean_cancel_scope_shutdown(exc)`:

- walks `ExceptionGroup`s recursively (`exc.exceptions`), and
- classifies the tree as a clean shutdown **only when every leaf** is a cancel-scope RuntimeError (per the existing `_ANYIO_CANCEL_SCOPE_SHUTDOWN_MESSAGES` markers).

A group mixing in any real failure still hits the barrier, logs at ERROR, and re-raises. `main()` now catches `(RuntimeError, ExceptionGroup)`; the bare-`RuntimeError` path is unchanged. Plain `BaseExceptionGroup`s containing non-`Exception` leaves (e.g. `KeyboardInterrupt`) keep propagating untouched, as before — `ExceptionGroup` is the `Exception`-derived variant, and a group whose leaves are all RuntimeErrors is always an `ExceptionGroup`.

## Tests

- `test_exception_group_wrapped_cancel_scope_error_exits_cleanly` — single-wrap and nested-group shapes (the message anyio actually uses, `"unhandled errors in a TaskGroup"`): clean exit, WARNING not ERROR. **Pre-fix this group escaped `main()` entirely** (uncaught, non-zero exit).
- `test_exception_group_with_real_failure_hits_barrier` — `[cancel-scope RuntimeError, ValueError]` group is logged and re-raised (also passes pre-fix via the generic barrier; pins no-regression on the strict side).
- Full suite: 2993 passed, 3 skipped (`-m "not ollama"`). `ruff` and `mypy` clean on the touched file.

## Known related gap (out of scope)

The daemon teardown path (`daemon/server.py` `_teardown`) can exit the LTM transport's cancel scope from a different task than entered it and currently swallows that error via `_quiet()`, which can leak the warm LTM child on shutdown. Fixing it is a contested design choice (eager adapter start in the serve task vs. a dedicated worker task vs. guard + force-kill) tracked in the 2026-06-10 implementation review backlog — deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)