### PR TITLE
fix(surfacing): classify no_results_demoted so it survives the stats healthy/fault split

### DIFF
--- a/src/memtomem_stm/surfacing/observability.py
+++ b/src/memtomem_stm/surfacing/observability.py
@@ -41,6 +41,11 @@ SkipReason = Literal[
     "gate_cooldown",
     "no_results_score",
     "no_results_dedup",
+    # #404: durable negative-feedback demotion excluded every candidate
+    # that passed the score filter — distinct from ``no_results_score`` /
+    # ``no_results_dedup`` so an operator can tell the demotion filter
+    # (not the threshold or session-dedup) is suppressing surfacing.
+    "no_results_demoted",
     "no_results_invalidated",
     "no_results_empty_cache",
     # #295: LTM adapter outcome typing — distinguish unreachable from
@@ -92,6 +97,7 @@ HEALTHY_SKIP_REASONS: frozenset[str] = frozenset(
         "gate_cooldown",
         "no_results_score",
         "no_results_dedup",
+        "no_results_demoted",
         "no_results_invalidated",
         "no_results_empty_cache",
         "progressive_mode_conflict",

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -2238,6 +2238,37 @@ class TestSurfacingEngineObservability:
         assert snap["skip_reasons"]["read_file"] == {"no_results_dedup": 1}
         assert snap["cache"] == {"miss": 1}
 
+    async def test_no_results_demoted_records_skip(self, tmp_path: Path):
+        """Results pass the score filter but durable negative feedback
+        demotes every candidate — distinct from ``no_results_dedup`` /
+        ``no_results_score`` (#404) so an operator can tell that feedback
+        demotion, not the score threshold or session-dedup, is suppressing
+        surfacing. Needs a real ``FeedbackTracker`` because the demotion
+        filter reads persisted negative-feedback counts."""
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+        from memtomem_stm.surfacing.observability import SurfacingObservability
+
+        tracker = FeedbackTracker(config=_make_config(), db_path=tmp_path / "fb.db")
+        try:
+            for i in range(3):
+                sid = f"sid-neg-{i}"
+                tracker.record_surfacing(sid, "gh", "read_file", "q", ["demoted"], [0.9])
+                tracker.record_feedback(sid, "not_relevant", "demoted")
+            results = [FakeSearchResult(chunk=FakeChunk(id="demoted", content="m"), score=0.9)]
+            obs = SurfacingObservability()
+            engine = SurfacingEngine(
+                config=_make_config(feedback_demotion_negative_threshold=3),
+                mcp_adapter=_make_mcp_adapter(results),
+                feedback_tracker=tracker,
+                observability=obs,
+            )
+            await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+            snap = obs.snapshot()
+            assert snap["skip_reasons"]["read_file"] == {"no_results_demoted": 1}
+            assert snap["cache"] == {"miss": 1}
+        finally:
+            tracker.close()
+
     async def test_no_results_invalidated_records_skip(self):
         """Cache hit returns results but all are in ``_invalidated_ids``
         (rated ``not_relevant`` / ``already_known`` within the cache TTL) —

--- a/tests/test_surfacing_observability.py
+++ b/tests/test_surfacing_observability.py
@@ -238,6 +238,28 @@ class TestSkipReasonCategorization:
         assert "ltm_unavailable: 23" in joined
         assert "circuit_open: 4" in joined
 
+    def test_no_results_demoted_renders_under_healthy_subsection(self):
+        """``no_results_demoted`` (#404) must survive the healthy/fault
+        split. It was originally recorded as a bare string in engine.py
+        with no ``SkipReason`` Literal member and no category assignment,
+        so ``_split_skip_reasons_by_category`` silently dropped it — the
+        exhaustiveness test above only inspects ``get_args(SkipReason)``
+        and stayed green. This pins the full render path so the label
+        cannot leak through unclassified again."""
+        snap = {
+            "any_call": True,
+            "skip_reasons": {
+                "read_file": {"no_results_demoted": 7},
+                "__total__": {"no_results_demoted": 7},
+            },
+            "outcomes": {},
+            "cache": {},
+        }
+        lines = _format_observability_sections(snap, tool_filter=None)
+        joined = "\n".join(lines)
+        assert "Healthy skips" in joined
+        assert "no_results_demoted: 7" in joined
+
     def test_mixed_skips_render_both_subsections_independently(self):
         """When a tool has skips in both categories the formatter must
         emit two subsections — that's the whole point of the split. A


### PR DESCRIPTION
## Summary

PR #404 introduced the `no_results_demoted` skip reason to distinguish "score filter passed but feedback demotion killed every candidate" from `no_results_dedup` / `no_results_score`. But the label was recorded as a bare string in `engine.py` and never added to the `SkipReason` Literal, `HEALTHY_SKIP_REASONS`, or `FAULT_SKIP_REASONS`. `_split_skip_reasons_by_category` (server.py) renders only reasons present in one of the two frozensets and silently drops everything else, so the count never reached `stm_surfacing_stats` output — the operator-facing signal #404 existed to provide. `docs/surfacing.md` already documents the label, so the documented operator workflow was broken.

The CI guard didn't catch it: `test_categorization_is_exhaustive_and_disjoint` inspects only `get_args(SkipReason)`, and the bare string never joined the Literal.

## Fix

- Add `no_results_demoted` to the `SkipReason` Literal — this also puts it under the exhaustiveness test's protection like every other reason.
- Classify it in `HEALTHY_SKIP_REASONS`: an expected threshold outcome (operator tuning knob: `feedback_demotion_negative_threshold`), not a degraded-LTM fault.

## Behavior change

`stm_surfacing_stats` output now includes `no_results_demoted` counts under the "Healthy skips" subsection. Previously the label was recorded internally but invisible in the rendered stats (and in any per-tool totals derived from the split views). No config or API surface changes.

## Tests

- `test_no_results_demoted_records_skip` (engine): drives the all-demoted path with a real `FeedbackTracker` + `SurfacingObservability` wired and pins `snapshot()["skip_reasons"]["read_file"] == {"no_results_demoted": 1}`, mirroring the sibling `test_no_results_dedup_records_skip`.
- `test_no_results_demoted_renders_under_healthy_subsection` (render path): pins that the label survives `_split_skip_reasons_by_category` into the Healthy skips subsection. **Fails before the fix** — the rendered output is empty because the only recorded reason is dropped.

`uv run pytest -m "not ollama"`: 2999 passed, 3 skipped. `ruff check src` + `ruff format --check src` clean. mypy: no errors in touched files (8 pre-existing in compression.py untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)