### PR TITLE
fix(mms): treat non-dict mcpServers in host configs as no candidates instead of crashing

### DIFF
--- a/src/memtomem_stm/mms/import_hosts.py
+++ b/src/memtomem_stm/mms/import_hosts.py
@@ -224,13 +224,26 @@ def _wrap(name: str, raw: dict[str, Any], source_label: str) -> ImportCandidate 
     )
 
 
+def _mcp_servers(config: dict[str, Any]) -> dict[str, Any]:
+    """Return ``config["mcpServers"]`` if it is a dict, else ``{}``.
+
+    A structurally-valid JSON whose ``mcpServers`` is a list/str/number is
+    truthy, so an ``or {}`` guard would pass it straight to ``.items()`` and
+    crash the scan with an AttributeError. Wrong-typed entries follow the
+    module contract for unreadable configs — no candidates, silent — same as
+    ``scan_codex``'s ``isinstance`` guard on ``mcp_servers``.
+    """
+    servers = config.get("mcpServers")
+    return servers if isinstance(servers, dict) else {}
+
+
 def scan_claude_code(cwd: Path) -> list[ImportCandidate]:
     """Scan ``~/.claude.json`` (user + per-project) plus ``<cwd>/.mcp.json``."""
     candidates: list[ImportCandidate] = []
 
     user_config = _read_json_safely(Path("~/.claude.json").expanduser())
     if user_config:
-        for name, raw in (user_config.get("mcpServers") or {}).items():
+        for name, raw in _mcp_servers(user_config).items():
             if not isinstance(raw, dict):
                 continue
             cand = _wrap(name, raw, "Claude Code (user)")
@@ -242,7 +255,7 @@ def scan_claude_code(cwd: Path) -> list[ImportCandidate]:
         if isinstance(projects, dict):
             project_entry = projects.get(str(cwd)) or projects.get(str(cwd.resolve())) or {}
             if isinstance(project_entry, dict):
-                for name, raw in (project_entry.get("mcpServers") or {}).items():
+                for name, raw in _mcp_servers(project_entry).items():
                     if not isinstance(raw, dict):
                         continue
                     cand = _wrap(name, raw, "Claude Code (project)")
@@ -251,7 +264,7 @@ def scan_claude_code(cwd: Path) -> list[ImportCandidate]:
 
     project_mcp = _read_json_safely(cwd / ".mcp.json")
     if project_mcp:
-        for name, raw in (project_mcp.get("mcpServers") or {}).items():
+        for name, raw in _mcp_servers(project_mcp).items():
             if not isinstance(raw, dict):
                 continue
             cand = _wrap(name, raw, ".mcp.json (project)")
@@ -272,7 +285,7 @@ def scan_cursor(cwd: Path) -> list[ImportCandidate]:
         config = _read_json_safely(path)
         if not config:
             continue
-        for name, raw in (config.get("mcpServers") or {}).items():
+        for name, raw in _mcp_servers(config).items():
             if not isinstance(raw, dict):
                 continue
             cand = _wrap(name, raw, label)
@@ -309,7 +322,7 @@ def scan_claude_desktop(cwd: Path) -> list[ImportCandidate]:
     if not config:
         return []
     out: list[ImportCandidate] = []
-    for name, raw in (config.get("mcpServers") or {}).items():
+    for name, raw in _mcp_servers(config).items():
         if not isinstance(raw, dict):
             continue
         cand = _wrap(name, raw, "Claude Desktop")

--- a/tests/cli/test_mms_host.py
+++ b/tests/cli/test_mms_host.py
@@ -365,6 +365,22 @@ class TestEdges:
             res = _status(runner, *args)
             assert res.exit_code == 0, (args, res.output)
 
+    def test_status_non_dict_mcpservers_exit_0(self, runner, sandbox):
+        """Structurally-valid JSON whose ``mcpServers`` is not a dict (e.g.
+        another tool's schema using a list) must behave like a missing host
+        config — exit 0, no AttributeError traceback. Same contract as the
+        invalid-JSON case above, which ``_read_json_safely`` already covers;
+        this pins the scanner-level type guard."""
+        _seed_claude_code(sandbox, {"x": {"command": "npx"}})
+        _apply_claude_code(runner)
+        (sandbox["home"] / ".claude.json").write_text(
+            json.dumps({"mcpServers": ["not", "a", "dict"]}), encoding="utf-8"
+        )
+
+        for args in ([], ["--json"]):
+            res = _status(runner, *args)
+            assert res.exit_code == 0, (args, res.output)
+
     def test_status_empty_registry(self, runner, sandbox):
         res = _status(runner)
         assert res.exit_code == 0, res.output

--- a/tests/mms/test_import_hosts.py
+++ b/tests/mms/test_import_hosts.py
@@ -327,6 +327,74 @@ class TestScanClaudeDesktop:
         assert ih.scan_claude_desktop(tmp_path) == []
 
 
+class TestNonDictMcpServers:
+    """Structurally-valid JSON whose ``mcpServers`` is a list/str/number is
+    truthy, so an ``(config.get("mcpServers") or {})`` guard passes it
+    straight to ``.items()`` — AttributeError. The module docstring contract
+    treats unreadable configs as "no candidates (silent)"; a wrong-typed
+    ``mcpServers`` (another tool's schema, or a hand-edit) must behave like
+    missing, not crash ``mms import`` / ``mms host status`` / ``mms host
+    scan`` / ``mms host sync``. ``scan_codex`` already guards with
+    ``isinstance``; these pin the four JSON scanner sites to the same
+    behavior.
+    """
+
+    BAD_VALUES = pytest.mark.parametrize(
+        "bad", [["entry"], "string", 7], ids=["list", "str", "int"]
+    )
+
+    @BAD_VALUES
+    def test_claude_code_user_scope_returns_empty(self, sandbox_home, tmp_path, bad):
+        (sandbox_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": bad}), encoding="utf-8"
+        )
+        assert ih.scan_claude_code(tmp_path) == []
+
+    @BAD_VALUES
+    def test_claude_code_project_scope_returns_empty(self, sandbox_home, tmp_path, bad):
+        cwd = tmp_path / "proj"
+        cwd.mkdir()
+        cfg = {"projects": {str(cwd): {"mcpServers": bad}}}
+        (sandbox_home / ".claude.json").write_text(json.dumps(cfg), encoding="utf-8")
+        assert ih.scan_claude_code(cwd) == []
+
+    @BAD_VALUES
+    def test_dot_mcp_json_returns_empty(self, sandbox_home, tmp_path, bad):
+        (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": bad}), encoding="utf-8")
+        assert ih.scan_claude_code(tmp_path) == []
+
+    @BAD_VALUES
+    def test_cursor_returns_empty(self, sandbox_home, tmp_path, bad):
+        cwd = tmp_path / "proj"
+        cwd.mkdir()
+        cursor_dir = sandbox_home / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "mcp.json").write_text(json.dumps({"mcpServers": bad}), encoding="utf-8")
+        assert ih.scan_cursor(cwd) == []
+
+    @BAD_VALUES
+    def test_claude_desktop_returns_empty(self, monkeypatch, tmp_path, bad):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        sandbox_path = tmp_path / "claude_desktop_config.json"
+        sandbox_path.write_text(json.dumps({"mcpServers": bad}), encoding="utf-8")
+        monkeypatch.setattr(ih, "_desktop_config_path", lambda: sandbox_path)
+        assert ih.scan_claude_desktop(tmp_path) == []
+
+    def test_bad_user_scope_does_not_block_other_scopes(self, sandbox_home, tmp_path):
+        """A wrong-typed ``mcpServers`` skips only that scope — the scan
+        continues to the next source (here ``.mcp.json``) instead of
+        aborting the whole scanner."""
+        (sandbox_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": ["bad"]}), encoding="utf-8"
+        )
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"local-tool": {"command": "echo"}}}),
+            encoding="utf-8",
+        )
+        candidates = ih.scan_claude_code(tmp_path)
+        assert [c.name for c in candidates] == ["local-tool"]
+
+
 # ---------------------------------------------------------------------------
 # discover() façade
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`scan_claude_code`, `scan_cursor`, and `scan_claude_desktop` guard `mcpServers` with `(config.get("mcpServers") or {})`, which only replaces falsy values. A structurally-valid JSON whose `mcpServers` key is a list, string, or number is truthy and goes straight to `.items()` — an unhandled `AttributeError` that crashes `mms import`, `mms host status`, `mms host scan`, and `mms host sync`. Any other tool writing `~/.claude.json`, `<cwd>/.mcp.json`, `~/.cursor/mcp.json`, or the Claude Desktop config with a different schema (or a simple hand-edit) triggers it.

The module docstring promises unreadable configs scan as "no candidates (silent)" — wrong-typed `mcpServers` should behave like a missing file, not a traceback. `scan_codex` already has exactly this guard (`if not isinstance(servers, dict): return []`); the JSON scanners were the inconsistency.

## Fix

Extract a `_mcp_servers(config) -> dict` helper (returns the value if it's a dict, else `{}`) and use it at all five `mcpServers` call sites — user scope, per-project scope, and `.mcp.json` in `scan_claude_code`, plus `scan_cursor` and `scan_claude_desktop` — so the guard cannot drift per-site.

## Tests

- `TestNonDictMcpServers` (scanner level): parametrized list/str/int at every site; **all fail before the fix** with `AttributeError: 'list' object has no attribute 'items'` (and str/int equivalents).
- `test_bad_user_scope_does_not_block_other_scopes`: a wrong-typed user scope skips only that scope — the scan still picks up `.mcp.json` candidates.
- `test_status_non_dict_mcpservers_exit_0` (CLI level): pins the exit-0 contract for `mms host status` against a list-typed `mcpServers`, extending the existing invalid-JSON edge case that `_read_json_safely` already covered.

`uv run pytest -m "not ollama"`: 3014 passed, 3 skipped. `ruff check src` + `ruff format --check src` clean. mypy: no errors in the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)