### PR TITLE
fix(cli): give the upstream probe an end-to-end deadline so mms health honors --timeout

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -2317,11 +2317,29 @@ def prune(
 
 
 async def _probe_one(cfg: dict[str, Any], timeout: float) -> dict[str, Any]:
-    """Probe a single upstream server: connect, initialize, list tools."""
+    """Probe a single upstream server: connect, initialize, list tools.
+
+    *timeout* is an **end-to-end** budget shared across transport connect +
+    ``initialize()`` + ``list_tools()`` — each ``wait_for`` gets
+    ``deadline - now`` so a stall in any phase can't push the probe past the
+    ``mms health --timeout`` / ``mms add --validate --timeout`` ceiling.
+    Mirrors ``_probe_ltm_mcp_server``'s deadline pattern; previously only
+    ``initialize()`` was bounded, so a network upstream hanging on TCP
+    connect (or any upstream stalling on ``tools/list``) blocked the probe
+    indefinitely and ``_safe_probe``'s timeout classification never fired.
+    """
     from mcp import ClientSession
     from mcp.client.sse import sse_client
     from mcp.client.stdio import StdioServerParameters, stdio_client
     from mcp.client.streamable_http import streamablehttp_client
+
+    deadline = asyncio.get_running_loop().time() + timeout
+
+    def remaining() -> float:
+        # ``asyncio.wait_for`` treats <=0 as "fire immediately"; clamp to a
+        # tiny positive so we always raise ``TimeoutError`` rather than
+        # returning a bogus result on an exhausted budget.
+        return max(1e-3, deadline - asyncio.get_running_loop().time())
 
     transport = cfg.get("transport", "stdio")
     if transport == "stdio":
@@ -2333,14 +2351,19 @@ async def _probe_one(cfg: dict[str, Any], timeout: float) -> dict[str, Any]:
             )
         )
     elif transport == "sse":
-        ctx = sse_client(cfg.get("url", ""))
+        sdk_timeout = remaining()
+        ctx = sse_client(cfg.get("url", ""), timeout=sdk_timeout, sse_read_timeout=sdk_timeout)
     else:
-        ctx = streamablehttp_client(cfg.get("url", ""))
+        sdk_timeout = remaining()
+        ctx = streamablehttp_client(
+            cfg.get("url", ""), timeout=sdk_timeout, sse_read_timeout=sdk_timeout
+        )
 
-    async with ctx as streams:
+    async with AsyncExitStack() as stack:
+        streams = await asyncio.wait_for(stack.enter_async_context(ctx), timeout=remaining())
         async with ClientSession(streams[0], streams[1]) as session:
-            await asyncio.wait_for(session.initialize(), timeout=timeout)
-            result = await session.list_tools()
+            await asyncio.wait_for(session.initialize(), timeout=remaining())
+            result = await asyncio.wait_for(session.list_tools(), timeout=remaining())
             prefix = cfg.get("prefix", "")
             overflowing = [
                 t.name for t in result.tools if tool_name_budget.overflows(prefix, t.name)

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -4214,6 +4214,117 @@ class TestHealth:
         assert data["servers"]["bad"]["error"]
         assert "surfacing" in data
 
+    @pytest.mark.parametrize(
+        ("transport", "client_path"),
+        [
+            ("sse", "mcp.client.sse.sse_client"),
+            ("streamable_http", "mcp.client.streamable_http.streamablehttp_client"),
+        ],
+    )
+    def test_upstream_probe_timeout_bounds_transport_enter(
+        self, monkeypatch, transport, client_path
+    ):
+        """#398 gave ``_probe_ltm_mcp_server`` an end-to-end deadline, but
+        the older upstream probe ``_probe_one`` only bounded
+        ``initialize()`` — a network upstream hanging on TCP connect
+        blocked ``mms health --timeout N`` / ``mms add --validate``
+        indefinitely, and no ``timeout=``/``sse_read_timeout=`` reached
+        the SDK client. Mirrors
+        ``test_sse_ltm_probe_timeout_bounds_transport_enter``."""
+        import time
+
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        captured = {}
+
+        class HangingTransport:
+            async def __aenter__(self):
+                await asyncio.sleep(8)
+
+            async def __aexit__(self, *_args):
+                return None
+
+        def fake_client(url, *, headers=None, timeout=None, sse_read_timeout=None):
+            captured.update(
+                {"url": url, "timeout": timeout, "sse_read_timeout": sse_read_timeout}
+            )
+            return HangingTransport()
+
+        monkeypatch.setattr(client_path, fake_client)
+
+        cfg = {"transport": transport, "url": "https://up.example/mcp", "prefix": "up"}
+        start = time.monotonic()
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(proxy_mod._probe_one(cfg, 0.1))
+        elapsed = time.monotonic() - start
+        assert elapsed < 5.0, f"transport-enter stall ran {elapsed:.2f}s past the 0.1s budget"
+        assert captured["url"] == "https://up.example/mcp"
+        assert captured["timeout"] == pytest.approx(0.1, rel=0.1)
+        assert captured["sse_read_timeout"] == pytest.approx(0.1, rel=0.1)
+
+    def test_upstream_probe_timeout_bounds_list_tools(self, monkeypatch):
+        """An upstream that connects and initializes fine but stalls on
+        ``tools/list`` must also resolve within the probe budget — this
+        phase was previously unbounded so ``_safe_probe``'s
+        ``asyncio.TimeoutError`` classification could never fire for it."""
+        import time
+
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        class FakeTransport:
+            async def __aenter__(self):
+                return (object(), object())
+
+            async def __aexit__(self, *_args):
+                return None
+
+        class FakeSession:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def initialize(self):
+                return None
+
+            async def list_tools(self):
+                await asyncio.sleep(8)
+
+        monkeypatch.setattr("mcp.client.sse.sse_client", lambda url, **_kw: FakeTransport())
+        monkeypatch.setattr("mcp.ClientSession", FakeSession)
+
+        cfg = {"transport": "sse", "url": "https://up.example/sse", "prefix": "up"}
+        start = time.monotonic()
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(proxy_mod._probe_one(cfg, 0.1))
+        elapsed = time.monotonic() - start
+        assert elapsed < 5.0, f"list_tools stall ran {elapsed:.2f}s past the 0.1s budget"
+
+    def test_safe_probe_classifies_deadline_timeout(self, monkeypatch):
+        """The end-to-end deadline surfaces through ``_probe_servers`` as
+        the same ``timeout (Ns)`` classification the initialize-phase
+        timeout already gets — DISCONNECTED with a clear cause, not a
+        hang or an unwrapped traceback."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        class HangingTransport:
+            async def __aenter__(self):
+                await asyncio.sleep(8)
+
+            async def __aexit__(self, *_args):
+                return None
+
+        monkeypatch.setattr("mcp.client.sse.sse_client", lambda url, **_kw: HangingTransport())
+
+        cfg = {"transport": "sse", "url": "https://up.example/sse", "prefix": "up"}
+        results = asyncio.run(proxy_mod._probe_servers({"up": cfg}, 0.1))
+        assert results["up"]["connected"] is False
+        assert results["up"]["error"] == "timeout (0.1s)"
+
     def test_health_error_unwraps_taskgroup_wrapper(self, runner, config):
         """Probe failures inside an anyio TaskGroup are wrapped as
         ``BaseExceptionGroup`` and stringify as ``unhandled errors in a


### PR DESCRIPTION
## Summary

`_probe_one` — the upstream-server probe behind `mms health` (per-server `--timeout`) and `mms add --validate` — only wrapped `session.initialize()` in `asyncio.wait_for`. The transport connect (`async with ctx`) and `session.list_tools()` were unbounded, and for `sse`/`streamable_http` transports no `timeout=`/`sse_read_timeout=` was passed to the SDK client at all. Consequences:

- An SSE/HTTP upstream whose endpoint hangs on TCP connect blocks `mms health --timeout N` indefinitely.
- Any upstream that completes initialize but stalls on `tools/list` does the same.
- `_safe_probe` only catches `asyncio.TimeoutError`, which was never raised for the unbounded phases — so the user never even got the `timeout (Ns)` classification.

This is exactly the failure mode `_probe_ltm_mcp_server` (#398) was written to avoid — that function uses a shared end-to-end deadline wrapping transport enter, `initialize()`, AND `list_tools()` — but the older upstream probe never received the same treatment.

## Fix

Mirror the sibling's deadline pattern in `_probe_one`: compute the deadline once, pass the remaining budget as `timeout=`/`sse_read_timeout=` to `sse_client`/`streamablehttp_client`, and wrap `stack.enter_async_context(ctx)`, `initialize()`, and `list_tools()` each in `asyncio.wait_for(..., timeout=remaining())`.

## Behavior change

`mms health` / `mms add --validate` now resolve to DISCONNECTED with `timeout (Ns)` within the `--timeout` bound for connect-phase and list_tools-phase stalls, instead of hanging indefinitely. Successful-probe behavior is unchanged.

## Tests

All invoke `_probe_one`/`_probe_servers` directly (CliRunner's stderr lacks `fileno` for the real subprocess path) and **fail before the fix** — each hangs ~8s on the fake transport instead of timing out at 0.1s:

- `test_upstream_probe_timeout_bounds_transport_enter` (parametrized sse + streamable_http): hanging `__aenter__` → `TimeoutError` within bound; also pins that the SDK client receives `timeout=`/`sse_read_timeout=` ≈ the budget (mirroring `test_sse_ltm_probe_timeout_bounds_transport_enter`).
- `test_upstream_probe_timeout_bounds_list_tools`: initialize succeeds, `tools/list` stalls → bounded.
- `test_safe_probe_classifies_deadline_timeout`: the deadline timeout surfaces through `_probe_servers` as `connected: False` + `error: "timeout (0.1s)"`.

`uv run pytest -m "not ollama"`: 3001 passed, 3 skipped. `ruff check src` + `ruff format --check src` clean. mypy: no errors in the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
