### PR TITLE
fix(config): load the JSON file even when MEMTOMEM_STM_PROXY__ENABLED is set, and propagate file consumer_model to surfacing

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -685,13 +685,13 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
     path = Path(config_path)
     resolved = path.expanduser().resolve()
 
-    # Resolve config + DB paths exactly as the server does (server.app_lifespan).
-    # ``STMConfig()`` pulls proxy + surfacing from ``MEMTOMEM_STM_*`` env. When
-    # the proxy is enabled via env, the server uses that env-only config and
-    # SKIPS the JSON file entirely (server.py), so honoring a file-level
-    # ``metrics.db_path`` here would point ``mms stats`` at a different
-    # ``proxy_metrics.db`` than the one the server actually writes to.
-    env_enabled = bool(os.environ.get("MEMTOMEM_STM_PROXY__ENABLED"))
+    # Resolve config + DB paths exactly as the server does (server.app_lifespan):
+    # JSON file loaded unconditionally with env vars deep-merged on top, so a
+    # file-level ``metrics.db_path`` points ``mms stats`` at the same
+    # ``proxy_metrics.db`` the server writes to even when the proxy is enabled
+    # via ``MEMTOMEM_STM_PROXY__ENABLED``. (The server used to skip the file
+    # in env-enabled mode and this command mirrored the bypass; both honor the
+    # file now.) ``STMConfig()`` still supplies the surfacing feedback path.
     try:
         stm_config: STMConfig | None = STMConfig()
     except Exception:
@@ -702,23 +702,18 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
         else Path("~/.memtomem/stm_feedback.db")
     )
 
-    if env_enabled and stm_config is not None:
-        # Env-only mode — the JSON file is bypassed, matching the server.
-        proxy_cfg = stm_config.proxy
-        config_status = "env"
+    loaded = ProxyConfig.load_from_file(path, env_overrides=collect_proxy_env_overrides())
+    if loaded is None:
+        # Parse/validation error — fall back to defaults purely to locate the
+        # DB paths to probe, but flag the config as invalid.
+        config_status = "invalid"
+        proxy_cfg = ProxyConfig()
+    elif not resolved.exists():
+        config_status = "missing"
+        proxy_cfg = loaded
     else:
-        loaded = ProxyConfig.load_from_file(path, env_overrides=collect_proxy_env_overrides())
-        if loaded is None:
-            # Parse/validation error — fall back to defaults purely to locate the
-            # DB paths to probe, but flag the config as invalid.
-            config_status = "invalid"
-            proxy_cfg = ProxyConfig()
-        elif not resolved.exists():
-            config_status = "missing"
-            proxy_cfg = loaded
-        else:
-            config_status = "ok"
-            proxy_cfg = loaded
+        config_status = "ok"
+        proxy_cfg = loaded
 
     compression = read_compression_summary(proxy_cfg.metrics.db_path, tool=tool_filter)
     surfacing = read_surfacing_summary(feedback_path, tool=tool_filter)
@@ -741,10 +736,7 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
         )
         return
 
-    if config_status == "env":
-        click.echo("Config : MEMTOMEM_STM_PROXY__ENABLED set — env config (JSON file bypassed)")
-    else:
-        click.echo(f"Config : {resolved} ({config_status})")
+    click.echo(f"Config : {resolved} ({config_status})")
     click.echo(f"Enabled: {'yes' if proxy_cfg.enabled else 'no'}")
     click.echo(f"Servers: {len(proxy_cfg.upstream_servers)}")
     if tool_filter:

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -709,8 +709,11 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
         config_status = "invalid"
         proxy_cfg = ProxyConfig()
     elif not resolved.exists():
+        # Missing file: mirror the server, which keeps STMConfig()'s
+        # pydantic-settings parse — it handles JSON-encoded complex env
+        # values (e.g. UPSTREAM_SERVERS) that the raw-string overlay can't.
         config_status = "missing"
-        proxy_cfg = loaded
+        proxy_cfg = stm_config.proxy if stm_config is not None else loaded
     else:
         config_status = "ok"
         proxy_cfg = loaded

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -702,21 +702,25 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
         else Path("~/.memtomem/stm_feedback.db")
     )
 
-    loaded = ProxyConfig.load_from_file(path, env_overrides=collect_proxy_env_overrides())
-    if loaded is None:
-        # Parse/validation error — fall back to defaults purely to locate the
-        # DB paths to probe, but flag the config as invalid.
-        config_status = "invalid"
-        proxy_cfg = ProxyConfig()
+    loaded = ProxyConfig.load_from_file(
+        path, env_overrides=collect_proxy_env_overrides(), missing_ok=False
+    )
+    if loaded is not None:
+        config_status = "ok"
+        proxy_cfg = loaded
     elif not resolved.exists():
         # Missing file: mirror the server, which keeps STMConfig()'s
         # pydantic-settings parse — it handles JSON-encoded complex env
         # values (e.g. UPSTREAM_SERVERS) that the raw-string overlay can't.
+        # (``missing_ok=False`` already folded "missing" into ``None``; the
+        # exists() here only picks the status label and fallback source.)
         config_status = "missing"
-        proxy_cfg = stm_config.proxy if stm_config is not None else loaded
+        proxy_cfg = stm_config.proxy if stm_config is not None else ProxyConfig()
     else:
-        config_status = "ok"
-        proxy_cfg = loaded
+        # Parse/validation error — fall back to defaults purely to locate the
+        # DB paths to probe, but flag the config as invalid.
+        config_status = "invalid"
+        proxy_cfg = ProxyConfig()
 
     compression = read_compression_summary(proxy_cfg.metrics.db_path, tool=tool_filter)
     surfacing = read_surfacing_summary(feedback_path, tool=tool_filter)

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -23,7 +23,8 @@ def collect_proxy_env_overrides(environ: dict[str, str] | None = None) -> dict[s
     Used to layer env-set proxy fields on top of the JSON config file so the
     documented precedence (env > file > defaults) holds end-to-end. Without
     this, the file-load path in ``server.py`` would clobber every env-set
-    field except ``MEMTOMEM_STM_PROXY__ENABLED``.
+    field (``MEMTOMEM_STM_PROXY__ENABLED`` included — the file load is
+    unconditional; env wins purely through this overlay).
 
     The returned dict mirrors the JSON config shape — nested by ``__``
     delimiters, lower-cased — and pydantic's coercion handles type

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -589,19 +589,32 @@ class ProxyConfig(BaseModel):
 
     @staticmethod
     def load_from_file(
-        path: Path, env_overrides: dict[str, Any] | None = None
+        path: Path, env_overrides: dict[str, Any] | None = None, *, missing_ok: bool = True
     ) -> ProxyConfig | None:
         """Load config from *path*. Returns ``None`` on parse/validation error
-        (distinct from file-not-found which returns a default ``ProxyConfig``).
+        (with ``missing_ok=True``, distinct from file-not-found which returns
+        a default ``ProxyConfig``).
 
         When *env_overrides* is supplied it is deep-merged on top of the file
         contents so env-set fields win over file-set fields, matching the
         ``env > file > defaults`` precedence documented in
         ``docs/configuration.md``.
+
+        With ``missing_ok=False`` a missing file returns ``None`` instead of
+        the env-only/defaults rebuild. Callers that already hold a better
+        env-aware config than the raw-string overlay can produce — e.g.
+        ``STMConfig()``'s pydantic-settings parse, which decodes JSON-encoded
+        complex env values the overlay cannot — use this to decline the swap
+        in a single atomic call, rather than a separate ``exists()``
+        pre-check that races with file deletion. A file deleted between the
+        existence check and the read also lands on ``None`` here, so every
+        disappearance mode converges on "do not swap".
         """
         resolved = path.expanduser().resolve()
         if not resolved.exists():
             logger.debug("Proxy config file not found: %s", resolved)
+            if not missing_ok:
+                return None
             if env_overrides:
                 try:
                     return ProxyConfig.model_validate(env_overrides)

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -62,23 +62,37 @@ class STMContext:
 CtxType = Context[ServerSession, STMContext]
 
 
+def _apply_proxy_file_config(config: STMConfig, proxy_env_overrides: dict[str, Any]) -> None:
+    """Load the JSON config file and overlay env vars on top of it, in place.
+
+    The documented precedence (env > file > defaults) is enforced by
+    ``load_from_file``'s deep-merge: every ``MEMTOMEM_STM_PROXY__*`` var —
+    including ``ENABLED`` — wins over its file counterpart, while file-only
+    fields (notably ``upstream_servers``, which env vars cannot practically
+    populate) survive. The load used to be skipped entirely whenever
+    ``MEMTOMEM_STM_PROXY__ENABLED`` was set, which started the proxy enabled
+    but with zero upstreams — proxying nothing.
+
+    Replacing ``config.proxy`` happens after ``STMConfig.model_post_init``
+    already ran, so its ``consumer_model`` propagation is re-applied here —
+    otherwise a consumer_model set only in the file reaches ``config.proxy``
+    but never surfacing's model-aware budgets
+    (``effective_max_injection_chars`` / ``effective_max_results``).
+    """
+    file_cfg = ProxyConfig.load_from_file(
+        config.proxy.config_path, env_overrides=proxy_env_overrides
+    )
+    if file_cfg is not None:
+        config.proxy = file_cfg
+    if config.proxy.consumer_model and not config.surfacing.consumer_model:
+        config.surfacing.consumer_model = config.proxy.consumer_model
+
+
 @asynccontextmanager
 async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
     config = STMConfig()
     proxy_env_overrides = collect_proxy_env_overrides()
-
-    # Load JSON config file and overlay env vars on top so the documented
-    # precedence (env > file > defaults) holds. The CLI writes
-    # ``"enabled": true`` to the JSON file, so a normal Quick Start enables
-    # the proxy without requiring ``MEMTOMEM_STM_PROXY__ENABLED``. Without
-    # the env overlay every other env-set field would be silently clobbered
-    # by the file values.
-    if not os.environ.get("MEMTOMEM_STM_PROXY__ENABLED"):
-        file_cfg = ProxyConfig.load_from_file(
-            config.proxy.config_path, env_overrides=proxy_env_overrides
-        )
-        if file_cfg is not None:
-            config.proxy = file_cfg
+    _apply_proxy_file_config(config, proxy_env_overrides)
 
     # Shared state — populated only when proxy is enabled
     from memtomem_stm.proxy.cache import ProxyCache

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -68,10 +68,18 @@ def _apply_proxy_file_config(config: STMConfig, proxy_env_overrides: dict[str, A
     The documented precedence (env > file > defaults) is enforced by
     ``load_from_file``'s deep-merge: every ``MEMTOMEM_STM_PROXY__*`` var —
     including ``ENABLED`` — wins over its file counterpart, while file-only
-    fields (notably ``upstream_servers``, which env vars cannot practically
-    populate) survive. The load used to be skipped entirely whenever
-    ``MEMTOMEM_STM_PROXY__ENABLED`` was set, which started the proxy enabled
-    but with zero upstreams — proxying nothing.
+    fields (notably ``upstream_servers``) survive. The load used to be
+    skipped entirely whenever ``MEMTOMEM_STM_PROXY__ENABLED`` was set, which
+    started the proxy enabled but with zero upstreams — proxying nothing.
+
+    When the file is MISSING, ``config.proxy`` is deliberately left as
+    constructed: ``STMConfig()``'s pydantic-settings parse already applied
+    every env var, including JSON-encoded complex values (e.g.
+    ``MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS='{"gh": ...}'``) that the
+    raw-string overlay dict cannot represent — rebuilding the config from
+    the overlay alone could only lose information, and a validation failure
+    in that rebuild would silently collapse a working env-only setup to
+    defaults.
 
     Replacing ``config.proxy`` happens after ``STMConfig.model_post_init``
     already ran, so its ``consumer_model`` propagation is re-applied here —
@@ -79,11 +87,12 @@ def _apply_proxy_file_config(config: STMConfig, proxy_env_overrides: dict[str, A
     but never surfacing's model-aware budgets
     (``effective_max_injection_chars`` / ``effective_max_results``).
     """
-    file_cfg = ProxyConfig.load_from_file(
-        config.proxy.config_path, env_overrides=proxy_env_overrides
-    )
-    if file_cfg is not None:
-        config.proxy = file_cfg
+    if config.proxy.config_path.expanduser().resolve().exists():
+        file_cfg = ProxyConfig.load_from_file(
+            config.proxy.config_path, env_overrides=proxy_env_overrides
+        )
+        if file_cfg is not None:
+            config.proxy = file_cfg
     if config.proxy.consumer_model and not config.surfacing.consumer_model:
         config.surfacing.consumer_model = config.proxy.consumer_model
 

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -79,7 +79,9 @@ def _apply_proxy_file_config(config: STMConfig, proxy_env_overrides: dict[str, A
     raw-string overlay dict cannot represent — rebuilding the config from
     the overlay alone could only lose information, and a validation failure
     in that rebuild would silently collapse a working env-only setup to
-    defaults.
+    defaults. ``missing_ok=False`` makes that decision inside the single
+    ``load_from_file`` call (missing → ``None`` → no swap), so there is no
+    separate existence pre-check to race with file deletion.
 
     Replacing ``config.proxy`` happens after ``STMConfig.model_post_init``
     already ran, so its ``consumer_model`` propagation is re-applied here —
@@ -87,12 +89,11 @@ def _apply_proxy_file_config(config: STMConfig, proxy_env_overrides: dict[str, A
     but never surfacing's model-aware budgets
     (``effective_max_injection_chars`` / ``effective_max_results``).
     """
-    if config.proxy.config_path.expanduser().resolve().exists():
-        file_cfg = ProxyConfig.load_from_file(
-            config.proxy.config_path, env_overrides=proxy_env_overrides
-        )
-        if file_cfg is not None:
-            config.proxy = file_cfg
+    file_cfg = ProxyConfig.load_from_file(
+        config.proxy.config_path, env_overrides=proxy_env_overrides, missing_ok=False
+    )
+    if file_cfg is not None:
+        config.proxy = file_cfg
     if config.proxy.consumer_model and not config.surfacing.consumer_model:
         config.surfacing.consumer_model = config.proxy.consumer_model
 

--- a/tests/cli/test_mms_stats.py
+++ b/tests/cli/test_mms_stats.py
@@ -103,16 +103,20 @@ class TestMmsStats:
         assert data["tool_filter"] == "query-docs"
         assert data["compression"]["total_calls"] == 2
 
-    def test_env_enabled_bypasses_file_metrics_path(self, runner, tmp_path, monkeypatch):
-        """When ``MEMTOMEM_STM_PROXY__ENABLED`` is set the server uses its
-        env-only proxy config and ignores the JSON file (server.app_lifespan),
-        so ``mms stats`` must too — otherwise it would probe a different
-        ``proxy_metrics.db`` than the one the server writes to."""
+    def test_env_enabled_still_honors_file_metrics_path(self, runner, tmp_path, monkeypatch):
+        """When ``MEMTOMEM_STM_PROXY__ENABLED`` is set the server now loads
+        the JSON file and overlays env on top
+        (``server._apply_proxy_file_config``), so ``mms stats`` must honor a
+        file-level ``metrics.db_path`` too — probing the same
+        ``proxy_metrics.db`` the server writes to. Previously both sides
+        skipped the file wholesale (``config_status: "env"``), which left
+        the proxy enabled with zero upstreams and pointed stats at the
+        wrong db."""
         set_home(monkeypatch, tmp_path)
         monkeypatch.setenv("MEMTOMEM_STM_PROXY__ENABLED", "1")
 
-        # A config file points metrics at a SEEDED db that the env-enabled
-        # server would ignore.
+        # A config file points metrics at a SEEDED db; env-enabled mode must
+        # still pick it up.
         file_db = tmp_path / "file_metrics.db"
         store = MetricsStore(file_db)
         store.initialize()
@@ -129,8 +133,7 @@ class TestMmsStats:
 
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
-        assert data["config_status"] == "env"
-        # The env path (default ~/.memtomem/proxy_metrics.db, unseeded under the
-        # patched HOME) is used — NOT the file's seeded db — so its row must not
-        # leak in.
-        assert data["compression"]["total_calls"] == 0
+        assert data["config_status"] == "ok"
+        assert data["enabled"] is True
+        # The file's seeded db is probed — its row shows up.
+        assert data["compression"]["total_calls"] == 1

--- a/tests/cli/test_mms_stats.py
+++ b/tests/cli/test_mms_stats.py
@@ -137,3 +137,29 @@ class TestMmsStats:
         assert data["enabled"] is True
         # The file's seeded db is probed — its row shows up.
         assert data["compression"]["total_calls"] == 1
+
+    def test_missing_file_env_only_uses_pydantic_settings_parse(
+        self, runner, tmp_path, monkeypatch
+    ):
+        """Missing config file + env-only setup: the server keeps
+        ``STMConfig()``'s pydantic-settings parse (which decodes
+        JSON-encoded complex env values like ``UPSTREAM_SERVERS``), so
+        ``mms stats`` must mirror that instead of rebuilding from the
+        raw-string env overlay — the rebuild would fail validation and
+        report defaults (disabled, zero servers) for a working setup."""
+        set_home(monkeypatch, tmp_path)
+        monkeypatch.setenv("MEMTOMEM_STM_PROXY__ENABLED", "1")
+        monkeypatch.setenv(
+            "MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS",
+            '{"gh": {"prefix": "gh", "command": "echo"}}',
+        )
+
+        result = runner.invoke(
+            cli, ["stats", "--config", str(tmp_path / "nonexistent.json"), "--json"]
+        )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["config_status"] == "missing"
+        assert data["enabled"] is True
+        assert data["servers"] == 1

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -96,6 +96,19 @@ class TestLoadFromFileWithEnvOverrides:
         assert cfg is not None
         assert cfg.default_max_result_chars == 7777
 
+    def test_missing_file_returns_none_when_missing_ok_false(self, tmp_path: Path) -> None:
+        """``missing_ok=False`` lets a caller that already holds a better
+        env-aware config (pydantic-settings parse) decline the swap in one
+        atomic call — a missing file must NOT be rebuilt from the raw-string
+        overlay, which can't represent JSON-encoded complex env values."""
+        cfg = ProxyConfig.load_from_file(
+            tmp_path / "nonexistent.json",
+            env_overrides={"default_max_result_chars": "7777"},
+            missing_ok=False,
+        )
+
+        assert cfg is None
+
     def test_nested_env_override_merges_with_file(self, tmp_path: Path) -> None:
         cfg_file = tmp_path / "stm_proxy.json"
         cfg_file.write_text(json.dumps({"cache": {"enabled": True, "default_ttl_seconds": 3600.0}}))

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1229,6 +1229,122 @@ class TestLifespan:
         mock_adapter.stop.assert_awaited_once()
         mock_pm_instance.stop.assert_awaited_once()
 
+    async def test_file_config_loaded_even_when_env_enabled(self, monkeypatch):
+        """``MEMTOMEM_STM_PROXY__ENABLED`` used to make app_lifespan skip the
+        JSON file load entirely — the proxy started enabled but with zero
+        upstreams (``upstream_servers`` is a file-only field env vars cannot
+        practically populate). The file must be loaded unconditionally; env
+        wins through the ``load_from_file`` overlay instead of a bypass."""
+        from memtomem_stm.server import app_lifespan, mcp
+
+        monkeypatch.setenv("MEMTOMEM_STM_PROXY__ENABLED", "1")
+
+        mock_pm_instance = MagicMock()
+        mock_pm_instance.start = AsyncMock()
+        mock_pm_instance.stop = AsyncMock()
+        mock_pm_instance.get_proxy_tools.return_value = []
+
+        with (
+            patch("memtomem_stm.server.STMConfig") as MockConfig,
+            patch("memtomem_stm.server.ProxyManager", return_value=mock_pm_instance),
+            patch(
+                "memtomem_stm.server.ProxyConfig.load_from_file", return_value=None
+            ) as mock_load,
+        ):
+            mock_cfg = MockConfig.return_value
+            mock_cfg.proxy = MagicMock()
+            mock_cfg.proxy.enabled = False
+            mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
+            mock_cfg.surfacing = MagicMock()
+            mock_cfg.surfacing.enabled = False
+            mock_cfg.langfuse = MagicMock()
+            mock_cfg.langfuse.enabled = False
+
+            async with app_lifespan(mcp) as _ctx:
+                pass
+
+        mock_load.assert_called_once()
+        # The env overlay (not a file bypass) is how env keeps winning.
+        assert mock_load.call_args.kwargs["env_overrides"].get("enabled") == "1"
+
+
+class TestApplyProxyFileConfig:
+    """``_apply_proxy_file_config`` — the app_lifespan config-resolution
+    helper: JSON file loaded unconditionally, env deep-merged on top, and
+    the ``consumer_model`` propagation from ``STMConfig.model_post_init``
+    re-applied after the ``config.proxy`` swap (post-init ran before the
+    swap, so a file-only consumer_model never reached surfacing's
+    model-aware budgets)."""
+
+    def _config(self, monkeypatch) -> STMConfig:
+        for var in (
+            "MEMTOMEM_STM_PROXY__ENABLED",
+            "MEMTOMEM_STM_PROXY__CONSUMER_MODEL",
+            "MEMTOMEM_STM_SURFACING__CONSUMER_MODEL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        return STMConfig()
+
+    def test_env_enabled_keeps_file_upstreams(self, tmp_path, monkeypatch):
+        import json
+
+        from memtomem_stm.proxy.config import collect_proxy_env_overrides
+        from memtomem_stm.server import _apply_proxy_file_config
+
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "enabled": False,
+                    "upstream_servers": {"gh": {"prefix": "gh", "command": "echo"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        config = self._config(monkeypatch)
+        config.proxy.config_path = cfg_file
+        monkeypatch.setenv("MEMTOMEM_STM_PROXY__ENABLED", "1")
+
+        _apply_proxy_file_config(config, collect_proxy_env_overrides())
+
+        assert config.proxy.enabled is True  # env wins over the file's False
+        assert set(config.proxy.upstream_servers) == {"gh"}  # file fields survive
+
+    def test_file_consumer_model_reaches_surfacing_budgets(self, tmp_path, monkeypatch):
+        import json
+
+        from memtomem_stm.server import _apply_proxy_file_config
+
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"consumer_model": "gpt-4.1-mini"}), encoding="utf-8")
+        config = self._config(monkeypatch)
+        config.proxy.config_path = cfg_file
+        # Pre-propagation: un-scaled default budget.
+        assert config.surfacing.effective_max_injection_chars() == 3000
+
+        _apply_proxy_file_config(config, {})
+
+        assert config.surfacing.consumer_model == "gpt-4.1-mini"
+        # A >200K-context model scales the injection budget up from 3000.
+        assert config.surfacing.effective_max_injection_chars() == 5000
+
+    def test_explicit_surfacing_consumer_model_not_clobbered(self, tmp_path, monkeypatch):
+        """Same guard as ``model_post_init``: an explicitly-set surfacing
+        consumer_model wins over the proxy-level one from the file."""
+        import json
+
+        from memtomem_stm.server import _apply_proxy_file_config
+
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"consumer_model": "gpt-4.1-mini"}), encoding="utf-8")
+        config = self._config(monkeypatch)
+        config.surfacing.consumer_model = "claude-sonnet-4"
+        config.proxy.config_path = cfg_file
+
+        _apply_proxy_file_config(config, {})
+
+        assert config.surfacing.consumer_model == "claude-sonnet-4"
+
 
 # ── advertise_observability_tools flag ──────────────────────────────────
 #

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1229,15 +1229,17 @@ class TestLifespan:
         mock_adapter.stop.assert_awaited_once()
         mock_pm_instance.stop.assert_awaited_once()
 
-    async def test_file_config_loaded_even_when_env_enabled(self, monkeypatch):
+    async def test_file_config_loaded_even_when_env_enabled(self, tmp_path, monkeypatch):
         """``MEMTOMEM_STM_PROXY__ENABLED`` used to make app_lifespan skip the
         JSON file load entirely — the proxy started enabled but with zero
-        upstreams (``upstream_servers`` is a file-only field env vars cannot
-        practically populate). The file must be loaded unconditionally; env
-        wins through the ``load_from_file`` overlay instead of a bypass."""
+        upstreams (``upstream_servers`` is a file-only field in practice).
+        An existing file must be loaded regardless of the env var; env wins
+        through the ``load_from_file`` overlay instead of a bypass."""
         from memtomem_stm.server import app_lifespan, mcp
 
         monkeypatch.setenv("MEMTOMEM_STM_PROXY__ENABLED", "1")
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text("{}", encoding="utf-8")
 
         mock_pm_instance = MagicMock()
         mock_pm_instance.start = AsyncMock()
@@ -1254,7 +1256,7 @@ class TestLifespan:
             mock_cfg = MockConfig.return_value
             mock_cfg.proxy = MagicMock()
             mock_cfg.proxy.enabled = False
-            mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
+            mock_cfg.proxy.config_path = cfg_file
             mock_cfg.surfacing = MagicMock()
             mock_cfg.surfacing.enabled = False
             mock_cfg.langfuse = MagicMock()
@@ -1344,6 +1346,32 @@ class TestApplyProxyFileConfig:
         _apply_proxy_file_config(config, {})
 
         assert config.surfacing.consumer_model == "claude-sonnet-4"
+
+    def test_missing_file_keeps_pydantic_settings_env_parse(self, tmp_path, monkeypatch):
+        """Env-only mode with NO config file: ``STMConfig()``'s
+        pydantic-settings parse supports JSON-encoded complex env values
+        (``UPSTREAM_SERVERS``) that the raw-string overlay dict cannot
+        represent. Rebuilding ``config.proxy`` from the overlay would fail
+        validation and silently collapse a working env-only setup to
+        defaults (disabled, zero upstreams) — when the file is missing the
+        helper must leave the env-parsed config untouched."""
+        from memtomem_stm.proxy.config import collect_proxy_env_overrides
+        from memtomem_stm.server import _apply_proxy_file_config
+
+        monkeypatch.setenv("MEMTOMEM_STM_PROXY__ENABLED", "1")
+        monkeypatch.setenv(
+            "MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS",
+            '{"gh": {"prefix": "gh", "command": "echo"}}',
+        )
+        config = STMConfig()
+        assert config.proxy.enabled is True
+        assert set(config.proxy.upstream_servers) == {"gh"}
+        config.proxy.config_path = tmp_path / "nonexistent.json"
+
+        _apply_proxy_file_config(config, collect_proxy_env_overrides())
+
+        assert config.proxy.enabled is True
+        assert set(config.proxy.upstream_servers) == {"gh"}
 
 
 # ── advertise_observability_tools flag ──────────────────────────────────

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1268,6 +1268,9 @@ class TestLifespan:
         mock_load.assert_called_once()
         # The env overlay (not a file bypass) is how env keeps winning.
         assert mock_load.call_args.kwargs["env_overrides"].get("enabled") == "1"
+        # missing → None → no swap is decided inside the single load call,
+        # not by a separate exists() pre-check that races with deletion.
+        assert mock_load.call_args.kwargs["missing_ok"] is False
 
 
 class TestApplyProxyFileConfig:


### PR DESCRIPTION
## Summary

Two silent config-propagation bugs (2026-06-10 review, medium):

1. **`MEMTOMEM_STM_PROXY__ENABLED` dropped the whole JSON file.** `app_lifespan` only called `load_from_file` when the env var was NOT set. Enabling the proxy via env (a documented method) skipped the file load entirely — `upstream_servers` (a file-only field env vars cannot practically populate) came up empty, so the proxy started enabled but proxied nothing. The env-overlay mechanism (`collect_proxy_env_overrides` + `_deep_merge`) was built precisely to layer env over the file, and it already includes `enabled` — so env still wins without the guard.

2. **File-set `consumer_model` never reached surfacing.** `STMConfig.model_post_init` copies `proxy.consumer_model` → `surfacing.consumer_model`, but it runs once at construction — before `app_lifespan` swaps `config.proxy` to the file config. A `consumer_model` set only in `stm_proxy.json` (the documented place) reached `config.proxy` but never surfacing, so the model-aware budgets (`effective_max_injection_chars` / `effective_max_results`) silently used un-scaled defaults.

## Fix

Both fixes live in a new `_apply_proxy_file_config(config, proxy_env_overrides)` helper called from `app_lifespan`: load the file unconditionally with env deep-merged on top, then re-apply the `consumer_model` propagation after the swap (same `if proxy set and surfacing unset` guard as `model_post_init`).

**CLI mirror (#420) updated in the same change:** `mms stats` mirrored the server's env bypass (`config_status: "env"`, "JSON file bypassed" output) to keep probing the same metrics db as the server. With the server now honoring the file, the mirror does too — the `"env"` status and bypass text are removed, and the file-level `metrics.db_path` is honored under env-enabled mode. Updating one side without the other would make them contradict. The `collect_proxy_env_overrides` docstring loses its stale "except `ENABLED`" clause.

## Behavior change

- With `MEMTOMEM_STM_PROXY__ENABLED` set **and** a JSON config file present, the server now loads the file (upstreams, metrics paths, compression settings, …) and overlays env vars on top, instead of running env-only with zero upstreams. Set env vars still win field-by-field; `enabled` from env still wins over the file.
- `mms stats` no longer reports `config_status: "env"` / "JSON file bypassed" — it reports the file status (`ok`/`missing`/`invalid`) and honors a file-level `metrics.db_path`, matching the new server behavior.
- A `consumer_model` set only in the JSON file now activates surfacing's model-aware injection/result scaling (previously inert).

## Tests

- `test_file_config_loaded_even_when_env_enabled` (lifespan level): pins that `load_from_file` is called with the env overlay even when the env var is set — **fails before the fix** (the guard skips the call).
- `TestApplyProxyFileConfig` (helper contract): env-enabled keeps file upstreams while env wins on `enabled`; file `consumer_model` reaches `effective_max_injection_chars()` (3000 → 5000 for a >200K-context model); an explicitly-set surfacing `consumer_model` is not clobbered.
- `test_env_enabled_still_honors_file_metrics_path` (CLI): rewritten from the #420 bypass test; asserts `config_status: "ok"` and that the file's seeded metrics db is probed — **fails before the fix** (`"env"`, db ignored).

`uv run pytest -m "not ollama"`: 3001 passed, 3 skipped. `ruff check src` + `ruff format --check src` clean. mypy: no errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
