### PR TITLE
fix(surfacing): re-apply durable feedback demotion on the cache-hit path

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -561,8 +561,13 @@ class SurfacingEngine:
 
         Filters out memory IDs in ``_invalidated_ids`` — memories the agent
         already rated ``not_relevant`` or ``already_known`` within the cache
-        TTL window. A filtered-empty result pass-throughs like the natural
-        empty case.
+        TTL window — and re-applies the durable feedback-demotion filter,
+        symmetric with the miss path: a memory that crossed the
+        negative-feedback threshold after this entry was cached (e.g.
+        feedback recorded by another process sharing ``stm_feedback.db``,
+        which never reaches this engine's in-memory sets) must not keep
+        resurfacing from a warm entry for the rest of the TTL. A
+        filtered-empty result pass-throughs like the natural empty case.
         """
         # Track whether the entry started non-empty so we can distinguish a
         # ``no_results_invalidated`` outcome (had results, all rejected) from
@@ -582,9 +587,31 @@ class SurfacingEngine:
                     original_count,
                     len(cached),
                 )
+        # ``_feedback_demoted_ids`` gates itself on the tracker /
+        # ``record_feedback_events`` / ``feedback_demotion_enabled``, so the
+        # dedup-only daemon path and no-tracker engines skip the DB read.
+        demoted_all = False
+        if cached:
+            demoted_ids = self._feedback_demoted_ids([str(r.chunk.id) for r in cached])
+            if demoted_ids:
+                original_count = len(cached)
+                cached = [r for r in cached if str(r.chunk.id) not in demoted_ids]
+                demoted_all = not cached
+                logger.debug(
+                    "Surfacing cache filter: %s/%s %d→%d (demoted)",
+                    server,
+                    tool,
+                    original_count,
+                    len(cached),
+                )
         if not cached:
             if was_empty:
                 self._observability.record_skip(tool, "no_results_empty_cache")
+            elif demoted_all:
+                # Same label as the miss path's all-demoted branch: the
+                # operator sees demotion (not invalidation) suppressing the
+                # cached result.
+                self._observability.record_skip(tool, "no_results_demoted")
             else:
                 self._observability.record_skip(tool, "no_results_invalidated")
             logger.debug("Surfacing cache hit (empty) for %s/%s", server, tool)
@@ -761,7 +788,9 @@ class SurfacingEngine:
         # Filter by score, then locally demote memories with repeated durable
         # negative feedback, then exclude already-surfaced memories in this
         # session. Demotion sits before cache write so a rejected memory does
-        # not keep reappearing from a cached query after process restart.
+        # not keep reappearing from a cached query after process restart;
+        # ``_render_cached`` re-applies it on the hit path for entries whose
+        # memories cross the threshold mid-TTL (e.g. via another process).
         scored = [r for r in results if r.score >= min_score]
         demoted_ids = self._feedback_demoted_ids([str(r.chunk.id) for r in scored])
         if demoted_ids:

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -933,6 +933,102 @@ class TestFeedbackDemotion:
         finally:
             tracker.close()
 
+    async def test_cache_hit_filters_durably_demoted_memory(self, tmp_path: Path):
+        """#404 applies the demotion filter only on the cache-MISS path. A
+        memory that crosses the durable negative-feedback threshold while a
+        cache entry is warm — e.g. feedback recorded by a different process
+        sharing ``stm_feedback.db``, which never touches this engine's
+        in-memory ``_invalidated_ids`` — must not resurface from the cache
+        hit for the rest of the TTL."""
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+        from memtomem_stm.surfacing.observability import SurfacingObservability
+
+        tracker = FeedbackTracker(config=_make_config(), db_path=tmp_path / "fb.db")
+        try:
+            results = [
+                FakeSearchResult(
+                    chunk=FakeChunk(id="late-demoted", content="memory that crossed mid-TTL"),
+                    score=0.9,
+                )
+            ]
+            obs = SurfacingObservability()
+            engine = SurfacingEngine(
+                config=_make_config(feedback_demotion_negative_threshold=3),
+                mcp_adapter=_make_mcp_adapter(results),
+                feedback_tracker=tracker,
+                observability=obs,
+            )
+            args = {"_context_query": "stable cache key for late demotion"}
+
+            # Miss path: zero negatives — the memory surfaces and is cached.
+            first = await engine.surface("gh", "read_file", args, LONG_RESPONSE)
+            assert "memory that crossed mid-TTL" in first
+
+            # Cross the threshold OUT of band — directly on the shared store,
+            # as another process would. ``_invalidated_ids`` stays empty.
+            for i in range(3):
+                sid = f"sid-ext-{i}"
+                tracker.record_surfacing(sid, "gh", "read_file", "q", ["late-demoted"], [0.9])
+                tracker.record_feedback(sid, "not_relevant", "late-demoted")
+
+            second = await engine.surface("gh", "read_file", args, LONG_RESPONSE)
+            assert "memory that crossed mid-TTL" not in second
+            snap = obs.snapshot()
+            assert snap["cache"] == {"miss": 1, "hit": 1}
+            # Same label the miss path records for an all-demoted result, so
+            # the operator sees demotion (not dedup / score) suppressing it.
+            assert snap["skip_reasons"]["read_file"] == {"no_results_demoted": 1}
+        finally:
+            tracker.close()
+
+    async def test_cache_hit_keeps_non_demoted_memories(self, tmp_path: Path):
+        """Partial demotion on the hit path filters only the offending
+        memory — the remaining cached results still render as a normal
+        cache-hit injection."""
+        from memtomem_stm.surfacing.feedback import FeedbackTracker
+        from memtomem_stm.surfacing.observability import SurfacingObservability
+
+        tracker = FeedbackTracker(config=_make_config(), db_path=tmp_path / "fb.db")
+        try:
+            results = [
+                FakeSearchResult(
+                    chunk=FakeChunk(id="bad", content="memory demoted mid-TTL"),
+                    score=0.9,
+                ),
+                FakeSearchResult(
+                    chunk=FakeChunk(id="good", content="memory that stays useful"),
+                    score=0.8,
+                ),
+            ]
+            obs = SurfacingObservability()
+            engine = SurfacingEngine(
+                config=_make_config(feedback_demotion_negative_threshold=3),
+                mcp_adapter=_make_mcp_adapter(results),
+                feedback_tracker=tracker,
+                observability=obs,
+            )
+            args = {"_context_query": "stable cache key for partial demotion"}
+
+            first = await engine.surface("gh", "read_file", args, LONG_RESPONSE)
+            assert "memory demoted mid-TTL" in first
+            assert "memory that stays useful" in first
+
+            for i in range(3):
+                sid = f"sid-ext-{i}"
+                tracker.record_surfacing(sid, "gh", "read_file", "q", ["bad"], [0.9])
+                tracker.record_feedback(sid, "not_relevant", "bad")
+
+            second = await engine.surface("gh", "read_file", args, LONG_RESPONSE)
+            assert "memory demoted mid-TTL" not in second
+            assert "memory that stays useful" in second
+            snap = obs.snapshot()
+            assert snap["outcomes"]["read_file"] == {
+                "surfaced_cache_miss": 1,
+                "surfaced_cache_hit": 1,
+            }
+        finally:
+            tracker.close()
+
 
 class TestHandleFeedbackBatch:
     """Batched per-memory ratings (#353 part 1).


### PR DESCRIPTION
## Summary

#404's negative-feedback demotion filter runs only on the cache-MISS path, before the cache write. `_render_cached` filters cache hits solely against `_invalidated_ids` — an in-memory set populated only by feedback submitted through *this* engine during the TTL window. A memory that crosses the durable demotion threshold via feedback recorded in a **different process** (the proxy and daemon share `stm_feedback.db`) is re-surfaced by every cache hit until the entry TTL-expires — contradicting the miss-path comment's promise that a rejected memory "does not keep reappearing from a cached query". (2026-06-10 review; reported both as the medium L89 and low L116 findings — same bug.)

## Fix

Intersect the cached list with `_feedback_demoted_ids(...)` in `_render_cached`, symmetric with the miss path:

- The helper already gates itself on `feedback_tracker` / `record_feedback_events` / `feedback_demotion_enabled`, so the dedup-only daemon path and no-tracker engines skip the DB read entirely — no new config knob needed.
- When demotion (not invalidation) empties a hit, the same `no_results_demoted` label the miss path records is used, so `stm_surfacing_stats` shows which filter suppressed the cached result. The miss-path comment now documents the hit-path symmetry.

## Tests

Both drive the real `FeedbackTracker` across a miss→hit sequence, with threshold-crossing feedback recorded **directly on the store** (as another process would — `_invalidated_ids` stays empty), and **fail before the fix** with the demoted memory resurfacing from cache:

- `test_cache_hit_filters_durably_demoted_memory`: all-demoted hit → content absent, `cache == {miss: 1, hit: 1}`, skip label `no_results_demoted`.
- `test_cache_hit_keeps_non_demoted_memories`: partial demotion → offending memory absent, surviving memory still renders as a normal `surfaced_cache_hit`.

`uv run pytest -m "not ollama"`: 2999 passed, 3 skipped. `ruff check src` + `ruff format --check src` clean.

Note: mypy (advisory) flags the bare `no_results_demoted` literal at both record sites — the miss-path one has existed since #404; both resolve when the `SkipReason` Literal member lands (#429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
