### PR TITLE
fix(compression): bound over-length LLM summaries to max_chars on the success path

### DIFF
--- a/docs/compression.md
+++ b/docs/compression.md
@@ -262,7 +262,7 @@ Routes through an external LLM for intelligent summarization:
 }
 ```
 
-Providers: `openai`, `anthropic`, `ollama`. `llm_timeout_seconds` (default 60.0) bounds the per-call LLM wait. On timeout, privacy-pattern hit, circuit-breaker open, or any other API failure, compression falls back to `TruncateCompressor` and records the strategy as `llm_summary→{timeout,privacy,circuit_breaker,llm_error}_fallback` in `proxy_metrics` for observability.
+Providers: `openai`, `anthropic`, `ollama`. `llm_timeout_seconds` (default 60.0) bounds the per-call LLM wait. On timeout, privacy-pattern hit, circuit-breaker open, or any other API failure, compression falls back to `TruncateCompressor` and records the strategy as `llm_summary→{timeout,privacy,circuit_breaker,llm_error}_fallback` in `proxy_metrics` for observability. A successful call whose summary still exceeds `max_chars` is clamped by the same truncation and recorded as `llm_summary→llm_overlength_fallback` — the model overshot the length instruction; the endpoint is fine, so the circuit breaker is unaffected.
 
 Sensitive content (API keys, passwords, PII) is auto-detected and **never** sent to external LLMs — falls back to local truncation.
 

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -2262,6 +2262,23 @@ class LLMCompressor:
                 timeout=self._cfg.llm_timeout_seconds,
             )
             self._cb.success()
+            if len(result) > max_chars:
+                # The system prompt only ASKS the model to honor max_chars;
+                # models routinely overshoot length constraints, and nothing
+                # downstream clamps the success path (the manager's ratio
+                # guard fires only on UNDER-retention). Bound the summary the
+                # way every sync tier bounds its output — keep the LLM's
+                # distillation, clamped. The breaker is not failed: the API
+                # responded fine, this is a model-quality event.
+                logger.warning(
+                    "LLM summary exceeded budget (%d > %d chars, strategy=llm/%s), "
+                    "truncating the summary",
+                    len(result),
+                    max_chars,
+                    self._cfg.provider.value,
+                )
+                self.last_fallback = "llm_overlength"
+                return TruncateCompressor().compress(result, max_chars=max_chars)
             return result
         except asyncio.TimeoutError:
             self._cb.failure()

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -380,6 +380,44 @@ class TestLLMCompressorFallback:
         await comp.compress("short", max_chars=1000)
         assert comp.last_fallback is None
 
+    @pytest.mark.asyncio
+    async def test_overlength_llm_output_is_bounded(self):
+        """The system prompt only ASKS the model to honor max_chars — a
+        model that overshoots must not leak an over-budget payload through
+        the success path. Every sync tier provably bounds its output to
+        max_chars; the LLM success path was the sole exception (it returned
+        the model string verbatim, and the manager's ratio guard checks
+        only UNDER-retention, never the upper bound)."""
+        comp = _make_llm_compressor()
+        text = "Long document content. " * 50
+        with patch.object(comp, "_call_api", new=AsyncMock(return_value="X" * 1000)):
+            result = await comp.compress(text, max_chars=200)
+        assert len(result) <= 200
+        assert comp.last_fallback == "llm_overlength"
+
+    @pytest.mark.asyncio
+    async def test_overlength_does_not_count_as_breaker_failure(self):
+        """Overshoot is a model-quality event, not an endpoint failure —
+        the API responded fine, so it must not accumulate toward opening
+        the circuit breaker the way timeouts and errors do."""
+        comp = _make_llm_compressor()
+        text = "Long document content. " * 50
+        with patch.object(comp, "_call_api", new=AsyncMock(return_value="X" * 1000)):
+            for _ in range(4):
+                await comp.compress(text, max_chars=200)
+        assert not comp._cb.is_open
+
+    @pytest.mark.asyncio
+    async def test_within_budget_llm_output_returned_verbatim(self):
+        """The clamp must not touch a compliant summary — within-budget
+        output is returned exactly as the model produced it."""
+        comp = _make_llm_compressor()
+        text = "Long document content. " * 50
+        with patch.object(comp, "_call_api", new=AsyncMock(return_value="ok summary")):
+            result = await comp.compress(text, max_chars=200)
+        assert result == "ok summary"
+        assert comp.last_fallback is None
+
 
 # ---------------------------------------------------------------------------
 # LLMCompressor — llm_timeout_seconds guards a slow/hung LLM endpoint (#207)


### PR DESCRIPTION
## Summary

Every sync compressor tier provably bounds its output to `max_chars` (the 2026-06-10 review verified this empirically across 300+ random JSON shapes — zero over-budget). `LLMCompressor.compress()` is the sole exception: the success path returns the model's content string verbatim. The system prompt only *asks* the model to honor `max_chars` (`system_prompt.format(max_chars=...)`), and LLMs routinely overshoot length constraints. Nothing downstream clamps it — the manager's ratio guard fires only on UNDER-retention — so `LLM_SUMMARY` can silently return a payload **larger** than the budget the whole pipeline exists to enforce. Every failure path (timeout / circuit-breaker / privacy / error) already bounds output via `TruncateCompressor`, which highlights the success path as the one gap.

## Fix

When the model's output exceeds `max_chars`, truncate the **summary** (not the original text — the LLM's distillation retains more signal per char) via the same `TruncateCompressor` the failure paths use, log a warning, and set `last_fallback = "llm_overlength"` so the overshoot is observable through the existing fallback channel (`manager` reads `compressor.last_fallback` for metrics). The circuit breaker is **not** failed — the API responded fine; overshoot is a model-quality event, not an endpoint failure.

## Tests

- `test_overlength_llm_output_is_bounded`: mocked `_call_api` returning a 1000-char string at `max_chars=200` → result ≤ 200 + `llm_overlength` marker. **Fails before the fix** (over-budget payload leaks through).
- `test_overlength_does_not_count_as_breaker_failure`: 4 consecutive overshoots leave the breaker closed.
- `test_within_budget_llm_output_returned_verbatim`: compliant summaries are untouched, `last_fallback` stays `None`.

`uv run pytest -m "not ollama"`: 3000 passed, 3 skipped. `ruff check src` + `ruff format --check src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
