### PR TITLE
fix(progressive): read_more continues with the originating tool's chunk_size and hint preference

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1044,6 +1044,8 @@ class ProxyManager:
             server=server,
             tool=tool,
             trace_id=trace_id,
+            chunk_size=cfg.chunk_size,
+            include_structure_hint=cfg.include_structure_hint,
         )
         store.put(key, resp)
 
@@ -1096,8 +1098,14 @@ class ProxyManager:
             },
         ):
             store.touch(key)
-            chunk_size = limit or 4000
-            chunker = ProgressiveChunker(chunk_size=chunk_size, include_hint=True)
+            # Continue with the chunking the first chunk used (persisted on
+            # the ProgressiveResponse) — an explicit ``limit`` from the agent
+            # still wins. Hardcoding ``4000`` here made follow-ups diverge
+            # from a tuned ``progressive.chunk_size`` / hint preference.
+            chunk_size = limit or resp.chunk_size
+            chunker = ProgressiveChunker(
+                chunk_size=chunk_size, include_hint=resp.include_structure_hint
+            )
             output = chunker.read_chunk(
                 resp.content, offset, limit, key=key, ttl_seconds=resp.ttl_seconds
             )

--- a/src/memtomem_stm/proxy/progressive.py
+++ b/src/memtomem_stm/proxy/progressive.py
@@ -43,6 +43,13 @@ class ProgressiveResponse:
     # ``None`` only for legacy rows deserialized without the key; the live
     # ``call_tool`` path always populates ``trace_id`` via auto-gen UUID.
     trace_id: str | None = None
+    # Chunking parameters from the originating tool's ``ProgressiveConfig``,
+    # persisted so ``read_more`` continues with the same chunk size and
+    # structure-hint preference the first chunk used — without these,
+    # follow-up reads reverted to a hardcoded 4000/hint-on. Defaults match
+    # that historical behavior so legacy rows deserialize unchanged.
+    chunk_size: int = 4000
+    include_structure_hint: bool = True
 
 
 class ProgressiveStoreAdapter:
@@ -66,6 +73,8 @@ class ProgressiveStoreAdapter:
                 "server": resp.server,
                 "tool": resp.tool,
                 "trace_id": resp.trace_id,
+                "chunk_size": resp.chunk_size,
+                "include_structure_hint": resp.include_structure_hint,
             },
             ensure_ascii=False,
         )
@@ -104,6 +113,8 @@ class ProgressiveStoreAdapter:
             server=meta.get("server", ""),
             tool=meta.get("tool", ""),
             trace_id=meta.get("trace_id"),
+            chunk_size=meta.get("chunk_size", 4000),
+            include_structure_hint=meta.get("include_structure_hint", True),
         )
 
     def touch(self, key: str) -> None:

--- a/tests/test_progressive.py
+++ b/tests/test_progressive.py
@@ -610,6 +610,114 @@ class TestProgressiveTTL:
         assert got.ttl_seconds == 600.0
 
 
+class TestReadMoreRespectsProgressiveConfig:
+    """``read_more`` must continue with the same chunking the first chunk
+    used. ``ProgressiveResponse`` did not persist ``chunk_size`` /
+    ``include_structure_hint``, so ``read_more`` hardcoded ``limit or 4000``
+    and ``include_hint=True``: a tool configured with
+    ``progressive.chunk_size=2000, include_structure_hint=False`` got a
+    2000-char hintless first chunk and then 4000-char hinted follow-ups."""
+
+    def _build_manager(self):
+        from memtomem_stm.proxy.config import ProxyConfig
+        from memtomem_stm.proxy.manager import ProxyManager
+        from memtomem_stm.proxy.metrics import TokenTracker
+
+        return ProxyManager(ProxyConfig(enabled=True), TokenTracker())
+
+    def _apply_and_get_key(self, mgr, text, cfg):
+        first = mgr._apply_progressive(text, cfg, server="srv", tool="tool_c", trace_id="t3")
+        store = mgr._get_progressive_store()
+        key = next(iter(store._store._data.keys()))  # type: ignore[attr-defined]
+        return first, key
+
+    def test_follow_up_uses_configured_chunk_size(self):
+        mgr = self._build_manager()
+        text = "z" * 12000  # no natural boundaries → exact-size chunks
+        cfg = ProgressiveConfig(chunk_size=2000, include_structure_hint=False)
+        first, key = self._apply_and_get_key(mgr, text, cfg)
+        initial = len(first.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
+        assert initial == 2000
+
+        second = mgr.read_more(key, offset=initial)  # no explicit limit
+        chunk = second.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0]
+        assert len(chunk) == 2000  # pre-fix: reverted to 4000
+
+    def test_follow_up_respects_hint_suppression(self):
+        mgr = self._build_manager()
+        # Headings dense enough that a follow-up footer would carry a
+        # ``[Remaining: ...]`` hint if include_hint were wrongly re-enabled.
+        text = "\n".join(f"## Heading {i}\n" + "body " * 80 for i in range(30))
+        cfg = ProgressiveConfig(chunk_size=1500, include_structure_hint=False)
+        first, key = self._apply_and_get_key(mgr, text, cfg)
+        assert "[Remaining:" not in first
+        initial = len(first.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
+
+        second = mgr.read_more(key, offset=initial)
+        assert PROGRESSIVE_FOOTER_TOKEN in second
+        assert "[Remaining:" not in second  # pre-fix: hint re-appeared
+
+    def test_explicit_limit_still_overrides(self):
+        """An explicit ``limit`` from the agent keeps winning over the
+        persisted config — only the no-limit default changes."""
+        mgr = self._build_manager()
+        text = "z" * 12000
+        cfg = ProgressiveConfig(chunk_size=2000, include_structure_hint=False)
+        first, key = self._apply_and_get_key(mgr, text, cfg)
+        initial = len(first.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
+
+        second = mgr.read_more(key, offset=initial, limit=500)
+        chunk = second.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0]
+        assert len(chunk) == 500
+
+    def test_store_adapter_round_trips_chunking_fields(self):
+        store = ProgressiveStoreAdapter(InMemoryPendingStore())
+        resp = ProgressiveResponse(
+            content="hello",
+            total_chars=5,
+            total_lines=1,
+            content_type="text",
+            structure_hint="1 lines",
+            created_at=time.monotonic(),
+            chunk_size=2500,
+            include_structure_hint=False,
+        )
+        store.put("key1", resp)
+        got = store.get("key1")
+        assert got is not None
+        assert got.chunk_size == 2500
+        assert got.include_structure_hint is False
+
+    def test_legacy_meta_rows_default_to_previous_behavior(self):
+        """Rows persisted before these fields existed deserialize to the
+        historical hardcoded behavior (4000 / hint on) — not a crash."""
+        import json
+
+        inner = InMemoryPendingStore()
+        store = ProgressiveStoreAdapter(inner)
+        resp = ProgressiveResponse(
+            content="hello",
+            total_chars=5,
+            total_lines=1,
+            content_type="text",
+            structure_hint="",
+            created_at=time.monotonic(),
+        )
+        store.put("key1", resp)
+        # Strip the new keys to simulate a legacy persisted row.
+        sel = inner.get("key1")
+        assert sel is not None
+        meta = json.loads(sel.chunks["__meta__"])
+        meta.pop("chunk_size", None)
+        meta.pop("include_structure_hint", None)
+        sel.chunks["__meta__"] = json.dumps(meta)
+
+        got = store.get("key1")
+        assert got is not None
+        assert got.chunk_size == 4000
+        assert got.include_structure_hint is True
+
+
 # ---------------------------------------------------------------------------
 # Remaining headings hint
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`read_more` hardcodes `chunk_size = limit or 4000` and `include_hint=True`, while `_apply_progressive` builds the **first** chunk from the per-tool `ProgressiveConfig` (`cfg.chunk_size` / `cfg.include_structure_hint`). `ProgressiveResponse` never persisted those values, so `read_more` couldn't recover them. For a tool configured with `progressive.chunk_size=2000, include_structure_hint=False`: the first chunk is 2000 chars with no `[Remaining: ...]` hint, but every follow-up reverts to 4000 chars **and** emits hints — operators who tuned the chunk size down to fit a smaller context window silently get 2x-larger continuation reads. (2026-06-10 review, medium; empirically reproduced there.)

## Fix

Persist `chunk_size` and `include_structure_hint` on `ProgressiveResponse` — set from `cfg` in `_apply_progressive`, round-tripped through `ProgressiveStoreAdapter`'s `__meta__` JSON — and read them back in `read_more` (`chunk_size = limit or resp.chunk_size`, `include_hint=resp.include_structure_hint`). An explicit `limit` from the agent still wins; only the no-limit default changes. The new dataclass fields default to `4000` / `True` (the historical hardcoded behavior), so rows persisted before this change deserialize to exactly the previous semantics.

## Tests

- `test_follow_up_uses_configured_chunk_size`: **fails before the fix** (`4000 != 2000`).
- `test_follow_up_respects_hint_suppression`: **fails before the fix** (hint re-appears on the follow-up).
- `test_explicit_limit_still_overrides`: agent-passed `limit` keeps winning (passes pre and post — invariant pin).
- `test_store_adapter_round_trips_chunking_fields` + `test_legacy_meta_rows_default_to_previous_behavior`: adapter round-trip and legacy-row compatibility.

`uv run pytest -m "not ollama"`: 3002 passed, 3 skipped. `ruff check src` + `ruff format --check src` clean. mypy: no errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
