### PR TITLE
fix(surfacing): clamp persisted AutoTuner adjustments to the current band on load

### DIFF
--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -115,6 +115,38 @@ class AutoTuner:
             config.min_score,
         )
         self._purge_pinned_adjustments()
+        self._clamp_loaded_adjustments()
+
+    def _clamp_loaded_adjustments(self) -> None:
+        """Re-clamp persisted adjustments to the CURRENT config band.
+
+        #392 made the floor/ceiling configurable, but persisted values
+        (#332) were resumed verbatim: narrowing the band between runs left
+        an out-of-band threshold in effect until fresh feedback happened to
+        fire ``maybe_adjust`` for that tool — with no feedback, forever
+        (``_purge_pinned_adjustments`` only drops pinned tools, not
+        out-of-band values). Clamping on load makes the configured bounds
+        authoritative regardless of restart timing. The clamped value is
+        persisted back so the DB row converges instead of re-clamping on
+        every start. Runs after the pin purge, so purged tools keep their
+        persisted row untouched per the purge contract.
+        """
+        floor = self._config.auto_tune_score_floor
+        ceiling = self._config.auto_tune_score_ceiling
+        for tool, score in list(self._adjustments.items()):
+            clamped = min(max(score, floor), ceiling)
+            if clamped != score:
+                self._adjustments[tool] = clamped
+                self._store.save_adjustment(tool, clamped)
+                logger.info(
+                    "AutoTuner: clamped persisted adjustment for %r from %.4f to %.4f "
+                    "(current band [%.4f, %.4f])",
+                    tool,
+                    score,
+                    clamped,
+                    floor,
+                    ceiling,
+                )
 
     def _purge_pinned_adjustments(self) -> None:
         """Suppress persisted adjustments for operator-pinned tools.

--- a/tests/test_surfacing_autotune_bounds.py
+++ b/tests/test_surfacing_autotune_bounds.py
@@ -117,3 +117,66 @@ class TestPinPurge:
         with caplog.at_level(logging.INFO, logger="memtomem_stm.surfacing.feedback"):
             AutoTuner(cfg, _store(adjustments={"read_file": 0.04}))
         assert any("suppressed 1 persisted adjustment" in r.message for r in caplog.records)
+
+
+class TestClampOnLoad:
+    """Persisted adjustments are re-clamped to the CURRENT config band on
+    load. #392 made the floor/ceiling configurable, but persistence (#332)
+    predates it and resumed values verbatim: an operator narrowing the band
+    between runs (e.g. ceiling 0.05 → 0.03, min_score kept in-band so config
+    validation passes) left the stale out-of-band threshold active until
+    fresh feedback happened to fire ``maybe_adjust`` for that tool — with no
+    feedback, forever."""
+
+    def test_loaded_adjustment_above_ceiling_is_clamped(self):
+        cfg = SurfacingConfig(
+            auto_tune_enabled=True,
+            min_score=0.02,
+            auto_tune_score_floor=0.005,
+            auto_tune_score_ceiling=0.03,
+        )
+        store = _store(adjustments={"read_file": 0.05})
+        tuner = AutoTuner(cfg, store)
+        assert tuner.get_effective_min_score("read_file") == 0.03
+        # The persisted row converges too — not just the in-memory view —
+        # so the clamp doesn't have to re-run on every start.
+        store.save_adjustment.assert_called_once_with("read_file", 0.03)
+
+    def test_loaded_adjustment_below_floor_is_clamped(self):
+        cfg = SurfacingConfig(
+            auto_tune_enabled=True,
+            min_score=0.03,
+            auto_tune_score_floor=0.02,
+        )
+        store = _store(adjustments={"read_file": 0.001})
+        tuner = AutoTuner(cfg, store)
+        assert tuner.get_effective_min_score("read_file") == 0.02
+        store.save_adjustment.assert_called_once_with("read_file", 0.02)
+
+    def test_in_band_adjustment_left_untouched(self):
+        cfg = SurfacingConfig(
+            auto_tune_enabled=True,
+            min_score=0.02,
+            auto_tune_score_ceiling=0.05,
+        )
+        store = _store(adjustments={"read_file": 0.04})
+        tuner = AutoTuner(cfg, store)
+        assert tuner.get_effective_min_score("read_file") == 0.04
+        store.save_adjustment.assert_not_called()
+
+    def test_pinned_tool_is_purged_not_clamped(self):
+        """Purge runs before the clamp: a pinned tool's out-of-band
+        persisted adjustment is dropped from the in-memory map with NO
+        store write — the purge contract leaves the persisted row intact
+        so removing the pin later restores the learned value (which the
+        next load then clamps if still out of band)."""
+        cfg = SurfacingConfig(
+            auto_tune_enabled=True,
+            min_score=0.02,
+            auto_tune_score_ceiling=0.03,
+            context_tools={"read_file": ToolSurfacingConfig(min_score=0.5)},
+        )
+        store = _store(adjustments={"read_file": 0.05})
+        tuner = AutoTuner(cfg, store)
+        assert "read_file" not in tuner.adjustments
+        store.save_adjustment.assert_not_called()


### PR DESCRIPTION
## Summary

`AutoTuner.__init__` resumes persisted per-tool `min_score` adjustments verbatim (#332). The configurable-bounds validation (#392) runs only at config-validation time, and the per-adjustment clamp only inside `maybe_adjust()` — `get_effective_min_score()` returns the raw persisted value with no re-clamp against the **current** config's `[auto_tune_score_floor, auto_tune_score_ceiling]`.

So an operator who narrows the band between runs (e.g. ceiling `0.05 → 0.03`, keeping `min_score` in-band so config validation passes) loads a value persisted at the old ceiling and uses it indefinitely. It converges only if fresh feedback happens to fire `maybe_adjust` for that tool — with no feedback, the stale out-of-band threshold persists forever. `_purge_pinned_adjustments()` only drops *pinned* tools, not out-of-band values. (2026-06-10 review; repro confirmed there: persisted `{'read_file': 0.05}` + new ceiling `0.03` → `get_effective_min_score` returns `0.05`.)

## Fix

`_clamp_loaded_adjustments()` at the end of `__init__`, after the pin purge:

- Clamps each loaded adjustment to `[floor, ceiling]`; the configured bounds are authoritative regardless of restart timing.
- Persists the clamped value back (`store.save_adjustment`) so the DB row converges instead of re-clamping on every start.
- Runs **after** `_purge_pinned_adjustments`, so purged (pinned) tools keep their persisted row untouched per the purge contract — removing the pin later restores the learned value, which the next load then clamps if still out of band.

## Tests

- `test_loaded_adjustment_above_ceiling_is_clamped` / `test_loaded_adjustment_below_floor_is_clamped`: **fail before the fix** (out-of-band values escape); also pin the convergence write.
- `test_in_band_adjustment_left_untouched`: no clamp, no store write.
- `test_pinned_tool_is_purged_not_clamped`: purge-before-clamp ordering — no store write for pinned tools.

This closes the companion test-gap finding too: the restart-bounded invariant ("a loaded adjustment never exceeds the current band") is now pinned, where previously only same-config round-trips were tested.

`uv run pytest -m "not ollama"`: 3001 passed, 3 skipped. `ruff check src` + `ruff format --check src` clean. mypy: the one flagged line (`feedback_store.py:341`) is pre-existing on main, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
