### PR TITLE
fix(daemon): sweep for a leaked LTM child when adapter teardown unwinds cross-task

### DIFF
--- a/src/memtomem_stm/daemon/server.py
+++ b/src/memtomem_stm/daemon/server.py
@@ -33,12 +33,15 @@ import logging
 import os
 import secrets
 import signal
+import subprocess
+import sys
 import time
 from typing import Any
 
 from memtomem_stm.cli.hook_cmd import run_surfacing_hook
 from memtomem_stm.config import STMConfig
 from memtomem_stm.daemon import discovery, locking
+from memtomem_stm.utils.anyio_shutdown import is_clean_cancel_scope_shutdown
 from memtomem_stm.daemon.protocol import (
     MAX_MESSAGE_BYTES,
     OP_PING,
@@ -65,6 +68,62 @@ async def _quiet(coro: Any, what: str) -> None:
         await coro
     except Exception:
         logger.debug("%s failed", what, exc_info=True)
+
+
+def _direct_child_pids() -> set[int]:
+    """Best-effort set of this process's direct child pids (POSIX only).
+
+    Used by the teardown leak sweep. Returns an empty set on Windows or when
+    ``pgrep`` is unavailable/fails, degrading the sweep to a no-op rather
+    than blocking shutdown. ``pgrep`` never reports its own pid, so the
+    probe doesn't observe itself.
+    """
+    if sys.platform == "win32":
+        return set()
+    try:
+        out = subprocess.run(
+            ["pgrep", "-P", str(os.getpid())],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+            check=False,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {int(tok) for tok in out.split() if tok.isdigit()}
+
+
+# Grace window between SIGTERM and SIGKILL for a leaked LTM child — matches
+# the escalation timeout mcp's own stdio shutdown sequence uses.
+_LEAK_KILL_ESCALATE_SECONDS = 2.0
+
+
+def _signal_pid(pid: int, sig: int) -> None:
+    """Best-effort signal to *pid*'s process group, or *pid* alone when it
+    shares the daemon's group (never signal our own group). The stdio LTM
+    child is spawned with ``start_new_session=True``, so the group kill also
+    reaches grandchildren (e.g. ``uv run memtomem`` wrappers)."""
+    try:
+        pgid = os.getpgid(pid)
+        if pgid != os.getpgid(0):
+            os.killpg(pgid, sig)
+        else:
+            os.kill(pid, sig)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+async def _terminate_leaked_children(pids: set[int]) -> None:
+    """SIGTERM each leaked child's process group, then SIGKILL stragglers."""
+    for pid in pids:
+        _signal_pid(pid, signal.SIGTERM)
+    deadline = asyncio.get_running_loop().time() + _LEAK_KILL_ESCALATE_SECONDS
+    remaining = {pid for pid in pids if discovery.is_pid_alive(pid)}
+    while remaining and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.05)
+        remaining = {pid for pid in remaining if discovery.is_pid_alive(pid)}
+    for pid in remaining:
+        _signal_pid(pid, signal.SIGKILL)
 
 
 class DaemonServer:
@@ -238,13 +297,45 @@ class DaemonServer:
             except Exception:
                 logger.debug("tracker close failed", exc_info=True)
         if self._adapter is not None:
-            await _quiet(self._adapter.stop(), "LTM adapter stop")
+            await self._stop_adapter()
         if self._handshake_written:
             discovery.remove_handshake_if_owner(
                 discovery.handshake_path(self._config.data_dir, self._fingerprint),
                 pid=os.getpid(),
                 token=self._token,
             )
+
+    async def _stop_adapter(self) -> None:
+        """Stop the LTM adapter without leaking its warm child process.
+
+        The adapter lazy-starts inside whichever connection-handler task
+        first needed LTM, so the stdio transport's anyio cancel scopes belong
+        to that (long-finished) task. Exiting them here — the serve task —
+        makes anyio raise its cross-task cancel-scope RuntimeError partway
+        through the transport's unwind, leaving the warm LTM child's reaping
+        unverified (today's mcp happens to terminate the child before the
+        scope exit, but that ordering is an implementation detail). When the
+        stop fails for any reason, sweep: a direct child present both before
+        and after a failed stop is the leaked LTM child — this process spawns
+        no other children — so terminate it.
+        """
+        before = _direct_child_pids()
+        try:
+            await self._adapter.stop()
+            return
+        except Exception as exc:
+            if is_clean_cancel_scope_shutdown(exc):
+                logger.warning(
+                    "LTM adapter stop hit the cross-task cancel-scope error — "
+                    "sweeping for a leaked LTM child"
+                )
+            else:
+                logger.debug("LTM adapter stop failed", exc_info=True)
+        leaked = before & _direct_child_pids()
+        if not leaked:
+            return
+        logger.warning("terminating leaked LTM child process(es): %s", sorted(leaked))
+        await _terminate_leaked_children(leaked)
 
     # ── connection handling ──────────────────────────────────────────────
 

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -28,13 +28,9 @@ from memtomem_stm.surfacing.observability import (
 )
 from memtomem_stm.observability.tracing import traced
 from memtomem_stm.surfacing.feedback import FeedbackTracker
+from memtomem_stm.utils.anyio_shutdown import is_clean_cancel_scope_shutdown
 
 logger = logging.getLogger(__name__)
-
-_ANYIO_CANCEL_SCOPE_SHUTDOWN_MESSAGES = (
-    "Attempted to exit a cancel scope that isn't the current tasks's current cancel scope",
-    "Attempted to exit cancel scope in a different task than it was entered in",
-)
 
 _HASHED_QUERY_PREVIEW_RE = re.compile(r"sha256:[0-9a-f]{16}")
 """Exact shape of the opaque ID `FeedbackStore.get_stats` passes through
@@ -1443,29 +1439,6 @@ async def stm_tuning_recommendations(
 # ---------------------------------------------------------------------------
 
 
-def _is_anyio_cancel_scope_shutdown_error(exc: RuntimeError) -> bool:
-    """Return true for the AnyIO shutdown cleanup error seen on stdio EOF."""
-
-    message = str(exc)
-    return any(marker in message for marker in _ANYIO_CANCEL_SCOPE_SHUTDOWN_MESSAGES)
-
-
-def _is_clean_cancel_scope_shutdown(exc: BaseException) -> bool:
-    """True when *exc* consists only of AnyIO cancel-scope shutdown errors.
-
-    ``mcp.run()`` executes the server inside ``anyio.create_task_group()``,
-    and anyio >= 4 (strict task groups) wraps anything escaping a task group
-    in an ``ExceptionGroup`` — on stdio EOF the cancel-scope RuntimeError
-    reaches ``main()`` in that wrapped shape, not bare. Walk groups
-    recursively and treat the tree as a clean shutdown only when EVERY leaf
-    is the cancel-scope error; any other leaf is a real failure that must
-    hit the exception barrier.
-    """
-    if isinstance(exc, BaseExceptionGroup):
-        return all(_is_clean_cancel_scope_shutdown(sub) for sub in exc.exceptions)
-    return isinstance(exc, RuntimeError) and _is_anyio_cancel_scope_shutdown_error(exc)
-
-
 def main() -> None:
     """Run the STM MCP server."""
     level = os.environ.get("MEMTOMEM_STM_LOG_LEVEL", "WARNING").upper()
@@ -1484,7 +1457,7 @@ def main() -> None:
         # The bare RuntimeError occurs when the cancel-scope error escapes
         # outside any task group; the ExceptionGroup shape is what anyio's
         # strict task groups actually deliver on stdio EOF (#410 follow-up).
-        if _is_clean_cancel_scope_shutdown(e):
+        if is_clean_cancel_scope_shutdown(e):
             logger.warning(
                 "STM MCP server shut down with AnyIO cancel scope warning (ignored): %s", e
             )

--- a/src/memtomem_stm/utils/anyio_shutdown.py
+++ b/src/memtomem_stm/utils/anyio_shutdown.py
@@ -1,0 +1,45 @@
+"""Detection helpers for AnyIO's cancel-scope shutdown errors.
+
+AnyIO cancel scopes are task-affine: exiting one from a different task than
+entered it raises a ``RuntimeError`` whose message is the only stable way to
+recognize it. Two paths in STM hit that error by construction and must treat
+it as a known shape rather than a crash:
+
+* ``server.main()`` — on stdio EOF the MCP server's own task-group unwind
+  raises it, wrapped in an ``ExceptionGroup`` by anyio >= 4 strict task
+  groups (#209/#410).
+* ``daemon.server.DaemonServer._teardown()`` — the LTM adapter lazy-starts
+  inside a connection-handler task, so stopping it from the serve task exits
+  the stdio transport's scopes cross-task (E-3); the daemon then sweeps for
+  a leaked LTM child.
+"""
+
+from __future__ import annotations
+
+_CANCEL_SCOPE_SHUTDOWN_MESSAGES = (
+    "Attempted to exit a cancel scope that isn't the current tasks's current cancel scope",
+    "Attempted to exit cancel scope in a different task than it was entered in",
+)
+
+
+def is_anyio_cancel_scope_shutdown_error(exc: RuntimeError) -> bool:
+    """Return true for the AnyIO shutdown cleanup error seen on stdio EOF."""
+
+    message = str(exc)
+    return any(marker in message for marker in _CANCEL_SCOPE_SHUTDOWN_MESSAGES)
+
+
+def is_clean_cancel_scope_shutdown(exc: BaseException) -> bool:
+    """True when *exc* consists only of AnyIO cancel-scope shutdown errors.
+
+    ``mcp.run()`` executes the server inside ``anyio.create_task_group()``,
+    and anyio >= 4 (strict task groups) wraps anything escaping a task group
+    in an ``ExceptionGroup`` — on stdio EOF the cancel-scope RuntimeError
+    reaches ``main()`` in that wrapped shape, not bare. Walk groups
+    recursively and treat the tree as a clean shutdown only when EVERY leaf
+    is the cancel-scope error; any other leaf is a real failure that must
+    hit the exception barrier.
+    """
+    if isinstance(exc, BaseExceptionGroup):
+        return all(is_clean_cancel_scope_shutdown(sub) for sub in exc.exceptions)
+    return isinstance(exc, RuntimeError) and is_anyio_cancel_scope_shutdown_error(exc)

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -9,6 +9,9 @@ RPC. That keeps the suite deterministic even on a dev box with a live LTM.
 from __future__ import annotations
 
 import asyncio
+import logging
+import signal
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,9 +20,15 @@ from uuid import uuid4
 
 import pytest
 
+import memtomem_stm.daemon.server as daemon_server
 from memtomem_stm.config import STMConfig
 from memtomem_stm.daemon import client
-from memtomem_stm.daemon.discovery import config_fingerprint, handshake_path, read_handshake
+from memtomem_stm.daemon.discovery import (
+    config_fingerprint,
+    handshake_path,
+    is_pid_alive,
+    read_handshake,
+)
 from memtomem_stm.daemon.protocol import (
     MAX_MESSAGE_BYTES,
     OP_SURFACE,
@@ -380,6 +389,148 @@ async def test_hook_run_hook_no_autospawn_when_daemon_live(
         assert calls == []  # live daemon → no duplicate spawn
     finally:
         await _stop(cfg, task)
+
+
+# ── teardown leak sweep (E-3) ─────────────────────────────────────────────────
+
+
+_CANCEL_SCOPE_MSG = "Attempted to exit cancel scope in a different task than it was entered in"
+
+_FAKE_LTM_SERVER = Path(__file__).parent.parent / "_fake_memtomem_server.py"
+
+
+class _StopRaisingAdapter:
+    """Adapter stub whose ``stop()`` fails like a cross-task scope exit."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def stop(self) -> None:
+        raise self._exc
+
+
+def _sleeping_child() -> subprocess.Popen:
+    """A real direct child mimicking a leaked warm LTM process: its own
+    session (like mcp's stdio child) and a sleep only a signal can end."""
+    return subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        start_new_session=True,
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signals/process groups")
+@pytest.mark.parametrize(
+    "exc",
+    [
+        RuntimeError(_CANCEL_SCOPE_MSG),
+        ExceptionGroup("unhandled errors in a TaskGroup", [RuntimeError(_CANCEL_SCOPE_MSG)]),
+    ],
+    ids=["bare", "group"],
+)
+async def test_teardown_kills_leaked_child_on_cancel_scope_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    exc: BaseException,
+) -> None:
+    # The known E-3 shape: the adapter's stdio scopes were entered in a
+    # connection-handler task, stop() from the serve task raises the
+    # cross-task cancel-scope error (bare, or group-wrapped by anyio >= 4)
+    # — teardown must warn and terminate the surviving LTM child.
+    server = DaemonServer(_config(tmp_path))
+    server._adapter = _StopRaisingAdapter(exc)
+    child = _sleeping_child()
+    try:
+        monkeypatch.setattr(daemon_server, "_direct_child_pids", lambda: {child.pid})
+        monkeypatch.setattr(daemon_server, "_LEAK_KILL_ESCALATE_SECONDS", 0.2)
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.daemon.server"):
+            await server._teardown()
+        assert child.wait(timeout=5.0) == -signal.SIGTERM
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("cross-task cancel-scope" in m for m in messages)
+        assert any("leaked LTM child" in m for m in messages)
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=5.0)
+
+
+async def test_teardown_sweeps_on_generic_stop_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Any stop() failure leaves the unwind incomplete, so the sweep runs —
+    # and kills exactly the children that survived it (before ∩ after).
+    server = DaemonServer(_config(tmp_path))
+    server._adapter = _StopRaisingAdapter(ValueError("boom"))
+    snapshots = iter([{111, 222}, {222}])
+    monkeypatch.setattr(daemon_server, "_direct_child_pids", lambda: next(snapshots))
+    killed: list[set[int]] = []
+
+    async def _record(pids: set[int]) -> None:
+        killed.append(pids)
+
+    monkeypatch.setattr(daemon_server, "_terminate_leaked_children", _record)
+    await server._teardown()
+    assert killed == [{222}]
+
+
+async def test_teardown_clean_adapter_stop_skips_sweep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A successful stop() already awaited the child's exit (mcp's stdio
+    # shutdown sequence) — no second probe, no kill.
+    server = DaemonServer(_config(tmp_path))
+    server._adapter = AsyncMock()
+    probes: list[int] = []
+    monkeypatch.setattr(daemon_server, "_direct_child_pids", lambda: probes.append(1) or set())
+    killed: list[set[int]] = []
+
+    async def _record(pids: set[int]) -> None:
+        killed.append(pids)
+
+    monkeypatch.setattr(daemon_server, "_terminate_leaked_children", _record)
+    await server._teardown()
+    assert probes == [1]  # only the pre-stop snapshot
+    assert killed == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="pgrep-based probe is POSIX-only")
+def test_direct_child_pids_sees_spawned_child() -> None:
+    child = _sleeping_child()
+    try:
+        assert child.pid in daemon_server._direct_child_pids()
+    finally:
+        child.terminate()
+        child.wait(timeout=5.0)
+    # Reaped → no longer listed.
+    assert child.pid not in daemon_server._direct_child_pids()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process probes")
+async def test_real_teardown_reaps_warm_ltm_child(tmp_path: Path) -> None:
+    # E-3 end-to-end: real engine wiring with a stdio LTM (the fake memtomem
+    # server). The lazy LTM start happens inside a connection-handler task,
+    # so daemon shutdown exits the transport's cancel scopes from the serve
+    # task — whatever path that unwind takes, no live LTM child may survive.
+    cfg = _config(tmp_path)
+    cfg.surfacing.timeout_seconds = 15.0
+    cfg.surfacing.ltm_mcp_command = sys.executable
+    cfg.surfacing.ltm_mcp_args = [str(_FAKE_LTM_SERVER)]
+    before = daemon_server._direct_child_pids()
+    _, task = await _start(cfg)  # real _build_engine
+    try:
+        out = await client.surface(cfg, _READ_PAYLOAD, timeout=15.0)
+        assert out is not None
+        ltm_children = daemon_server._direct_child_pids() - before
+        assert ltm_children  # the surface call warmed a real stdio LTM child
+    finally:
+        await client.shutdown(cfg)
+        await asyncio.wait_for(task, timeout=20.0)
+    deadline = asyncio.get_running_loop().time() + 5.0
+    while any(is_pid_alive(pid) for pid in ltm_children):
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(f"leaked LTM child process(es) after teardown: {ltm_children}")
+        await asyncio.sleep(0.1)
 
 
 # ── lifetime ownership lock ───────────────────────────────────────────────────

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -1,9 +1,13 @@
 """End-to-end transport + lifecycle tests for the surfacing daemon.
 
-These never contact a real LTM server: the surface-hit path injects a
+These never contact a *production* LTM server: the surface-hit path injects a
 ``SurfacingEngine`` over a mock adapter, and the real-wiring path exercises a
 non-allowlisted tool so ``run_surfacing_hook`` returns ``{}`` before any LTM
-RPC. That keeps the suite deterministic even on a dev box with a live LTM.
+RPC. The one exception is the teardown leak-sweep e2e
+(``test_real_teardown_reaps_warm_ltm_child``), which deliberately warms a real
+stdio MCP round trip — against the in-repo ``_fake_memtomem_server.py``, never
+an installed memtomem. That keeps the suite deterministic even on a dev box
+with a live LTM.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Background

E-3 from the 2026-06-10 implementation review (the one remaining item after #429–#437): `DaemonServer._teardown()` exits the LTM adapter's anyio cancel scopes from the serve task, while they were entered in whichever connection-handler task first lazy-started the adapter. anyio raises its cross-task cancel-scope `RuntimeError` partway through the stdio transport's unwind; `_quiet()` swallowed it at DEBUG, so whether the warm LTM child was actually reaped went unverified.

The new end-to-end test confirms the error **does** fire on every real warm teardown (real engine wiring against `tests/_fake_memtomem_server.py`). Today's mcp terminates the child before the failing scope exit — the child does not leak with the current pin — but that ordering is an implementation detail of mcp's stdio shutdown `finally`, and a reorder silently re-opens the leak with no signal at default log levels.

This is option (c) from the review: guard + force-kill, no change to the daemon's resource model (no eager warm-up, no dedicated LTM worker task).

## What changed

- `_teardown()` stops the adapter via a new `_stop_adapter()`:
  - The known cancel-scope shape (bare `RuntimeError` or the anyio ≥ 4 group-wrapped form) is logged at WARNING instead of being swallowed at DEBUG.
  - After **any** failed stop, the daemon sweeps its direct children (`pgrep -P`, POSIX best-effort, no-op on Windows): a child present both before and after a failed stop is the leaked LTM child — the daemon process spawns nothing else. Leaked children get SIGTERM to their own process group (the stdio child is spawned `start_new_session=True`, so the group kill also reaches `uv run`-style grandchildren), escalating to SIGKILL after the same 2 s grace mcp's own shutdown sequence uses. A clean stop performs no sweep.
- The cancel-scope detection helpers (`_is_anyio_cancel_scope_shutdown_error` / `_is_clean_cancel_scope_shutdown` and the message tuple) move from `server.py` to a new `utils/anyio_shutdown.py` so the daemon can reuse them without importing the whole proxy stack. `server.py`'s stdio-EOF exception barrier imports them from there; nothing outside `server.py` referenced the old underscore names.

## Behavior change

- Daemon shutdown now emits a WARNING (`cross-task cancel-scope`) on every warm-LTM teardown under the current mcp pin — previously this path was silent outside DEBUG. This is intentional observability for a real (if currently benign) error.
- On a failed adapter stop, the daemon may now signal surviving direct child processes. In the dedicated `mms daemon run` process the only possible direct child is the LTM stdio child; the sweep is intersection-scoped (before ∩ after) and skipped entirely when stop succeeds.

## Tests

- Unit: leaked-child kill on the bare and group-wrapped cancel-scope shapes (real `sleep` child in its own session, asserts `-SIGTERM` exit and both WARNING lines).
- Unit: generic stop failure sweeps exactly the before ∩ after intersection; clean stop performs no sweep and no second probe.
- Unit: `_direct_child_pids()` observes a real spawned child and stops listing it after reap.
- E2E regression: real `_build_engine` wiring + fake memtomem stdio server; a surface call warms a real LTM child in a connection-handler task, daemon shutdown must leave no live LTM child (pinned regardless of which unwind path reaps it).

Full suite: 3062 passed, 3 skipped (`-m "not ollama"`). `ruff check` + `ruff format --check src` clean; mypy introduces no new errors in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)