### PR TITLE
fix(proxy): null the extractor on stop and sanitize _context_query on the miss path

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -421,6 +421,10 @@ class ProxyManager:
             self._llm_compressor = None
         if self._extractor is not None:
             await self._extractor.close()
+            # Null it like _llm_compressor above: _get_extractor() rebuilds on
+            # None, so a stop->start cycle gets a fresh httpx client instead of
+            # the closed instance (whose extract() asserts _client is not None).
+            self._extractor = None
         for conn in self._connections.values():
             if conn.stack is not None:
                 try:
@@ -1306,8 +1310,13 @@ class ProxyManager:
         # hot-reload changing the config between accesses.
         cfg_snap = self._config
 
-        # Extract _context_query before forwarding
-        context_query = arguments.get("_context_query") if arguments else None
+        # Extract _context_query before forwarding. Coerce non-str values to
+        # None at the single extraction point — the cache-hit path already
+        # sanitizes this way, and without the mirror here the same malformed
+        # argument reaches scorers/compressors raw on a miss but is dropped on
+        # a hit, so whether it raises depends on cache state.
+        raw_context_query = arguments.get("_context_query") if arguments else None
+        context_query = raw_context_query if isinstance(raw_context_query, str) else None
         upstream_args = (
             {k: v for k, v in arguments.items() if k != "_context_query"} if arguments else {}
         )

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -163,6 +163,17 @@ class TestStop:
 
         mock_ext.close.assert_awaited_once()
 
+    async def test_stop_nulls_extractor_so_restart_rebuilds(self):
+        """stop() nulls _extractor (like _llm_compressor) — _get_extractor()
+        rebuilds on None, so a stop->start cycle gets a fresh httpx client
+        instead of the closed instance whose extract() would AssertionError."""
+        mgr = _make_manager(servers={})
+        mgr._extractor = AsyncMock()
+
+        await mgr.stop()
+
+        assert mgr._extractor is None
+
     async def test_stop_closes_connection_stacks(self):
         """stop() closes per-connection stacks and clears _connections."""
         mgr = _make_manager(servers={})

--- a/tests/test_proxy_manager_pipeline.py
+++ b/tests/test_proxy_manager_pipeline.py
@@ -905,6 +905,37 @@ class TestAutoIndex:
         assert "Auto-index failed" in caplog.text
 
 
+# ── _context_query sanitization ──────────────────────────────────────────
+
+
+class TestContextQuerySanitization:
+    async def test_non_str_context_query_coerced_to_none_on_miss_path(self, tmp_path):
+        """A non-str ``_context_query`` reaches downstream stages as None on
+        the miss path — mirroring the cache-hit path's isinstance guard, so
+        whether a malformed value raises no longer depends on cache state —
+        and is still stripped from the upstream arguments."""
+        mgr = _make_manager(tmp_path=tmp_path)
+        session = _inject_connection(mgr, text="upstream content " * 5)
+        captured: dict[str, object] = {}
+
+        async def _spy_surfacing(
+            server, tool, arguments, text, *, trace_id=None, context_query=None
+        ):
+            captured["context_query"] = context_query
+            return text
+
+        with patch.object(mgr, "_apply_surfacing", side_effect=_spy_surfacing):
+            result = await mgr.call_tool(
+                "srv", "some_tool", {"q": 1, "_context_query": {"not": "a str"}}
+            )
+
+        assert isinstance(result, str)
+        assert captured["context_query"] is None
+        upstream_args = session.call_tool.call_args.args[1]
+        assert "_context_query" not in upstream_args
+        assert upstream_args["q"] == 1  # real args still forwarded (plus _trace_id, #204)
+
+
 # ── _extract_and_store ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Background

Two low findings from the 2026-06-10 implementation review (report L55, L59 — first wave of the low-severity backlog, re-verified against current main before fixing).

## What changed

- **`stop()` now nulls `_extractor` after closing it.** It closed the extractor but left the attribute pointing at the closed instance, unlike `_llm_compressor` two lines above which is set to `None`. `_get_extractor()` rebuilds only on `None`, so a stop→start cycle returned the closed extractor and the first post-restart extraction hit `FactExtractor`'s `assert self._client is not None` (extraction.py sets `_client = None` in `close()`). A restarted manager could never extract again.

- **The miss path now coerces a non-str `_context_query` to `None` at the extraction point.** The cache-hit path already guards with `isinstance(context_query, str)`; the miss path threaded the raw value into compression, surfacing, progressive surfacing, auto-index, and extract-and-store. An agent passing `_context_query` as a JSON object/number could raise inside a scorer on a miss but be silently dropped on a hit — behavior depending solely on cache state. Both paths now sanitize identically; `_context_query` is still stripped from upstream arguments.

## Tests

- `test_stop_nulls_extractor_so_restart_rebuilds` — pins `_extractor is None` after `stop()` (fails pre-fix).
- `TestContextQuerySanitization::test_non_str_context_query_coerced_to_none_on_miss_path` — drives `call_tool` end-to-end with a dict `_context_query`, asserts downstream surfacing receives `None` and upstream args are stripped (fails pre-fix).

Affected suites: 55 passed (`test_proxy_manager_lifecycle.py` + `test_proxy_manager_pipeline.py`); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)