### PR TITLE
fix(proxy): keep InMemoryPendingStore eviction order in sync across put/touch/delete

### DIFF
--- a/src/memtomem_stm/proxy/pending_store.py
+++ b/src/memtomem_stm/proxy/pending_store.py
@@ -37,8 +37,16 @@ class InMemoryPendingStore:
         self._order: deque[str] = deque()
         self._lock = threading.Lock()
 
+    # Invariant: ``_order`` holds exactly the keys of ``_data``, once each,
+    # in recency order (oldest left) — matching the SQLite backend, whose
+    # evict_oldest keeps the most recent ``created_at`` rows. Every mutation
+    # below maintains it; a duplicate or stale ``_order`` entry makes
+    # evict_oldest silently drop a fresh entry.
+
     def put(self, key: str, selection: PendingSelection) -> None:
         with self._lock:
+            if key in self._data:
+                self._order.remove(key)
             self._data[key] = selection
             self._order.append(key)
 
@@ -51,10 +59,13 @@ class InMemoryPendingStore:
             sel = self._data.get(key)
             if sel is not None:
                 sel.created_at = time.monotonic()
+                self._order.remove(key)
+                self._order.append(key)
 
     def delete(self, key: str) -> None:
         with self._lock:
-            self._data.pop(key, None)
+            if self._data.pop(key, None) is not None:
+                self._order.remove(key)
 
     def evict_expired(self, ttl: float) -> None:
         with self._lock:

--- a/tests/test_pending_store.py
+++ b/tests/test_pending_store.py
@@ -74,6 +74,43 @@ class TestInMemoryPendingStore:
         store.delete("k1")
         assert len(store) == 0
 
+    def test_reput_refreshes_recency_for_eviction(self):
+        # A re-put key must count as the NEWEST entry (SQLite: INSERT OR
+        # REPLACE rewrites created_at). A duplicate _order entry used to make
+        # evict_oldest pop the re-put key first — dropping the fresh data.
+        store = InMemoryPendingStore()
+        store.put("k1", _make_selection())
+        store.put("k2", _make_selection())
+        store.put("k1", _make_selection({"sec": "fresh"}))
+        store.evict_oldest(max_size=1)
+        assert store.get("k2") is None  # oldest
+        fresh = store.get("k1")
+        assert fresh is not None and fresh.chunks == {"sec": "fresh"}
+
+    def test_touch_moves_key_to_back_of_eviction_order(self):
+        # touch() refreshes created_at; eviction order must follow (SQLite
+        # orders by created_at), else a just-touched entry is dropped first.
+        store = InMemoryPendingStore()
+        store.put("k1", _make_selection())
+        store.put("k2", _make_selection())
+        store.touch("k1")
+        store.evict_oldest(max_size=1)
+        assert store.get("k2") is None
+        assert store.get("k1") is not None
+
+    def test_delete_then_reput_does_not_leave_stale_order_entry(self):
+        # delete() must drop the _order entry too: a stale entry plus a later
+        # re-put would otherwise duplicate the key and resurface the
+        # evict-the-fresh-entry bug through the delete path.
+        store = InMemoryPendingStore()
+        store.put("k1", _make_selection())
+        store.delete("k1")
+        store.put("k2", _make_selection())
+        store.put("k1", _make_selection({"sec": "fresh"}))
+        store.evict_oldest(max_size=1)
+        assert store.get("k2") is None  # oldest live entry
+        assert store.get("k1") is not None
+
 
 # ── SQLitePendingStore ──────────────────────────────────────────────────
 
@@ -231,7 +268,13 @@ class TestSelectiveCompressorWithStore:
         comp2 = SelectiveCompressor(store=store2)
 
         # comp1 creates a TOC
-        text = "# Title\n\n## Section1\n" + "Hello world " * 50 + "\n\n## Section2\n" + "Goodbye " * 50 + "\n"
+        text = (
+            "# Title\n\n## Section1\n"
+            + "Hello world " * 50
+            + "\n\n## Section2\n"
+            + "Goodbye " * 50
+            + "\n"
+        )
         result = comp1.compress(text, max_chars=50)
         toc = json.loads(result)
         key = toc["selection_key"]


### PR DESCRIPTION
## Background

Low findings from the 2026-06-10 implementation review (report L297, L301), re-verified against current main.

`InMemoryPendingStore.evict_oldest` pops from `_order` (insertion order), but three mutations let `_order` drift from recency:

- `put()` appended unconditionally — re-putting an existing key left a duplicate `_order` entry, so eviction popped the re-put key first and **dropped the fresh selection**.
- `touch()` refreshed `created_at` but never moved the key — a just-touched entry was evicted first.
- `delete()` never removed its `_order` entry — a stale entry plus a later re-put reintroduced the duplicate through the delete path (consequent to the `put` fix; on main alone it only wasted an eviction iteration).

The SQLite backend already behaves correctly on all three (`INSERT OR REPLACE` rewrites `created_at`; `evict_oldest` orders by it), so this aligns the in-memory backend with its documented drop-in sibling.

## What changed

A stated invariant — `_order` holds exactly the keys of `_data`, once each, in recency order — and the three mutations now maintain it: `put` moves an existing key to the back, `touch` moves the key to the back, `delete` removes the key's `_order` entry.

## Tests

Three regression tests, each failing pre-fix (verified by stashing the src change):
- `test_reput_refreshes_recency_for_eviction`
- `test_touch_moves_key_to_back_of_eviction_order`
- `test_delete_then_reput_does_not_leave_stale_order_entry`

`test_pending_store.py` 21 passed, `test_progressive.py` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)