### PR TITLE
fix(surfacing): redact URL userinfo from LTM connection log lines

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -32,7 +32,7 @@ from memtomem_stm.mms.import_hosts import (
 )
 from memtomem_stm.proxy import tool_name_budget
 from memtomem_stm.utils.fileio import atomic_write_text
-from memtomem_stm.utils.redact import redact_url_userinfo
+from memtomem_stm.utils.redact import redact_exception_text, redact_url_userinfo
 
 _PREFIX_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
 
@@ -2585,7 +2585,10 @@ def _ltm_mcp_status(surfacing: Any, timeout: float) -> dict[str, Any]:
         if isinstance(root, TimeoutError):
             status["error"] = f"{display}: timeout ({probe_timeout:g}s)"
         else:
-            status["error"] = f"{display}: {str(root) or type(root).__name__}"
+            # httpx exceptions embed the full request URL — userinfo included
+            # — so the rendered message is scrubbed against the raw url.
+            message = redact_exception_text(str(root), url) or type(root).__name__
+            status["error"] = f"{display}: {message}"
     else:
         status.update(probe)
     return status

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -32,6 +32,7 @@ from memtomem_stm.mms.import_hosts import (
 )
 from memtomem_stm.proxy import tool_name_budget
 from memtomem_stm.utils.fileio import atomic_write_text
+from memtomem_stm.utils.redact import redact_url_userinfo
 
 _PREFIX_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*$")
 
@@ -2518,16 +2519,19 @@ def _ltm_mcp_status(surfacing: Any, timeout: float) -> dict[str, Any]:
     headers = getattr(surfacing, "ltm_mcp_headers", None)
     if not isinstance(headers, dict):
         headers = None
+    # ``status`` is the operator-facing payload (text lines AND ``--json``
+    # dump), so the URL fields are userinfo-redacted; only the local ``url``
+    # stays raw for the probe's actual connection below.
     display = (
         _format_command_for_display(command, args)
         if transport == "stdio" and command
-        else url or "(empty url)"
+        else redact_url_userinfo(url) or "(empty url)"
     )
     status: dict[str, Any] = {
         "transport": transport,
         "command": command,
         "args": args,
-        "url": url,
+        "url": redact_url_userinfo(url),
         "display": display,
         "connected": None,
         "version": None,

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -18,6 +18,7 @@ from memtomem_stm.surfacing.formatter import SurfacingFormatter
 from memtomem_stm.surfacing.observability import _NOOP_OBSERVABILITY, SurfacingObservability
 from memtomem_stm.surfacing.relevance import RelevanceGate
 from memtomem_stm.utils.circuit_breaker import CircuitBreaker
+from memtomem_stm.utils.redact import redact_url_userinfo
 
 logger = logging.getLogger(__name__)
 
@@ -751,7 +752,9 @@ class SurfacingEngine:
                 if self._config.ltm_mcp_transport == "stdio":
                     ltm_target = self._config.ltm_mcp_command
                 else:
-                    ltm_target = self._config.ltm_mcp_url
+                    # Display-only: a network URL may carry basic-auth
+                    # credentials that must not reach the WARNING line.
+                    ltm_target = redact_url_userinfo(self._config.ltm_mcp_url)
                 logger.warning(
                     "Surfacing skipped: LTM MCP %s target %r is not reachable "
                     "(outcome=%s). Subsequent skips counted as 'ltm_unavailable' "

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -11,7 +11,6 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
-from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from mcp import ClientSession
@@ -22,6 +21,7 @@ from mcp.types import TextContent
 
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.utils.numeric import safe_float
+from memtomem_stm.utils.redact import redact_url_userinfo
 
 logger = logging.getLogger(__name__)
 
@@ -228,22 +228,6 @@ def get_parser(fmt: str = "compact") -> ResultParser:
 _compact_parser = CompactResultParser()
 
 
-def _redact_url_userinfo(url: str) -> str:
-    """Strip ``user:password@`` userinfo from *url* for log display.
-
-    A URL the stdlib cannot parse is replaced wholesale rather than echoed —
-    an unparseable value could still embed credentials.
-    """
-    try:
-        parts = urlsplit(url)
-    except ValueError:
-        return "<unparseable url>"
-    if "@" not in parts.netloc:
-        return url
-    host = parts.netloc.rpartition("@")[2]
-    return urlunsplit(parts._replace(netloc=f"***@{host}"))
-
-
 class McpClientSearchAdapter:
     """Connects to a memtomem MCP server and calls mem_search.
 
@@ -330,7 +314,7 @@ class McpClientSearchAdapter:
         """
         if self._config.ltm_mcp_transport == "stdio":
             return self._config.ltm_mcp_command
-        return _redact_url_userinfo(self._config.ltm_mcp_url)
+        return redact_url_userinfo(self._config.ltm_mcp_url)
 
     async def _negotiate_format(self) -> None:
         """Downgrade to compact if core doesn't advertise structured support.

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -21,7 +21,7 @@ from mcp.types import TextContent
 
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.utils.numeric import safe_float
-from memtomem_stm.utils.redact import redact_url_userinfo
+from memtomem_stm.utils.redact import redact_exception_text, redact_url_userinfo
 
 logger = logging.getLogger(__name__)
 
@@ -316,6 +316,15 @@ class McpClientSearchAdapter:
             return self._config.ltm_mcp_command
         return redact_url_userinfo(self._config.ltm_mcp_url)
 
+    def _scrub_exc(self, exc: BaseException) -> str:
+        """Render *exc* for logging with URL userinfo scrubbed.
+
+        httpx exceptions embed the full request URL (credentials included),
+        so every log line in this module that interpolates an exception must
+        go through here rather than passing ``exc`` to the logger raw.
+        """
+        return redact_exception_text(str(exc), self._config.ltm_mcp_url)
+
     async def _negotiate_format(self) -> None:
         """Downgrade to compact if core doesn't advertise structured support.
 
@@ -339,7 +348,7 @@ class McpClientSearchAdapter:
                     logger.info("Core supports structured format — keeping StructuredResultParser")
                     return
         except Exception as exc:
-            logger.debug("Version negotiation failed (older core?): %s", exc)
+            logger.debug("Version negotiation failed (older core?): %s", self._scrub_exc(exc))
 
         logger.info("Core does not advertise structured format — falling back to compact")
         self._parser = CompactResultParser()
@@ -425,7 +434,10 @@ class McpClientSearchAdapter:
                     self._start_attempted = False
                     raise
                 except Exception as exc:
-                    logger.warning("Lazy MCP adapter start failed — surfacing disabled: %s", exc)
+                    logger.warning(
+                        "Lazy MCP adapter start failed — surfacing disabled: %s",
+                        self._scrub_exc(exc),
+                    )
                     return False
                 return True
         if not self._needs_reconnect:
@@ -433,7 +445,9 @@ class McpClientSearchAdapter:
         try:
             await self._reconnect()
         except Exception as exc:
-            logger.warning("Lazy reconnect after mid-RPC cancellation failed: %s", exc)
+            logger.warning(
+                "Lazy reconnect after mid-RPC cancellation failed: %s", self._scrub_exc(exc)
+            )
             return False
         self._needs_reconnect = False
         return True
@@ -485,14 +499,16 @@ class McpClientSearchAdapter:
         try:
             result = await self._session.call_tool("mem_search", args)
         except self._TRANSPORT_ERRORS as exc:
-            logger.warning("MCP transport error, attempting reconnect: %s", exc)
+            logger.warning("MCP transport error, attempting reconnect: %s", self._scrub_exc(exc))
             try:
                 await self._reconnect()
                 assert self._session is not None
                 result = await self._session.call_tool("mem_search", args)
             except Exception as retry_exc:
                 # Upstream LTM is unreachable; surfacing will return empty.
-                logger.warning("MCP mem_search failed after reconnect: %s", retry_exc)
+                logger.warning(
+                    "MCP mem_search failed after reconnect: %s", self._scrub_exc(retry_exc)
+                )
                 return [], [], "transport_error"
         except asyncio.CancelledError:
             # #290: outer wait_for cancelled us mid-RPC. Mark for lazy
@@ -502,7 +518,7 @@ class McpClientSearchAdapter:
             self._needs_reconnect = True
             raise
         except Exception as exc:
-            logger.warning("MCP mem_search failed: %s", exc)
+            logger.warning("MCP mem_search failed: %s", self._scrub_exc(exc))
             return [], [], "call_error"
 
         # Parse text response into results
@@ -549,20 +565,25 @@ class McpClientSearchAdapter:
         try:
             await self._session.call_tool("mem_do", call_args)
         except self._TRANSPORT_ERRORS as exc:
-            logger.warning("MCP transport error in increment_access, reconnecting: %s", exc)
+            logger.warning(
+                "MCP transport error in increment_access, reconnecting: %s", self._scrub_exc(exc)
+            )
             try:
                 await self._reconnect()
                 assert self._session is not None
                 await self._session.call_tool("mem_do", call_args)
             except Exception as retry_exc:
-                logger.debug("MCP mem_do(increment_access) failed after reconnect: %s", retry_exc)
+                logger.debug(
+                    "MCP mem_do(increment_access) failed after reconnect: %s",
+                    self._scrub_exc(retry_exc),
+                )
         except asyncio.CancelledError:
             # #290: see search() — mid-RPC cancellation marks the session
             # for lazy reconnect; propagate per the cooperative model.
             self._needs_reconnect = True
             raise
         except Exception as exc:
-            logger.debug("MCP mem_do(increment_access) failed: %s", exc)
+            logger.debug("MCP mem_do(increment_access) failed: %s", self._scrub_exc(exc))
 
     async def scratch_list(self, *, trace_id: str | None = None) -> list[dict]:
         """Fetch working memory entries via mem_do(action="scratch_get").
@@ -588,7 +609,9 @@ class McpClientSearchAdapter:
         try:
             result = await self._session.call_tool("mem_do", call_args)
         except self._TRANSPORT_ERRORS as exc:
-            logger.warning("MCP transport error in scratch_list, reconnecting: %s", exc)
+            logger.warning(
+                "MCP transport error in scratch_list, reconnecting: %s", self._scrub_exc(exc)
+            )
             try:
                 await self._reconnect()
                 assert self._session is not None
@@ -601,7 +624,7 @@ class McpClientSearchAdapter:
             self._needs_reconnect = True
             raise
         except Exception as exc:
-            logger.debug("MCP mem_do(scratch_get) failed: %s", exc)
+            logger.debug("MCP mem_do(scratch_get) failed: %s", self._scrub_exc(exc))
             return []
 
         # ``result.content or []`` tolerates spec-noncompliant upstreams that

--- a/src/memtomem_stm/surfacing/mcp_client.py
+++ b/src/memtomem_stm/surfacing/mcp_client.py
@@ -11,6 +11,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from mcp import ClientSession
@@ -227,6 +228,22 @@ def get_parser(fmt: str = "compact") -> ResultParser:
 _compact_parser = CompactResultParser()
 
 
+def _redact_url_userinfo(url: str) -> str:
+    """Strip ``user:password@`` userinfo from *url* for log display.
+
+    A URL the stdlib cannot parse is replaced wholesale rather than echoed —
+    an unparseable value could still embed credentials.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return "<unparseable url>"
+    if "@" not in parts.netloc:
+        return url
+    host = parts.netloc.rpartition("@")[2]
+    return urlunsplit(parts._replace(netloc=f"***@{host}"))
+
+
 class McpClientSearchAdapter:
     """Connects to a memtomem MCP server and calls mem_search.
 
@@ -304,9 +321,16 @@ class McpClientSearchAdapter:
                 return stdio_client(params)
 
     def _target_display(self) -> str:
+        """Loggable connection target — URL userinfo is redacted.
+
+        ``ltm_mcp_url`` may carry ``user:password@`` credentials (basic-auth
+        proxies in front of a network LTM, #398), and this string goes to
+        INFO logs in ``start()`` and ``_reconnect()``. Only the display is
+        redacted; the transport itself receives the configured URL verbatim.
+        """
         if self._config.ltm_mcp_transport == "stdio":
             return self._config.ltm_mcp_command
-        return self._config.ltm_mcp_url
+        return _redact_url_userinfo(self._config.ltm_mcp_url)
 
     async def _negotiate_format(self) -> None:
         """Downgrade to compact if core doesn't advertise structured support.

--- a/src/memtomem_stm/utils/redact.py
+++ b/src/memtomem_stm/utils/redact.py
@@ -21,7 +21,37 @@ def redact_url_userinfo(url: str) -> str:
         parts = urlsplit(url)
     except ValueError:
         return "<unparseable url>"
-    if "@" not in parts.netloc:
-        return url
-    host = parts.netloc.rpartition("@")[2]
-    return urlunsplit(parts._replace(netloc=f"***@{host}"))
+    if parts.netloc:
+        if "@" not in parts.netloc:
+            return url
+        host = parts.netloc.rpartition("@")[2]
+        return urlunsplit(parts._replace(netloc=f"***@{host}"))
+    # No netloc: urlsplit parses a scheme-less "alice:pw@host/path" as a bare
+    # path without raising, so a credential-looking value would be echoed
+    # verbatim. Anything '@'-bearing that we couldn't decompose is replaced
+    # wholesale.
+    if "@" in url:
+        return "<unparseable url>"
+    return url
+
+
+def redact_exception_text(text: str, url: str) -> str:
+    """Scrub *url*'s userinfo out of arbitrary *text* (exception messages).
+
+    httpx exception strings embed the full request URL — userinfo included —
+    so a log line rendering a transport exception for a credentialed endpoint
+    leaks even when the *display* string was redacted. Best-effort string
+    replacement: the exact configured URL, then its ``user:pw@`` prefix (which
+    also catches URL variants httpx derives from the original).
+    """
+    if not text or not url or "@" not in url:
+        return text
+    out = text.replace(url, redact_url_userinfo(url))
+    try:
+        netloc = urlsplit(url).netloc
+    except ValueError:
+        netloc = ""
+    userinfo = netloc.rpartition("@")[0]
+    if userinfo:
+        out = out.replace(f"{userinfo}@", "***@")
+    return out

--- a/src/memtomem_stm/utils/redact.py
+++ b/src/memtomem_stm/utils/redact.py
@@ -1,0 +1,27 @@
+"""Display/log redaction helpers."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+
+def redact_url_userinfo(url: str) -> str:
+    """Strip ``user:password@`` userinfo from *url* for display/logging.
+
+    ``ltm_mcp_url`` may carry basic-auth credentials in front of a network
+    LTM (#398); every operator-facing rendering of it (adapter connect logs,
+    the engine's unreachable-LTM warning, ``mms health`` output) must go
+    through here. The connection itself always uses the configured URL
+    verbatim — only displays are redacted.
+
+    A URL the stdlib cannot parse is replaced wholesale rather than echoed —
+    an unparseable value could still embed credentials.
+    """
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return "<unparseable url>"
+    if "@" not in parts.netloc:
+        return url
+    host = parts.netloc.rpartition("@")[2]
+    return urlunsplit(parts._replace(netloc=f"***@{host}"))

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3895,7 +3895,8 @@ class TestHealth:
 
         async def fake_probe(transport, command, args, url, headers, timeout, errlog):
             captured["url"] = url
-            raise ConnectionError("connection refused")
+            # httpx-style message embedding the full credentialed request URL
+            raise ConnectionError(f"Client error '401 Unauthorized' for url '{url}'")
 
         monkeypatch.setattr(proxy_mod, "_probe_ltm_mcp_server", fake_probe)
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -3885,6 +3885,39 @@ class TestHealth:
         assert captured["url"] == "https://ltm.example/sse"
         assert captured["headers"] == {"Authorization": "Bearer token"}
 
+    def test_ltm_network_health_redacts_url_credentials(self, monkeypatch):
+        # ``status`` feeds both the text lines and the ``--json`` dump, so a
+        # basic-auth URL must be redacted in url/display/error — while the
+        # probe itself still receives the raw configured URL.
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        captured = {}
+
+        async def fake_probe(transport, command, args, url, headers, timeout, errlog):
+            captured["url"] = url
+            raise ConnectionError("connection refused")
+
+        monkeypatch.setattr(proxy_mod, "_probe_ltm_mcp_server", fake_probe)
+
+        status = proxy_mod._ltm_mcp_status(
+            SimpleNamespace(
+                enabled=True,
+                ltm_mcp_transport="sse",
+                ltm_mcp_command="",
+                ltm_mcp_args=[],
+                ltm_mcp_url="https://alice:s3cret@ltm.example/sse",
+                ltm_mcp_headers=None,
+            ),
+            timeout=2,
+        )
+
+        assert captured["url"] == "https://alice:s3cret@ltm.example/sse"  # probe stays raw
+        assert status["connected"] is False
+        for field in ("url", "display", "error"):
+            assert "s3cret" not in str(status[field]), field
+        assert status["display"] == "https://***@ltm.example/sse"
+        assert "***@ltm.example" in status["error"]
+
     def test_sse_ltm_probe_timeout_bounds_transport_enter(self, monkeypatch):
         from memtomem_stm.cli import proxy as proxy_mod
 

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -126,6 +126,63 @@ class TestLtmTransportSelection:
 # ── Reconnect retry paths ────────────────────────────────────────────────
 
 
+class TestTargetDisplayRedaction:
+    """_target_display feeds INFO logs in start()/_reconnect() — URL userinfo
+    (basic-auth credentials in front of a network LTM, #398) must not leak."""
+
+    def test_url_userinfo_is_redacted(self):
+        adapter = McpClientSearchAdapter(
+            SurfacingConfig(
+                ltm_mcp_transport="sse",
+                ltm_mcp_url="https://alice:s3cret@ltm.example/sse",
+            )
+        )
+        display = adapter._target_display()
+        assert "s3cret" not in display
+        assert "alice" not in display
+        assert display == "https://***@ltm.example/sse"
+
+    def test_url_without_userinfo_unchanged(self):
+        adapter = McpClientSearchAdapter(
+            SurfacingConfig(
+                ltm_mcp_transport="streamable_http",
+                ltm_mcp_url="https://ltm.example/mcp",
+            )
+        )
+        assert adapter._target_display() == "https://ltm.example/mcp"
+
+    def test_stdio_returns_command(self):
+        adapter = McpClientSearchAdapter(SurfacingConfig(ltm_mcp_command="memtomem-dev"))
+        assert adapter._target_display() == "memtomem-dev"
+
+    def test_transport_still_receives_raw_url(self, monkeypatch):
+        # Redaction is display-only — the connection must use the verbatim
+        # configured URL, credentials included.
+        from memtomem_stm.surfacing import mcp_client as mod
+
+        captured = {}
+        monkeypatch.setattr(
+            mod,
+            "sse_client",
+            lambda url, *, headers=None: captured.update(url=url) or object(),
+        )
+        adapter = McpClientSearchAdapter(
+            SurfacingConfig(
+                ltm_mcp_transport="sse",
+                ltm_mcp_url="https://alice:s3cret@ltm.example/sse",
+            )
+        )
+        adapter._open_transport()
+        assert captured["url"] == "https://alice:s3cret@ltm.example/sse"
+
+    def test_unparseable_url_not_echoed(self):
+        from memtomem_stm.surfacing.mcp_client import _redact_url_userinfo
+
+        # Malformed IPv6 brackets make urlsplit raise ValueError; the raw
+        # string could still embed credentials, so it is replaced wholesale.
+        assert _redact_url_userinfo("https://user:pw@[::1/mcp") == "<unparseable url>"
+
+
 class TestReconnectRetrySuccess:
     """A transient transport failure followed by a successful reconnect must
     deliver the retry's actual results to the caller, not silently drop them."""

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -176,11 +176,11 @@ class TestTargetDisplayRedaction:
         assert captured["url"] == "https://alice:s3cret@ltm.example/sse"
 
     def test_unparseable_url_not_echoed(self):
-        from memtomem_stm.surfacing.mcp_client import _redact_url_userinfo
+        from memtomem_stm.utils.redact import redact_url_userinfo
 
         # Malformed IPv6 brackets make urlsplit raise ValueError; the raw
         # string could still embed credentials, so it is replaced wholesale.
-        assert _redact_url_userinfo("https://user:pw@[::1/mcp") == "<unparseable url>"
+        assert redact_url_userinfo("https://user:pw@[::1/mcp") == "<unparseable url>"
 
 
 class TestReconnectRetrySuccess:

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -182,6 +182,49 @@ class TestTargetDisplayRedaction:
         # string could still embed credentials, so it is replaced wholesale.
         assert redact_url_userinfo("https://user:pw@[::1/mcp") == "<unparseable url>"
 
+    def test_schemeless_credential_value_not_echoed(self):
+        from memtomem_stm.utils.redact import redact_url_userinfo
+
+        # urlsplit parses a scheme-less value as a bare path (empty netloc,
+        # no exception) — it must still not be echoed verbatim.
+        assert redact_url_userinfo("alice:s3cret@ltm.example/sse") == "<unparseable url>"
+
+    def test_exception_text_scrubs_userinfo_variants(self):
+        from memtomem_stm.utils.redact import redact_exception_text
+
+        url = "https://alice:s3cret@ltm.example/sse"
+        text = (
+            f"Client error '401 Unauthorized' for url '{url}'; "
+            "retried 'https://alice:s3cret@ltm.example/other'"
+        )
+        out = redact_exception_text(text, url)
+        assert "s3cret" not in out
+        assert out.count("***@ltm.example") == 2  # exact URL and derived variant
+
+    async def test_start_failure_log_scrubs_url_credentials(self, caplog):
+        # httpx exceptions embed the full request URL; the lazy-start failure
+        # WARNING must scrub it rather than logging the exception raw.
+        adapter = McpClientSearchAdapter(
+            SurfacingConfig(
+                ltm_mcp_transport="sse",
+                ltm_mcp_url="https://alice:s3cret@ltm.example/sse",
+            )
+        )
+
+        async def _boom():
+            raise RuntimeError(
+                "Server error '502 Bad Gateway' for url 'https://alice:s3cret@ltm.example/sse'"
+            )
+
+        adapter.start = _boom  # type: ignore[method-assign]
+        with caplog.at_level("WARNING", logger="memtomem_stm.surfacing.mcp_client"):
+            ok = await adapter._heal_if_needed()
+        assert ok is False
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "surfacing disabled" in joined
+        assert "s3cret" not in joined
+        assert "***@ltm.example" in joined
+
 
 class TestReconnectRetrySuccess:
     """A transient transport failure followed by a successful reconnect must

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -2508,6 +2508,28 @@ class TestSurfacingLtmOutcomeDispatch:
         assert snap["skip_reasons"]["read_file"]["ltm_unavailable"] == 2
         assert snap["skip_reasons"]["another_tool"]["ltm_unavailable"] == 1
 
+    async def test_unavailable_warning_redacts_url_credentials(self, caplog):
+        """The one-time unreachable-LTM WARNING renders a network target
+        through redact_url_userinfo — a basic-auth ``ltm_mcp_url`` must not
+        leak credentials into operator logs."""
+        from memtomem_stm.surfacing.observability import SurfacingObservability
+
+        engine = SurfacingEngine(
+            config=_make_config(
+                ltm_mcp_transport="sse",
+                ltm_mcp_url="https://alice:s3cret@ltm.example/sse",
+            ),
+            mcp_adapter=_make_mcp_adapter(None, outcome="no_session"),
+            observability=SurfacingObservability(),
+        )
+        with caplog.at_level("WARNING", logger="memtomem_stm.surfacing.engine"):
+            await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
+        warnings = [r for r in caplog.records if "is not reachable" in r.message]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "s3cret" not in message
+        assert "***@ltm.example" in message
+
     async def test_call_error_outcome_does_not_log_unavailable_warning(self, caplog):
         """The WARNING is scoped to the no-session / transport-error bucket
         (LTM not reachable). A mid-call ``call_error`` means the session


### PR DESCRIPTION
## Background

Low finding from the 2026-06-10 implementation review (report L97): `ltm_mcp_url` may carry basic-auth credentials (`user:password@` in front of a network LTM, #398), and several operator-facing renderings leaked them. Scope grew across two codex review rounds from the adapter's connect log to every rendering path.

## What changed

- New `utils/redact.py`:
  - `redact_url_userinfo(url)` — `https://alice:s3cret@host/p` → `https://***@host/p`; unparseable or scheme-less `@`-bearing values become `<unparseable url>` rather than being echoed.
  - `redact_exception_text(text, url)` — scrubs the configured URL and its `user:pw@` prefix from arbitrary text; httpx exception strings embed the full request URL, so display-only redaction was not enough (codex reproduced the leak via `httpx.HTTPStatusError`).
- All renderings route through them:
  - adapter `_target_display()` (connect/reconnect INFO lines) — display redacted, transport still receives the raw URL;
  - adapter `_scrub_exc()` applied at all 11 exception-interpolating log sites (start failure, search/increment_access/scratch_list transport errors and retries, version negotiation);
  - engine's one-time unreachable-LTM WARNING;
  - `mms health` `status["url"]` / `display` / `error` (text and `--json`) — the probe keeps the raw URL.

## Review

Codex R1 NEEDS-FIX (engine warning + health display raw) → R2 NEEDS-FIX (exception-text leaks, scheme-less echo) → **R3 SHIP** (verified `@`-in-path/fragment URLs stay unchanged, no `exc_info` semantics lost).

## Tests

Redaction unit tests (userinfo, no-userinfo, unparseable, scheme-less, exception-text variants), adapter display + raw-transport pins, start-failure log scrub, engine warning scrub, `mms health` url/display/error scrub with probe-stays-raw pin. Full suite 3072 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)