### PR TITLE
fix(compression): forward the TOC budget, guard scorer length, and survive all-empty BM25 sections

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -143,6 +143,24 @@ class NoopCompressor:
         return text
 
 
+def _scores_or_none(
+    scorer: RelevanceScorer, query: str, sections: list[tuple[str, str]]
+) -> list[float] | None:
+    """Score *sections*, returning ``None`` when there is no usable signal.
+
+    No-signal covers both an all-non-positive score vector AND a scorer
+    returning the wrong number of scores (custom ``RelevanceScorer`` drift).
+    Every consumer indexes, sorts, or ``zip()``s the scores against its
+    sections, so a wrong-length list would raise IndexError, silently
+    truncate, or mis-allocate budgets — all consumers must obtain scores
+    through this helper and fall back to their query-less path on ``None``.
+    """
+    scores = scorer.score_sections(query, sections)
+    if len(scores) != len(sections) or not any(s > 0 for s in scores):
+        return None
+    return scores
+
+
 class TruncateCompressor:
     """Character limit with sentence/word boundary awareness.
 
@@ -264,12 +282,7 @@ class TruncateCompressor:
         relevance_weights: list[float] | None = None
         if context_query and context_query.strip():
             sections = [(k, ser) for k, ser, _ in key_sizes]
-            raw = self._scorer.score_sections(context_query, sections)
-            # A scorer returning the wrong number of scores (custom
-            # RelevanceScorer drift) would IndexError at
-            # relevance_weights[idx] below — treat it as no signal.
-            if len(raw) == len(key_sizes) and any(s > 0 for s in raw):
-                relevance_weights = raw
+            relevance_weights = _scores_or_none(self._scorer, context_query, sections)
 
         # Build output: each key gets budget allocation
         parts: list[str] = []
@@ -476,9 +489,7 @@ class TruncateCompressor:
             # Compute per-section relevance scores if query is provided
             scores: list[float] | None = None
             if context_query and context_query.strip():
-                raw_scores = self._scorer.score_sections(context_query, sections)
-                if any(s > 0 for s in raw_scores):
-                    scores = raw_scores
+                scores = _scores_or_none(self._scorer, context_query, sections)
 
             if scores is not None:
                 # ── Query-aware: allocate budget proportional to relevance ──
@@ -845,8 +856,8 @@ class SelectiveCompressor:
         # search below rebuilds the same entries in the same order.
         items = list(chunks.items())
         if context_query and context_query.strip():
-            scores = self._scorer.score_sections(context_query, items)
-            if any(s > 0 for s in scores):
+            scores = _scores_or_none(self._scorer, context_query, items)
+            if scores is not None:
                 order = sorted(range(len(items)), key=lambda i: -scores[i])
                 items = [items[i] for i in order]
 
@@ -1721,8 +1732,8 @@ class SchemaPruningCompressor:
         caller to fall back to the uniform path for byte-identical output.
         """
         sections = [(k, json.dumps(v, ensure_ascii=False)) for k, v in data.items()]
-        scores = self._scorer.score_sections(context_query, sections)
-        if not any(s > 0 for s in scores):
+        scores = _scores_or_none(self._scorer, context_query, sections)
+        if scores is None:
             return None
         return {k for (k, _), s in zip(sections, scores) if s > 0}
 
@@ -2026,13 +2037,16 @@ class SkeletonCompressor:
             return [base] * n
 
         scored = [(heading, "\n".join(body)) for heading, body in sections]
+        raw = _scores_or_none(self._scorer, context_query, scored)
+        if raw is None:
+            return [base] * n
         # Clamp to non-negative: BM25 scores are always >= 0 (no-op, preserves
         # byte-identity), but an EmbeddingScorer returns cosine similarities that
         # can be negative. Raw negatives would skew the proportional split into
         # negative/huge per-section budgets, overfilling early sections so the
         # final hard slice drops trailing headings — breaking the skeleton's
         # every-heading-survives invariant.
-        scores = [max(0.0, s) for s in self._scorer.score_sections(context_query, scored)]
+        scores = [max(0.0, s) for s in raw]
         total = sum(scores)
         if total <= 0:
             return [base] * n

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -265,7 +265,10 @@ class TruncateCompressor:
         if context_query and context_query.strip():
             sections = [(k, ser) for k, ser, _ in key_sizes]
             raw = self._scorer.score_sections(context_query, sections)
-            if any(s > 0 for s in raw):
+            # A scorer returning the wrong number of scores (custom
+            # RelevanceScorer drift) would IndexError at
+            # relevance_weights[idx] below — treat it as no signal.
+            if len(raw) == len(key_sizes) and any(s > 0 for s in raw):
                 relevance_weights = raw
 
         # Build output: each key gets budget allocation
@@ -807,7 +810,7 @@ class SelectiveCompressor:
             chunks = self._decompose_single_chunk(chunks, fmt)
             if len(chunks) <= 1:
                 return None
-        return self._store_and_build_toc(text, fmt, chunks, context_query)
+        return self._store_and_build_toc(text, fmt, chunks, context_query, max_chars=max_chars)
 
     # Largest per-entry preview length (the historical default).
     _MAX_PREVIEW = 80

--- a/src/memtomem_stm/proxy/relevance.py
+++ b/src/memtomem_stm/proxy/relevance.py
@@ -71,6 +71,12 @@ class BM25Scorer:
             doc_lens.append(len(heading_tokens) * self._HEADING_WEIGHT + len(body_tokens))
 
         avgdl = sum(doc_lens) / len(doc_lens) if doc_lens else 1.0
+        if avgdl == 0.0:
+            # Every section tokenized to nothing (symbols-only content):
+            # dl/avgdl in the BM25 denominator below would divide by zero.
+            # Any positive stand-in works — tf is 0 everywhere, so every
+            # score comes out 0.0 regardless.
+            avgdl = 1.0
 
         # IDF per query term
         n = len(sections)

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -127,6 +127,22 @@ class TestSelectiveCompressor:
         assert toc["type"] == "toc"
         assert any(e["key"] == "Section A" for e in toc["entries"])
 
+    def test_compress_full_toc_honors_max_chars(self):
+        # compress_full_toc accepted max_chars but never forwarded it to
+        # _store_and_build_toc, so the TOC was built with full-size previews
+        # regardless of budget.
+        data = {f"key{i}": f"word{i} " * 60 for i in range(10)}
+        text = json.dumps(data)
+        c = SelectiveCompressor()
+        unbounded = c.compress_full_toc(text, max_chars=10**9)
+        assert unbounded is not None
+        budget = len(unbounded) - 200  # force the preview-shrink path
+        result = c.compress_full_toc(text, max_chars=budget)
+        assert result is not None
+        assert len(result) <= budget
+        toc = json.loads(result)
+        assert len(toc["entries"]) == 10  # every section stays addressable
+
     def test_select_returns_requested_sections(self):
         data = {"alpha": "AAA" * 100, "beta": "BBB" * 100, "gamma": "CCC" * 100}
         text = json.dumps(data)

--- a/tests/test_query_aware.py
+++ b/tests/test_query_aware.py
@@ -40,6 +40,13 @@ class TestBM25Scorer:
         scores = scorer.score_sections("kubernetes deployment", sections)
         assert all(s == 0.0 for s in scores)
 
+    def test_all_empty_sections_no_crash(self):
+        """Symbols-only sections tokenize to nothing, so every doc length is
+        0 and avgdl used to come out 0 — dividing by zero in the BM25
+        denominator. Must return zeros, not raise."""
+        scores = BM25Scorer().score_sections("redis", [("!!!", "@@@"), ("???", "###")])
+        assert scores == [0.0, 0.0]
+
     def test_partial_match(self):
         """Some sections match, others don't → mixed scores."""
         sections = [
@@ -207,6 +214,27 @@ class TestRelevanceScorerProtocol:
         third_len = len(result) - third_start
         # Custom scorer gave 10.0 to Third, 0.0 to others → Third gets most budget
         assert third_len >= first_len
+
+    def test_wrong_length_scorer_treated_as_no_signal(self):
+        """A custom scorer returning the wrong number of scores must not
+        IndexError the JSON budget allocation — it degrades to the
+        size-proportional path as if there were no query signal."""
+        import json as _json
+
+        class ShortScorer:
+            def score_sections(self, query, sections):
+                return [10.0]  # always one score, regardless of section count
+
+        # Config-like dict (>=2 keys, all values dicts) — the only shape
+        # compress() routes into _json_key_truncate's weighted allocation.
+        data = {k: {"field": "x" * 200, "other": "y" * 100} for k in ("alpha", "beta", "gamma")}
+        text = _json.dumps(data)
+        result = TruncateCompressor(scorer=ShortScorer()).compress(
+            text, max_chars=400, context_query="anything"
+        )
+        # No-signal degradation == byte-identical to the query-less path.
+        baseline = TruncateCompressor().compress(text, max_chars=400)
+        assert result == baseline
 
 
 # ── EmbeddingScorer OpenAI response parsing (#68) ──────────────────────

--- a/tests/test_query_aware.py
+++ b/tests/test_query_aware.py
@@ -215,26 +215,93 @@ class TestRelevanceScorerProtocol:
         # Custom scorer gave 10.0 to Third, 0.0 to others → Third gets most budget
         assert third_len >= first_len
 
-    def test_wrong_length_scorer_treated_as_no_signal(self):
-        """A custom scorer returning the wrong number of scores must not
-        IndexError the JSON budget allocation — it degrades to the
-        size-proportional path as if there were no query signal."""
-        import json as _json
 
-        class ShortScorer:
-            def score_sections(self, query, sections):
-                return [10.0]  # always one score, regardless of section count
+# ── wrong-length scorer degradation (all score_sections consumers) ─────
+
+
+class _ShortScorer:
+    """Misbehaving custom scorer: one score regardless of section count."""
+
+    def score_sections(self, query, sections):
+        return [10.0]
+
+
+class TestWrongLengthScorerDegradation:
+    """A custom scorer returning the wrong number of scores must degrade to
+    the query-less path at EVERY ``score_sections`` consumer — not raise
+    IndexError, not let ``zip()`` truncation pass as real signal, not
+    mis-allocate per-section budgets. All consumers route through
+    ``_scores_or_none``."""
+
+    def test_truncate_json_key_allocation(self):
+        import json as _json
 
         # Config-like dict (>=2 keys, all values dicts) — the only shape
         # compress() routes into _json_key_truncate's weighted allocation.
         data = {k: {"field": "x" * 200, "other": "y" * 100} for k in ("alpha", "beta", "gamma")}
         text = _json.dumps(data)
-        result = TruncateCompressor(scorer=ShortScorer()).compress(
+        result = TruncateCompressor(scorer=_ShortScorer()).compress(
             text, max_chars=400, context_query="anything"
         )
-        # No-signal degradation == byte-identical to the query-less path.
-        baseline = TruncateCompressor().compress(text, max_chars=400)
-        assert result == baseline
+        assert result == TruncateCompressor().compress(text, max_chars=400)
+
+    def test_truncate_section_aware_markdown(self):
+        # Multi-line bodies keep the phase-1 minimums (heading + first line)
+        # small, so the enrich phase actually runs — that's where scores[i]
+        # indexes past a short score list.
+        doc = "\n\n".join(
+            f"## Section {i}\n\n" + "\n".join(f"line {j} of section {i}." for j in range(20))
+            for i in range(3)
+        )
+        budget = int(len(doc) * 0.8)
+        result = TruncateCompressor(scorer=_ShortScorer()).compress(
+            doc, max_chars=budget, context_query="anything"
+        )
+        assert result == TruncateCompressor().compress(doc, max_chars=budget)
+
+    def test_selective_toc_ordering(self):
+        import json as _json
+
+        from memtomem_stm.proxy.compression import SelectiveCompressor
+
+        data = {f"key{i}": "x" * 200 for i in range(3)}
+        text = _json.dumps(data)
+        result = SelectiveCompressor(scorer=_ShortScorer()).compress(
+            text, max_chars=100, context_query="anything"
+        )
+        baseline = SelectiveCompressor().compress(text, max_chars=100)
+        # TOCs embed a random selection_key — compare the entry ordering,
+        # which is what the scorer path reorders.
+        result_keys = [e["key"] for e in _json.loads(result)["entries"]]
+        baseline_keys = [e["key"] for e in _json.loads(baseline)["entries"]]
+        assert result_keys == baseline_keys
+
+    def test_schema_pruning_relevant_keys(self):
+        import json as _json
+
+        from memtomem_stm.proxy.compression import SchemaPruningCompressor
+
+        # zip() against a one-score list used to mark ONLY the first key
+        # relevant — fake signal from truncation, not from the query.
+        data = {f"key{i}": {"field": "x" * 200} for i in range(3)}
+        text = _json.dumps(data)
+        result = SchemaPruningCompressor(scorer=_ShortScorer()).compress(
+            text, max_chars=300, context_query="anything"
+        )
+        assert result == SchemaPruningCompressor().compress(text, max_chars=300)
+
+    def test_skeleton_budgets(self):
+        from memtomem_stm.proxy.compression import SkeletonCompressor
+
+        # A one-element budget list used to zip-render only the first
+        # heading, breaking the skeleton's every-heading-survives invariant.
+        doc = "\n\n".join(f"## Section {i}\n\n" + f"body {i} text. " * 30 for i in range(3))
+        result = SkeletonCompressor(scorer=_ShortScorer()).compress(
+            doc, max_chars=len(doc) // 3, context_query="anything"
+        )
+        assert result == SkeletonCompressor().compress(doc, max_chars=len(doc) // 3)
+        for i in range(3):
+            assert f"## Section {i}" in result
 
 
 # ── EmbeddingScorer OpenAI response parsing (#68) ──────────────────────


### PR DESCRIPTION
## Background

Low findings L131, L320, L324(+L328 test) from the 2026-06-10 implementation review, re-verified against current main. L324 had been mis-triaged as a false positive by a verification agent — re-running the probe showed `BM25Scorer().score_sections('redis', [('!!!','@@@')])` → `ZeroDivisionError`, so it ships as a real fix.

## What changed

- **`compress_full_toc` forwards `max_chars`** to `_store_and_build_toc`, engaging the existing preview-shrink search (was accepted-and-ignored; method currently has no in-repo callers — contract fix only, flagged for possible future removal).
- **Centralized wrong-length scorer validation** (`_scores_or_none`): codex round 1 found the initial `_json_key_truncate`-only guard left four sibling `score_sections` consumers exposed to a custom scorer returning the wrong number of scores — selective TOC ordering (IndexError in sort key), `_enrich_by_relevance` (IndexError), SchemaPruning (`zip()` prefix taken as real signal), Skeleton (one-element budgets rendered only the first heading). All five consumers now route through the helper and fall back to their query-less path; byte-identical for well-behaved scorers.
- **BM25 `avgdl` floors to 1.0 when it computes to 0** — all-empty tokenization leaves `doc_lens` non-empty but all zeros, passing the existing `if doc_lens` guard and dividing by zero in the BM25 denominator.

## Review

Codex R1 NEEDS-FIX (major: guard only one of five consumers) → **R2 SHIP** (verified byte-identity at all five sites, Skeleton negative-only fallback intact, no consumers outside compression.py).

## Tests

`TestWrongLengthScorerDegradation` — one regression per consumer (four failing pre-fix; the already-guarded site pins the helper refactor), plus `test_all_empty_sections_no_crash` and `test_compress_full_toc_honors_max_chars` (both failing pre-fix). Affected suites 275 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)