### PR TITLE
fix(hook): skip compression below the sentinel budget, offload spawn, fix _orchestrate docs

### DIFF
--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -231,7 +231,13 @@ def maybe_compress_builtin(
         # at/near ``max_chars`` (TruncateCompressor's own suffix may still add a
         # small, bounded overage — the budget is a target, not a hard cap).
         prefix = f"{_COMPRESS_SENTINEL}\n"
-        body_budget = max(1, cfg.max_chars - len(prefix))
+        if cfg.max_chars <= len(prefix):
+            # A budget that cannot even hold the sentinel cannot produce a
+            # meaningful replacement — prepending anyway would EXPAND the
+            # configured cap many-fold (max_chars=1 → ~18 chars of sentinel).
+            # Leave the output unchanged instead.
+            return None
+        body_budget = cfg.max_chars - len(prefix)
         compressed = TruncateCompressor().compress(stdout, max_chars=body_budget)
         clone = dict(original)
         clone["stdout"] = prefix + compressed
@@ -486,13 +492,15 @@ async def _run_hook(
             return out
         # Daemon unreachable. Kick off a lock-guarded background spawn so the
         # next call is warm (this call still degrades below). request_spawn is a
-        # quick flock probe + detached Popen — fire-and-forget, never blocking
-        # the hook budget, never raising into the hot path.
+        # quick flock probe + detached Popen — fire-and-forget, never raising
+        # into the hot path. Both steps are blocking syscalls (flock; fork/exec
+        # with a close_fds scan), so run them in a thread to keep the event
+        # loop free while the outer wait_for budget clock runs.
         if config.hook.auto_spawn:
             try:
                 from memtomem_stm.daemon.spawn import request_spawn
 
-                request_spawn(config)
+                await asyncio.to_thread(request_spawn, config)
             except Exception:
                 logger.debug("daemon auto-spawn failed", exc_info=True)
         if config.hook.fallback != "cold":
@@ -505,14 +513,16 @@ async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
     """Resolve the full hook output: in-process Bash *compression* merged with
     LTM *surfacing*, as one ``hookSpecificOutput``.
 
-    Ordering matters. Compression runs **first and in-process** so a multi-MB
-    Bash result is shrunk before it could be sent whole to the daemon's 4 MiB
-    frame, and it is **independent of the surfacing gate** — it still runs when
-    surfacing is disabled or Bash is not in the *surface* allowlist. Surfacing
-    then runs on a frame-bounded copy of the payload, wrapped so that a
-    surfacing failure degrades to "no memories" while still returning the
-    compression half (``maybe_compress_builtin`` is itself non-raising). The CLI
-    wrapper backstops the whole call.
+    The two stages are independent. Compression is an opt-in, Bash-only
+    ``updatedToolOutput`` stage that clones the payload — it never alters
+    what surfacing (or the daemon) receives, and it still runs when
+    surfacing is disabled or Bash is not in the *surface* allowlist.
+    Daemon-frame protection comes solely from ``_bounded_surfacing_payload``
+    (:data:`_SAFE_DAEMON_BUDGET`), which caps the payload copy handed to
+    surfacing whether or not compression ran. Surfacing is wrapped so a
+    failure degrades to "no memories" while still returning the compression
+    half (``maybe_compress_builtin`` is itself non-raising). The CLI wrapper
+    backstops the whole call.
     """
     from memtomem_stm.config import STMConfig
 

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -490,12 +490,14 @@ async def _run_hook(
             out = None
         if out is not None:
             return out
-        # Daemon unreachable. Kick off a lock-guarded background spawn so the
-        # next call is warm (this call still degrades below). request_spawn is a
-        # quick flock probe + detached Popen — fire-and-forget, never raising
-        # into the hot path. Both steps are blocking syscalls (flock; fork/exec
-        # with a close_fds scan), so run them in a thread to keep the event
-        # loop free while the outer wait_for budget clock runs.
+        # Daemon unreachable. Request a lock-guarded spawn so the NEXT call is
+        # warm (this call still degrades below). request_spawn is a quick flock
+        # probe + detached Popen that returns right after fork — the daemon
+        # itself comes up detached — and never raises into the hot path. The
+        # probe and fork/exec are blocking syscalls (flock; close_fds scan), so
+        # they run in a worker thread, awaited only for that brief offloaded
+        # call, keeping the event loop free while the outer wait_for budget
+        # clock runs.
         if config.hook.auto_spawn:
             try:
                 from memtomem_stm.daemon.spawn import request_spawn

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -401,6 +401,15 @@ def test_compress_reserves_sentinel_from_budget(monkeypatch: pytest.MonkeyPatch)
     assert out["stdout"] == f"{_COMPRESS_SENTINEL}\nBODY"
 
 
+def test_compress_skipped_when_budget_below_sentinel():
+    # max_chars only validates gt=0, so it can be configured below the
+    # sentinel prefix length. Prepending the sentinel anyway would EXPAND
+    # the configured cap many-fold (max_chars=1 → ~18 chars) — the stage
+    # must skip instead of "compressing" past its own budget.
+    cfg = HookCompressionConfig(enabled=True, max_chars=len(_COMPRESS_SENTINEL))
+    assert maybe_compress_builtin(_bash_payload({"stdout": _BIG_STDOUT}), cfg) is None
+
+
 def test_compress_noop_for_plain_string_response():
     # For the built-in Bash tool, updatedToolOutput must be a structured object;
     # a bare string would be ignored by the host, so an unstructured response is

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -300,6 +300,33 @@ async def test_hook_run_hook_skips_when_daemon_absent(
     assert calls == [1]  # fire-and-forget spawn requested
 
 
+async def test_hook_run_hook_autospawn_runs_off_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # request_spawn does blocking work (flock probe + fork/exec); _run_hook
+    # must offload it via asyncio.to_thread so the event loop stays free
+    # while the outer wait_for budget clock runs.
+    import threading
+
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "1")
+
+    from memtomem_stm.daemon import spawn
+
+    threads: list[bool] = []
+    monkeypatch.setattr(
+        spawn,
+        "request_spawn",
+        lambda cfg: threads.append(threading.current_thread() is not threading.main_thread()),
+    )
+
+    from memtomem_stm.cli.hook_cmd import _run_hook
+
+    out = await _run_hook(_READ_PAYLOAD)
+    assert out == {}
+    assert threads == [True]  # ran in a worker thread, not on the loop thread
+
+
 async def test_hook_run_hook_no_autospawn_when_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Background

Three low findings from the 2026-06-10 implementation review (report L181, L185, L189), re-verified against current main — all in `cli/hook_cmd.py`.

## What changed

- **Tiny-budget skip (L181):** `HookCompressionConfig.max_chars` only validates `gt=0`, so it can be configured below the ~18-char sentinel prefix. `maybe_compress_builtin` floored the body budget at 1 and prepended the sentinel unconditionally — `max_chars=1` produced a ~18-char replacement, ~18× the configured cap. It now returns `None` (leave output unchanged) when the budget cannot hold the sentinel; the now-dead `max(1, ...)` floor is removed.
- **Spawn offload (L185):** on the daemon-unreachable branch, `request_spawn` (flock probe + `subprocess.Popen` fork/exec with a `close_fds` scan) ran directly on the event loop inside the `wait_for`-bounded hook call. Now `await asyncio.to_thread(request_spawn, config)` — same fire-and-forget semantics, off the loop.
- **Docstring (L189):** `_orchestrate` claimed compression shrinks output "before it could be sent whole to the daemon's 4 MiB frame" — actually compression clones the payload and never alters what surfacing receives; frame protection comes solely from `_bounded_surfacing_payload` / `_SAFE_DAEMON_BUDGET`. Reworded to attribute the mechanisms correctly.

## Behavior change

With `max_chars` configured at or below the sentinel length (pathological config), Bash output is now left unchanged instead of being replaced by a sentinel-only stub. Valid configs are unaffected.

## Tests

- `test_compress_skipped_when_budget_below_sentinel` (fails pre-fix)
- `test_hook_run_hook_autospawn_runs_off_event_loop` — asserts the patched `request_spawn` runs on a worker thread (fails pre-fix)

`test_hook_cmd.py` + `test_server.py` 82 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)