### PR TITLE
fix(daemon): cap start respawns, bound the response drain, honor sub-second idle timeouts

### DIFF
--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -128,6 +128,13 @@ def run_cmd(detached: bool, foreground: bool) -> None:
     raise SystemExit(run_daemon(config))
 
 
+# Cap on detached children `mms daemon start` may launch in one invocation.
+# A crashed child releases the lifetime lock, making "lock free" ambiguous
+# (mid-shutdown handoff vs crash loop); 3 covers the handoff with margin while
+# a persistently-failing config produces a handful of children, not dozens.
+_START_MAX_SPAWNS = 3
+
+
 @daemon_group.command(name="start")
 def start_cmd() -> None:
     """Spawn the daemon detached if one isn't already running for this config.
@@ -154,6 +161,7 @@ def start_cmd() -> None:
         return
 
     deadline = time.time() + 10.0
+    spawns = 0
     while time.time() < deadline:
         hs = asyncio.run(client.ping(config, timeout=1.0))
         if hs is not None:
@@ -162,9 +170,15 @@ def start_cmd() -> None:
         # request_spawn launches a detached child iff our config's lock is free;
         # it returns False only when a same-config daemon already holds it
         # (mid-startup → ping succeeds soon, or mid-shutdown → the lock frees and
-        # the next attempt wins). Either way we just keep retrying. We never hold
-        # the lock, so the spawned child can take ownership.
-        request_spawn(config)
+        # the next attempt wins). We never hold the lock, so the spawned child
+        # can take ownership. BUT a free lock can also mean the child we just
+        # spawned crashed on startup (bad config) — without a cap, a
+        # crash-looping config would fire a detached child every 0.3s for the
+        # whole window (~33 processes). Cap actual spawns and keep only
+        # ping-polling afterwards; the mid-shutdown handoff needs at most one
+        # respawn after the old daemon releases.
+        if spawns < _START_MAX_SPAWNS and request_spawn(config):
+            spawns += 1
         time.sleep(0.3)
     click.echo(
         _warn(

--- a/src/memtomem_stm/daemon/discovery.py
+++ b/src/memtomem_stm/daemon/discovery.py
@@ -75,13 +75,15 @@ def config_fingerprint(config: STMConfig) -> str:
     reads directly (so it isn't in any model), and exactly the one ``hook``
     field the daemon engine wiring consumes: ``record_feedback_events``.
 
-    Deliberately **excluded**: the client-only ``hook`` fields ``use_daemon``,
-    ``fallback`` and ``daemon_timeout_seconds``. They govern how the *hook*
-    talks to the daemon, never what the daemon does — the daemon's behavior is
-    independent of them (``mms daemon start`` warms the same daemon whether or
-    not the hook has opted out via ``MEMTOMEM_STM_HOOK__USE_DAEMON=0``).
-    Including them would make a live daemon look stale and the hook would reject
-    it (then, under the default ``fallback=skip``, return ``{}`` forever).
+    Deliberately **excluded**: every other ``hook`` field — the client-only
+    ``use_daemon``, ``fallback``, ``daemon_timeout_seconds`` and ``auto_spawn``,
+    plus the whole ``compression`` sub-block (it runs in the hook process,
+    never in the daemon). They govern how the *hook* behaves or talks to the
+    daemon, never what the daemon does — the daemon's behavior is independent
+    of them (``mms daemon start`` warms the same daemon whether or not the
+    hook has opted out via ``MEMTOMEM_STM_HOOK__USE_DAEMON=0``). Including
+    them would make a live daemon look stale and the hook would reject it
+    (then, under the default ``fallback=skip``, return ``{}`` forever).
     ``mode="json"`` makes ``Path``/enum values serializable.
     """
     material = {

--- a/src/memtomem_stm/daemon/server.py
+++ b/src/memtomem_stm/daemon/server.py
@@ -61,6 +61,12 @@ logger = logging.getLogger(__name__)
 # handler open forever; well above a warm surface round trip.
 _READ_TIMEOUT_SECONDS = 30.0
 
+# Outbound write+drain budget — symmetric to the read bound. A peer that sent
+# its request and then stopped reading (half-open socket, full receive buffer)
+# would otherwise block drain() forever, pinning the handler task and its
+# buffered response for the process lifetime.
+_WRITE_TIMEOUT_SECONDS = 30.0
+
 
 async def _quiet(coro: Any, what: str) -> None:
     """Await a cleanup coroutine, swallowing (and debug-logging) any error."""
@@ -353,7 +359,9 @@ class DaemonServer:
             resp = await self._dispatch(req)
             if resp is not None:
                 writer.write(encode_line(resp))
-                await writer.drain()
+                # Timeout → the generic handler below logs it and the finally
+                # block closes the writer, dropping the stuck consumer.
+                await asyncio.wait_for(writer.drain(), timeout=_WRITE_TIMEOUT_SECONDS)
         except Exception:
             logger.debug("daemon connection handler error", exc_info=True)
         finally:
@@ -395,7 +403,11 @@ class DaemonServer:
     async def _idle_watch(self) -> None:
         if self._idle_timeout <= 0:
             return
-        interval = min(30.0, max(1.0, self._idle_timeout / 2))
+        # Poll at half the timeout, floored low enough that sub-second
+        # idle_timeout values (tests, aggressive resource configs) shut down
+        # near the configured threshold instead of ~1s late, and capped so a
+        # huge timeout still notices the shutdown event reasonably often.
+        interval = min(30.0, max(0.05, self._idle_timeout / 2))
         while not self._shutdown_event.is_set():
             try:
                 await asyncio.wait_for(self._shutdown_event.wait(), timeout=interval)

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -131,6 +131,12 @@ def test_config_fingerprint_excludes_client_only_hook_fields(monkeypatch: pytest
         c = STMConfig()
         setattr(c.hook, field, value)
         assert discovery.config_fingerprint(c) == fp, field
+    # The whole compression sub-block runs in the hook process, never in the
+    # daemon — toggling it must not move the fingerprint either.
+    c = STMConfig()
+    c.hook.compression.enabled = True
+    c.hook.compression.max_chars = 123
+    assert discovery.config_fingerprint(c) == fp
     # record_feedback_events DOES drive daemon engine wiring → must move it.
     c = STMConfig()
     c.hook.record_feedback_events = True
@@ -173,6 +179,50 @@ def test_start_retries_spawn_until_lock_frees(tmp_path: Path, monkeypatch: pytes
     assert state["spawns"] >= 3  # retried past the initial declines
     assert all(state["lock_free_seen"])  # start never held the lock
     assert "daemon started" in result.output
+
+
+def test_start_caps_spawn_attempts_for_crash_looping_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A child that crashes on startup (bad config) releases the lifetime lock
+    # immediately, so every retry iteration finds it free. Without a cap,
+    # `start` fired a detached child every 0.3s for the whole 10s window
+    # (~33 crash-looping processes).
+    from types import SimpleNamespace
+
+    from click.testing import CliRunner
+
+    from memtomem_stm.cli.proxy import cli
+
+    monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+
+    spawns = {"n": 0}
+
+    def crash_looping_spawn(config):
+        spawns["n"] += 1
+        return True  # lock free every time — the spawned child died instantly
+
+    async def never_ready(config, *, timeout=2.0):
+        return None
+
+    monkeypatch.setattr("memtomem_stm.daemon.spawn.request_spawn", crash_looping_spawn)
+    monkeypatch.setattr("memtomem_stm.daemon.client.ping", never_ready)
+    # Compress the 10s wall-clock window: sleep advances a fake clock.
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        "memtomem_stm.cli.daemon_cmd.time",
+        SimpleNamespace(
+            time=lambda: clock["t"],
+            sleep=lambda s: clock.__setitem__("t", clock["t"] + s),
+        ),
+    )
+
+    result = CliRunner().invoke(cli, ["daemon", "start"])
+    assert result.exit_code == 0
+    assert "did not become ready" in result.output
+    from memtomem_stm.cli.daemon_cmd import _START_MAX_SPAWNS
+
+    assert spawns["n"] == _START_MAX_SPAWNS  # capped, not ~33
 
 
 def test_start_coexists_with_different_config_daemon(
@@ -394,9 +444,7 @@ def _write_handshake(payload: dict) -> Path:
     import json
 
     config = STMConfig()
-    p = discovery.handshake_path(
-        config.data_dir.expanduser(), discovery.config_fingerprint(config)
-    )
+    p = discovery.handshake_path(config.data_dir.expanduser(), discovery.config_fingerprint(config))
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(json.dumps(payload), encoding="utf-8")
     return p
@@ -610,9 +658,7 @@ class TestDaemonRestartCli:
         assert "daemon started" in result.output
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock semantics")
-    def test_wedged_teardown_reports_clearly(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_wedged_teardown_reports_clearly(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """When the old daemon never frees its lifetime lock, restart must
         report the wedged teardown instead of a misleading start timeout."""
         from click.testing import CliRunner

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -35,6 +35,7 @@ from memtomem_stm.daemon.discovery import (
 )
 from memtomem_stm.daemon.protocol import (
     MAX_MESSAGE_BYTES,
+    OP_PING,
     OP_SURFACE,
     build_request,
     encode_line,
@@ -263,6 +264,56 @@ async def test_build_engine_dedup_only_wiring(tmp_path: Path) -> None:
         if server._tracker is not None:
             server._tracker.close()
         await server._adapter.stop()
+
+
+async def test_handler_write_timeout_drops_stuck_consumer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A peer that sends its request then never reads must not pin the handler
+    # task for the process lifetime — the bounded drain drops the connection
+    # and the finally block closes the writer.
+    server = DaemonServer(_config(tmp_path))
+    monkeypatch.setattr(daemon_server, "_WRITE_TIMEOUT_SECONDS", 0.1)
+
+    reader = asyncio.StreamReader()
+    reader.feed_data(encode_line(build_request(server._token, OP_PING)))
+    reader.feed_eof()
+
+    class _StuckWriter:
+        closed = False
+
+        def write(self, data: bytes) -> None:
+            pass
+
+        async def drain(self) -> None:
+            await asyncio.Event().wait()  # peer never reads; buffer never drains
+
+        def close(self) -> None:
+            self.closed = True
+
+        async def wait_closed(self) -> None:
+            return None
+
+    writer = _StuckWriter()
+    await asyncio.wait_for(server._handle_conn(reader, writer), timeout=5.0)
+    assert writer.closed
+
+
+async def test_sub_second_idle_timeout_shuts_down_promptly(tmp_path: Path) -> None:
+    # The idle poll used to floor at 1.0s, so idle_timeout=0.2 shut down ~1s+
+    # after start (the test below only proves *eventual* shutdown). With the
+    # lowered floor the daemon exits near the configured threshold.
+    cfg = _config(tmp_path)
+    cfg.daemon.idle_timeout_seconds = 0.2
+    server = DaemonServer(cfg)
+    server._build_engine = lambda: setattr(server, "_engine", _engine_with_result())  # type: ignore[method-assign]
+    task = asyncio.create_task(server.serve())
+    await _await_handshake(cfg)
+    t0 = asyncio.get_running_loop().time()
+    await asyncio.wait_for(task, timeout=5.0)
+    elapsed = asyncio.get_running_loop().time() - t0
+    # Pre-fix lower bound was the 1.0s poll floor; expected now ≈ 0.2-0.4s.
+    assert elapsed < 0.9, f"idle shutdown took {elapsed:.2f}s — poll floor regressed?"
 
 
 async def test_idle_shutdown_stops_daemon(tmp_path: Path) -> None:


### PR DESCRIPTION
## Background

Low findings L154, L162, L166 (+ L258 docs-drift) from the 2026-06-10 implementation review, re-verified against current main.

## What changed

- **Spawn cap (L154):** `mms daemon start` retried `request_spawn` every 0.3 s for 10 s. A child that crashes during startup (invalid LTM command, unreadable DB, bad config) releases the lifetime lock immediately, so every iteration found the lock free and spawned another detached, DEVNULL'd child — ~33 crash-looping processes per `start`. Actual spawns (`request_spawn` returning `True`) are now capped at `_START_MAX_SPAWNS = 3`; the rest of the window keeps ping-polling. The mid-shutdown handoff the loop was built for needs at most one respawn, so the existing retry-until-lock-frees behavior is preserved (its test still passes — declined probes don't count toward the cap).
- **Bounded drain (L162):** `_handle_conn` bounded only the inbound read; `writer.drain()` was unbounded, so a half-open peer that stopped reading pinned the handler task and its buffered response forever. Now `asyncio.wait_for(..., _WRITE_TIMEOUT_SECONDS=30.0)`, symmetric to the read bound; timeout falls through to the existing close path.
- **Idle poll floor (L166):** `_idle_watch` floored its poll at 1.0 s, so `idle_timeout=0.2` shut down ~1 s+ late. Floor lowered to 0.05 s and documented; default (multi-second) timeouts poll exactly as before.
- **Docs (L258):** `config_fingerprint`'s exclusion list now states that *all* of `config.hook` except `record_feedback_events` is excluded — explicitly naming `auto_spawn` and the `compression` sub-block — and the exclusion test gains a compression-toggle pin.

## Tests

- `test_start_caps_spawn_attempts_for_crash_looping_child` — fake clock compresses the 10 s window; asserts exactly 3 spawns instead of ~33 (fails pre-fix).
- `test_handler_write_timeout_drops_stuck_consumer` — stuck-drain writer; handler completes and closes (hangs pre-fix, fails via outer wait_for).
- `test_sub_second_idle_timeout_shuts_down_promptly` — `idle_timeout=0.2` exits in < 0.9 s (pre-fix lower bound was the 1.0 s floor).
- Compression-toggle fingerprint invariance pin.

`tests/daemon/` 63 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)