### PR TITLE
fix(cli): config-file handling consistency in the mms proxy CLI

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -332,8 +332,16 @@ def _write_mcp_json_for_stm(target_dir: Path, server_cmd: str, server_args: list
         servers["memtomem-stm"] = entry
     # Atomic like every sibling config writer (_save, _desktop_json_remove_entry):
     # Claude Code re-reads .mcp.json at project load, and a crash/disk-full
-    # mid-write must leave the prior contents, not truncated JSON.
-    atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n")
+    # mid-write must leave the prior contents, not truncated JSON. Unlike
+    # those secret-bearing configs, .mcp.json is a shared project file: keep
+    # an existing file's mode, default new ones to 0o644 — without an
+    # explicit mode the helper's mkstemp temp (0600) survives the rename and
+    # silently makes the file unreadable to group/other.
+    try:
+        file_mode = mcp_path.stat().st_mode & 0o777
+    except OSError:
+        file_mode = 0o644
+    atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n", mode=file_mode)
     return mcp_path
 
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -330,7 +330,10 @@ def _write_mcp_json_for_stm(target_dir: Path, server_cmd: str, server_args: list
         existing["mcpServers"] = {"memtomem-stm": entry}
     else:
         servers["memtomem-stm"] = entry
-    mcp_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+    # Atomic like every sibling config writer (_save, _desktop_json_remove_entry):
+    # Claude Code re-reads .mcp.json at project load, and a crash/disk-full
+    # mid-write must leave the prior contents, not truncated JSON.
+    atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n")
     return mcp_path
 
 
@@ -1358,7 +1361,16 @@ def _handle_source_prune(
         return
 
     pruned, failed = _prune_imported_candidates(imported_candidates)
+    _report_prune_results(pruned, failed)
 
+
+def _report_prune_results(
+    pruned: list[tuple[str, str]], failed: list[tuple[str, str, str]]
+) -> bool:
+    """Print the prune outcome — shared by ``_handle_source_prune`` and the
+    ``prune`` command so the operator-facing wording cannot drift between
+    them. Returns ``True`` when any removal failed (the command path exits
+    non-zero on that)."""
     if pruned:
         click.echo("")
         click.echo(f"{_ok('Removed from source client(s):')}")
@@ -1377,6 +1389,7 @@ def _handle_source_prune(
         click.echo("Run the following to remove them manually:", err=True)
         for name, src, _ in failed:
             click.echo(f"  {_source_removal_hint(name, src)}", err=True)
+    return bool(failed)
 
 
 def _find_dual_registered(
@@ -2036,6 +2049,18 @@ def init(
         click.echo(f"    mms list --config {resolved}")
         click.echo(f"    mms health --config {resolved}")
         click.echo(f"    mms add --import --config {resolved}")
+        # The MCP client entry registered below carries no --config reference,
+        # so the registered server boots reading the DEFAULT config and would
+        # silently ignore the file this run just built.
+        click.echo("")
+        click.echo(
+            _warn(
+                "note: any MCP client entry registered by this run reads the DEFAULT "
+                "config path, not this file — set "
+                f"MEMTOMEM_STM_PROXY__CONFIG_PATH={resolved} in the entry's env "
+                "for the server to use this config."
+            )
+        )
 
     click.echo("")
     _run_mcp_integration(_MCP_MODE_TO_CHOICE.get(mcp_mode) if mcp_mode else None)
@@ -2100,6 +2125,14 @@ def register(config_path: str, mcp_mode: str | None) -> None:
 def remove(name: str, config_path: str, yes: bool) -> None:
     """Remove an upstream MCP server from the proxy configuration."""
     path = Path(config_path)
+    # Missing-config guard matching prune/register: _load returns the default
+    # empty config for a missing file, which would misreport a wrong --config
+    # path as "server not found" instead of "config not found".
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        click.echo(f"{_err('Error:')} config not found at {resolved}.", err=True)
+        click.echo("  Run `mms init` first.", err=True)
+        sys.exit(1)
     data = _load(path)
     servers: dict[str, Any] = data.get("upstream_servers", {})
 
@@ -2290,25 +2323,7 @@ def prune(
         return
 
     pruned, failed = _prune_imported_candidates(dual)
-
-    if pruned:
-        click.echo("")
-        click.echo(f"{_ok('Removed from source client(s):')}")
-        for name, src in pruned:
-            click.echo(f"  {name} — {src}")
-
-    if failed:
-        click.echo("")
-        click.echo(
-            f"{_warn('Warning:')} could not remove {len(failed)} direct registration(s):",
-            err=True,
-        )
-        for name, src, err in failed:
-            click.echo(f"  {name} ({src}): {err}", err=True)
-        click.echo("", err=True)
-        click.echo("Run the following to remove them manually:", err=True)
-        for name, src, _ in failed:
-            click.echo(f"  {_source_removal_hint(name, src)}", err=True)
+    if _report_prune_results(pruned, failed):
         sys.exit(1)
 
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -757,6 +757,26 @@ class TestAtomicSave:
         assert mcp_path.read_text(encoding="utf-8") == prior  # untouched
         assert list(tmp_path.glob(".mcp.json.*.tmp")) == []  # no temp litter
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+    def test_write_mcp_json_preserves_existing_mode(self, tmp_path: Path) -> None:
+        # .mcp.json is a shared (non-secret) project file. The atomic helper's
+        # mkstemp temp is 0600; without an explicit mode that would survive
+        # the rename and silently drop group/other read access (codex catch).
+        from memtomem_stm.cli.proxy import _write_mcp_json_for_stm
+
+        mcp_path = tmp_path / ".mcp.json"
+        mcp_path.write_text("{}", encoding="utf-8")
+        mcp_path.chmod(0o644)
+        _write_mcp_json_for_stm(tmp_path, "memtomem-stm", [])
+        assert (mcp_path.stat().st_mode & 0o777) == 0o644
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+    def test_write_mcp_json_new_file_gets_project_mode(self, tmp_path: Path) -> None:
+        from memtomem_stm.cli.proxy import _write_mcp_json_for_stm
+
+        _write_mcp_json_for_stm(tmp_path, "memtomem-stm", [])
+        assert ((tmp_path / ".mcp.json").stat().st_mode & 0o777) == 0o644
+
     def test_save_writes_payload_and_leaves_no_temp_file(self, tmp_path: Path) -> None:
         from memtomem_stm.cli.proxy import _save
 

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -735,6 +735,28 @@ class TestAtomicSave:
     truncate-then-write).
     """
 
+    def test_write_mcp_json_failure_leaves_prior_contents(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # .mcp.json is re-read by Claude Code at project load; a failed write
+        # must leave the previous contents intact, not truncated JSON (the
+        # previous Path.write_text path was truncate-then-write).
+        from memtomem_stm.cli.proxy import _write_mcp_json_for_stm
+
+        mcp_path = tmp_path / ".mcp.json"
+        prior = '{"mcpServers": {"existing": {"command": "keep-me"}}}\n'
+        mcp_path.write_text(prior, encoding="utf-8")
+
+        def boom(*_a, **_kw):
+            raise OSError("simulated rename failure")
+
+        monkeypatch.setattr("memtomem_stm.utils.fileio.os.replace", boom)
+        with pytest.raises(OSError, match="simulated rename"):
+            _write_mcp_json_for_stm(tmp_path, "memtomem-stm", [])
+
+        assert mcp_path.read_text(encoding="utf-8") == prior  # untouched
+        assert list(tmp_path.glob(".mcp.json.*.tmp")) == []  # no temp litter
+
     def test_save_writes_payload_and_leaves_no_temp_file(self, tmp_path: Path) -> None:
         from memtomem_stm.cli.proxy import _save
 
@@ -990,6 +1012,22 @@ class TestInit:
         assert srv["transport"] == "stdio"
         assert srv["command"] == "npx"
         assert srv["args"] == ["-y", "@modelcontextprotocol/server-fs"]
+
+    def test_init_custom_config_warns_registered_entry_reads_default(
+        self, runner, config, no_discovery
+    ):
+        # A non-default --config gets the management hints PLUS a note that
+        # any registered MCP client entry boots reading the DEFAULT config —
+        # otherwise the divergence is invisible until tools don't appear.
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="filesystem\nfs\nstdio\nnpx\n-y @modelcontextprotocol/server-fs\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Manage this config:" in result.output
+        assert "MEMTOMEM_STM_PROXY__CONFIG_PATH" in result.output
+        assert "DEFAULT config path" in result.output
 
     def test_init_aborts_if_config_exists(self, runner, config):
         """Init is for first-time setup only; `mms add` handles append."""
@@ -3718,6 +3756,17 @@ class TestRemove:
         result = runner.invoke(cli, ["remove", "ghost", "--yes", *_cfg_args(config)])
         assert result.exit_code == 1
         assert "not found" in result.output
+
+    def test_remove_missing_config_reports_config_not_found(self, runner, tmp_path):
+        # A wrong --config path must be diagnosed as a missing CONFIG (like
+        # prune/register), not as a missing server — _load's default empty
+        # config used to make this report "server 'ghost' not found".
+        missing = tmp_path / "nope.json"
+        result = runner.invoke(cli, ["remove", "ghost", "--yes", "--config", str(missing)])
+        assert result.exit_code == 1
+        assert "config not found" in result.output
+        assert "mms init" in result.output
+        assert "server 'ghost'" not in result.output
 
     def test_remove_without_yes_requires_confirm(self, runner, config):
         runner.invoke(cli, ["add", "fs", "--prefix", "fs", "--command", "x", *_cfg_args(config)])


### PR DESCRIPTION
## Background

Low findings L204, L208, L212, L216 from the 2026-06-10 implementation review, re-verified against current main — all in `cli/proxy.py`. Note: a verification agent had marked L208/L212 as fixed by #432 with mismatched evidence; direct re-verification showed both still open (#432 touched server config loading, not these CLI paths).

## What changed

- **Atomic `.mcp.json` (L204):** `_write_mcp_json_for_stm` used plain `write_text` while `_save` and `_desktop_json_remove_entry` go through `atomic_write_text` precisely because a concurrent reader (Claude Code at project load) can hit a truncated file. Now atomic.
- **`init --config <custom>` divergence note (L208):** the registered MCP client entry carries no `--config` reference, so the registered server boots reading the DEFAULT config — silently ignoring the file the user just built. The non-default-path hint block now warns about this and names the `MEMTOMEM_STM_PROXY__CONFIG_PATH` env override (verified live: `server.py` loads from `config.proxy.config_path`, which pydantic-settings binds from that env).
- **`remove` missing-config guard (L212):** `prune`/`register` pre-check `resolved.exists()`; `remove` called `_load` directly, so a wrong `--config` path reported `server 'X' not found` instead of `config not found`. Same guard, same wording.
- **Prune reporting helper (L216):** the 18-line "Removed from source client(s) / could not remove N" block duplicated verbatim between `_handle_source_prune` and the `prune` command is now `_report_prune_results(pruned, failed) -> bool`; the command path exits non-zero on `True`. Byte-identical output.

## Tests

- `test_write_mcp_json_failure_leaves_prior_contents` — patched `os.replace` failure leaves the prior file intact, no temp litter (fails pre-fix).
- `test_init_custom_config_warns_registered_entry_reads_default` (fails pre-fix).
- `test_remove_missing_config_reports_config_not_found` (fails pre-fix).
- Helper extraction covered by the existing prune suites.

`tests/cli/test_proxy_cli.py` 224 passed; ruff clean (the file's pre-existing unformatted spots are untouched — CI format gate covers `src` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)