### PR TITLE
fix(mms): reject unknown names in project enable, refuse ambiguous show, drop dead guard

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -477,7 +477,7 @@ Options:
 
 `enable` adds MCP names to the project's `[mcp].enabled` list; `disable` removes them. Both require either a marker at cwd (or up the tree) or an explicit `--project NAME`. `enable` additionally requires a non-empty `~/.mms/registry.toml` — populate it with `mms import` first. `disable` works regardless of registry state since it only mutates project state.
 
-The MCP-name validity check (does this name actually exist in the registry?) is intentionally deferred to sync time (W2) per RFC §7.1, so `enable` accepts any name as long as the registry is non-empty.
+`enable` validates every requested name against the registry and rejects unknown ones, listing the registered set as a hint — register or import the MCP first, then enable it. (The validity check was originally deferred to sync time, but no sync surface ever consumed the project enabled list, so a typo would have sat in `project.toml` and silently resolved to nothing at proxy time.) `disable` stays registry-agnostic by design.
 
 ## `mms import` — populate the registry from host configs
 

--- a/src/memtomem_stm/cli/mms_project.py
+++ b/src/memtomem_stm/cli/mms_project.py
@@ -188,7 +188,7 @@ def show_cmd(name: str | None, json_output: bool) -> None:
         if len(matches) > 1:
             raise click.ClickException(
                 f"Project name '{name}' is ambiguous ({len(matches)} matches). "
-                "Run `mms project show` without --project from inside the "
+                "Run `mms project show` without NAME from inside the "
                 "target project root instead."
             )
         entry = matches[0]

--- a/src/memtomem_stm/cli/mms_project.py
+++ b/src/memtomem_stm/cli/mms_project.py
@@ -182,6 +182,15 @@ def show_cmd(name: str | None, json_output: bool) -> None:
             raise click.ClickException(
                 f"Project '{name}' not found in {state.projects_index_path()}."
             )
+        # The index is keyed by canonical path, so two projects can share a
+        # name — mirror _resolve_project_for_mutation's ambiguity error
+        # instead of silently showing an arbitrary one of them.
+        if len(matches) > 1:
+            raise click.ClickException(
+                f"Project name '{name}' is ambiguous ({len(matches)} matches). "
+                "Run `mms project show` without --project from inside the "
+                "target project root instead."
+            )
         entry = matches[0]
         marker = Path(entry.path) / state.PROJECT_MARKER_RELPATH
         if not marker.is_file():
@@ -305,6 +314,18 @@ def enable_cmd(mcps: tuple[str, ...], project_name: str | None) -> None:
         # mode (PR2 has not landed yet). Pinned literal text per plan.
         click.echo(_REGISTRY_EMPTY_MSG, nl=False, err=True)
         raise click.exceptions.Exit(1)
+
+    # Reject names absent from the registry: a typo would otherwise be
+    # silently persisted to the enabled list and resolve to nothing at proxy
+    # time, with no signal to the user. `disable` stays registry-agnostic by
+    # design (its docstring: must work against an empty registry).
+    unknown = [m for m in mcps if m not in registry.servers]
+    if unknown:
+        known = ", ".join(sorted(registry.servers))
+        raise click.ClickException(
+            f"Unknown MCP name(s): {', '.join(unknown)}. "
+            f"Registered: {known}. Run `mms list` to inspect the registry."
+        )
 
     assert proj.config is not None  # _resolve_project_for_mutation guarantees MARKER
     current = list(proj.config.mcp.enabled)

--- a/src/memtomem_stm/mms/secrets.py
+++ b/src/memtomem_stm/mms/secrets.py
@@ -96,7 +96,7 @@ def _value_looks_secret(value: str) -> str | None:
     """
     if len(value) < _VALUE_HEURISTIC_MIN_LEN:
         return None
-    if not value or any(c.isspace() for c in value):
+    if any(c.isspace() for c in value):
         return None
     if _HEX_RE.match(value):
         return "hex"

--- a/tests/cli/test_mms_project.py
+++ b/tests/cli/test_mms_project.py
@@ -274,6 +274,36 @@ def test_enable_appends_unique(runner, sandbox):
     assert cfg.mcp.enabled == ["a", "b", "c"]
 
 
+def test_show_duplicate_name_is_ambiguous(runner, sandbox):
+    # The index is keyed by canonical path, so two projects can share a name.
+    # `show NAME` must refuse like enable/disable do, not silently pick one.
+    a = sandbox["home"] / "proj-a"
+    b = sandbox["home"] / "proj-b"
+    a.mkdir()
+    b.mkdir()
+    runner.invoke(project_group, ["init", str(a), "--name", "same"])
+    runner.invoke(project_group, ["init", str(b), "--name", "same"])
+
+    res = runner.invoke(project_group, ["show", "same"])
+    assert res.exit_code != 0
+    assert "ambiguous (2 matches)" in res.output
+
+
+def test_enable_unknown_name_rejected_with_hint(runner, sandbox):
+    # A typo must not be silently persisted to the enabled list — it would
+    # resolve to nothing at proxy time with no signal to the user.
+    runner.invoke(project_group, ["init"])
+    _seed_registry("filesystem")
+
+    res = runner.invoke(project_group, ["enable", "filesytem"])  # typo
+    assert res.exit_code != 0
+    assert "Unknown MCP name(s): filesytem" in res.output
+    assert "filesystem" in res.output  # registered set shown as the hint
+
+    cfg = state.load_project_config(sandbox["cwd"] / state.PROJECT_MARKER_RELPATH)
+    assert cfg.mcp.enabled == []  # nothing persisted
+
+
 def test_enable_with_project_flag(runner, sandbox):
     other = sandbox["home"] / "other-proj"
     other.mkdir()


### PR DESCRIPTION
## Background

Low findings L235, L239, L243 from the 2026-06-10 implementation review, re-verified against current main. (L235's earlier agent-triage claimed it fixed by #430 with mismatched evidence; direct verification showed `show_cmd` still took `matches[0]` unguarded.)

## What changed

- **`mms project show NAME` ambiguity (L235):** the projects index is keyed by canonical path, so two projects can legitimately share a name. `enable`/`disable` (via `_resolve_project_for_mutation`) raise "ambiguous (N matches)" for that state, but `show` silently displayed `matches[0]`. It now raises the mirrored error and points at running `show` from inside the target project root.
- **`mms project enable` validation (L239):** any requested name was appended to the enabled list with no registry check — `mms project enable filesytem` (typo) succeeded and persisted a name that resolves to nothing at proxy time. Unknown names now raise a `ClickException` listing them plus the registered set; nothing is persisted. `disable` intentionally stays registry-agnostic (its contract: works against an empty registry).
- **Dead guard (L243):** `_value_looks_secret`'s `not value or` disjunct was unreachable after the `len(value) < 32` floor; dropped, whitespace check unchanged.

## Behavior change

`mms project enable` now exits non-zero on unregistered names instead of silently persisting them. Scripts enabling names before registering them would need to reorder — registering first was already the documented flow (RFC §7.1).

## Tests

- `test_show_duplicate_name_is_ambiguous` (fails pre-fix)
- `test_enable_unknown_name_rejected_with_hint` — asserts the error, the hint, and that nothing was persisted (fails pre-fix)

`test_mms_project.py` + `tests/mms/` + `test_mms_host.py` 284 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)