### PR TITLE
fix(server): warn at startup when surfacing is enabled but the proxy is disabled

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -244,15 +244,19 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
                 logger.warning("Langfuse init failed, continuing without tracing", exc_info=True)
         else:
             logger.info("Proxy disabled (enabled=false) — only STM control tools available")
-            if config.surfacing.enabled:
+            if config.surfacing.enabled and "enabled" in config.surfacing.model_fields_set:
                 # Mirror the #288 "enabled but inert" pattern: the surfacing
                 # engine only initializes inside the proxy branch above, so a
-                # surfacing.enabled=true config silently does nothing here —
+                # surfacing-enabled config silently does nothing here —
                 # otherwise visible only on demand via stm_proxy_health.
+                # Gated on model_fields_set because surfacing.enabled defaults
+                # to True: only an EXPLICIT enablement (env/config) is a
+                # config-says-enabled mismatch; the plain control-only default
+                # startup must stay warning-free.
                 logger.warning(
-                    "surfacing enabled but the proxy is disabled — config is "
-                    "enabled but inert; no memories will be surfaced. Enable "
-                    "the proxy or set surfacing.enabled=false to silence."
+                    "surfacing explicitly enabled but the proxy is disabled — "
+                    "config is enabled but inert; no memories will be surfaced. "
+                    "Enable the proxy or set surfacing.enabled=false to silence."
                 )
 
         # Initialize proxy manager (always created for STM control tools like stm_proxy_stats)

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -244,6 +244,16 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
                 logger.warning("Langfuse init failed, continuing without tracing", exc_info=True)
         else:
             logger.info("Proxy disabled (enabled=false) — only STM control tools available")
+            if config.surfacing.enabled:
+                # Mirror the #288 "enabled but inert" pattern: the surfacing
+                # engine only initializes inside the proxy branch above, so a
+                # surfacing.enabled=true config silently does nothing here —
+                # otherwise visible only on demand via stm_proxy_health.
+                logger.warning(
+                    "surfacing enabled but the proxy is disabled — config is "
+                    "enabled but inert; no memories will be surfaced. Enable "
+                    "the proxy or set surfacing.enabled=false to silence."
+                )
 
         # Initialize proxy manager (always created for STM control tools like stm_proxy_stats)
         proxy_manager = ProxyManager(

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1121,15 +1121,23 @@ class TestLifespan:
                 # ProxyManager.start() should NOT be called when proxy is disabled
                 mock_pm_instance.start.assert_not_awaited()
 
-    async def test_proxy_disabled_warns_when_surfacing_configured_on(self, caplog):
-        """surfacing.enabled=true under a disabled proxy silently does nothing
-        (the engine only initializes inside the proxy branch), previously
-        visible only on demand via stm_proxy_health — startup must emit the
-        #288-style "enabled but inert" warning. And ONLY then: the plain
-        proxy-disabled default must stay warning-free."""
+    async def test_proxy_disabled_warns_when_surfacing_explicitly_on(self, caplog):
+        """An EXPLICITLY surfacing-enabled config under a disabled proxy
+        silently does nothing (the engine only initializes inside the proxy
+        branch), previously visible only on demand via stm_proxy_health —
+        startup must emit the #288-style "enabled but inert" warning. And
+        ONLY then: surfacing.enabled defaults to True, so the plain
+        control-only default startup (enabled-by-default, not explicitly
+        set) must stay warning-free, as must an explicit opt-out."""
         from memtomem_stm.server import app_lifespan, mcp
 
-        for surfacing_enabled in (True, False):
+        cases = [
+            # (enabled, explicitly set?, expect warning)
+            (True, {"enabled"}, True),  # operator turned it on → warn
+            (True, set(), False),  # default-on, never touched → quiet
+            (False, {"enabled"}, False),  # explicit opt-out → quiet
+        ]
+        for enabled, fields_set, expect_warning in cases:
             caplog.clear()
             mock_pm_instance = MagicMock()
             mock_pm_instance.start = AsyncMock()
@@ -1145,7 +1153,8 @@ class TestLifespan:
                 mock_cfg.proxy.enabled = False
                 mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
                 mock_cfg.surfacing = MagicMock()
-                mock_cfg.surfacing.enabled = surfacing_enabled
+                mock_cfg.surfacing.enabled = enabled
+                mock_cfg.surfacing.model_fields_set = fields_set
                 mock_cfg.langfuse = MagicMock()
                 mock_cfg.langfuse.enabled = False
 
@@ -1154,7 +1163,7 @@ class TestLifespan:
                         pass
 
             inert = [r for r in caplog.records if "enabled but inert" in r.getMessage()]
-            assert bool(inert) is surfacing_enabled, f"surfacing_enabled={surfacing_enabled}"
+            assert bool(inert) is expect_warning, (enabled, fields_set)
 
     async def test_feedback_tracker_init_failure_degrades_gracefully(self):
         """FeedbackTracker raising at init should log and fall back to

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1121,6 +1121,41 @@ class TestLifespan:
                 # ProxyManager.start() should NOT be called when proxy is disabled
                 mock_pm_instance.start.assert_not_awaited()
 
+    async def test_proxy_disabled_warns_when_surfacing_configured_on(self, caplog):
+        """surfacing.enabled=true under a disabled proxy silently does nothing
+        (the engine only initializes inside the proxy branch), previously
+        visible only on demand via stm_proxy_health — startup must emit the
+        #288-style "enabled but inert" warning. And ONLY then: the plain
+        proxy-disabled default must stay warning-free."""
+        from memtomem_stm.server import app_lifespan, mcp
+
+        for surfacing_enabled in (True, False):
+            caplog.clear()
+            mock_pm_instance = MagicMock()
+            mock_pm_instance.start = AsyncMock()
+            mock_pm_instance.stop = AsyncMock()
+            mock_pm_instance.get_proxy_tools.return_value = []
+
+            with (
+                patch("memtomem_stm.server.STMConfig") as MockConfig,
+                patch("memtomem_stm.server.ProxyManager", return_value=mock_pm_instance),
+            ):
+                mock_cfg = MockConfig.return_value
+                mock_cfg.proxy = MagicMock()
+                mock_cfg.proxy.enabled = False
+                mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
+                mock_cfg.surfacing = MagicMock()
+                mock_cfg.surfacing.enabled = surfacing_enabled
+                mock_cfg.langfuse = MagicMock()
+                mock_cfg.langfuse.enabled = False
+
+                with caplog.at_level("WARNING", logger="memtomem_stm.server"):
+                    async with app_lifespan(mcp) as _ctx:
+                        pass
+
+            inert = [r for r in caplog.records if "enabled but inert" in r.getMessage()]
+            assert bool(inert) is surfacing_enabled, f"surfacing_enabled={surfacing_enabled}"
+
     async def test_feedback_tracker_init_failure_degrades_gracefully(self):
         """FeedbackTracker raising at init should log and fall back to
         feedback_tracker=None — learning-loop feature must not crash the


### PR DESCRIPTION
## Background

Low finding L74 from the 2026-06-10 implementation review, re-verified against current main. The surfacing-engine init block is nested inside `if config.proxy.enabled:` in `app_lifespan`, so `surfacing.enabled=true` with the proxy disabled (the default control-only mode) is silently skipped. The only startup log said nothing about surfacing; the mismatch was observable solely via `stm_proxy_health`.

## What changed

The proxy-disabled branch now emits a WARNING when surfacing is configured-enabled, mirroring the #288 `auto_index`/`extraction` "config is enabled but inert" pattern: names what is inert, the consequence (no memories surfaced), and both remedies (enable the proxy / set `surfacing.enabled=false`).

## Tests

`test_proxy_disabled_warns_when_surfacing_configured_on` — covers both directions: the warning fires with surfacing configured on (fails pre-fix) and the plain proxy-disabled default stays warning-free. `test_server_tools.py` 75 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)