### PR TITLE
fix(proxy): degrade on third-party API drift in tool registration and tracing

### DIFF
--- a/src/memtomem_stm/observability/tracing.py
+++ b/src/memtomem_stm/observability/tracing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import os
 import random
+import threading
 from contextlib import nullcontext
 from typing import Any
 
@@ -21,14 +22,17 @@ _SERVICE_NAME = "memtomem-stm"
 # hot paths, so a persistently broken exporter must not emit a stack trace
 # per call — the first failure warns, repeats go to DEBUG.
 _warned_observation_failure = False
+_warned_observation_failure_lock = threading.Lock()
 
 
 def _log_observation_failure(stage: str) -> None:
     global _warned_observation_failure
-    if _warned_observation_failure:
+    with _warned_observation_failure_lock:
+        first = not _warned_observation_failure
+        _warned_observation_failure = True
+    if not first:
         logger.debug("Langfuse observation %s failed (repeat, ignored)", stage, exc_info=True)
         return
-    _warned_observation_failure = True
     logger.warning(
         "Langfuse observation %s failed — proceeding untraced (repeats logged at DEBUG)",
         stage,

--- a/src/memtomem_stm/observability/tracing.py
+++ b/src/memtomem_stm/observability/tracing.py
@@ -5,10 +5,13 @@ If langfuse is not installed or disabled, all functions gracefully return None/n
 
 from __future__ import annotations
 
+import logging
 import os
 import random
 from contextlib import nullcontext
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 _langfuse_client: Any = None
 _sampling_rate: float = 1.0
@@ -56,6 +59,42 @@ def shutdown_langfuse(client: Any = None) -> None:
         c.shutdown()
 
 
+class _SafeObservation:
+    """Delegate to a Langfuse observation context manager, degrading to a
+    no-op when the SDK raises.
+
+    ``traced()`` wraps the proxy and surfacing hot paths, whose contract is
+    that tracing must never break the proxied call. The SDK's context
+    manager typically does its real work in ``__enter__`` (OTEL context
+    attach, exporter I/O), so guarding only the constructor would still let
+    a misconfigured exporter fail the call at ``with`` time. Exceptions
+    raised by the traced *body* still propagate normally — only the SDK's
+    own enter/exit failures are swallowed.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self._entered = False
+
+    def __enter__(self) -> Any:
+        try:
+            result = self._inner.__enter__()
+            self._entered = True
+            return result
+        except Exception:
+            logger.warning("Langfuse observation start failed — proceeding untraced", exc_info=True)
+            return None
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        if not self._entered:
+            return False
+        try:
+            return bool(self._inner.__exit__(exc_type, exc, tb))
+        except Exception:
+            logger.warning("Langfuse observation exit failed (ignored)", exc_info=True)
+            return False
+
+
 def traced(name: str, **kwargs: Any) -> Any:
     """Return a Langfuse observation context manager.
 
@@ -63,11 +102,17 @@ def traced(name: str, **kwargs: Any) -> Any:
     sampled out (``sampling_rate < 1.0``).  Nested calls within an
     existing ``traced()`` block automatically create parent-child
     relationships via OpenTelemetry context propagation (Langfuse
-    ≥ 4.x).
+    ≥ 4.x). A raising SDK degrades to a no-op (``_SafeObservation``) —
+    per the module contract, tracing failures must never break the
+    traced call.
     """
     client = _langfuse_client
     if client is None:
         return nullcontext()
     if _sampling_rate < 1.0 and random.random() >= _sampling_rate:  # noqa: S311
         return nullcontext()
-    return client.start_as_current_observation(name=name, **kwargs)
+    try:
+        return _SafeObservation(client.start_as_current_observation(name=name, **kwargs))
+    except Exception:
+        logger.warning("Langfuse traced() failed — proceeding untraced", exc_info=True)
+        return nullcontext()

--- a/src/memtomem_stm/observability/tracing.py
+++ b/src/memtomem_stm/observability/tracing.py
@@ -17,6 +17,24 @@ _langfuse_client: Any = None
 _sampling_rate: float = 1.0
 _SERVICE_NAME = "memtomem-stm"
 
+# One-shot escalation for SDK failures: traced() sits on the proxy/surfacing
+# hot paths, so a persistently broken exporter must not emit a stack trace
+# per call — the first failure warns, repeats go to DEBUG.
+_warned_observation_failure = False
+
+
+def _log_observation_failure(stage: str) -> None:
+    global _warned_observation_failure
+    if _warned_observation_failure:
+        logger.debug("Langfuse observation %s failed (repeat, ignored)", stage, exc_info=True)
+        return
+    _warned_observation_failure = True
+    logger.warning(
+        "Langfuse observation %s failed — proceeding untraced (repeats logged at DEBUG)",
+        stage,
+        exc_info=True,
+    )
+
 
 def init_langfuse(config: object, *, service_name: str = _SERVICE_NAME) -> Any:
     """Initialize Langfuse client if enabled and installed. Returns client or None."""
@@ -82,7 +100,7 @@ class _SafeObservation:
             self._entered = True
             return result
         except Exception:
-            logger.warning("Langfuse observation start failed — proceeding untraced", exc_info=True)
+            _log_observation_failure("start")
             return None
 
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
@@ -91,7 +109,7 @@ class _SafeObservation:
         try:
             return bool(self._inner.__exit__(exc_type, exc, tb))
         except Exception:
-            logger.warning("Langfuse observation exit failed (ignored)", exc_info=True)
+            _log_observation_failure("exit")
             return False
 
 
@@ -114,5 +132,5 @@ def traced(name: str, **kwargs: Any) -> Any:
     try:
         return _SafeObservation(client.start_as_current_observation(name=name, **kwargs))
     except Exception:
-        logger.warning("Langfuse traced() failed — proceeding untraced", exc_info=True)
+        _log_observation_failure("creation")
         return nullcontext()

--- a/src/memtomem_stm/proxy/_fastmcp_compat.py
+++ b/src/memtomem_stm/proxy/_fastmcp_compat.py
@@ -104,6 +104,22 @@ def register_proxy_tool(
         )
         return
     if registered is not None:
-        if info.input_schema:
-            registered.parameters = info.input_schema
-        registered.fn_metadata = _PASSTHROUGH_METADATA
+        # Same version-drift posture as the two guards above: a future
+        # fastmcp that renames/removes these pydantic fields raises on
+        # assignment (pydantic v2 rejects setattr to a non-field), and the
+        # caller loops register_proxy_tool with no per-tool guard — one
+        # renamed field would otherwise abort registration of every
+        # remaining proxied tool and fail server startup.
+        try:
+            if info.input_schema:
+                registered.parameters = info.input_schema
+            registered.fn_metadata = _PASSTHROUGH_METADATA
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Cannot override schema for '%s' — FastMCP internal API changed. "
+                "Tool is registered but may show incorrect parameter schema.",
+                info.prefixed_name,
+                exc_info=True,
+            )

--- a/src/memtomem_stm/proxy/_fastmcp_compat.py
+++ b/src/memtomem_stm/proxy/_fastmcp_compat.py
@@ -110,10 +110,18 @@ def register_proxy_tool(
         # caller loops register_proxy_tool with no per-tool guard — one
         # renamed field would otherwise abort registration of every
         # remaining proxied tool and fail server startup.
+        #
+        # Order matters for a partial failure: fn_metadata (permissive
+        # passthrough validation) is written FIRST, so if the parameters
+        # write then fails the tool merely advertises a stale default
+        # schema while accepting real args. The reverse partial state —
+        # advertising the upstream schema while still validating with the
+        # original signature-derived model — would reject the very args
+        # the advertised schema invites.
         try:
+            registered.fn_metadata = _PASSTHROUGH_METADATA
             if info.input_schema:
                 registered.parameters = info.input_schema
-            registered.fn_metadata = _PASSTHROUGH_METADATA
         except Exception:
             import logging
 

--- a/tests/test_fastmcp_compat.py
+++ b/tests/test_fastmcp_compat.py
@@ -99,3 +99,37 @@ def test_register_proxy_tool_degrades_when_schema_fields_renamed(caplog) -> None
 
     assert "Cannot override schema for 'srv_tool'" in caplog.text
     server.add_tool.assert_called_once()  # the tool itself stayed registered
+
+
+def test_register_proxy_tool_partial_failure_keeps_default_schema(caplog) -> None:
+    # fn_metadata is written FIRST: if that write fails, parameters must not
+    # be written either. The reverse partial state — advertising the
+    # upstream schema while still validating with the original
+    # signature-derived model — would reject the very args the advertised
+    # schema invites, which is worse than staying on the default schema.
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from memtomem_stm.proxy._fastmcp_compat import register_proxy_tool
+
+    class _MetadataFrozenTool:
+        def __setattr__(self, name: str, value: object) -> None:
+            if name == "fn_metadata":
+                raise ValueError("pydantic: 'fn_metadata' is not a field")
+            object.__setattr__(self, name, value)
+
+    tool = _MetadataFrozenTool()
+    server = MagicMock()
+    server._tool_manager._tools.get.return_value = tool
+    info = SimpleNamespace(
+        prefixed_name="srv_tool",
+        description="desc",
+        annotations=None,
+        server="srv",
+        input_schema={"type": "object"},
+    )
+
+    register_proxy_tool(server, lambda: None, info)
+
+    assert not hasattr(tool, "parameters")  # no partial patch
+    assert "Cannot override schema for 'srv_tool'" in caplog.text

--- a/tests/test_fastmcp_compat.py
+++ b/tests/test_fastmcp_compat.py
@@ -68,3 +68,34 @@ def test_tag_title_falls_back_to_original_when_model_copy_raises() -> None:
     broken = _BrokenCopy()
     tagged = _tag_annotations_title(broken, "playwright")
     assert tagged is broken
+
+
+def test_register_proxy_tool_degrades_when_schema_fields_renamed(caplog) -> None:
+    # The .parameters/.fn_metadata overrides poke fastmcp internals; a future
+    # fastmcp that renames those pydantic fields raises on assignment. The
+    # caller loops register_proxy_tool over every proxied tool with no
+    # per-tool guard, so this must degrade to a warning — not abort the
+    # whole registration loop and fail server startup.
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from memtomem_stm.proxy._fastmcp_compat import register_proxy_tool
+
+    class _FrozenTool:
+        def __setattr__(self, name: str, value: object) -> None:
+            raise ValueError(f"pydantic: {name!r} is not a field")
+
+    server = MagicMock()
+    server._tool_manager._tools.get.return_value = _FrozenTool()
+    info = SimpleNamespace(
+        prefixed_name="srv_tool",
+        description="desc",
+        annotations=None,
+        server="srv",
+        input_schema={"type": "object"},
+    )
+
+    register_proxy_tool(server, lambda: None, info)  # must not raise
+
+    assert "Cannot override schema for 'srv_tool'" in caplog.text
+    server.add_tool.assert_called_once()  # the tool itself stayed registered

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -150,6 +150,7 @@ class TestTracing:
         import memtomem_stm.observability.tracing as tracing_mod
 
         old = tracing_mod._langfuse_client
+        old_rate = tracing_mod._sampling_rate
         old_env = os.environ.get("OTEL_SERVICE_NAME")
         try:
             mock_langfuse_cls = MagicMock()
@@ -163,6 +164,10 @@ class TestTracing:
             config.public_key = "pk-test"
             config.secret_key = "sk-test"
             config.host = "http://localhost:3000"
+            # A real float: init_langfuse writes this into the module-global
+            # _sampling_rate, and a leaked MagicMock breaks every later
+            # traced() sampling comparison in the suite.
+            config.sampling_rate = 1.0
 
             os.environ.pop("OTEL_SERVICE_NAME", None)
             with patch.dict(sys.modules, {"langfuse": mock_module}):
@@ -177,6 +182,7 @@ class TestTracing:
             assert os.environ.get("OTEL_SERVICE_NAME") == "memtomem-stm"
         finally:
             tracing_mod._langfuse_client = old
+            tracing_mod._sampling_rate = old_rate
             if old_env is not None:
                 os.environ["OTEL_SERVICE_NAME"] = old_env
             else:
@@ -204,7 +210,8 @@ class TestTracing:
         old = tracing_mod._langfuse_client
         old_rate = tracing_mod._sampling_rate
         try:
-            tracing_mod._sampling_rate = 1.0  # an earlier init test leaves a MagicMock here
+            tracing_mod._sampling_rate = 1.0
+            tracing_mod._warned_observation_failure = False
             client = MagicMock()
             client.start_as_current_observation.side_effect = RuntimeError("exporter down")
             tracing_mod._langfuse_client = client
@@ -226,6 +233,7 @@ class TestTracing:
         old_rate = tracing_mod._sampling_rate
         try:
             tracing_mod._sampling_rate = 1.0
+            tracing_mod._warned_observation_failure = False
             broken_cm = MagicMock()
             broken_cm.__enter__ = MagicMock(side_effect=RuntimeError("otel context corrupt"))
             client = MagicMock()
@@ -261,6 +269,33 @@ class TestTracing:
         finally:
             tracing_mod._langfuse_client = old
             tracing_mod._sampling_rate = old_rate
+
+    def test_traced_sdk_failure_warns_once_then_debug(self, caplog) -> None:
+        # traced() sits on the hot path: a persistently broken exporter must
+        # warn exactly once, with repeats demoted to DEBUG.
+        import logging
+
+        import memtomem_stm.observability.tracing as tracing_mod
+
+        old = tracing_mod._langfuse_client
+        old_rate = tracing_mod._sampling_rate
+        try:
+            tracing_mod._sampling_rate = 1.0
+            tracing_mod._warned_observation_failure = False
+            client = MagicMock()
+            client.start_as_current_observation.side_effect = RuntimeError("exporter down")
+            tracing_mod._langfuse_client = client
+            with caplog.at_level(logging.DEBUG, logger="memtomem_stm.observability.tracing"):
+                with tracing_mod.traced("a"):
+                    pass
+                with tracing_mod.traced("b"):
+                    pass
+            records = [r for r in caplog.records if "Langfuse observation" in r.getMessage()]
+            assert [r.levelname for r in records] == ["WARNING", "DEBUG"]
+        finally:
+            tracing_mod._langfuse_client = old
+            tracing_mod._sampling_rate = old_rate
+            tracing_mod._warned_observation_failure = False
 
     def test_shutdown_langfuse_calls_shutdown(self) -> None:
         import memtomem_stm.observability.tracing as tracing_mod

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -283,6 +283,7 @@ class TestTracing:
 
         old = tracing_mod._langfuse_client
         old_rate = tracing_mod._sampling_rate
+        old_warned = tracing_mod._warned_observation_failure
         try:
             tracing_mod._sampling_rate = 1.0
             tracing_mod._warned_observation_failure = False
@@ -299,7 +300,7 @@ class TestTracing:
         finally:
             tracing_mod._langfuse_client = old
             tracing_mod._sampling_rate = old_rate
-            tracing_mod._warned_observation_failure = False
+            tracing_mod._warned_observation_failure = old_warned
 
     def test_shutdown_langfuse_calls_shutdown(self) -> None:
         import memtomem_stm.observability.tracing as tracing_mod

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -195,6 +195,73 @@ class TestTracing:
         finally:
             tracing_mod._langfuse_client = old
 
+    def test_traced_degrades_when_client_method_raises(self) -> None:
+        # The proxy/surfacing hot paths wrap calls in `with traced(...)`; an
+        # SDK that raises while constructing the observation must degrade to
+        # untraced, never fail the proxied call.
+        import memtomem_stm.observability.tracing as tracing_mod
+
+        old = tracing_mod._langfuse_client
+        old_rate = tracing_mod._sampling_rate
+        try:
+            tracing_mod._sampling_rate = 1.0  # an earlier init test leaves a MagicMock here
+            client = MagicMock()
+            client.start_as_current_observation.side_effect = RuntimeError("exporter down")
+            tracing_mod._langfuse_client = client
+            ran = False
+            with tracing_mod.traced("span"):
+                ran = True
+            assert ran
+        finally:
+            tracing_mod._langfuse_client = old
+            tracing_mod._sampling_rate = old_rate
+
+    def test_traced_degrades_when_observation_enter_raises(self) -> None:
+        # Langfuse CMs do their real work in __enter__ (OTEL context attach,
+        # exporter I/O) — a raising __enter__ must not break the traced body,
+        # and the never-entered inner CM must not get an __exit__ call.
+        import memtomem_stm.observability.tracing as tracing_mod
+
+        old = tracing_mod._langfuse_client
+        old_rate = tracing_mod._sampling_rate
+        try:
+            tracing_mod._sampling_rate = 1.0
+            broken_cm = MagicMock()
+            broken_cm.__enter__ = MagicMock(side_effect=RuntimeError("otel context corrupt"))
+            client = MagicMock()
+            client.start_as_current_observation.return_value = broken_cm
+            tracing_mod._langfuse_client = client
+            ran = False
+            with tracing_mod.traced("span"):
+                ran = True
+            assert ran
+            broken_cm.__exit__.assert_not_called()
+        finally:
+            tracing_mod._langfuse_client = old
+            tracing_mod._sampling_rate = old_rate
+
+    def test_traced_body_exception_still_propagates(self) -> None:
+        # Only SDK enter/exit failures are swallowed — an exception raised by
+        # the traced body must propagate through the safe wrapper.
+        import memtomem_stm.observability.tracing as tracing_mod
+
+        old = tracing_mod._langfuse_client
+        old_rate = tracing_mod._sampling_rate
+        try:
+            tracing_mod._sampling_rate = 1.0
+            healthy_cm = MagicMock()
+            healthy_cm.__exit__ = MagicMock(return_value=False)
+            client = MagicMock()
+            client.start_as_current_observation.return_value = healthy_cm
+            tracing_mod._langfuse_client = client
+            with pytest.raises(ValueError, match="body error"):
+                with tracing_mod.traced("span"):
+                    raise ValueError("body error")
+            healthy_cm.__exit__.assert_called_once()
+        finally:
+            tracing_mod._langfuse_client = old
+            tracing_mod._sampling_rate = old_rate
+
     def test_shutdown_langfuse_calls_shutdown(self) -> None:
         import memtomem_stm.observability.tracing as tracing_mod
 

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -209,6 +209,7 @@ class TestTracing:
 
         old = tracing_mod._langfuse_client
         old_rate = tracing_mod._sampling_rate
+        old_warned = tracing_mod._warned_observation_failure
         try:
             tracing_mod._sampling_rate = 1.0
             tracing_mod._warned_observation_failure = False
@@ -222,6 +223,7 @@ class TestTracing:
         finally:
             tracing_mod._langfuse_client = old
             tracing_mod._sampling_rate = old_rate
+            tracing_mod._warned_observation_failure = old_warned
 
     def test_traced_degrades_when_observation_enter_raises(self) -> None:
         # Langfuse CMs do their real work in __enter__ (OTEL context attach,
@@ -231,6 +233,7 @@ class TestTracing:
 
         old = tracing_mod._langfuse_client
         old_rate = tracing_mod._sampling_rate
+        old_warned = tracing_mod._warned_observation_failure
         try:
             tracing_mod._sampling_rate = 1.0
             tracing_mod._warned_observation_failure = False
@@ -247,6 +250,7 @@ class TestTracing:
         finally:
             tracing_mod._langfuse_client = old
             tracing_mod._sampling_rate = old_rate
+            tracing_mod._warned_observation_failure = old_warned
 
     def test_traced_body_exception_still_propagates(self) -> None:
         # Only SDK enter/exit failures are swallowed — an exception raised by


### PR DESCRIPTION
## Background

Low findings L51 and L70 from the 2026-06-10 implementation review, re-verified against current main (L51 had been mis-triaged as fixed by #412 with mismatched evidence; the unguarded assignments are still at `_fastmcp_compat.py:107-109` on main). Both are "third-party boundary must fail open" gaps. This completes the bucket-1+2 low drive.

## What changed

- **`register_proxy_tool` (L51):** `server.add_tool` and `_tool_manager._tools.get` were already wrapped in version-drift guards, but the `.parameters`/`.fn_metadata` assignments were bare. pydantic v2 raises on setattr to a non-field, and `server.py` loops `register_proxy_tool` with no per-tool guard — one renamed fastmcp field would abort registration of every remaining proxied tool and fail server startup. Now the same try/except + WARNING posture: the tool stays registered with a default schema.
- **`traced()` (L70):** called `client.start_as_current_observation` unguarded while the module contract promises tracing never breaks the traced call (the proxy hot path wraps upstream calls in `with traced(...)` at 7 sites, surfacing at 2). The report's suggested constructor-only guard was marked *fix-incomplete* — Langfuse CMs do their real work in `__enter__` — so the fix adds a `_SafeObservation` delegating wrapper: SDK enter/exit failures degrade to untraced (WARNING), a never-entered inner CM gets no `__exit__`, and traced-body exceptions still propagate.

## Review

Codex R1 NEEDS-FIX (test sampling-rate pollution at source; non-atomic schema override — fn_metadata now written FIRST so a partial failure never advertises a schema the original model rejects; per-call warning spam — once-then-DEBUG with lock) → R2/R3 test-global hygiene → **R4 SHIP**.

## Tests

- `test_register_proxy_tool_degrades_when_schema_fields_renamed` — frozen-tool object raising on setattr; no exception, warning logged, tool stays registered (fails pre-fix).
- `test_traced_degrades_when_client_method_raises` / `..._when_observation_enter_raises` (both fail pre-fix) and `test_traced_body_exception_still_propagates` (semantics pin).
- New tracing tests save/restore `_sampling_rate`, which an earlier init test pollutes with a MagicMock.

`test_fastmcp_compat.py` + `test_stm_remaining.py` 48 passed; `test_server_tools.py` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)