### PR TITLE
fix(compression): refill the freed budget after _json_key_truncate drops keys

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -352,12 +352,12 @@ class TruncateCompressor:
             # max_chars=80 through 1500 on a one-huge-key payload). Grow the
             # boundary to the largest ``_truncate_json_value`` form that still
             # fits: the rendered length is monotone in the value budget, so
-            # binary-search it. Only ONE key is refilled: a full-form boundary
-            # would re-create the ``keep + 1`` candidate this loop already
-            # rejected, so (apart from the few-char window where a truncated
-            # string render exceeds its full form by up to 3 chars) the
-            # boundary stays partial and no room is left for the keys after
-            # it.
+            # binary-search it (sound because ``_truncate_json_value`` never
+            # expands a value, so the rendered length is monotone in the value
+            # budget). Only ONE key is refilled: a full-form boundary would
+            # re-create the ``keep + 1`` candidate this loop already rejected
+            # with a smaller-or-equal boundary, so the boundary always stays
+            # partial and no room is left for the keys after it.
             omitted = len(parts) - keep - 1
             lo, hi, best = 0, max_chars, None
             while lo <= hi:
@@ -373,10 +373,18 @@ class TruncateCompressor:
         return "{}"
 
     def _truncate_json_value(self, value: object, budget: int) -> object:
-        """Truncate a JSON value to fit within character budget."""
+        """Truncate a JSON value to fit within character budget.
+
+        The truncated form must never be LONGER than the full value (the
+        no-expand rule from #395): ``value[:budget] + "..."`` would render
+        budget+3 chars, overshooting the full value by up to 3 near the
+        full-value crossing — which made the rendered length non-monotone in
+        ``budget`` and broke the refill binary search in
+        ``_json_key_truncate`` (a probe at ``len(value) - 1`` failed to fit
+        and discarded the fitting full-value region above it)."""
         if isinstance(value, str):
             if len(value) > budget:
-                return value[:budget] + "..."
+                return value[: max(0, budget - 3)] + "..."
             return value
         if isinstance(value, dict):
             preview: dict = {}

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -310,27 +310,66 @@ class TruncateCompressor:
         # Assemble as valid JSON. The old path sliced the assembled string to
         # max_chars and appended a note — producing INVALID JSON and STILL
         # overshooting the budget. Instead drop whole trailing keys (recording
-        # the count in a valid ``_truncated`` member) until the object fits, so
-        # the result always parses and stays within budget.
+        # the count in a valid, collision-safe ``_truncated`` member) until the
+        # object fits, so the result always parses and stays within budget.
         #
         # Contract floor: valid JSON cannot be shorter than ``{}`` (2 chars).
         # For any ``max_chars >= 2`` the result is ``<= max_chars``; at a
         # pathological sub-2-char budget (never produced by config or the
         # manager retention ladder, which raises tiny budgets) JSON validity
         # takes precedence and we still return ``{}``.
+        key_items = list(data.items())
+        marker_key = "_truncated"
+        while marker_key in data:
+            marker_key += "_"
+
         def _assemble(kept: list[str], omitted: int) -> str:
             members = list(kept)
             if omitted:
-                members.append(f'"_truncated": "{omitted} of {len(parts)} keys omitted"')
+                members.append(f'"{marker_key}": "{omitted} of {len(parts)} keys omitted"')
             return "{\n" + ",\n".join(members) + "\n}"
 
         result = _assemble(parts, 0)
         if len(result) <= max_chars:
             return result
+
+        def _render(idx: int, value_budget: int) -> str:
+            k, v = key_items[idx]
+            part = json.dumps(
+                {k: self._truncate_json_value(v, value_budget)}, ensure_ascii=False, indent=2
+            )
+            return part.strip()[1:-1].strip()
+
         for keep in range(len(parts) - 1, -1, -1):
             candidate = _assemble(parts[:keep], len(parts) - keep)
-            if len(candidate) <= max_chars:
-                return candidate
+            if len(candidate) > max_chars:
+                continue
+            # Refill the freed budget into the BOUNDARY key (the first dropped
+            # one). Each part was sized against the FULL key set, so once
+            # trailing keys are dropped the assembly could sit far below
+            # ``max_chars`` and stay there no matter how much the budget grew
+            # (the output used to freeze at the drop point — 66 chars from
+            # max_chars=80 through 1500 on a one-huge-key payload). Grow the
+            # boundary to the largest ``_truncate_json_value`` form that still
+            # fits: the rendered length is monotone in the value budget, so
+            # binary-search it. Only ONE key is refilled: a full-form boundary
+            # would re-create the ``keep + 1`` candidate this loop already
+            # rejected, so (apart from the few-char window where a truncated
+            # string render exceeds its full form by up to 3 chars) the
+            # boundary stays partial and no room is left for the keys after
+            # it.
+            omitted = len(parts) - keep - 1
+            lo, hi, best = 0, max_chars, None
+            while lo <= hi:
+                mid = (lo + hi) // 2
+                cand_part = _render(keep, mid)
+                if len(_assemble([*parts[:keep], cand_part], omitted)) <= max_chars:
+                    best, lo = cand_part, mid + 1
+                else:
+                    hi = mid - 1
+            if best is not None:
+                return _assemble([*parts[:keep], best], omitted)
+            return candidate
         return "{}"
 
     def _truncate_json_value(self, value: object, budget: int) -> object:

--- a/tests/test_truncate_output_invariants.py
+++ b/tests/test_truncate_output_invariants.py
@@ -123,6 +123,104 @@ def test_json_key_truncate_records_omitted_keys() -> None:
     assert "omitted" in parsed["_truncated"]
 
 
+# ── JSON path: budget refill after key drops (the freeze regression) ──────────
+
+
+def _skewed_config() -> str:
+    """One huge key between small ones. Pre-fix, every budget from 80 through
+    1500 returned the same 66-char output (key ``a`` + marker): the per-key
+    parts were sized against the FULL key set, and the assembler only dropped
+    whole keys — it never re-spent the freed budget."""
+    return json.dumps({"a": {"x": "aaa"}, "b": {"big": "B" * 3000}, "c": {"y": "ccc"}})
+
+
+def _preserved_chars(truncated: object, original: object) -> int:
+    """Chars of ORIGINAL leaf content preserved in the truncated form."""
+    if isinstance(original, str):
+        if not isinstance(truncated, str):
+            return 0
+        s = truncated[:-3] if truncated.endswith("...") else truncated
+        return len(s) if original.startswith(s) else 0
+    if isinstance(original, dict):
+        if not isinstance(truncated, dict):
+            return 0
+        return sum(_preserved_chars(truncated[k], v) for k, v in original.items() if k in truncated)
+    if isinstance(original, list):
+        if not isinstance(truncated, list):
+            return 0
+        return sum(_preserved_chars(t, o) for t, o in zip(truncated, original))
+    return len(json.dumps(original)) if truncated == original else 0
+
+
+@pytest.mark.parametrize("lo,hi", [(80, 200), (200, 400), (400, 800), (800, 1500)])
+def test_json_key_truncate_output_grows_with_budget(lo: int, hi: int) -> None:
+    """A larger budget must produce more output, not freeze at the key-drop
+    point (pre-fix: 66 chars at every budget in [80, 1500] for this payload)."""
+    text = _skewed_config()
+    out_lo = TruncateCompressor().compress(text, max_chars=lo)
+    out_hi = TruncateCompressor().compress(text, max_chars=hi)
+    json.loads(out_lo)
+    json.loads(out_hi)
+    assert len(out_lo) <= lo
+    assert len(out_hi) <= hi
+    assert len(out_hi) > len(out_lo)
+
+
+def test_json_key_truncate_refills_boundary_key() -> None:
+    """The freed budget is re-spent on a truncated form of the first dropped
+    key instead of dropping it whole."""
+    out = TruncateCompressor().compress(_skewed_config(), max_chars=800)
+    parsed = json.loads(out)
+    assert parsed["a"] == {"x": "aaa"}
+    assert parsed["b"]["big"].startswith("B")
+    assert parsed["b"]["big"].endswith("...")
+    assert parsed["_truncated"] == "1 of 3 keys omitted"
+    assert len(out) > 700  # fills the budget instead of freezing at 66
+
+
+@pytest.mark.parametrize(
+    "name,data",
+    [
+        ("skewed", {"a": {"x": "aaa"}, "b": {"big": "B" * 3000}, "c": {"y": "ccc"}}),
+        (
+            "tail_smalls",
+            {
+                "big": {"v": "B" * 400},
+                "m1": {"v": "M" * 50},
+                "m2": {"v": "N" * 50},
+                "s": {"x": "y"},
+            },
+        ),
+    ],
+)
+def test_json_key_truncate_content_is_monotone_in_budget(name: str, data: dict) -> None:
+    """Preserved ORIGINAL content never shrinks as the budget grows, swept
+    contiguously so a one-char cliff cannot hide between sampled points. Raw
+    length may wobble by a few framing chars where the allocator crosses its
+    everything-fits threshold; preserved content is the contract. Output stays
+    valid JSON and within budget at every step."""
+    text = json.dumps(data)
+    prev = -1
+    for budget in range(40, len(text) + 40):
+        out = TruncateCompressor().compress(text, max_chars=budget)
+        parsed = json.loads(out)
+        assert len(out) <= max(2, budget), f"{name}@{budget}: {len(out)} over budget"
+        preserved = _preserved_chars(parsed, data)
+        assert preserved >= prev, f"{name}@{budget}: content shrank {prev} -> {preserved}"
+        prev = preserved
+
+
+def test_json_key_truncate_marker_key_is_collision_safe() -> None:
+    """A real top-level ``_truncated`` key is never clobbered by the synthetic
+    omitted-count marker."""
+    data: dict = {"_truncated": {"real": "VALUE"}}
+    data.update({f"k{i}": {"v": "x" * 80} for i in range(10)})
+    out = TruncateCompressor().compress(json.dumps(data), max_chars=300)
+    parsed = json.loads(out)
+    assert parsed["_truncated"] == {"real": "VALUE"}
+    assert "keys omitted" in parsed["_truncated_"]
+
+
 @pytest.mark.parametrize("budget", [1, 2, 5])
 def test_json_path_stays_valid_json_at_pathological_budget(budget: int) -> None:
     """Contract floor: valid JSON cannot be shorter than ``{}`` (2 chars), so a

--- a/tests/test_truncate_output_invariants.py
+++ b/tests/test_truncate_output_invariants.py
@@ -191,14 +191,27 @@ def test_json_key_truncate_refills_boundary_key() -> None:
                 "s": {"x": "y"},
             },
         ),
+        # The full-value crossing: pre-fix, _truncate_json_value rendered
+        # budget+3 chars just below a string's full length, so the refill
+        # binary search probed a non-monotone domain and discarded the fitting
+        # full-value region (preserved content shrank 60 -> 58 chars going
+        # from max_chars=147 to 148).
+        ("ellipsis_crossing", {"a": {"v": "X" * 10}, "b": {"v": "X" * 50}, "c": {"v": "X" * 50}}),
     ],
 )
 def test_json_key_truncate_content_is_monotone_in_budget(name: str, data: dict) -> None:
-    """Preserved ORIGINAL content never shrinks as the budget grows, swept
-    contiguously so a one-char cliff cannot hide between sampled points. Raw
-    length may wobble by a few framing chars where the allocator crosses its
-    everything-fits threshold; preserved content is the contract. Output stays
-    valid JSON and within budget at every step."""
+    """Preserved ORIGINAL content never shrinks as the budget grows on these
+    curated defect shapes, swept contiguously so a one-char cliff cannot hide
+    between sampled points. Output stays valid JSON and within budget at every
+    step.
+
+    Scope note: across ARBITRARY shapes the proportional allocator's integer
+    rounding can still trade a few chars between two kept keys as the budget
+    grows (net wobble bounded by framing overhead — observed -2 chars on a
+    random-shape probe). That is allocation noise, not a cliff, and is
+    accepted: this path's contract is proportional/relevance-weighted
+    distribution without the freeze/whole-key-discard defects pinned here, not
+    the strict global monotonicity of the structural final tiers."""
     text = json.dumps(data)
     prev = -1
     for budget in range(40, len(text) + 40):


### PR DESCRIPTION
From the 2026-06-10 implementation review (low tier, report item L127).

## Problem

`TruncateCompressor._json_key_truncate` sized each per-key part ONCE against
the FULL key set, then its assembler only dropped whole trailing keys to fit.
When one key's value was large, everything after the drop point was discarded
and the freed budget was never re-spent — the output froze far below
`max_chars`. Reproduced before fixing: for
`{"a": {...}, "b": {"big": "B"*3000}, "c": {...}}` the output was the same 66
chars (key `a` + marker) at every budget from 80 through 1500 (18x waste).

## Fix

- After the whole-key drop loop finds the fitting prefix, the BOUNDARY key
  (first dropped) is grown to the largest `_truncate_json_value` form that
  still fits, found by binary search.
- `_truncate_json_value` now applies the #395 no-expand rule
  (`value[:max(0, budget-3)] + "..."`): the old `value[:budget] + "..."`
  rendered budget+3 chars, so just below a string's full length the truncated
  form was LONGER than the full value — a non-monotone search domain that let
  the binary search discard the fitting full-value region (codex R1 Major,
  reproduced: preserved content shrank 60 → 58 chars from budget 147 → 148).
- The omitted-count marker key is now collision-safe against a real top-level
  `_truncated` key, mirroring the convention everywhere else in the file.

Only one key is ever refilled: a full-form boundary would re-create the
`keep+1` candidate the drop loop already rejected with a smaller-or-equal
boundary, so the boundary always stays partial.

## Verification

Contiguous sweeps over curated fixtures plus 150 random config shapes: output
is always valid JSON, within `max(2, budget)`, and preserved ORIGINAL content
is non-decreasing in the budget. Adjudicated + accepted residual (documented
in the test scope note): on arbitrary shapes the proportional allocator's
integer rounding can trade a few chars between two KEPT keys as the budget
grows (net −2 observed, no keys dropped) — allocation noise inherent to
proportional/BM25-weighted shares, not a cliff.

New tests: coarse freeze regression, boundary refill, contiguous
content-monotonicity sweeps (incl. the ellipsis-crossing shape from codex R1),
marker collision safety. Full suite: 3112 passed.

Codex review: R1 NEEDS-FIX (ellipsis render expansion breaking the search
domain — fixed) → R2 SHIP (exhaustive small-shape search vs brute force).

🤖 Generated with [Claude Code](https://claude.com/claude-code)