### PR TITLE
fix(config): validate hybrid ordering, rescue zero model budgets, name env overrides in load warnings

### DIFF
--- a/docs/compression.md
+++ b/docs/compression.md
@@ -264,6 +264,8 @@ Routes through an external LLM for intelligent summarization:
 
 Providers: `openai`, `anthropic`, `ollama`. `llm_timeout_seconds` (default 60.0) bounds the per-call LLM wait. On timeout, privacy-pattern hit, circuit-breaker open, or any other API failure, compression falls back to `TruncateCompressor` and records the strategy as `llm_summary→{timeout,privacy,circuit_breaker,llm_error}_fallback` in `proxy_metrics` for observability. A successful call whose summary still exceeds `max_chars` is clamped by the same truncation and recorded as `llm_summary→llm_overlength_fallback` — the model overshot the length instruction; the endpoint is fine, so the circuit breaker is unaffected.
 
+> **`api_key` is validated eagerly.** Every `llm` block in the config is validated when the config loads — for `provider: openai` / `anthropic`, a missing `api_key` (and missing `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env var) fails the load even if nothing selects the `llm_summary` strategy or the block sits under a disabled `extraction`. This keeps the startup fail-fast for configs that DO use the LLM. Don't leave placeholder `llm` blocks you aren't using — remove them, or point them at `provider: ollama` (no key required).
+
 Sensitive content (API keys, passwords, PII) is auto-detected and **never** sent to external LLMs — falls back to local truncation.
 
 `LLMCompressor` holds a single `httpx.AsyncClient` for the life of the instance. `ProxyManager` caches one compressor per active `llm` config and swaps it (awaiting `close()` on the old one) whenever the config changes at runtime, so integrators generally do not need to manage it directly. If you construct an `LLMCompressor` standalone, `await compressor.close()` before discarding it to release the client.

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -74,41 +74,38 @@ def _env_override_hint(
     <file>" and debugs the FILE while the file is fine. (Fallback semantics
     are unchanged: this only improves the warning.)
 
-    Hints are derived from the env overlay's LEAVES — the var names the
-    operator actually set — never synthesized from the error location alone:
-    a model-level validator reports its error at the MODEL's path (e.g. a
-    HybridConfig cross-field error at ``upstream_servers.gh.hybrid``), and
-    naming that prefix would point at a var that was never set.
+    Attribution is two-staged:
 
-    - An error location that resolves to an env subtree names every env
-      leaf under it.
-    - One that runs PAST an env leaf (the env string replaced a whole
-      container) names that leaf.
-    - One that leaves the env subtree mid-walk is attributed by PROVENANCE
-      against *file_data* (the pre-merge file contents): if the file also
-      supplies that subtree, the failing value is file-set and nothing is
-      named; if the subtree exists only because the env created it (e.g. a
-      required field missing from an env-built upstream entry), the env
-      leaves under it are named — that collapse is env-caused even though
-      the failing location itself was never set.
-    - A ROOT-level model-validator error (``loc=()``, e.g. duplicate or
-      empty upstream prefixes) has no path to walk; it is attributed by
-      DIFFERENTIAL validation — if the file alone validates (or there is no
-      file), the env overlay flipped the root check, and every env leaf is
-      named.
+    1. DIFFERENTIAL pre-filter — every error of the merged config whose
+       ``(loc, type)`` the file reproduces ON ITS OWN is file-caused and
+       skipped: an env var that merely touched the same subtree (an innocent
+       ``tail_mode`` under a hybrid block whose ordering the file itself
+       breaks) must not be implicated. The file-alone validation runs
+       lazily, once, only on this already-failing path. Matching includes
+       the error TYPE so an env value that re-breaks a file-broken location
+       DIFFERENTLY (gt-violation -> int-parsing) is still attributed. (If
+       the env adds a second instance of an aggregated root error the file
+       already has — e.g. one more duplicate-prefix pair — it stays hidden
+       until the file is fixed; the rerun then re-attributes.)
+
+    2. NAMING — hints are derived from the env overlay's LEAVES, the var
+       names the operator actually set, never synthesized from the error
+       location alone (a model-level validator reports at the MODEL's path,
+       e.g. ``upstream_servers.gh.hybrid``, and naming that prefix would
+       point at a var that was never set):
+
+       - a location resolving to an env leaf names that leaf (also when the
+         location runs PAST it — the env string replaced a container);
+       - a location resolving to an env subtree — a cross-field validator
+         there, or a missing required field of an env-created entry — names
+         every env leaf under it;
+       - a ROOT-level error (``loc=()``, duplicate/empty upstream prefixes)
+         has no path at all and names every env leaf;
+       - a location the env never touched names nothing.
     """
     if not env_overrides or not isinstance(exc, ValidationError):
         return ""
     implicated: set[str] = set()
-
-    def _file_has(path: list[str]) -> bool:
-        node: Any = file_data
-        for part in path:
-            if isinstance(node, dict) and part in node:
-                node = node[part]
-            else:
-                return False
-        return True
 
     def _add_leaves(path: list[str], subtree: dict[str, Any]) -> None:
         stack: list[tuple[list[str], dict[str, Any]]] = [(path, subtree)]
@@ -122,28 +119,29 @@ def _env_override_hint(
                         _PROXY_ENV_PREFIX + "__".join(p.upper() for p in [*prefix, str(key)])
                     )
 
-    env_caused_root: bool | None = None  # lazily computed, shared across errors
+    file_error_keys: frozenset[tuple[tuple[Any, ...], str]] | None = None
 
-    def _root_failure_is_env_caused() -> bool:
-        # Top-level model validators (duplicate / empty upstream prefixes)
-        # report at loc=() — there is no path to walk, so attribute by
-        # DIFFERENTIAL validation: if the file alone validates (or there is
-        # no file at all), the env overlay is what flipped the root check.
+    def _file_alone_error_keys() -> frozenset[tuple[tuple[Any, ...], str]]:
         if file_data is None:
-            return True
+            return frozenset()  # no file at all: every failure is env-caused
         try:
             ProxyConfig.model_validate(file_data)
-        except Exception:
-            return False  # the file fails on its own — fix the file first
-        return True
+        except ValidationError as file_exc:
+            return frozenset(
+                (tuple(e.get("loc", ())), str(e.get("type", ""))) for e in file_exc.errors()
+            )
+        except Exception:  # non-pydantic failure: attribute nothing to the file
+            return frozenset()
+        return frozenset()
 
     for err in exc.errors():
         loc = err.get("loc", ())
+        if file_error_keys is None:
+            file_error_keys = _file_alone_error_keys()
+        if (tuple(loc), str(err.get("type", ""))) in file_error_keys:
+            continue  # the file fails this same check on its own — file-caused
         if not loc:
-            if env_caused_root is None:
-                env_caused_root = _root_failure_is_env_caused()
-            if env_caused_root:
-                _add_leaves([], env_overrides)
+            _add_leaves([], env_overrides)
             continue
         node: Any = env_overrides
         consumed: list[str] = []
@@ -160,13 +158,13 @@ def _env_override_hint(
             # error location goes deeper, this leaf REPLACED a container the
             # model expected, so it is still the var to fix.
             implicated.add(_PROXY_ENV_PREFIX + "__".join(p.upper() for p in consumed))
-        elif len(consumed) == len(loc) or not _file_has(consumed):
-            # Either a model-level (cross-field) error at a subtree the env
-            # touched, or the walk broke inside a subtree the env CREATED
-            # (the file doesn't supply it) — name the env leaves under it.
+        else:
+            # A subtree the env touched: a cross-field validator error there
+            # (consumed == loc) or a walk that broke inside it (e.g. the
+            # missing required field of an env-created entry — the file-
+            # caused variants were already filtered above). Name the env
+            # leaves under it.
             _add_leaves(consumed, node)
-        # else: the file supplies this subtree, so the failing value is
-        # file-set; implicate nothing.
     if not implicated:
         return ""
     return " (env override(s) implicated: " + ", ".join(sorted(implicated)) + ")"

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -61,7 +61,11 @@ def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, An
     return out
 
 
-def _env_override_hint(exc: Exception, env_overrides: dict[str, Any] | None) -> str:
+def _env_override_hint(
+    exc: Exception,
+    env_overrides: dict[str, Any] | None,
+    file_data: dict[str, Any] | None = None,
+) -> str:
     """Name the env var(s) implicated in a config ValidationError.
 
     A malformed ``MEMTOMEM_STM_PROXY__*`` value fails validation of the
@@ -74,14 +78,45 @@ def _env_override_hint(exc: Exception, env_overrides: dict[str, Any] | None) -> 
     operator actually set — never synthesized from the error location alone:
     a model-level validator reports its error at the MODEL's path (e.g. a
     HybridConfig cross-field error at ``upstream_servers.gh.hybrid``), and
-    naming that prefix would point at a var that was never set. An error
-    location that resolves to an env subtree names every env leaf under it;
-    one that runs PAST an env leaf (the env string replaced a whole
-    container) names that leaf; one the env never touched names nothing.
+    naming that prefix would point at a var that was never set.
+
+    - An error location that resolves to an env subtree names every env
+      leaf under it.
+    - One that runs PAST an env leaf (the env string replaced a whole
+      container) names that leaf.
+    - One that leaves the env subtree mid-walk is attributed by PROVENANCE
+      against *file_data* (the pre-merge file contents): if the file also
+      supplies that subtree, the failing value is file-set and nothing is
+      named; if the subtree exists only because the env created it (e.g. a
+      required field missing from an env-built upstream entry), the env
+      leaves under it are named — that collapse is env-caused even though
+      the failing location itself was never set.
     """
     if not env_overrides or not isinstance(exc, ValidationError):
         return ""
     implicated: set[str] = set()
+
+    def _file_has(path: list[str]) -> bool:
+        node: Any = file_data
+        for part in path:
+            if isinstance(node, dict) and part in node:
+                node = node[part]
+            else:
+                return False
+        return True
+
+    def _add_leaves(path: list[str], subtree: dict[str, Any]) -> None:
+        stack: list[tuple[list[str], dict[str, Any]]] = [(path, subtree)]
+        while stack:
+            prefix, node = stack.pop()
+            for key, value in node.items():
+                if isinstance(value, dict):
+                    stack.append(([*prefix, str(key)], value))
+                else:
+                    implicated.add(
+                        _PROXY_ENV_PREFIX + "__".join(p.upper() for p in [*prefix, str(key)])
+                    )
+
     for err in exc.errors():
         loc = err.get("loc", ())
         node: Any = env_overrides
@@ -94,24 +129,18 @@ def _env_override_hint(exc: Exception, env_overrides: dict[str, Any] | None) -> 
                 break
         if not consumed:
             continue  # the env overlay never touched this error's path
-        if isinstance(node, dict):
-            if len(consumed) < len(loc):
-                continue  # walk left the env subtree: the failing value is file-set
-            stack: list[tuple[list[str], dict[str, Any]]] = [(consumed, node)]
-            while stack:
-                path, sub = stack.pop()
-                for key, value in sub.items():
-                    if isinstance(value, dict):
-                        stack.append(([*path, str(key)], value))
-                    else:
-                        implicated.add(
-                            _PROXY_ENV_PREFIX + "__".join(p.upper() for p in [*path, str(key)])
-                        )
-        else:
+        if not isinstance(node, dict):
             # Landed on an env leaf — exact when consumed == loc; when the
             # error location goes deeper, this leaf REPLACED a container the
             # model expected, so it is still the var to fix.
             implicated.add(_PROXY_ENV_PREFIX + "__".join(p.upper() for p in consumed))
+        elif len(consumed) == len(loc) or not _file_has(consumed):
+            # Either a model-level (cross-field) error at a subtree the env
+            # touched, or the walk broke inside a subtree the env CREATED
+            # (the file doesn't supply it) — name the env leaves under it.
+            _add_leaves(consumed, node)
+        # else: the file supplies this subtree, so the failing value is
+        # file-set; implicate nothing.
     if not implicated:
         return ""
     return " (env override(s) implicated: " + ", ".join(sorted(implicated)) + ")"
@@ -722,17 +751,17 @@ class ProxyConfig(BaseModel):
                 )
         except OSError:
             pass
+        file_data: dict[str, Any] | None = None
         try:
-            data: dict[str, Any] = json.loads(resolved.read_text(encoding="utf-8"))
-            if env_overrides:
-                data = _deep_merge(data, env_overrides)
+            file_data = json.loads(resolved.read_text(encoding="utf-8"))
+            data = _deep_merge(file_data, env_overrides) if env_overrides else file_data
             return ProxyConfig.model_validate(data)
         except (json.JSONDecodeError, Exception) as exc:
             logger.warning(
                 "Failed to parse proxy config %s: %s%s",
                 resolved,
                 exc,
-                _env_override_hint(exc, env_overrides),
+                _env_override_hint(exc, env_overrides, file_data),
             )
             return None
 

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -753,7 +753,14 @@ class ProxyConfig(BaseModel):
             pass
         file_data: dict[str, Any] | None = None
         try:
-            file_data = json.loads(resolved.read_text(encoding="utf-8"))
+            loaded = json.loads(resolved.read_text(encoding="utf-8"))
+            if not isinstance(loaded, dict):
+                # Reject non-object roots BEFORE the env merge: ``[]`` would
+                # otherwise slip through ``_deep_merge`` (``dict([])`` is
+                # ``{}``) and an env override on top would validate cleanly,
+                # silently accepting an invalid config file.
+                raise ValueError(f"config root must be a JSON object, got {type(loaded).__name__}")
+            file_data = loaded
             data = _deep_merge(file_data, env_overrides) if env_overrides else file_data
             return ProxyConfig.model_validate(data)
         except (json.JSONDecodeError, Exception) as exc:

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -77,16 +77,18 @@ def _env_override_hint(
     Attribution is two-staged:
 
     1. DIFFERENTIAL pre-filter — every error of the merged config whose
-       ``(loc, type)`` the file reproduces ON ITS OWN is file-caused and
-       skipped: an env var that merely touched the same subtree (an innocent
-       ``tail_mode`` under a hybrid block whose ordering the file itself
-       breaks) must not be implicated. The file-alone validation runs
-       lazily, once, only on this already-failing path. Matching includes
-       the error TYPE so an env value that re-breaks a file-broken location
-       DIFFERENTLY (gt-violation -> int-parsing) is still attributed. (If
-       the env adds a second instance of an aggregated root error the file
-       already has — e.g. one more duplicate-prefix pair — it stays hidden
-       until the file is fixed; the rerun then re-attributes.)
+       ``(loc, type, msg)`` the file reproduces ON ITS OWN is file-caused
+       and skipped: an env var that merely touched the same subtree (an
+       innocent ``tail_mode`` under a hybrid block whose ordering the file
+       itself breaks) must not be implicated. The file-alone validation runs
+       lazily, once, only on this already-failing path. The error TYPE keeps
+       an env value that re-breaks a file-broken location DIFFERENTLY
+       (gt-violation -> int-parsing) attributed; the MESSAGE disambiguates
+       model validators, which all share ``type="value_error"`` — a
+       file-caused duplicate-prefix error must not mask a separate
+       env-caused empty-prefix error at the same root location (and an env
+       var that changes an aggregated root message, e.g. adds a collision,
+       is attributed too).
 
     2. NAMING — hints are derived from the env overlay's LEAVES, the var
        names the operator actually set, never synthesized from the error
@@ -119,17 +121,18 @@ def _env_override_hint(
                         _PROXY_ENV_PREFIX + "__".join(p.upper() for p in [*prefix, str(key)])
                     )
 
-    file_error_keys: frozenset[tuple[tuple[Any, ...], str]] | None = None
+    def _error_key(e: dict[str, Any]) -> tuple[tuple[Any, ...], str, str]:
+        return (tuple(e.get("loc", ())), str(e.get("type", "")), str(e.get("msg", "")))
 
-    def _file_alone_error_keys() -> frozenset[tuple[tuple[Any, ...], str]]:
+    file_error_keys: frozenset[tuple[tuple[Any, ...], str, str]] | None = None
+
+    def _file_alone_error_keys() -> frozenset[tuple[tuple[Any, ...], str, str]]:
         if file_data is None:
             return frozenset()  # no file at all: every failure is env-caused
         try:
             ProxyConfig.model_validate(file_data)
         except ValidationError as file_exc:
-            return frozenset(
-                (tuple(e.get("loc", ())), str(e.get("type", ""))) for e in file_exc.errors()
-            )
+            return frozenset(_error_key(e) for e in file_exc.errors())
         except Exception:  # non-pydantic failure: attribute nothing to the file
             return frozenset()
         return frozenset()
@@ -138,7 +141,7 @@ def _env_override_hint(
         loc = err.get("loc", ())
         if file_error_keys is None:
             file_error_keys = _file_alone_error_keys()
-        if (tuple(loc), str(err.get("type", ""))) in file_error_keys:
+        if _error_key(err) in file_error_keys:
             continue  # the file fails this same check on its own — file-caused
         if not loc:
             _add_leaves([], env_overrides)

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,36 @@ def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, An
         else:
             out[k] = v
     return out
+
+
+def _env_override_hint(exc: Exception, env_overrides: dict[str, Any] | None) -> str:
+    """Name the env var(s) implicated in a config ValidationError.
+
+    A malformed ``MEMTOMEM_STM_PROXY__*`` value fails validation of the
+    MERGED config, and the load falls back to defaults with a single warning
+    — without this hint the operator sees "Failed to parse proxy config
+    <file>" and debugs the FILE while the file is fine. Every error location
+    that resolves to a value supplied by the env overlay is mapped back to
+    its env var name. (Fallback semantics are unchanged: this only improves
+    the warning.)
+    """
+    if not env_overrides or not isinstance(exc, ValidationError):
+        return ""
+    implicated: set[str] = set()
+    for err in exc.errors():
+        node: Any = env_overrides
+        loc = err.get("loc", ())
+        for part in loc:
+            if isinstance(node, dict) and part in node:
+                node = node[part]
+            else:
+                break
+        else:
+            if loc:
+                implicated.add(_PROXY_ENV_PREFIX + "__".join(str(p).upper() for p in loc))
+    if not implicated:
+        return ""
+    return " (env override(s) implicated: " + ", ".join(sorted(implicated)) + ")"
 
 
 class CompressionStrategy(StrEnum):
@@ -119,6 +149,15 @@ class LLMCompressorConfig(BaseModel):
 
     @model_validator(mode="after")
     def _require_api_key_for_hosted_providers(self) -> LLMCompressorConfig:
+        # Deliberately EAGER: every llm block in the config is validated at
+        # load, even when the strategy that would use it is not selected
+        # (compression: truncate with an attached llm block, or
+        # extraction.enabled: false). The trade was reviewed 2026-06-11 and
+        # kept: deferring the key check to first use would also defer the
+        # failure of a genuinely-enabled compressor from startup to the first
+        # tool call. Operators pasting an example llm block they don't use
+        # yet should remove it (or use provider: ollama) — documented in
+        # docs/compression.md.
         if self.provider not in (LLMProvider.OPENAI, LLMProvider.ANTHROPIC):
             return self
         if self.api_key:
@@ -147,6 +186,19 @@ class HybridConfig(BaseModel):
     min_toc_budget: int = Field(default=200, gt=0)
     min_head_chars: int = Field(default=100, gt=0)
     head_ratio: float = Field(default=0.6, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _check_ordering(self) -> Self:
+        # min_head_chars > head_chars makes HybridCompressor's head-budget
+        # guard fire on every call, silently degrading the operator's chosen
+        # hybrid strategy to plain truncation. Reject the combination at load
+        # like UpstreamServerConfig does for its dependent numeric fields,
+        # instead of accepting a config that is structurally a no-op.
+        if self.min_head_chars > self.head_chars:
+            raise ValueError(
+                f"min_head_chars ({self.min_head_chars}) must be <= head_chars ({self.head_chars})"
+            )
+        return self
 
 
 class SelectiveConfig(BaseModel):
@@ -585,6 +637,14 @@ class ProxyConfig(BaseModel):
         if ctx_tokens is None:
             return self.default_max_result_chars
         model_budget = int(ctx_tokens * self.context_budget_ratio * self.chars_per_token)
+        if model_budget <= 0:
+            # context_budget_ratio is validated ge=0.0, so 0 is a legal value —
+            # but a 0-char budget would flow into every per-server max_chars
+            # and compress responses to nothing whenever min_result_retention
+            # (itself disable-able with 0) doesn't rescue it. A degenerate
+            # model budget means "model scaling effectively off", not "no
+            # output": fall back to the static default, which is gt=0.
+            return self.default_max_result_chars
         return min(model_budget, self.default_max_result_chars)
 
     @staticmethod
@@ -620,7 +680,9 @@ class ProxyConfig(BaseModel):
                     return ProxyConfig.model_validate(env_overrides)
                 except Exception as exc:
                     logger.warning(
-                        "Env-only proxy config failed validation: %s — using defaults", exc
+                        "Env-only proxy config failed validation: %s%s — using defaults",
+                        exc,
+                        _env_override_hint(exc, env_overrides),
                     )
             return ProxyConfig()
         # Warn if config is group/world-readable (may contain API keys)
@@ -640,7 +702,12 @@ class ProxyConfig(BaseModel):
                 data = _deep_merge(data, env_overrides)
             return ProxyConfig.model_validate(data)
         except (json.JSONDecodeError, Exception) as exc:
-            logger.warning("Failed to parse proxy config %s: %s", resolved, exc)
+            logger.warning(
+                "Failed to parse proxy config %s: %s%s",
+                resolved,
+                exc,
+                _env_override_hint(exc, env_overrides),
+            )
             return None
 
 

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -91,6 +91,11 @@ def _env_override_hint(
       required field missing from an env-built upstream entry), the env
       leaves under it are named — that collapse is env-caused even though
       the failing location itself was never set.
+    - A ROOT-level model-validator error (``loc=()``, e.g. duplicate or
+      empty upstream prefixes) has no path to walk; it is attributed by
+      DIFFERENTIAL validation — if the file alone validates (or there is no
+      file), the env overlay flipped the root check, and every env leaf is
+      named.
     """
     if not env_overrides or not isinstance(exc, ValidationError):
         return ""
@@ -117,8 +122,29 @@ def _env_override_hint(
                         _PROXY_ENV_PREFIX + "__".join(p.upper() for p in [*prefix, str(key)])
                     )
 
+    env_caused_root: bool | None = None  # lazily computed, shared across errors
+
+    def _root_failure_is_env_caused() -> bool:
+        # Top-level model validators (duplicate / empty upstream prefixes)
+        # report at loc=() — there is no path to walk, so attribute by
+        # DIFFERENTIAL validation: if the file alone validates (or there is
+        # no file at all), the env overlay is what flipped the root check.
+        if file_data is None:
+            return True
+        try:
+            ProxyConfig.model_validate(file_data)
+        except Exception:
+            return False  # the file fails on its own — fix the file first
+        return True
+
     for err in exc.errors():
         loc = err.get("loc", ())
+        if not loc:
+            if env_caused_root is None:
+                env_caused_root = _root_failure_is_env_caused()
+            if env_caused_root:
+                _add_leaves([], env_overrides)
+            continue
         node: Any = env_overrides
         consumed: list[str] = []
         for part in loc:

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -67,25 +67,51 @@ def _env_override_hint(exc: Exception, env_overrides: dict[str, Any] | None) -> 
     A malformed ``MEMTOMEM_STM_PROXY__*`` value fails validation of the
     MERGED config, and the load falls back to defaults with a single warning
     — without this hint the operator sees "Failed to parse proxy config
-    <file>" and debugs the FILE while the file is fine. Every error location
-    that resolves to a value supplied by the env overlay is mapped back to
-    its env var name. (Fallback semantics are unchanged: this only improves
-    the warning.)
+    <file>" and debugs the FILE while the file is fine. (Fallback semantics
+    are unchanged: this only improves the warning.)
+
+    Hints are derived from the env overlay's LEAVES — the var names the
+    operator actually set — never synthesized from the error location alone:
+    a model-level validator reports its error at the MODEL's path (e.g. a
+    HybridConfig cross-field error at ``upstream_servers.gh.hybrid``), and
+    naming that prefix would point at a var that was never set. An error
+    location that resolves to an env subtree names every env leaf under it;
+    one that runs PAST an env leaf (the env string replaced a whole
+    container) names that leaf; one the env never touched names nothing.
     """
     if not env_overrides or not isinstance(exc, ValidationError):
         return ""
     implicated: set[str] = set()
     for err in exc.errors():
-        node: Any = env_overrides
         loc = err.get("loc", ())
+        node: Any = env_overrides
+        consumed: list[str] = []
         for part in loc:
             if isinstance(node, dict) and part in node:
                 node = node[part]
+                consumed.append(str(part))
             else:
                 break
+        if not consumed:
+            continue  # the env overlay never touched this error's path
+        if isinstance(node, dict):
+            if len(consumed) < len(loc):
+                continue  # walk left the env subtree: the failing value is file-set
+            stack: list[tuple[list[str], dict[str, Any]]] = [(consumed, node)]
+            while stack:
+                path, sub = stack.pop()
+                for key, value in sub.items():
+                    if isinstance(value, dict):
+                        stack.append(([*path, str(key)], value))
+                    else:
+                        implicated.add(
+                            _PROXY_ENV_PREFIX + "__".join(p.upper() for p in [*path, str(key)])
+                        )
         else:
-            if loc:
-                implicated.add(_PROXY_ENV_PREFIX + "__".join(str(p).upper() for p in loc))
+            # Landed on an env leaf — exact when consumed == loc; when the
+            # error location goes deeper, this leaf REPLACED a container the
+            # model expected, so it is still the var to fix.
+            implicated.add(_PROXY_ENV_PREFIX + "__".join(p.upper() for p in consumed))
     if not implicated:
         return ""
     return " (env override(s) implicated: " + ", ".join(sorted(implicated)) + ")"

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -9,6 +9,7 @@ from memtomem_stm.config import LangfuseConfig, STMConfig
 from memtomem_stm.proxy.config import (
     AutoIndexConfig,
     ExtractionConfig,
+    HybridConfig,
     LLMCompressorConfig,
     LLMProvider,
     ProxyConfig,
@@ -78,6 +79,21 @@ class TestProxyNumericConstraints:
             prefix="x", reconnect_delay_seconds=5, max_reconnect_delay_seconds=5
         )
         assert cfg.reconnect_delay_seconds == 5
+
+    def test_hybrid_min_head_must_not_exceed_head(self) -> None:
+        """min_head_chars > head_chars makes HybridCompressor's head-budget
+        guard fall back to truncation on EVERY call — the operator's chosen
+        hybrid strategy silently never runs. Rejected at load instead."""
+        with pytest.raises(ValidationError, match="min_head_chars"):
+            HybridConfig(head_chars=5000, min_head_chars=9000)
+
+    def test_hybrid_min_head_equal_to_head_is_valid(self) -> None:
+        cfg = HybridConfig(head_chars=500, min_head_chars=500)
+        assert cfg.min_head_chars == cfg.head_chars
+
+    def test_hybrid_defaults_are_valid(self) -> None:
+        cfg = HybridConfig()
+        assert cfg.min_head_chars <= cfg.head_chars
 
 
 class TestSurfacingLtmTransportConfig:

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -76,9 +76,16 @@ class TestEffectiveMaxResultChars:
         # 200K * 0.05 * 3.5 = 35000 → capped at 5000
         assert cfg.effective_max_result_chars() == 5000
 
-    def test_zero_ratio(self):
+    def test_zero_ratio_falls_back_to_default(self):
+        """context_budget_ratio=0 is a legal value (``ge=0.0``), but the 0-char
+        model budget it used to return flowed into every per-server max_chars
+        and compressed responses to ~nothing whenever min_result_retention
+        (itself disable-able with 0) didn't rescue it. A degenerate model
+        budget now means "model scaling off", not "no output": the static
+        default (``gt=0``) is used instead. (This flips the old
+        characterization pin ``== 0``.)"""
         cfg = ProxyConfig(consumer_model="o1-mini", context_budget_ratio=0.0)
-        assert cfg.effective_max_result_chars() == 0
+        assert cfg.effective_max_result_chars() == 16000
 
     def test_gpt4o_budget(self):
         """gpt-4o: 128K * 0.05 * 3.5 = 22400 → capped at 16000."""

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -7,6 +7,7 @@ win over file values both at startup and on hot-reload.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from pathlib import Path
 
@@ -108,6 +109,79 @@ class TestLoadFromFileWithEnvOverrides:
         )
 
         assert cfg is None
+
+
+class TestMalformedEnvOverrideDiagnostics:
+    """A malformed MEMTOMEM_STM_PROXY__* value still collapses the load to
+    defaults / None (the fallback semantics are deliberately unchanged), but
+    the warning must name the env var — otherwise the operator debugs the
+    healthy FILE while the env overlay is what broke the merged validation."""
+
+    def test_malformed_env_value_named_in_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 9000}))
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__DEFAULT_MAX_RESULT_CHARS": "abc"}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None  # fallback unchanged: the whole load still degrades
+        assert any(
+            "MEMTOMEM_STM_PROXY__DEFAULT_MAX_RESULT_CHARS" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_nested_malformed_env_value_named_in_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"cache": {"enabled": True}}))
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__CACHE__MAX_ENTRIES": "-5"}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert any(
+            "MEMTOMEM_STM_PROXY__CACHE__MAX_ENTRIES" in r.getMessage() for r in caplog.records
+        )
+
+    def test_file_caused_error_carries_no_env_hint(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A validation error caused by the FILE (no env override at that
+        location) must not implicate env vars."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": "abc"}))
+        overrides = collect_proxy_env_overrides({"MEMTOMEM_STM_PROXY__CACHE__ENABLED": "true"})
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert not any("implicated" in r.getMessage() for r in caplog.records)
+
+    def test_env_only_path_names_the_env_var(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """File missing: the env-only rebuild degrades to defaults and the
+        warning names the malformed var."""
+        overrides = collect_proxy_env_overrides({"MEMTOMEM_STM_PROXY__LOCK_TIMEOUT_SECONDS": "x"})
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(tmp_path / "nonexistent.json", overrides)
+
+        assert cfg is not None  # env-only path degrades to defaults, not None
+        assert cfg.lock_timeout_seconds == 30.0
+        assert any(
+            "MEMTOMEM_STM_PROXY__LOCK_TIMEOUT_SECONDS" in r.getMessage() for r in caplog.records
+        )
 
     def test_nested_env_override_merges_with_file(self, tmp_path: Path) -> None:
         cfg_file = tmp_path / "stm_proxy.json"

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -131,8 +131,7 @@ class TestMalformedEnvOverrideDiagnostics:
 
         assert cfg is None  # fallback unchanged: the whole load still degrades
         assert any(
-            "MEMTOMEM_STM_PROXY__DEFAULT_MAX_RESULT_CHARS" in r.getMessage()
-            for r in caplog.records
+            "MEMTOMEM_STM_PROXY__DEFAULT_MAX_RESULT_CHARS" in r.getMessage() for r in caplog.records
         )
 
     def test_nested_malformed_env_value_named_in_warning(
@@ -140,9 +139,7 @@ class TestMalformedEnvOverrideDiagnostics:
     ) -> None:
         cfg_file = tmp_path / "stm_proxy.json"
         cfg_file.write_text(json.dumps({"cache": {"enabled": True}}))
-        overrides = collect_proxy_env_overrides(
-            {"MEMTOMEM_STM_PROXY__CACHE__MAX_ENTRIES": "-5"}
-        )
+        overrides = collect_proxy_env_overrides({"MEMTOMEM_STM_PROXY__CACHE__MAX_ENTRIES": "-5"})
 
         with caplog.at_level(logging.WARNING):
             cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
@@ -270,6 +267,63 @@ class TestMalformedEnvOverrideDiagnostics:
         overrides = collect_proxy_env_overrides(
             {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GH__MAX_RESULT_CHARS": "5000"}
         )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert not any("implicated" in r.getMessage() for r in caplog.records)
+
+    def test_env_caused_duplicate_prefix_names_env_leaves(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Top-level model validators (duplicate upstream prefixes) report at
+        loc=() — no path to walk. When the file alone validates and only the
+        merged config trips the root check, the env overlay flipped it and
+        its leaves must be named."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"upstream_servers": {"a": {"prefix": "a"}}}))
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__B__PREFIX": "a"}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert any(
+            "MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__B__PREFIX" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_env_caused_whitespace_prefix_names_env_leaves(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 9000}))
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__B__PREFIX": "   "}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert any(
+            "MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__B__PREFIX" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_file_caused_root_validator_error_carries_no_env_hint(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When the FILE alone already fails the root validator (its own
+        duplicate prefixes), an innocent env var must not be implicated."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(
+            json.dumps({"upstream_servers": {"a": {"prefix": "x"}, "b": {"prefix": "x"}}})
+        )
+        overrides = collect_proxy_env_overrides({"MEMTOMEM_STM_PROXY__CACHE__ENABLED": "true"})
 
         with caplog.at_level(logging.WARNING):
             cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -277,6 +277,23 @@ class TestMalformedEnvOverrideDiagnostics:
         assert cfg is None
         assert not any("implicated" in r.getMessage() for r in caplog.records)
 
+    def test_non_dict_config_root_rejected_even_with_env_overrides(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A ``[]`` config root must fail the load even when env overrides
+        are present: ``dict([])`` is ``{}``, so the deep merge used to turn
+        the invalid file into a valid env-only config, silently dropping the
+        fact that the file is broken."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text("[]")
+        overrides = collect_proxy_env_overrides({"MEMTOMEM_STM_PROXY__ENABLED": "true"})
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert any("JSON object" in r.getMessage() for r in caplog.records)
+
     def test_env_only_path_names_the_env_var(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -323,6 +323,29 @@ class TestMalformedEnvOverrideDiagnostics:
             "MEMTOMEM_STM_PROXY__CACHE__MAX_ENTRIES" in r.getMessage() for r in caplog.records
         )
 
+    def test_file_root_error_does_not_mask_a_different_env_root_error(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Model validators all share type="value_error", so the differential
+        key includes the MESSAGE: the file's duplicate-prefix root error must
+        not mask a separate env-caused empty-prefix root error."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(
+            json.dumps({"upstream_servers": {"a": {"prefix": "x"}, "b": {"prefix": "x"}}})
+        )
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__C__PREFIX": "   "}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert any(
+            "MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__C__PREFIX" in r.getMessage()
+            for r in caplog.records
+        )
+
     def test_env_caused_duplicate_prefix_names_env_leaves(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -236,6 +236,47 @@ class TestMalformedEnvOverrideDiagnostics:
         assert cfg is None
         assert not any("implicated" in r.getMessage() for r in caplog.records)
 
+    def test_missing_field_in_env_created_entry_names_env_leaves(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An env var can CREATE an upstream entry that then fails on a
+        missing required field (prefix). The error loc points at the absent
+        field — outside the env subtree — but the collapse is env-caused:
+        the entry exists only because the env built it, so the env leaves
+        under it must be named."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"default_max_result_chars": 9000}))
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GH__MAX_RESULT_CHARS": "5000"}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert any(
+            "MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GH__MAX_RESULT_CHARS" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_missing_field_in_file_entry_carries_no_env_hint(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The provenance counterpart: when the FILE supplies the entry that
+        is missing its required field, an env var that merely touched the
+        same entry is innocent and must not be implicated."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"upstream_servers": {"gh": {"command": "gh-mcp"}}}))
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GH__MAX_RESULT_CHARS": "5000"}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert not any("implicated" in r.getMessage() for r in caplog.records)
+
     def test_env_only_path_names_the_env_var(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -167,6 +167,75 @@ class TestMalformedEnvOverrideDiagnostics:
         assert cfg is None
         assert not any("implicated" in r.getMessage() for r in caplog.records)
 
+    def test_model_validator_error_names_env_leaves_not_the_model_prefix(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A cross-field model validator reports its error at the MODEL's
+        path (upstream_servers.gh.hybrid), not the field. The hint must name
+        the env LEAF actually set under that subtree, never synthesize a
+        non-leaf var (MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GH__HYBRID) that
+        was never in the environment."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(
+            json.dumps(
+                {"upstream_servers": {"gh": {"prefix": "gh", "hybrid": {"head_chars": 5000}}}}
+            )
+        )
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GH__HYBRID__MIN_HEAD_CHARS": "9000"}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        messages = [r.getMessage() for r in caplog.records]
+        leaf = "MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GH__HYBRID__MIN_HEAD_CHARS"
+        assert any(leaf in m for m in messages)
+        assert not any("HYBRID," in m or m.rstrip(")").endswith("HYBRID") for m in messages)
+
+    def test_env_leaf_replacing_a_container_names_that_leaf(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An env string clobbering a whole sub-model (cache='oops') is named
+        as the leaf the operator set, even though the error location may sit
+        at or below the container."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"cache": {"enabled": True}}))
+        overrides = collect_proxy_env_overrides({"MEMTOMEM_STM_PROXY__CACHE": "oops"})
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert any("MEMTOMEM_STM_PROXY__CACHE" in r.getMessage() for r in caplog.records)
+
+    def test_env_untouched_error_path_names_nothing(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An error in an upstream entry the env never touched must not be
+        attributed to env overrides set on a SIBLING entry."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "good": {"prefix": "good"},
+                        "bad": {"prefix": "bad", "hybrid": {"head_chars": -1}},
+                    }
+                }
+            )
+        )
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GOOD__MAX_RESULT_CHARS": "5000"}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert not any("implicated" in r.getMessage() for r in caplog.records)
+
     def test_env_only_path_names_the_env_var(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -274,6 +274,55 @@ class TestMalformedEnvOverrideDiagnostics:
         assert cfg is None
         assert not any("implicated" in r.getMessage() for r in caplog.records)
 
+    def test_file_caused_nested_validator_error_carries_no_env_hint(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When the FILE's own hybrid block breaks the ordering validator, an
+        env var that merely set an innocent sibling field (tail_mode) under
+        the same subtree must not be implicated — the file reproduces the
+        identical (loc, type) error on its own."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "gh": {
+                            "prefix": "gh",
+                            "hybrid": {"head_chars": 5000, "min_head_chars": 9000},
+                        }
+                    }
+                }
+            )
+        )
+        overrides = collect_proxy_env_overrides(
+            {"MEMTOMEM_STM_PROXY__UPSTREAM_SERVERS__GH__HYBRID__TAIL_MODE": "toc"}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert not any("implicated" in r.getMessage() for r in caplog.records)
+
+    def test_env_rebreaking_a_file_broken_leaf_is_still_named(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Type-sensitive matching: the file breaks cache.max_entries one way
+        (gt violation) and the env re-breaks the SAME location differently
+        (unparseable int). The env value is what the merged config actually
+        validated, so it must be named despite the shared location."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"cache": {"max_entries": -5}}))
+        overrides = collect_proxy_env_overrides({"MEMTOMEM_STM_PROXY__CACHE__MAX_ENTRIES": "abc"})
+
+        with caplog.at_level(logging.WARNING):
+            cfg = ProxyConfig.load_from_file(cfg_file, env_overrides=overrides)
+
+        assert cfg is None
+        assert any(
+            "MEMTOMEM_STM_PROXY__CACHE__MAX_ENTRIES" in r.getMessage() for r in caplog.records
+        )
+
     def test_env_caused_duplicate_prefix_names_env_leaves(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:


### PR DESCRIPTION
## Summary

Four config-validation findings from the 2026-06-10 implementation review (lows L262/L266/L270/L274), all in `ProxyConfig` load/validation:

- **L270 — `HybridConfig` cross-field validation**: `min_head_chars > head_chars` previously loaded fine but made `HybridCompressor`'s head-budget guard fire on every call, silently degrading the operator's chosen hybrid strategy to plain truncation. Now rejected at load (`_check_ordering`), mirroring `UpstreamServerConfig`'s dependent numeric-field validators.
- **L274 — zero model budget falls back to the static default**: `context_budget_ratio` is validated `ge=0.0`, so `0` is legal — but it produced a 0-char model budget that flowed into every per-server `max_chars`. A degenerate budget now means "model scaling effectively off", not "no output": fall back to `default_max_result_chars` (itself `gt=0`). The previous behavior was pinned by a characterization test (`test_zero_ratio`), which this PR deliberately flips.
- **L262 — env-override hints in load-failure warnings**: a malformed `MEMTOMEM_STM_PROXY__*` value fails validation of the MERGED config, and the warning blamed the file — the operator debugs a file that is fine. The warning now appends the implicated env var name(s). Attribution is two-staged: a differential `(loc, type, msg)` pre-filter against a file-alone validation (so file-caused errors are never pinned on an innocent env sibling), then naming derived from the env overlay's leaves (never synthesized from the error location). Full contract in the `_env_override_hint` docstring. Fallback semantics are unchanged — this only improves the warning text.
- **L266 — eager `api_key` validation documented as deliberate**: every `llm` block is validated at load, even when nothing selects the `llm_summary` strategy or the block sits under a disabled `extraction`. Reviewed and kept — deferring the check would move a genuinely-enabled compressor's failure from startup to the first tool call. Now stated in a comment at the validator and a callout in `docs/compression.md`.

## Behavior change

- Configs with `hybrid.min_head_chars > hybrid.head_chars` now **fail validation** (previously loaded and silently no-opped to truncation).
- `context_budget_ratio: 0` (or any ratio that floors the model budget to 0 chars) now yields `default_max_result_chars` instead of a 0-char budget.
- Non-object config roots (e.g. a top-level JSON array) are rejected **before** the env merge — previously `[]` slipped through `_deep_merge` (`dict([])` is `{}`) and could validate cleanly under env overrides, silently accepting an invalid file.

## Review

7 codex rounds. R1–R6 each caught a real corner of the env-hint attribution (loc-synthesized names → leaf-derived; missing-field in env-created subtrees → file provenance; `[]` root; `loc=()` root validators → differential validation; file-broken-subtree false positive → generalized `(loc, type)` pre-filter; same-key masking between model validators → key extended with the message). R7: **SHIP**, with one acknowledged non-blocking nit — when the file and an env override break the same leaf with the identical pydantic message, the hint is skipped; refining that comparison risks reintroducing the innocent-sibling misattribution R5 fixed.

## Test plan

- `tests/test_env_overrides.py` — attribution matrix: leaf / subtree / root locations, env-created subtrees, file-broken-sibling pre-filter, `[]` root, `loc=()` root validators, same-location different-message disambiguation
- `tests/test_config_constraints.py` — hybrid ordering rejection + zero-budget fallback (flipped `test_zero_ratio` pin)
- Full suite: 3122 passed, 3 skipped (`-m "not ollama"`); `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)