### PR TITLE
fix(mms): serialize sync --apply / import --apply behind a cross-process write lock

### DIFF
--- a/src/memtomem_stm/cli/_write_lock.py
+++ b/src/memtomem_stm/cli/_write_lock.py
@@ -1,0 +1,49 @@
+"""Write-lock decorator shared by the mutating mms CLI commands.
+
+Lives in its own module rather than joining the ``mms_import`` →
+``mms_host`` cross-import: the promotion trigger documented at
+``_classify_against_registry`` fires when the *next domain helper* joins
+that pair, and this is CLI glue around
+:func:`memtomem_stm.mms.state.write_lock`, not sync/import domain logic.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+import click
+
+from memtomem_stm.mms import state
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def with_write_lock(f: F) -> F:
+    """Run a Click command callback under the mms cross-process write lock.
+
+    Applied between the ``@click.option`` stack and the callback so the lock
+    spans the ENTIRE command — load, classification, the TTY confirmation
+    prompt, and both saves (see :func:`memtomem_stm.mms.state.write_lock`
+    for why the prompt must stay inside the span). ``--plan`` invocations
+    (``is_plan=True``) skip the lock: they never write, and the mutating
+    side's atomic per-file writes already keep readers consistent.
+
+    A timed-out acquisition surfaces as :class:`click.ClickException` —
+    "Error: <reason>", exit code 1 — instead of a traceback.
+
+    ``functools.wraps`` keeps the callback's docstring visible to Click's
+    help renderer.
+    """
+
+    @functools.wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        enabled = not kwargs.get("is_plan", False)
+        try:
+            with state.write_lock(enabled=enabled):
+                return f(*args, **kwargs)
+        except state.WriteLockTimeout as exc:
+            raise click.ClickException(str(exc)) from exc
+
+    return wrapper  # type: ignore[return-value]

--- a/src/memtomem_stm/cli/mms_host.py
+++ b/src/memtomem_stm/cli/mms_host.py
@@ -60,6 +60,7 @@ from pathlib import Path
 
 import click
 
+from memtomem_stm.cli._write_lock import with_write_lock
 from memtomem_stm.cli.mms_import import _classify_against_registry, _format_env_summary
 from memtomem_stm.mms import state
 from memtomem_stm.mms.drift import HASH_VERSION, compute_drift_hash
@@ -893,6 +894,7 @@ def _render_orphan_no_baseline_footer(n: int) -> None:
         "prompt)."
     ),
 )
+@with_write_lock
 def sync_cmd(is_plan: bool, json_output: bool, yes: bool, force: bool) -> None:
     """Reconcile registry + sidecar with the union of host scans.
 

--- a/src/memtomem_stm/cli/mms_import.py
+++ b/src/memtomem_stm/cli/mms_import.py
@@ -59,6 +59,7 @@ from pathlib import Path
 
 import click
 
+from memtomem_stm.cli._write_lock import with_write_lock
 from memtomem_stm.mms import state
 from memtomem_stm.mms.drift import HASH_VERSION, compute_drift_hash
 from memtomem_stm.mms.import_hosts import (
@@ -166,6 +167,7 @@ def _classify_against_registry(
     is_flag=True,
     help="In --plan mode, reveal secret values instead of redacting.",
 )
+@with_write_lock
 def import_command(from_host: str, is_plan: bool, show_imported: bool) -> None:
     """Import MCP definitions from host configs into the mms registry."""
     cwd = Path.cwd().resolve()

--- a/src/memtomem_stm/mms/state.py
+++ b/src/memtomem_stm/mms/state.py
@@ -22,7 +22,11 @@ sandbox.
 
 from __future__ import annotations
 
+import os
+import time
 import tomllib
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -30,6 +34,11 @@ import tomli_w
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from memtomem_stm.utils.fileio import atomic_write_text
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover — Windows builds lack fcntl
+    fcntl = None  # type: ignore[assignment]
 
 SCHEMA_VERSION = 1
 """Version constant for the three RFC §5.3 files (registry / projects index /
@@ -76,6 +85,11 @@ def import_state_path() -> Path:
     return mms_home() / "import_state.toml"
 
 
+def write_lock_path() -> Path:
+    """Advisory cross-process write lock for registry + sidecar mutations."""
+    return mms_home() / ".lock"
+
+
 PROJECT_MARKER_RELPATH = Path(".mms") / "project.toml"
 """Per-project marker relative path. Detection walks parents looking for this."""
 
@@ -118,6 +132,85 @@ class CorruptedConfig(MmsConfigError):
         super().__init__(f"{path}: {reason}")
         self.path = path
         self.reason = reason
+
+
+class WriteLockTimeout(MmsConfigError):
+    """Another process held the mms write lock past the acquisition timeout."""
+
+    def __init__(self, path: Path, timeout: float) -> None:
+        super().__init__(
+            f"timed out after {timeout:.0f}s waiting for the mms write lock ({path}) — "
+            "another `mms host sync --apply` or `mms import --apply` appears to be "
+            "running (possibly waiting at its confirmation prompt). Retry after it "
+            "finishes; the lock releases automatically when that process exits."
+        )
+        self.path = path
+        self.timeout = timeout
+
+
+# ---------------------------------------------------------------------------
+# Cross-process write lock
+# ---------------------------------------------------------------------------
+
+WRITE_LOCK_TIMEOUT_SECONDS = 10.0
+"""Default :func:`write_lock` acquisition timeout. Module-level so tests (and
+desperate operators via monkeypatching) can shrink it without threading a
+parameter through the CLI."""
+
+_WRITE_LOCK_POLL_SECONDS = 0.05
+
+
+@contextmanager
+def write_lock(*, enabled: bool = True, timeout: float | None = None) -> Iterator[None]:
+    """Hold the cross-process mms write lock for a load→mutate→save span.
+
+    ``mms host sync --apply`` and ``mms import --apply`` both read the
+    registry + sidecar, decide, and write both files back. The individual
+    writes are atomic (:func:`memtomem_stm.utils.fileio.atomic_write_text`),
+    but the read-modify-write spans are not: two concurrent ``--apply`` runs
+    interleave and the loser's load goes stale — its save silently drops the
+    winner's mutation. The lock serializes the whole span, *including* the
+    TTY confirmation prompt (releasing around the prompt would re-open the
+    stale-load window the lock exists to close).
+
+    ``flock`` is advisory and auto-releases when the holding process exits,
+    so a crashed holder cannot wedge later runs — no stale-lock cleanup
+    exists or is needed. Acquisition polls non-blocking so a held lock turns
+    into :class:`WriteLockTimeout` after ``timeout`` seconds (default
+    :data:`WRITE_LOCK_TIMEOUT_SECONDS`) instead of hanging the CLI behind an
+    unattended prompt.
+
+    No-ops when ``enabled`` is False (``--plan`` runs read but never write)
+    and on Windows (no ``fcntl``; single-user CLI, the lock is best-effort
+    hardening there, not a correctness guarantee).
+    """
+    if not enabled or fcntl is None:
+        yield
+        return
+    wait = WRITE_LOCK_TIMEOUT_SECONDS if timeout is None else timeout
+    lock_path = write_lock_path()
+    lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        deadline = time.monotonic() + wait
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError:
+                # EWOULDBLOCK (held elsewhere) is the expected case; rarer
+                # flock failures (e.g. ENOLCK) retry the same way and
+                # surface as the same timeout — the operator action is
+                # identical either way.
+                if time.monotonic() >= deadline:
+                    raise WriteLockTimeout(lock_path, wait) from None
+                time.sleep(_WRITE_LOCK_POLL_SECONDS)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mms/test_write_lock.py
+++ b/tests/mms/test_write_lock.py
@@ -1,0 +1,198 @@
+"""Tests for the mms cross-process write lock (``state.write_lock``).
+
+Two ``--apply`` runs (``mms host sync`` / ``mms import``) racing the same
+registry + sidecar interleave their load→save spans: the loser's stale load
+silently drops the winner's mutation on save. The lock serializes the span;
+these tests pin the lock's own semantics (contention, timeout, release,
+no-op modes) and the CLI wiring (held lock → clean error; ``--plan`` never
+locks).
+
+``flock`` contention is exercised through a SECOND file descriptor — flock
+locks attach to the open file description, so two ``os.open``\\ s of the same
+path contend even inside one process/thread. That makes the cross-process
+race testable without subprocesses.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem_stm.cli.mms_host import host_group
+from memtomem_stm.cli.mms_import import import_command
+from memtomem_stm.mms import state
+from helpers import set_home
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="flock is POSIX-only; write_lock is documented as a no-op on Windows",
+)
+
+if sys.platform != "win32":
+    import fcntl
+
+
+@pytest.fixture
+def sandbox_home(tmp_path, monkeypatch):
+    """Repoint ``~/.mms`` at a sandbox dir; yield it."""
+    set_home(monkeypatch, tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def cli_sandbox(tmp_path, monkeypatch):
+    """HOME + cwd sandbox for CLI invocations (mirrors tests/cli idiom)."""
+    set_home(monkeypatch, tmp_path)
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    return {"home": tmp_path, "cwd": cwd}
+
+
+@contextmanager
+def _hold_lock(home: Path):
+    """Hold the write lock through a raw fd, as a foreign process would."""
+    lock = home / ".mms" / ".lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        yield
+    finally:
+        os.close(fd)  # closing the fd releases the flock
+
+
+# ---------------------------------------------------------------------------
+# Lock semantics
+# ---------------------------------------------------------------------------
+
+
+def test_lock_file_lives_under_mms_home_with_0600(sandbox_home):
+    with state.write_lock():
+        pass
+    lock = sandbox_home / ".mms" / ".lock"
+    assert state.write_lock_path() == lock
+    assert lock.is_file()
+    assert stat.S_IMODE(lock.stat().st_mode) == 0o600
+
+
+def test_held_lock_times_out_with_clean_error(sandbox_home):
+    with state.write_lock():
+        t0 = time.monotonic()
+        with pytest.raises(state.WriteLockTimeout) as exc_info:
+            with state.write_lock(timeout=0.2):
+                pytest.fail("second acquisition must not succeed while held")
+        assert time.monotonic() - t0 >= 0.2
+        msg = str(exc_info.value)
+        assert str(state.write_lock_path()) in msg
+        assert "mms host sync --apply" in msg  # operator-facing attribution
+
+
+def test_waiter_acquires_after_holder_releases(sandbox_home):
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def holder() -> None:
+        with state.write_lock():
+            acquired.set()
+            release.wait(timeout=5)
+
+    t = threading.Thread(target=holder)
+    t.start()
+    try:
+        assert acquired.wait(timeout=5)
+        threading.Timer(0.2, release.set).start()
+        # Generous timeout: the point is that polling SUCCEEDS after the
+        # holder releases, not how fast.
+        with state.write_lock(timeout=5):
+            pass
+    finally:
+        release.set()
+        t.join(timeout=5)
+
+
+def test_release_allows_immediate_reacquire(sandbox_home):
+    with state.write_lock():
+        pass
+    with state.write_lock(timeout=0.2):
+        pass  # would raise WriteLockTimeout if the first exit leaked the lock
+
+
+def test_disabled_lock_is_a_true_no_op(sandbox_home):
+    with state.write_lock(enabled=False):
+        pass
+    assert not (sandbox_home / ".mms" / ".lock").exists()
+
+
+def test_disabled_lock_ignores_a_held_lock(sandbox_home):
+    with _hold_lock(sandbox_home):
+        with state.write_lock(enabled=False, timeout=0.1):
+            pass  # enters immediately despite the holder
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring — both mutating commands acquire; --plan never does
+# ---------------------------------------------------------------------------
+
+
+def test_sync_apply_under_held_lock_exits_cleanly(runner, cli_sandbox, monkeypatch):
+    monkeypatch.setattr(state, "WRITE_LOCK_TIMEOUT_SECONDS", 0.2)
+    with _hold_lock(cli_sandbox["home"]):
+        res = runner.invoke(host_group, ["sync", "--apply", "--yes"])
+    assert res.exit_code == 1
+    assert "Error:" in res.output  # ClickException render, not a traceback
+    assert "write lock" in res.output
+    assert "Traceback" not in res.output
+
+
+def test_import_apply_under_held_lock_exits_cleanly(runner, cli_sandbox, monkeypatch):
+    monkeypatch.setattr(state, "WRITE_LOCK_TIMEOUT_SECONDS", 0.2)
+    with _hold_lock(cli_sandbox["home"]):
+        res = runner.invoke(import_command, ["--apply"])
+    assert res.exit_code == 1
+    assert "Error:" in res.output
+    assert "write lock" in res.output
+
+
+def test_plan_invocations_skip_the_lock(runner, cli_sandbox, monkeypatch):
+    # If --plan took the lock, the shrunken timeout would fail it fast and
+    # the exit-0 asserts below would catch it.
+    monkeypatch.setattr(state, "WRITE_LOCK_TIMEOUT_SECONDS", 0.05)
+    with _hold_lock(cli_sandbox["home"]):
+        res_sync = runner.invoke(host_group, ["sync"])  # --plan is the default
+        res_import = runner.invoke(import_command, [])  # --plan is the default
+    assert res_sync.exit_code == 0, res_sync.output
+    assert res_import.exit_code == 0, res_import.output
+
+
+def test_apply_still_mutates_after_lock_wraps_the_command(runner, cli_sandbox):
+    """The decorator must not swallow the command's normal write path."""
+    cfg = {"mcpServers": {"filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]}}}
+    import json
+
+    (cli_sandbox["home"] / ".claude.json").write_text(json.dumps(cfg), encoding="utf-8")
+    res = runner.invoke(import_command, ["--from", "claude-code", "--apply"])
+    assert res.exit_code == 0, res.output
+    registry = state.load_registry()
+    assert "filesystem" in registry.servers
+    assert (cli_sandbox["home"] / ".mms" / ".lock").is_file()  # lock was taken
+
+
+def test_wrapped_commands_keep_help_docstrings(runner):
+    res = runner.invoke(host_group, ["sync", "--help"])
+    assert "Reconcile registry + sidecar" in res.output
+    res = runner.invoke(import_command, ["--help"])
+    assert "Import MCP definitions" in res.output


### PR DESCRIPTION
## Summary

`mms host sync --apply` and `mms import --apply` both load `~/.mms/registry.toml` + `import_state.toml`, decide, and save both files back. The individual writes are atomic (`atomic_write_text`), but the read-modify-write span is not: two concurrent `--apply` runs interleave, the loser's load goes stale, and its save silently drops the winner's mutation (2026-06-10 implementation review, L231).

- **`state.write_lock()`** — advisory `fcntl.flock` on `~/.mms/.lock` (0600), non-blocking poll with a 10s default timeout (`WRITE_LOCK_TIMEOUT_SECONDS`, monkeypatch-friendly). Timeout raises `WriteLockTimeout`; `flock` auto-releases on process exit, so a crashed holder cannot wedge later runs and no stale-lock cleanup exists or is needed.
- **`cli/_write_lock.py: with_write_lock`** — decorator between the `@click.option` stack and the callback, so the lock spans the ENTIRE command: load → classification → the TTY confirmation prompt → both saves. Releasing around the prompt would re-open the stale-load window the lock exists to close, so the prompt deliberately stays inside. `WriteLockTimeout` surfaces as a clean `ClickException` (exit 1), not a traceback.
- **`--plan` never locks** (`enabled=not is_plan`): plan runs only read, and the mutating side's atomic writes keep readers consistent.
- **Windows**: no `fcntl` → documented no-op (single-user CLI; the lock is best-effort hardening there). The `import fcntl` is `try/except ImportError`-guarded, satisfying `test_no_posix_only_imports`.

The decorator lives in its own module rather than joining the `mms_import` → `mms_host` cross-import: the promotion trigger documented at `_classify_against_registry` fires when the next *domain* helper joins that pair, and this is CLI glue, not sync/import domain logic.

## Behavior change

A second concurrent `--apply` now fails after 10s with `Error: timed out ... waiting for the mms write lock` instead of silently dropping the first run's mutation. `--plan` behavior is unchanged.

## Review

codex R1: **SHIP**, no findings.

## Test plan

`tests/mms/test_write_lock.py` (11 new): contention via a second fd (flock attaches to the open file description, so same-process fds contend like cross-process holders), timeout error content, waiter acquires after release, release/reacquire, `enabled=False` no-ops, held-lock CLI exits cleanly for both commands, `--plan` skips the lock under a held lock, post-wrap mutation still works, `--help` docstrings preserved. Full suite: 3114 passed, 3 skipped; ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)