### PR TITLE
fix(stores): chmod feedback/progressive/pending SQLite files to 0600

### DIFF
--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from memtomem_stm.utils.sqlite_private import ensure_private_db_files
 from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
@@ -93,10 +94,7 @@ class ProxyCache:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
         try:
-            try:
-                self._db_path.chmod(0o600)
-            except OSError:
-                pass
+            ensure_private_db_files(self._db_path)
             tune_connection(db)
             db.execute(_CREATE_TABLE)
             db.execute(_CREATE_INDEX)

--- a/src/memtomem_stm/proxy/compression_feedback_store.py
+++ b/src/memtomem_stm/proxy/compression_feedback_store.py
@@ -19,6 +19,7 @@ import threading
 import time
 from pathlib import Path
 
+from memtomem_stm.utils.sqlite_private import ensure_private_db_files
 from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
@@ -93,6 +94,7 @@ class CompressionFeedbackStore:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         db = sqlite3.connect(str(self._db_path), check_same_thread=False)
         try:
+            ensure_private_db_files(self._db_path)
             tune_connection(db)
             db.executescript(_SCHEMA)
             db.commit()

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 
 from memtomem_stm.proxy.metrics import CallMetrics
+from memtomem_stm.utils.sqlite_private import ensure_private_db_files
 from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
@@ -170,10 +171,7 @@ class MetricsStore:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
         try:
-            try:
-                self._db_path.chmod(0o600)
-            except OSError:
-                pass
+            ensure_private_db_files(self._db_path)
             tune_connection(db)
             db.execute(_CREATE)
             db.execute(_INDEX)

--- a/src/memtomem_stm/proxy/pending_store.py
+++ b/src/memtomem_stm/proxy/pending_store.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Protocol
 
 from memtomem_stm.proxy.compression import PendingSelection
+from memtomem_stm.utils.sqlite_private import ensure_private_db_files
 from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,7 @@ class SQLitePendingStore:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
         try:
+            ensure_private_db_files(self._db_path)
             tune_connection(db)
             db.execute(
                 """CREATE TABLE IF NOT EXISTS pending_selections (

--- a/src/memtomem_stm/proxy/progressive_reads_store.py
+++ b/src/memtomem_stm/proxy/progressive_reads_store.py
@@ -21,6 +21,7 @@ import threading
 import time
 from pathlib import Path
 
+from memtomem_stm.utils.sqlite_private import ensure_private_db_files
 from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,7 @@ class ProgressiveReadsStore:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         db = sqlite3.connect(str(self._db_path), check_same_thread=False)
         try:
+            ensure_private_db_files(self._db_path)
             tune_connection(db)
             db.executescript(_SCHEMA)
             db.commit()

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -10,6 +10,7 @@ import threading
 import time
 from pathlib import Path
 
+from memtomem_stm.utils.sqlite_private import ensure_private_db_files
 from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
@@ -247,6 +248,7 @@ class FeedbackStore:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         db = sqlite3.connect(str(self._db_path), check_same_thread=False)
         try:
+            ensure_private_db_files(self._db_path)
             tune_connection(db)
             db.executescript(_SCHEMA)
             _relax_surfacing_events_query_notnull(db)

--- a/src/memtomem_stm/utils/sqlite_private.py
+++ b/src/memtomem_stm/utils/sqlite_private.py
@@ -1,0 +1,40 @@
+"""Private file modes for STM-owned SQLite stores.
+
+Every STM SQLite store keeps user-scoped data (cached upstream responses,
+surfacing queries and ratings, feedback text, read telemetry) under
+``~/.memtomem``, so the DB files must not be readable by other local
+users. ``mkdir(mode=0o700)`` on the parent only applies when the
+directory is created — a pre-existing permissive ``~/.memtomem`` leaves
+freshly created DB files at the umask default (typically ``0o644``).
+
+SQLite creates ``-wal`` / ``-shm`` sidecars by copying the main DB
+file's mode, so correcting the DB file at open time also governs
+sidecars created later in the same or future runs — but sidecars left
+behind by earlier runs under a permissive umask must be corrected
+explicitly.
+
+Centralized so every store applies the same policy (mirrors
+``sqlite_tuning.tune_connection`` for PRAGMAs).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SIDECAR_SUFFIXES = ("-wal", "-shm")
+
+
+def ensure_private_db_files(db_path: Path) -> None:
+    """``chmod 0o600`` the SQLite DB at ``db_path`` and existing sidecars.
+
+    Call right after ``sqlite3.connect`` so the DB file exists.
+    Best-effort: a missing sidecar or a filesystem without mode support
+    must never fail store initialization (mirrors the previous inline
+    chmod in ``ProxyCache`` / ``MetricsStore``).
+    """
+    sidecars = (db_path.with_name(db_path.name + s) for s in _SIDECAR_SUFFIXES)
+    for path in (db_path, *sidecars):
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass

--- a/tests/test_sqlite_private.py
+++ b/tests/test_sqlite_private.py
@@ -11,6 +11,7 @@ previous permissive run — at 0600.
 from __future__ import annotations
 
 import sqlite3
+import sys
 from pathlib import Path
 
 import pytest
@@ -28,7 +29,18 @@ def _mode(path: Path) -> int:
     return path.stat().st_mode & 0o777
 
 
+# POSIX 0600 modes are unenforceable on Windows: ``os.chmod`` only toggles the
+# read-only bit, so a writable DB file always reports ``0o666``. The production
+# helper is a best-effort no-op there; only the mode-equality assertions need to
+# skip (``test_missing_db_does_not_raise`` still runs to prove no Windows crash).
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX 0600 modes are unenforceable on Windows; chmod only toggles the read-only bit",
+)
+
+
 class TestEnsurePrivateDbFiles:
+    @_skip_on_windows
     def test_chmods_db_and_existing_sidecars(self, tmp_path: Path) -> None:
         db = tmp_path / "x.db"
         wal = tmp_path / "x.db-wal"
@@ -43,6 +55,7 @@ class TestEnsurePrivateDbFiles:
         assert _mode(wal) == 0o600
         assert _mode(shm) == 0o600
 
+    @_skip_on_windows
     def test_missing_sidecars_are_ignored(self, tmp_path: Path) -> None:
         db = tmp_path / "x.db"
         db.touch()
@@ -55,6 +68,7 @@ class TestEnsurePrivateDbFiles:
     def test_missing_db_does_not_raise(self, tmp_path: Path) -> None:
         ensure_private_db_files(tmp_path / "absent.db")
 
+    @_skip_on_windows
     def test_unrelated_files_untouched(self, tmp_path: Path) -> None:
         db = tmp_path / "x.db"
         db.touch()
@@ -77,6 +91,7 @@ STORE_FACTORIES = [
 ]
 
 
+@_skip_on_windows
 @pytest.mark.parametrize("store_cls", STORE_FACTORIES)
 class TestStoreDbModes:
     def test_fresh_db_is_private(self, store_cls, tmp_path: Path) -> None:

--- a/tests/test_sqlite_private.py
+++ b/tests/test_sqlite_private.py
@@ -1,0 +1,113 @@
+"""0600 modes on STM-owned SQLite store files (utils/sqlite_private, #455).
+
+``ProxyCache`` and ``MetricsStore`` historically chmod-ed their DB files
+inline; the feedback/progressive/pending stores did not, so their DBs were
+created at the umask default (typically 0644) when ``~/.memtomem`` already
+existed. These tests pin the centralized policy: every store's
+``initialize()`` leaves the DB file — and any sidecars left over from a
+previous permissive run — at 0600.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.proxy.cache import ProxyCache
+from memtomem_stm.proxy.compression_feedback_store import CompressionFeedbackStore
+from memtomem_stm.proxy.metrics_store import MetricsStore
+from memtomem_stm.proxy.pending_store import SQLitePendingStore
+from memtomem_stm.proxy.progressive_reads_store import ProgressiveReadsStore
+from memtomem_stm.surfacing.feedback_store import FeedbackStore
+from memtomem_stm.utils.sqlite_private import ensure_private_db_files
+
+
+def _mode(path: Path) -> int:
+    return path.stat().st_mode & 0o777
+
+
+class TestEnsurePrivateDbFiles:
+    def test_chmods_db_and_existing_sidecars(self, tmp_path: Path) -> None:
+        db = tmp_path / "x.db"
+        wal = tmp_path / "x.db-wal"
+        shm = tmp_path / "x.db-shm"
+        for p in (db, wal, shm):
+            p.touch()
+            p.chmod(0o644)
+
+        ensure_private_db_files(db)
+
+        assert _mode(db) == 0o600
+        assert _mode(wal) == 0o600
+        assert _mode(shm) == 0o600
+
+    def test_missing_sidecars_are_ignored(self, tmp_path: Path) -> None:
+        db = tmp_path / "x.db"
+        db.touch()
+        db.chmod(0o644)
+
+        ensure_private_db_files(db)
+
+        assert _mode(db) == 0o600
+
+    def test_missing_db_does_not_raise(self, tmp_path: Path) -> None:
+        ensure_private_db_files(tmp_path / "absent.db")
+
+    def test_unrelated_files_untouched(self, tmp_path: Path) -> None:
+        db = tmp_path / "x.db"
+        db.touch()
+        other = tmp_path / "x.db.bak"
+        other.touch()
+        other.chmod(0o644)
+
+        ensure_private_db_files(db)
+
+        assert _mode(other) == 0o644
+
+
+STORE_FACTORIES = [
+    pytest.param(ProxyCache, id="proxy_cache"),
+    pytest.param(MetricsStore, id="metrics_store"),
+    pytest.param(FeedbackStore, id="feedback_store"),
+    pytest.param(CompressionFeedbackStore, id="compression_feedback_store"),
+    pytest.param(ProgressiveReadsStore, id="progressive_reads_store"),
+    pytest.param(SQLitePendingStore, id="pending_store"),
+]
+
+
+@pytest.mark.parametrize("store_cls", STORE_FACTORIES)
+class TestStoreDbModes:
+    def test_fresh_db_is_private(self, store_cls, tmp_path: Path) -> None:
+        db_path = tmp_path / "store.db"
+        store = store_cls(db_path)
+        store.initialize()
+        try:
+            assert _mode(db_path) == 0o600
+        finally:
+            store.close()
+
+    def test_permissive_db_and_sidecars_are_corrected(self, store_cls, tmp_path: Path) -> None:
+        db_path = tmp_path / "store.db"
+        # Simulate a DB created by an earlier release under a permissive
+        # umask: valid (empty-schema) SQLite file plus leftover WAL
+        # sidecars, all world-readable. SQLite copies the DB file's mode
+        # when it creates sidecars, so a 0644 DB keeps producing 0644
+        # sidecars until the DB itself is corrected.
+        sqlite3.connect(str(db_path)).close()
+        wal = tmp_path / "store.db-wal"
+        shm = tmp_path / "store.db-shm"
+        wal.touch()
+        shm.touch()
+        for p in (db_path, wal, shm):
+            p.chmod(0o644)
+
+        store = store_cls(db_path)
+        store.initialize()
+        try:
+            assert _mode(db_path) == 0o600
+            assert _mode(wal) == 0o600
+            assert _mode(shm) == 0o600
+        finally:
+            store.close()


### PR DESCRIPTION
Closes #455.

## Summary

- Extract `utils/sqlite_private.ensure_private_db_files()`: chmods the SQLite DB file **and any existing `-wal`/`-shm` sidecars** to `0600`, best-effort (`OSError` swallowed per path, mirroring the previous inline chmod).
- Wire it into all six SQLite-backed stores, right after `sqlite3.connect`:
  - `ProxyCache`, `MetricsStore` — replace their inline chmod (which covered only the DB file, not sidecars),
  - `FeedbackStore`, `CompressionFeedbackStore`, `ProgressiveReadsStore`, `SQLitePendingStore` — previously no chmod at all.
- Tests (`tests/test_sqlite_private.py`): helper unit tests (sidecar correction, missing files, unrelated files untouched) plus a 6-store parametrized pin — fresh DB is `0600`, and a pre-existing `0644` DB with leftover `0644` sidecars is corrected by `initialize()`.

## Why sidecars matter

SQLite creates `-wal`/`-shm` by copying the main DB file's mode, so a `0644` DB keeps producing `0644` sidecars until the DB itself is corrected — and sidecars left behind by earlier permissive runs are never touched by a DB-file-only chmod. Confirmed on a real install: `stm_feedback.db`, `stm_feedback.db-wal`, and `stm_feedback.db-shm` were all `-rw-r--r--`.

## Behavior change

On startup, every store now corrects the modes of its existing DB file and sidecars to `0600`. Installs with world-readable `stm_feedback.db` (surfacing queries, ratings, feedback text, read telemetry) get corrected at the next start. No schema or API change; failure to chmod never fails store initialization.

## Out of scope

The "warn when `~/.memtomem` itself is group/world-accessible" idea from #455 is intentionally dropped rather than deferred: with all DB files at `0600`, a permissive parent directory discloses file names only, not contents — and the directory is shared with the LTM server, so a per-store warning would nag on every start for marginal benefit. Reopen if file-name disclosure is considered sensitive.

## Verification

- `uv run pytest -m "not ollama"` — 3148 passed, 3 skipped (includes 16 new tests)
- `uv run ruff check src tests && uv run ruff format --check src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)