### PR TITLE
docs(proxy): state the sync-sqlite-on-event-loop invariant at every store write path

### DIFF
--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -83,6 +83,17 @@ def response_carries_transient_key(text: str) -> bool:
 
 
 class ProxyCache:
+    """SQLite-backed cross-restart cache for proxied tool results.
+
+    Every method does synchronous sqlite I/O on the caller's thread — in
+    the proxy that is the asyncio event loop. Deliberate under the proxy's
+    single-MCP-client invariant: a blocking ``get``/``set`` delays only the
+    one in-flight call it serves, and is far cheaper than the upstream
+    call a hit avoids. Multi-client serving is the reopen trigger — then
+    move the I/O to ``asyncio.to_thread``; ``self._lock`` already makes
+    the connection access thread-safe.
+    """
+
     def __init__(self, db_path: Path, max_entries: int = 10000) -> None:
         self._db_path = db_path
         self._max_entries = max_entries

--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -85,13 +85,15 @@ def response_carries_transient_key(text: str) -> bool:
 class ProxyCache:
     """SQLite-backed cross-restart cache for proxied tool results.
 
-    Every method does synchronous sqlite I/O on the caller's thread — in
-    the proxy that is the asyncio event loop. Deliberate under the proxy's
-    single-MCP-client invariant: a blocking ``get``/``set`` delays only the
-    one in-flight call it serves, and is far cheaper than the upstream
-    call a hit avoids. Multi-client serving is the reopen trigger — then
-    move the I/O to ``asyncio.to_thread``; ``self._lock`` already makes
-    the connection access thread-safe.
+    Every method does synchronous sqlite I/O on the asyncio event loop:
+    while a ``get``/``set`` runs, every runnable coroutine stalls — other
+    in-flight proxied calls included, not just the one being served.
+    Accepted for the current local single-MCP-client deployment, where
+    call volume is low and the I/O is far cheaper than the upstream call
+    a hit avoids. Multi-client serving (or materially higher concurrency)
+    is the reopen trigger: move the I/O off-loop (e.g.
+    ``asyncio.to_thread``) — all connection access here already goes
+    through ``self._lock``, so this store is lock-ready for that move.
     """
 
     def __init__(self, db_path: Path, max_entries: int = 10000) -> None:

--- a/src/memtomem_stm/proxy/compression_feedback_store.py
+++ b/src/memtomem_stm/proxy/compression_feedback_store.py
@@ -116,11 +116,17 @@ class CompressionFeedbackStore:
     ) -> None:
         """Persist a feedback row. ``kind`` is assumed already validated.
 
-        Synchronous sqlite write on the asyncio event loop — deliberate
-        under the proxy's single-MCP-client invariant (it delays only
-        the feedback call being served). Multi-client serving is the
-        reopen trigger — then move the write to ``asyncio.to_thread``;
-        ``self._lock`` already makes that safe.
+        Synchronous sqlite write on the asyncio event loop: while it
+        runs, every runnable coroutine stalls — other in-flight proxied
+        calls included, not just the feedback call being served.
+        Accepted for the current local single-MCP-client deployment
+        (low call volume; cheap local insert). Multi-client serving (or
+        materially higher concurrency) is the reopen trigger: move the
+        write off-loop (e.g. ``asyncio.to_thread``) — and note
+        ``self._lock`` serializes the write paths only; reads share the
+        connection unlocked, so a thread move also needs every
+        connection access locked (the ``MetricsStore.__init__``
+        reader/writer convention) or per-thread connections.
         """
         if self._db is None:
             return

--- a/src/memtomem_stm/proxy/compression_feedback_store.py
+++ b/src/memtomem_stm/proxy/compression_feedback_store.py
@@ -114,7 +114,14 @@ class CompressionFeedbackStore:
         missing: str,
         trace_id: str | None,
     ) -> None:
-        """Persist a feedback row. ``kind`` is assumed already validated."""
+        """Persist a feedback row. ``kind`` is assumed already validated.
+
+        Synchronous sqlite write on the asyncio event loop — deliberate
+        under the proxy's single-MCP-client invariant (it delays only
+        the feedback call being served). Multi-client serving is the
+        reopen trigger — then move the write to ``asyncio.to_thread``;
+        ``self._lock`` already makes that safe.
+        """
         if self._db is None:
             return
         with self._lock:

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -251,14 +251,16 @@ class MetricsStore:
     def record(self, metrics: CallMetrics) -> None:
         """Persist one per-call metrics row.
 
-        Synchronous sqlite write on the caller's thread — in the proxy
-        that is the asyncio event loop. Deliberate under the proxy's
-        single-MCP-client invariant: blocking the loop here delays only
-        the one in-flight call that produced the row, and a local WAL
-        insert is far cheaper than the upstream tool call it accounts
-        for. Multi-client serving is the reopen trigger — then move the
-        write to ``asyncio.to_thread``; ``self._lock`` (see the note in
-        ``__init__``) already makes that safe.
+        Synchronous sqlite write on the asyncio event loop: while it
+        runs, every runnable coroutine stalls — other in-flight proxied
+        calls included, not just the one that produced the row.
+        Accepted for the current local single-MCP-client deployment,
+        where call volume is low and a local WAL insert is far cheaper
+        than the upstream call it accounts for. Multi-client serving
+        (or materially higher concurrency) is the reopen trigger: move
+        persistence off-loop (e.g. ``asyncio.to_thread``) — readers and
+        writers here already share ``self._lock`` (see ``__init__``),
+        so this store is lock-ready for that move.
         """
         if self._db is None:
             return

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -249,6 +249,17 @@ class MetricsStore:
             self._db = None
 
     def record(self, metrics: CallMetrics) -> None:
+        """Persist one per-call metrics row.
+
+        Synchronous sqlite write on the caller's thread — in the proxy
+        that is the asyncio event loop. Deliberate under the proxy's
+        single-MCP-client invariant: blocking the loop here delays only
+        the one in-flight call that produced the row, and a local WAL
+        insert is far cheaper than the upstream tool call it accounts
+        for. Multi-client serving is the reopen trigger — then move the
+        write to ``asyncio.to_thread``; ``self._lock`` (see the note in
+        ``__init__``) already makes that safe.
+        """
         if self._db is None:
             return
         now = time.time()

--- a/src/memtomem_stm/proxy/progressive_reads_store.py
+++ b/src/memtomem_stm/proxy/progressive_reads_store.py
@@ -97,11 +97,17 @@ class ProgressiveReadsStore:
         path would be a shutdown-race and losing a row is preferable
         to raising into the response path.
 
-        Synchronous sqlite write on the asyncio event loop — deliberate
-        under the proxy's single-MCP-client invariant (it delays only
-        the request being served). Multi-client serving is the reopen
-        trigger — then move the write to ``asyncio.to_thread``;
-        ``self._lock`` already makes that safe.
+        Synchronous sqlite write on the asyncio event loop: while it
+        runs, every runnable coroutine stalls — other in-flight proxied
+        calls included, not just the request being served. Accepted for
+        the current local single-MCP-client deployment (low call
+        volume; far cheaper than the upstream call). Multi-client
+        serving (or materially higher concurrency) is the reopen
+        trigger: move the write off-loop (e.g. ``asyncio.to_thread``) —
+        and note ``self._lock`` serializes the write paths only; reads
+        share the connection unlocked, so a thread move also needs
+        every connection access locked (the ``MetricsStore.__init__``
+        reader/writer convention) or per-thread connections.
         """
         if self._db is None:
             return

--- a/src/memtomem_stm/proxy/progressive_reads_store.py
+++ b/src/memtomem_stm/proxy/progressive_reads_store.py
@@ -96,6 +96,12 @@ class ProgressiveReadsStore:
         finally-block close, so hitting a closed store from the hot
         path would be a shutdown-race and losing a row is preferable
         to raising into the response path.
+
+        Synchronous sqlite write on the asyncio event loop — deliberate
+        under the proxy's single-MCP-client invariant (it delays only
+        the request being served). Multi-client serving is the reopen
+        trigger — then move the write to ``asyncio.to_thread``;
+        ``self._lock`` already makes that safe.
         """
         if self._db is None:
             return

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -232,7 +232,17 @@ def read_surfacing_summary(db_path: Path, tool: str | None = None) -> dict[str, 
 
 
 class FeedbackStore:
-    """SQLite store for surfacing events and feedback ratings."""
+    """SQLite store for surfacing events and feedback ratings.
+
+    The write paths (``record_surfacing`` / ``record_feedback`` /
+    ``mark_surfaced`` / ``save_adjustment`` / the ``cleanup_*`` sweeps)
+    do synchronous sqlite I/O on the caller's thread — on the proxy and
+    daemon paths that is the asyncio event loop. Deliberate under the
+    single-MCP-client invariant: a blocking write delays only the call
+    being served. Multi-client serving is the reopen trigger — then move
+    the writes to ``asyncio.to_thread``; ``self._lock`` already makes
+    them thread-safe.
+    """
 
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -236,12 +236,18 @@ class FeedbackStore:
 
     The write paths (``record_surfacing`` / ``record_feedback`` /
     ``mark_surfaced`` / ``save_adjustment`` / the ``cleanup_*`` sweeps)
-    do synchronous sqlite I/O on the caller's thread — on the proxy and
-    daemon paths that is the asyncio event loop. Deliberate under the
-    single-MCP-client invariant: a blocking write delays only the call
-    being served. Multi-client serving is the reopen trigger — then move
-    the writes to ``asyncio.to_thread``; ``self._lock`` already makes
-    them thread-safe.
+    do synchronous sqlite I/O on the asyncio event loop (proxy and
+    daemon paths alike): while one runs, every runnable coroutine
+    stalls — other in-flight calls included, not just the one being
+    served. Accepted for the current local single-MCP-client
+    deployment, where call volume is low and the writes are cheap local
+    inserts. Multi-client serving (or materially higher concurrency) is
+    the reopen trigger: move the writes off-loop (e.g.
+    ``asyncio.to_thread``) — and note ``self._lock`` serializes the
+    write paths only; the read/stat methods share the connection
+    unlocked, so a thread move also needs every connection access
+    locked (the ``MetricsStore.__init__`` reader/writer convention) or
+    per-thread connections.
     """
 
     def __init__(self, db_path: Path) -> None:


### PR DESCRIPTION
## Summary

All five sqlite stores (proxy `MetricsStore`, `ProxyCache`, `ProgressiveReadsStore`, `CompressionFeedbackStore`, surfacing `FeedbackStore`) execute synchronous writes directly on the asyncio event loop. That is a deliberate trade for the current local single-MCP-client deployment — but nothing in the code said so, and a future multi-client change could inherit the blocking writes silently (2026-06-10 implementation review, L293; decided document-only).

Each site now states:
- the real blast radius — while a write runs, **every runnable coroutine stalls** (other in-flight proxied calls included), not just the call that produced it;
- why it is accepted — local single-client deployment, low call volume, cheap local WAL writes vs the upstream calls they account for;
- the reopen trigger — multi-client serving (or materially higher concurrency) → move persistence off-loop (`asyncio.to_thread`);
- per-store lock readiness for that move — `MetricsStore`/`ProxyCache` lock all connection access (lock-ready); the other three lock **writes only**, so a thread move also needs their read/stat paths locked (the `MetricsStore.__init__` reader/writer convention) or per-thread connections.

Comment/docstring-only; no behavior change.

## Review

codex R1 NEEDS-FIX: initial wording overstated the blast radius ("delays only the call being served") and overclaimed `to_thread` readiness for the three write-only-locked stores — both reworded per store after verifying lock coverage. R2: **SHIP**, no findings ("rewording is accurate per store").

## Test plan

Doc-only — full suite 3132 passed, 3 skipped; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)