### PR TITLE
fix(cache): never persist secret-looking responses to the response cache

### DIFF
--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -131,8 +131,9 @@ class ProxyCache:
             # scan and the gate share ``contains_sensitive_content`` so they
             # can never diverge. Runs on every startup (matching the marker
             # purge) — after the first pass it finds nothing, because ``set()``
-            # refuses new matching rows; the rescan also covers rows written by
-            # older processes still running pre-gate code against this file.
+            # refuses new matching rows. Rows written LATER by an older
+            # still-running pre-gate process are outside this purge's reach;
+            # the read-side guard in ``get()`` refuses and evicts those.
             stale_keys = [
                 key
                 for key, result in db.execute("SELECT cache_key, result FROM proxy_cache")
@@ -167,6 +168,21 @@ class ProxyCache:
             return None
         entry = CacheEntry(result=row[0], created_at=row[1], ttl_seconds=row[2])
         if entry.is_expired():
+            return None
+        if contains_sensitive_content(entry.result):
+            # Read-side mirror of the ``set()`` gate: a row can land here
+            # without passing ``set()`` — written by an older still-running
+            # pre-gate process or an external SQL writer — and the startup
+            # purge only covers rows present at ``initialize()``. Serving it
+            # would break the SECURITY.md exclusion, so evict and miss.
+            with self._lock:
+                self._db.execute("DELETE FROM proxy_cache WHERE cache_key = ?", (key,))
+                self._db.commit()
+            logger.debug(
+                "Evicted cached response for %s/%s: result matches a privacy pattern",
+                server,
+                tool,
+            )
             return None
         return entry.result
 

--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -167,22 +167,36 @@ class ProxyCache:
         if row is None:
             return None
         entry = CacheEntry(result=row[0], created_at=row[1], ttl_seconds=row[2])
-        if entry.is_expired():
-            return None
         if contains_sensitive_content(entry.result):
             # Read-side mirror of the ``set()`` gate: a row can land here
             # without passing ``set()`` — written by an older still-running
             # pre-gate process or an external SQL writer — and the startup
             # purge only covers rows present at ``initialize()``. Serving it
             # would break the SECURITY.md exclusion, so evict and miss.
-            with self._lock:
-                self._db.execute("DELETE FROM proxy_cache WHERE cache_key = ?", (key,))
-                self._db.commit()
+            # Checked BEFORE expiry: an expired sensitive row must still be
+            # deleted, not left resting on disk until the next startup.
+            try:
+                with self._lock:
+                    self._db.execute("DELETE FROM proxy_cache WHERE cache_key = ?", (key,))
+                    self._db.commit()
+            except sqlite3.Error:
+                # Eviction is best-effort: a concurrent writer holding the
+                # file lock must degrade this to a plain miss, never abort
+                # the caller's request. The row is retried on the next
+                # ``get()`` and swept by the next startup purge.
+                logger.warning(
+                    "Privacy eviction failed for %s/%s — serving a miss",
+                    server,
+                    tool,
+                    exc_info=True,
+                )
             logger.debug(
                 "Evicted cached response for %s/%s: result matches a privacy pattern",
                 server,
                 tool,
             )
+            return None
+        if entry.is_expired():
             return None
         return entry.result
 

--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from memtomem_stm.proxy.privacy import contains_sensitive_content
 from memtomem_stm.utils.sqlite_tuning import tune_connection
 
 logger = logging.getLogger(__name__)
@@ -123,6 +124,26 @@ class ProxyCache:
                 (_PROGRESSIVE_MARKER, _SELECTION_KEY_MARKER, _TOC_SHAPE_MARKER),
             )
             db.commit()
+            # Purge of legacy rows cached before the privacy gate in ``set()``
+            # (#453) — they may embed secret-looking content that SECURITY.md
+            # promises is never persisted. Privacy patterns are Python regexes,
+            # so unlike the marker purge above this scans rows in Python; the
+            # scan and the gate share ``contains_sensitive_content`` so they
+            # can never diverge. Runs on every startup (matching the marker
+            # purge) — after the first pass it finds nothing, because ``set()``
+            # refuses new matching rows; the rescan also covers rows written by
+            # older processes still running pre-gate code against this file.
+            stale_keys = [
+                key
+                for key, result in db.execute("SELECT cache_key, result FROM proxy_cache")
+                if contains_sensitive_content(result)
+            ]
+            if stale_keys:
+                db.executemany(
+                    "DELETE FROM proxy_cache WHERE cache_key = ?",
+                    [(key,) for key in stale_keys],
+                )
+                db.commit()
         except Exception:
             db.close()
             raise
@@ -158,6 +179,17 @@ class ProxyCache:
         ttl_seconds: float | None,
     ) -> None:
         if self._db is None:
+            return
+        if contains_sensitive_content(result):
+            # SECURITY.md: responses that look like secrets are never
+            # persisted to the response cache. Enforced at the store
+            # chokepoint so no caller can bypass it (#453); a false positive
+            # only costs one un-cached response, never correctness.
+            logger.debug(
+                "Skipping cache store for %s/%s: response matches a privacy pattern",
+                server,
+                tool,
+            )
             return
         key = _make_key(server, tool, args)
         now = time.time()

--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -179,6 +179,11 @@ class ProxyCache:
                 with self._lock:
                     self._db.execute("DELETE FROM proxy_cache WHERE cache_key = ?", (key,))
                     self._db.commit()
+                logger.debug(
+                    "Evicted cached response for %s/%s: result matches a privacy pattern",
+                    server,
+                    tool,
+                )
             except sqlite3.Error:
                 # Eviction is best-effort: a concurrent writer holding the
                 # file lock must degrade this to a plain miss, never abort
@@ -190,11 +195,6 @@ class ProxyCache:
                     tool,
                     exc_info=True,
                 )
-            logger.debug(
-                "Evicted cached response for %s/%s: result matches a privacy pattern",
-                server,
-                tool,
-            )
             return None
         if entry.is_expired():
             return None

--- a/tests/test_proxy_cache.py
+++ b/tests/test_proxy_cache.py
@@ -246,9 +246,9 @@ class TestPrivacyGate:
         assert proxy_cache.get("s", "t", {}) == "ordinary tool response"
 
     def test_email_bearing_result_is_not_cached(self, proxy_cache: ProxyCache):
-        # DEFAULT_PATTERNS include an email regex, so email-bearing responses
-        # are deliberately uncacheable — the gate shares the sensitivity set
-        # of the LLM-route scan rather than maintaining a second definition.
+        # The cache is a STORAGE consumer, so it scans the full
+        # DEFAULT_PATTERNS (credentials + PII) per the #461 split: an email
+        # is fine to show an external summarizer but not fine to persist.
         # The cost is one pipeline re-run per repeat call, never correctness.
         proxy_cache.set("s", "t", {}, "contact: dev@example.com", ttl_seconds=60.0)
         assert proxy_cache.get("s", "t", {}) is None

--- a/tests/test_proxy_cache.py
+++ b/tests/test_proxy_cache.py
@@ -330,6 +330,93 @@ class TestPrivacyGate:
         finally:
             cache.close()
 
+    def test_get_evicts_expired_sensitive_row(self, tmp_path):
+        # The sensitivity check must run BEFORE the expiry check: an
+        # already-expired sensitive row would otherwise return a miss while
+        # the secret keeps resting on disk until the next startup purge.
+        db_path = tmp_path / "expired_secret.db"
+        cache = ProxyCache(db_path, max_entries=100)
+        cache.initialize()
+        try:
+            raw = sqlite3.connect(str(db_path))
+            try:
+                raw.execute(
+                    "INSERT INTO proxy_cache "
+                    "(cache_key, server, tool, result, created_at, ttl_seconds) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        _make_key("s", "sec", {}),
+                        "s",
+                        "sec",
+                        "login password=hunter2",
+                        time.time() - 100.0,
+                        1.0,
+                    ),
+                )
+                raw.commit()
+            finally:
+                raw.close()
+
+            assert cache.get("s", "sec", {}) is None
+
+            check = sqlite3.connect(str(db_path))
+            try:
+                count = check.execute("SELECT COUNT(*) FROM proxy_cache").fetchone()[0]
+            finally:
+                check.close()
+            assert count == 0
+        finally:
+            cache.close()
+
+    def test_get_serves_miss_when_eviction_is_blocked(self, tmp_path):
+        # A concurrent writer holding the SQLite write lock makes the
+        # privacy-eviction DELETE raise OperationalError; get() must degrade
+        # to a plain miss (never propagate), keep the row for a later sweep,
+        # and evict it once the writer releases the lock.
+        db_path = tmp_path / "blocked_eviction.db"
+        cache = ProxyCache(db_path, max_entries=100)
+        cache.initialize()
+        try:
+            assert cache._db is not None
+            # Shrink the busy timeout so the blocked DELETE fails fast
+            # instead of stalling the test for the 3 s default.
+            cache._db.execute("PRAGMA busy_timeout=50")
+
+            raw = sqlite3.connect(str(db_path))
+            try:
+                raw.execute(
+                    "INSERT INTO proxy_cache "
+                    "(cache_key, server, tool, result, created_at, ttl_seconds) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        _make_key("s", "sec", {}),
+                        "s",
+                        "sec",
+                        "login password=hunter2",
+                        time.time(),
+                        None,
+                    ),
+                )
+                raw.commit()
+
+                raw.execute("BEGIN IMMEDIATE")  # hold the write lock
+                assert cache.get("s", "sec", {}) is None  # miss, no raise
+                count = raw.execute("SELECT COUNT(*) FROM proxy_cache").fetchone()[0]
+                assert count == 1  # eviction failed, row still present
+                raw.rollback()  # release the lock
+            finally:
+                raw.close()
+
+            assert cache.get("s", "sec", {}) is None  # retried eviction
+            check = sqlite3.connect(str(db_path))
+            try:
+                count = check.execute("SELECT COUNT(*) FROM proxy_cache").fetchone()[0]
+            finally:
+                check.close()
+            assert count == 0
+        finally:
+            cache.close()
+
 
 class TestMakeKey:
     def test_deterministic(self):

--- a/tests/test_proxy_cache.py
+++ b/tests/test_proxy_cache.py
@@ -291,6 +291,45 @@ class TestPrivacyGate:
         finally:
             reopened.close()
 
+    def test_get_refuses_and_evicts_sensitive_row_written_after_startup(self, tmp_path):
+        # An older still-running pre-gate process (or an external SQL writer)
+        # can insert AFTER this process's startup purge ran — the read-side
+        # guard must refuse to serve the row and evict it.
+        db_path = tmp_path / "live_writer.db"
+        cache = ProxyCache(db_path, max_entries=100)
+        cache.initialize()
+        try:
+            raw = sqlite3.connect(str(db_path))
+            try:
+                raw.execute(
+                    "INSERT INTO proxy_cache "
+                    "(cache_key, server, tool, result, created_at, ttl_seconds) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        _make_key("s", "sec", {}),
+                        "s",
+                        "sec",
+                        "login password=hunter2",
+                        time.time(),
+                        None,
+                    ),
+                )
+                raw.commit()
+            finally:
+                raw.close()
+
+            assert cache.get("s", "sec", {}) is None
+
+            # Evicted, not just hidden: the row is gone from the table.
+            check = sqlite3.connect(str(db_path))
+            try:
+                count = check.execute("SELECT COUNT(*) FROM proxy_cache").fetchone()[0]
+            finally:
+                check.close()
+            assert count == 0
+        finally:
+            cache.close()
+
 
 class TestMakeKey:
     def test_deterministic(self):

--- a/tests/test_proxy_cache.py
+++ b/tests/test_proxy_cache.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import sqlite3
 import time
+
+import pytest
 
 from memtomem_stm.proxy.cache import (
     ProxyCache,
@@ -216,6 +219,75 @@ class TestLegacyTransientPurge:
         try:
             assert reopened.get("s", "field", {}) == field_row
             assert reopened.get("s", "upper", {}) == upper_row
+        finally:
+            reopened.close()
+
+
+class TestPrivacyGate:
+    """``set()`` refuses secret-looking results (SECURITY.md exclusion, #453)
+    and ``initialize`` purges matching rows that pre-date the gate."""
+
+    @pytest.mark.parametrize(
+        "secret_text",
+        [
+            "api_key: abc123-def",
+            "password=hunter2",
+            "token sk-" + "a" * 24,
+            "creds AKIA" + "B" * 16 + " end",
+            "-----BEGIN RSA PRIVATE KEY-----",
+        ],
+    )
+    def test_set_skips_secret_bearing_result(self, proxy_cache: ProxyCache, secret_text: str):
+        proxy_cache.set("s", "t", {}, secret_text, ttl_seconds=60.0)
+        assert proxy_cache.get("s", "t", {}) is None
+
+    def test_set_stores_clean_result(self, proxy_cache: ProxyCache):
+        proxy_cache.set("s", "t", {}, "ordinary tool response", ttl_seconds=60.0)
+        assert proxy_cache.get("s", "t", {}) == "ordinary tool response"
+
+    def test_email_bearing_result_is_not_cached(self, proxy_cache: ProxyCache):
+        # DEFAULT_PATTERNS include an email regex, so email-bearing responses
+        # are deliberately uncacheable — the gate shares the sensitivity set
+        # of the LLM-route scan rather than maintaining a second definition.
+        # The cost is one pipeline re-run per repeat call, never correctness.
+        proxy_cache.set("s", "t", {}, "contact: dev@example.com", ttl_seconds=60.0)
+        assert proxy_cache.get("s", "t", {}) is None
+
+    def test_initialize_purges_legacy_secret_rows(self, tmp_path):
+        db_path = tmp_path / "legacy_secrets.db"
+        seed = ProxyCache(db_path, max_entries=100)
+        seed.initialize()
+        try:
+            seed.set("s", "plain", {}, "ordinary cached response", ttl_seconds=None)
+        finally:
+            seed.close()
+        # Seed the secret row via raw SQL: it models a row written by a
+        # pre-gate release — ``set()`` itself now refuses such content.
+        raw = sqlite3.connect(str(db_path))
+        try:
+            raw.execute(
+                "INSERT INTO proxy_cache "
+                "(cache_key, server, tool, result, created_at, ttl_seconds) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    _make_key("s", "sec", {}),
+                    "s",
+                    "sec",
+                    "login password=hunter2",
+                    time.time(),
+                    None,
+                ),
+            )
+            raw.commit()
+        finally:
+            raw.close()
+
+        # Re-open the SAME db: the startup purge runs in initialize().
+        reopened = ProxyCache(db_path, max_entries=100)
+        reopened.initialize()
+        try:
+            assert reopened.get("s", "sec", {}) is None
+            assert reopened.get("s", "plain", {}) == "ordinary cached response"
         finally:
             reopened.close()
 


### PR DESCRIPTION
Part of #453 (cache leg — the default-on path; auto-index/extraction legs follow separately).

## Summary

- `ProxyCache.set()` drops the row when `contains_sensitive_content(result)` matches (debug-logged with server/tool, never the content; the response to the agent is unaffected). Enforced at the store chokepoint so no caller can bypass it — the transient-key check stays in the manager because it is a pipeline-freshness concern, while this is a store-confidentiality invariant.
- `ProxyCache.get()` mirrors the gate on the read path: a sensitive row that never went through `set()` (written by an older still-running pre-gate process, or an external SQL writer after the startup purge ran) is refused and physically evicted. The sensitivity check runs **before** the expiry check so an already-expired secret row is deleted rather than left resting on disk. Eviction is best-effort: if a concurrent writer holds the file lock, `get()` warns and serves a miss instead of aborting the caller's request; the row is retried on the next `get()` and swept at the next startup.
- `ProxyCache.initialize()` purges matching rows written by pre-gate releases, mirroring the transient-key legacy purge. Purge, write gate, and read guard all share `contains_sensitive_content`, so they cannot diverge.
- Tests (11): parametrized gate pins (api_key/password/sk-token/AKIA/private-key header), clean-row contrast, an explicit email-PII pin (see below), legacy-purge round-trip, post-startup raw-SQL insert refused + evicted, expired-sensitive eviction, and a blocked-eviction scenario under a held `BEGIN IMMEDIATE` write lock.

## Behavior change

- Secret-looking upstream responses are no longer cached — each repeat identical call re-runs the pipeline. A false positive costs one un-cached response, never correctness.
- The gate scans the full `DEFAULT_PATTERNS` (credentials + PII): per the #461 storage-vs-action split, the cache is a STORAGE consumer — an email is fine to show an external summarizer but not fine to persist. **Email-bearing responses are deliberately uncacheable**, pinned by a dedicated test so any future pattern change is a conscious decision.
- On startup, rows matching the patterns are deleted from existing `proxy_cache.db` files. The scan runs every startup (like the marker purge); cost is bounded by `max_entries` (default 10k rows) and is a no-op steady-state.

## Verification

- `uv run pytest -m "not ollama"` — full suite green at each round (latest local run: 3143 passed, 3 skipped)
- `uv run ruff check src tests && uv run ruff format --check src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)