### PR TITLE
fix(privacy): gate LLM routing on credentials only — emails are PII, not secrets

### DIFF
--- a/docs/compression.md
+++ b/docs/compression.md
@@ -266,7 +266,7 @@ Providers: `openai`, `anthropic`, `ollama`. `llm_timeout_seconds` (default 60.0)
 
 > **`api_key` is validated eagerly.** Every `llm` block in the config is validated when the config loads — for `provider: openai` / `anthropic`, a missing `api_key` (and missing `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env var) fails the load even if nothing selects the `llm_summary` strategy or the block sits under a disabled `extraction`. This keeps the startup fail-fast for configs that DO use the LLM. Don't leave placeholder `llm` blocks you aren't using — remove them, or point them at `provider: ollama` (no key required).
 
-Sensitive content (API keys, passwords, PII) is auto-detected and **never** sent to external LLMs — falls back to local truncation.
+Credential-bearing content (API keys, passwords, provider tokens, JWTs, private keys) is auto-detected and **never** sent to external LLMs — falls back to local truncation. Email addresses alone do **not** trigger this fallback: they appear in ordinary compressible content (git logs, issue threads, contact pages), and routing on them silently degraded the chosen strategy to truncation. Emails remain protected where storage is at stake — surfacing query persistence hashes any query matching the full sensitive set (credentials *and* emails) before it reaches disk.
 
 `LLMCompressor` holds a single `httpx.AsyncClient` for the life of the instance. `ProxyManager` caches one compressor per active `llm` config and swaps it (awaiting `close()` on the old one) whenever the config changes at runtime, so integrators generally do not need to manage it directly. If you construct an `LLMCompressor` standalone, `await compressor.close()` before discarding it to release the client.
 

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -60,7 +60,7 @@ from memtomem_stm.proxy.memory_ops import (
     extract_and_store,
     format_fact_md,
 )
-from memtomem_stm.proxy.privacy import DEFAULT_PATTERNS as PRIVACY_DEFAULT_PATTERNS
+from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS as PRIVACY_CREDENTIAL_PATTERNS
 from memtomem_stm.proxy.token_estimate import tokens_to_chars
 from memtomem_stm.proxy.tool_metadata import (
     convention_suffix,
@@ -731,9 +731,13 @@ class ProxyManager:
                 # #289: scan for API keys / JWT / private keys before sending
                 # the response to the LLM provider. Default-on; operators
                 # disable per-config when the upstream is known sensitive-free
-                # or the provider is local/trusted.
+                # or the provider is local/trusted. CREDENTIALS only — email
+                # addresses (the PII set) appear in ordinary compressible
+                # content (git logs, issue threads) and routing on them
+                # silently degraded the chosen strategy to truncation; the
+                # surfacing persistence path still scans the full default set.
                 privacy_patterns = (
-                    PRIVACY_DEFAULT_PATTERNS if llm_cfg.privacy_scan_enabled else None
+                    PRIVACY_CREDENTIAL_PATTERNS if llm_cfg.privacy_scan_enabled else None
                 )
                 result = await compressor.compress(
                     text, max_chars=max_chars, privacy_patterns=privacy_patterns

--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -8,10 +8,14 @@ from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_PATTERNS = [
+# Secrets proper: anything whose disclosure grants access. Consumers that
+# gate an ACTION on sensitivity (e.g. "may this response be sent to an
+# external LLM provider?") should use this set — matching here means the
+# payload likely carries a credential, which is categorically worth a
+# degraded compression strategy.
+CREDENTIAL_PATTERNS = [
     r"(?i)(api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]",
     r"(?i)(password|passwd|pwd)\s*[:=]",
-    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
     # Provider-prefixed token formats. Anchored by prefix so false positives
     # on arbitrary high-entropy strings are rare.
     r"(?i)(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[0-9A-Za-z-]+)",
@@ -25,6 +29,22 @@ DEFAULT_PATTERNS = [
     r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
     r"(?i)(BEGIN\s+(RSA|EC|OPENSSH|DSA|PGP)\s+PRIVATE\s+KEY)",
 ]
+
+# PII that is sensitive to PERSIST but not a credential. Email addresses
+# appear in legitimately compressible content all the time (git logs,
+# issue threads, contact pages), so treating them as credentials made the
+# LLM routing gate fire on ordinary responses and silently degrade the
+# operator's chosen strategy to truncation. Consumers that gate STORAGE
+# (e.g. surfacing query persistence) should keep scanning the full
+# DEFAULT_PATTERNS.
+PII_PATTERNS = [
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
+]
+
+# Backwards-compatible union — the default for contains_sensitive_content
+# and the right set wherever the question is "is anything here sensitive?"
+# rather than "is this specifically a credential?".
+DEFAULT_PATTERNS = [*CREDENTIAL_PATTERNS, *PII_PATTERNS]
 
 
 @lru_cache(maxsize=1)

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -166,13 +166,17 @@ class SurfacingEngine:
         disk**, nothing about the in-process surface call.
 
         Secret guard: regardless of ``persist_query_text``, a query whose
-        text matches a known secret pattern (API key, bearer token, JWT,
-        ``password=``/``api_key=`` assignment, private-key header) is
-        hashed before persistence, so an inline credential in a Bash
-        ``command`` argument or a tokenized URL never reaches disk verbatim
-        on the proxy path (the hook/daemon cold paths already disable
-        persistence). Only the persisted value is affected — the in-flight
-        ``query`` keeps its raw text as described above.
+        text matches a known sensitive pattern (API key, bearer token, JWT,
+        ``password=``/``api_key=`` assignment, private-key header, email
+        address) is hashed before persistence, so an inline credential in a
+        Bash ``command`` argument or a tokenized URL never reaches disk
+        verbatim on the proxy path (the hook/daemon cold paths already
+        disable persistence). This deliberately scans the FULL default set
+        — credentials *and* PII — unlike the LLM compression routing gate,
+        which scans ``CREDENTIAL_PATTERNS`` only: an email is fine to show
+        an external summarizer but not fine to persist. Only the persisted
+        value is affected — the in-flight ``query`` keeps its raw text as
+        described above.
         """
         if not self._config.persist_query_text:
             return self._hashed_query(query)

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -185,3 +185,49 @@ class TestDefaultPatternCoverage:
         text = ("safe content " * 900) + "password: hunter2"
         assert len(text) > 10_000
         assert privacy.contains_sensitive_content(text) is True
+
+
+class TestCredentialPiiSplit:
+    """L278: the default set splits into ``CREDENTIAL_PATTERNS`` (gates
+    ACTIONS — e.g. "may this response go to an external LLM?") and
+    ``PII_PATTERNS`` (gates STORAGE — e.g. surfacing query persistence).
+    ``DEFAULT_PATTERNS`` stays the union for callers asking "is anything
+    here sensitive?". The split exists because emails appear in ordinary
+    compressible content (git logs, issue threads) and routing on them
+    silently degraded llm_summary to truncation.
+    """
+
+    def test_default_is_credentials_then_pii(self):
+        assert privacy.DEFAULT_PATTERNS == [
+            *privacy.CREDENTIAL_PATTERNS,
+            *privacy.PII_PATTERNS,
+        ]
+
+    def test_sets_are_disjoint_and_nonempty(self):
+        assert privacy.CREDENTIAL_PATTERNS
+        assert privacy.PII_PATTERNS
+        assert not set(privacy.CREDENTIAL_PATTERNS) & set(privacy.PII_PATTERNS)
+
+    @pytest.mark.parametrize(
+        "sample",
+        [
+            "user@example.com",
+            "contact: alice.bob+tag@sub.example.co.uk",
+        ],
+    )
+    def test_email_is_pii_not_credential(self, sample: str) -> None:
+        assert privacy.contains_sensitive_content(sample, privacy.PII_PATTERNS) is True
+        assert privacy.contains_sensitive_content(sample, privacy.CREDENTIAL_PATTERNS) is False
+
+    @pytest.mark.parametrize(
+        "sample",
+        [
+            "ghp_" + "A" * 36,
+            "api_key=sk-" + "a" * 48,
+            "psql password=hunter2",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",
+            "-----BEGIN RSA PRIVATE KEY-----",
+        ],
+    )
+    def test_credentials_match_via_credential_set_alone(self, sample: str) -> None:
+        assert privacy.contains_sensitive_content(sample, privacy.CREDENTIAL_PATTERNS) is True

--- a/tests/test_proxy_manager_pipeline.py
+++ b/tests/test_proxy_manager_pipeline.py
@@ -234,6 +234,50 @@ class TestApplyCompression:
         assert result == "llm-output"
         mock_call.assert_awaited_once()
 
+    async def test_llm_summary_email_only_content_reaches_llm(self, tmp_path):
+        """L278: the routing gate scans CREDENTIAL_PATTERNS only — an email
+        address alone (PII, ubiquitous in git logs / issue threads) no longer
+        silently degrades llm_summary to truncation. The scan still RUNS
+        (privacy_scan_enabled defaults True); it just has nothing to match."""
+        from memtomem_stm.proxy import compression as compression_mod
+
+        mgr = _make_manager(tmp_path=tmp_path)
+        llm_cfg = LLMCompressorConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="k",
+        )
+        with patch.object(
+            compression_mod.LLMCompressor,
+            "_call_api",
+            new_callable=AsyncMock,
+            return_value="llm-output",
+        ) as mock_call:
+            text = "commit log: Author: Alice <alice@example.com> fixed the bug " * 30
+            result, fallback = await mgr._apply_compression(
+                text,
+                CompressionStrategy.LLM_SUMMARY,
+                max_chars=200,
+                sel_cfg=None,
+                llm_cfg=llm_cfg,
+                hybrid_cfg=None,
+                server="srv",
+                tool="t",
+            )
+        assert fallback is None
+        assert result == "llm-output"
+        mock_call.assert_awaited_once()
+
+    def test_apply_compression_gates_llm_on_credential_set(self):
+        """Source pin: the #289 routing gate must reference the credential
+        set, not the full default set — DEFAULT would reintroduce the email
+        over-routing the L278 split removed. (Source-inspection precedent:
+        test_observability.py's shape-identical call-site pins.)"""
+        import inspect
+
+        src = inspect.getsource(ProxyManager._apply_compression)
+        assert "PRIVACY_CREDENTIAL_PATTERNS" in src
+        assert "PRIVACY_DEFAULT_PATTERNS" not in src
+
 
 # ── LLMCompressor lifecycle (regression for #61) ────────────────────────
 

--- a/tests/test_proxy_manager_pipeline.py
+++ b/tests/test_proxy_manager_pipeline.py
@@ -180,8 +180,9 @@ class TestApplyCompression:
             api_key="k",
             # default privacy_scan_enabled = True
         )
-        # Real LLMCompressor instance — privacy scan runs against real
-        # DEFAULT_PATTERNS. Patch _call_api to fail loudly if reached.
+        # Real LLMCompressor instance — privacy scan runs against the real
+        # CREDENTIAL_PATTERNS the gate passes (L278 split). Patch _call_api
+        # to fail loudly if reached.
         with patch.object(
             compression_mod.LLMCompressor,
             "_call_api",

--- a/tests/test_surfacing_persist_query_text.py
+++ b/tests/test_surfacing_persist_query_text.py
@@ -254,6 +254,25 @@ class TestSecretGuard:
         assert out.startswith(_QUERY_HASH_PREFIX)
         assert engine._persistable_query("ordinary search text") == "ordinary search text"
 
+    async def test_email_query_hashed_pii_not_credential(self):
+        # L278 contrast pin: an email is NOT a credential — the LLM routing
+        # gate (CREDENTIAL_PATTERNS) ignores it — but it IS
+        # persist-sensitive: this guard scans the full default set
+        # (credentials + PII), so an email-bearing query still hashes.
+        from memtomem_stm.proxy import privacy
+
+        query = "email bob.smith@example.com about the outage"
+        assert privacy.contains_sensitive_content(query, privacy.CREDENTIAL_PATTERNS) is False
+
+        engine = SurfacingEngine(
+            config=_make_config(),
+            mcp_adapter=_make_mcp_adapter([]),
+            feedback_tracker=_make_tracker(),
+        )
+        out = engine._persistable_query(query)
+        assert out.startswith(_QUERY_HASH_PREFIX)
+        assert "bob.smith@example.com" not in out
+
 
 class TestPersistSitesRouteThroughGuard:
     """Both persistence sites must funnel through ``_persistable_query`` so


### PR DESCRIPTION
## Summary

The LLM compression privacy scan used the full `DEFAULT_PATTERNS`, whose email regex matches ordinary compressible content — git logs, issue threads, contact pages — so `llm_summary` silently degraded to truncation on responses carrying nothing more sensitive than an email address (2026-06-10 implementation review, L278; behavior change user-approved).

The split keys on what the consumer gates:

- **`CREDENTIAL_PATTERNS`** (everything but email) — gates **actions**: the #289 routing scan in `ProxyManager._apply_compression` now uses this, so a credential still short-circuits before any outbound LLM call, but an email alone no longer does.
- **`PII_PATTERNS`** (email) — sensitive to **persist**: the surfacing query secret guard keeps scanning the full union, so an email-bearing query still hashes before reaching disk. An email is fine to show an external summarizer; it is not fine to store.
- **`DEFAULT_PATTERNS`** stays the backwards-compatible union and the `contains_sensitive_content` default — every consumer that didn't opt into the credential set behaves exactly as before.

`docs/compression.md`'s sensitive-content paragraph now states the credential-only routing rule and where emails remain protected.

## Behavior change

With `llm_summary` + `privacy_scan_enabled` (default), a response whose only sensitive match is an email address is now **sent to the configured LLM provider** instead of falling back to local truncation (`llm_summary→privacy_fallback`). Responses with API keys, passwords, provider tokens, JWTs, or private-key headers still short-circuit before any network call. The surfacing persistence path is unchanged: email-bearing queries are still hashed.

## Review

codex R1: **SHIP** ("behavior change is correctly scoped; credential-only LLM routing and full-set persistence hashing are both pinned"), one optional nit — a stale test comment referencing `DEFAULT_PATTERNS` — fixed in the follow-up commit.

## Test plan

- Pattern-set pins: `DEFAULT == [*CREDENTIAL, *PII]`, disjoint and non-empty, email matches PII-only, credential shapes match the credential set alone
- Pipeline: email-only payload reaches the (mocked) LLM with the scan enabled; credential payload still privacy-falls-back before network
- Source-inspection pin: `_apply_compression` references `PRIVACY_CREDENTIAL_PATTERNS`, not `PRIVACY_DEFAULT_PATTERNS`
- Secret-guard contrast: email query hashes on persistence despite not matching the credential set
- Full suite: 3144 passed, 3 skipped; ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)