### PR TITLE
fix(memory-ops): never persist secret-looking content via auto-index or extraction

### DIFF
--- a/src/memtomem_stm/proxy/index_observability.py
+++ b/src/memtomem_stm/proxy/index_observability.py
@@ -49,9 +49,14 @@ from typing import Literal
 # - ``error``: per error event. Outer ``extractor.extract`` failure counts
 #   once (per call); per-fact ``index_file`` failure counts per fact;
 #   auto_index ``index_file`` failure counts once per call.
+# - ``privacy_skip``: per call, terminal — the content matched a privacy
+#   pattern before anything was written (#453), so no file and no
+#   ``index_file`` call exist for this attempt. Fires from both paths:
+#   auto_index scans the exact markdown it would persist; extract scans
+#   the response text + rendered arguments before the extractor runs.
 #
-# Both write paths share this 4-label outcome set deliberately. auto_index
-# only fires ``stored`` and ``error``; ``dedup_skip`` and
+# Both write paths share this 5-label outcome set deliberately. auto_index
+# only fires ``stored``, ``error``, and ``privacy_skip``; ``dedup_skip`` and
 # ``extracted_zero_facts`` are extract-specific. Operators read the raw
 # mem_add count as ``outcomes["__total__"]["stored"]`` regardless of
 # which path produced the write — path attribution lives in ``attempts``.
@@ -75,6 +80,7 @@ IndexOutcome = Literal[
     "stored",
     "dedup_skip",
     "extracted_zero_facts",
+    "privacy_skip",
     "error",
 ]
 

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -59,6 +59,7 @@ from memtomem_stm.proxy.memory_ops import (
     compose_index_footer,
     extract_and_store,
     format_fact_md,
+    index_content_matches_privacy,
 )
 from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS as PRIVACY_CREDENTIAL_PATTERNS
 from memtomem_stm.proxy.token_estimate import tokens_to_chars
@@ -1890,7 +1891,26 @@ class ProxyManager:
             and self._index_engine is not None
             and len(cleaned) >= ai_cfg.min_chars
         ):
-            if ai_cfg.background:
+            if ai_cfg.background and index_content_matches_privacy(
+                server, tool, upstream_args, cleaned, context_query=context_query
+            ):
+                # #453: the ``[Indexing…] · scheduled`` placeholder below
+                # would promise an indexing run that the task's own privacy
+                # gate is about to decline — pre-check with the SAME
+                # predicate and return the un-footered response instead of
+                # scheduling. Records what the skipped task would have
+                # recorded, and mirrors the sync skip's metrics shape
+                # (ok=True / 0 chunks).
+                logger.info(
+                    "Auto-index skipped for %s/%s: content matches a privacy pattern",
+                    server,
+                    tool,
+                )
+                self.index_observability.record_attempt(tool, "auto_index")
+                self.index_observability.record_outcome(tool, "privacy_skip")
+                final_result = surfaced
+                index_ok = True
+            elif ai_cfg.background:
                 # F4: schedule indexing off the request path. The placeholder
                 # footer ([Indexing…] … · scheduled, namespace dropped) ships
                 # to the agent synchronously while the indexing task runs in

--- a/src/memtomem_stm/proxy/memory_ops.py
+++ b/src/memtomem_stm/proxy/memory_ops.py
@@ -17,9 +17,19 @@ from memtomem_stm.proxy.index_observability import (
     IndexObservability,
     _NoOpIndexObservability,
 )
+from memtomem_stm.proxy.privacy import contains_sensitive_content
 from memtomem_stm.utils.fileio import atomic_write_text
 
 logger = logging.getLogger(__name__)
+
+
+def _render_args(arguments: dict[str, Any]) -> str:
+    """Render call arguments the way the persisted markdown embeds them.
+
+    Shared by the markdown builders AND the privacy gates so the scanned
+    value and the persisted value can never diverge.
+    """
+    return ", ".join(f"{k}={v!r}" for k, v in arguments.items()) if arguments else "(none)"
 
 
 @dataclass(frozen=True, slots=True)
@@ -113,19 +123,19 @@ async def auto_index_response(
     working unchanged. When the manager wires a real
     ``IndexObservability``, this function records one
     ``record_attempt(tool, "auto_index")`` per invocation plus one of
-    ``stored`` / ``error`` outcomes — auto_index has no extraction or
-    dedup phase so the other two ``IndexOutcome`` labels do not fire here.
+    ``stored`` / ``error`` / ``privacy_skip`` outcomes — auto_index has no
+    extraction or dedup phase so the other two ``IndexOutcome`` labels do
+    not fire here.
     """
     observability.record_attempt(tool, "auto_index")
     memory_dir = ai_cfg.memory_dir.expanduser().resolve()
-    memory_dir.mkdir(parents=True, exist_ok=True)
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
     safe_tool = tool.replace("/", "_")
     fname = f"{server}__{safe_tool}__{ts}.md"
     file_path = memory_dir / fname
 
-    args_str = ", ".join(f"{k}={v!r}" for k, v in arguments.items()) if arguments else "(none)"
+    args_str = _render_args(arguments)
 
     frontmatter_lines = [
         "---",
@@ -152,8 +162,23 @@ async def auto_index_response(
         f"{intent_section}"
         f"## Content\n\n{text}\n"
     )
+
+    if contains_sensitive_content(md_content):
+        # SECURITY.md: secret-looking content is never indexed into LTM.
+        # Scans the exact markdown that would be persisted — response text,
+        # rendered arguments, and agent intent included. The agent still
+        # receives ``agent_summary`` unchanged; only persistence is skipped.
+        logger.info(
+            "Auto-index skipped for %s/%s: content matches a privacy pattern",
+            server,
+            tool,
+        )
+        observability.record_outcome(tool, "privacy_skip")
+        return AutoIndexOutcome(summary=agent_summary, ok=True, chunks_indexed=0)
+
+    memory_dir.mkdir(parents=True, exist_ok=True)
     # Atomic so the auto-indexer (called next) can't observe a partial file
-    # if the writer is killed mid-flush. Caller has already mkdir'd memory_dir.
+    # if the writer is killed mid-flush. The mkdir above ensured memory_dir.
     atomic_write_text(file_path, md_content, ensure_parent=False)
 
     ns = ai_cfg.namespace.format(server=server, tool=tool)
@@ -217,6 +242,19 @@ async def extract_and_store(
     """
     indexed_count = 0
     observability.record_attempt(tool, "extract")
+    if contains_sensitive_content(f"{_render_args(arguments)}\n{text}"):
+        # SECURITY.md: secret-looking content is never indexed into LTM.
+        # Checked before ``extractor.extract()`` so the (possibly remote)
+        # extraction LLM never sees the text either. The rendered arguments
+        # are part of the scanned value because ``format_fact_md`` embeds
+        # them in every persisted fact file.
+        logger.info(
+            "Fact extraction skipped for %s/%s: content matches a privacy pattern",
+            server,
+            tool,
+        )
+        observability.record_outcome(tool, "privacy_skip")
+        return ExtractOutcome(ok=True, facts_stored=0)
     try:
         facts = await extractor.extract(text, server=server, tool=tool)
         if not facts:
@@ -291,7 +329,7 @@ def format_fact_md(
 ) -> str:
     """Format an extracted fact as a Markdown file with frontmatter."""
     tags_str = ", ".join(fact.tags) if fact.tags else ""
-    args_str = ", ".join(f"{k}={v!r}" for k, v in arguments.items()) if arguments else "(none)"
+    args_str = _render_args(arguments)
     title = fact.content[:80].rstrip(".")
     lines = [
         "---",

--- a/src/memtomem_stm/proxy/memory_ops.py
+++ b/src/memtomem_stm/proxy/memory_ops.py
@@ -32,6 +32,28 @@ def _render_args(arguments: dict[str, Any]) -> str:
     return ", ".join(f"{k}={v!r}" for k, v in arguments.items()) if arguments else "(none)"
 
 
+def index_content_matches_privacy(
+    server: str,
+    tool: str,
+    arguments: dict[str, Any],
+    text: str,
+    context_query: str | None = None,
+) -> bool:
+    """True when the caller-controlled content that the INDEX paths would
+    persist matches a privacy pattern (#453).
+
+    Scans every variable field that reaches the persisted markdown —
+    server/tool names, rendered arguments, agent intent, response text;
+    the static scaffolding cannot match a pattern. Shared by the
+    in-function gates below and ``ProxyManager``'s background pre-check,
+    so the scheduled-footer decision and the task's own gate can never
+    diverge. Scans the full ``DEFAULT_PATTERNS`` (credentials + PII):
+    these are STORAGE consumers per the #461 split.
+    """
+    probe = f"{server}/{tool}\n{_render_args(arguments)}\n{context_query or ''}\n{text}"
+    return contains_sensitive_content(probe)
+
+
 @dataclass(frozen=True, slots=True)
 class AutoIndexOutcome:
     """Structured result of a single ``auto_index_response`` call.
@@ -128,6 +150,19 @@ async def auto_index_response(
     not fire here.
     """
     observability.record_attempt(tool, "auto_index")
+    if index_content_matches_privacy(server, tool, arguments, text, context_query):
+        # SECURITY.md: secret-looking content is never indexed into LTM.
+        # The predicate covers every caller-controlled field of the
+        # markdown built below. The agent still receives ``agent_summary``
+        # unchanged; only persistence is skipped, and nothing touches disk.
+        logger.info(
+            "Auto-index skipped for %s/%s: content matches a privacy pattern",
+            server,
+            tool,
+        )
+        observability.record_outcome(tool, "privacy_skip")
+        return AutoIndexOutcome(summary=agent_summary, ok=True, chunks_indexed=0)
+
     memory_dir = ai_cfg.memory_dir.expanduser().resolve()
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
@@ -162,19 +197,6 @@ async def auto_index_response(
         f"{intent_section}"
         f"## Content\n\n{text}\n"
     )
-
-    if contains_sensitive_content(md_content):
-        # SECURITY.md: secret-looking content is never indexed into LTM.
-        # Scans the exact markdown that would be persisted — response text,
-        # rendered arguments, and agent intent included. The agent still
-        # receives ``agent_summary`` unchanged; only persistence is skipped.
-        logger.info(
-            "Auto-index skipped for %s/%s: content matches a privacy pattern",
-            server,
-            tool,
-        )
-        observability.record_outcome(tool, "privacy_skip")
-        return AutoIndexOutcome(summary=agent_summary, ok=True, chunks_indexed=0)
 
     memory_dir.mkdir(parents=True, exist_ok=True)
     # Atomic so the auto-indexer (called next) can't observe a partial file
@@ -242,12 +264,13 @@ async def extract_and_store(
     """
     indexed_count = 0
     observability.record_attempt(tool, "extract")
-    if contains_sensitive_content(f"{_render_args(arguments)}\n{text}"):
+    if index_content_matches_privacy(server, tool, arguments, text):
         # SECURITY.md: secret-looking content is never indexed into LTM.
         # Checked before ``extractor.extract()`` so the (possibly remote)
         # extraction LLM never sees the text either. The rendered arguments
         # are part of the scanned value because ``format_fact_md`` embeds
-        # them in every persisted fact file.
+        # them in every persisted fact file. (``context_query`` is not part
+        # of the probe here: fact files never persist it.)
         logger.info(
             "Fact extraction skipped for %s/%s: content matches a privacy pattern",
             server,
@@ -261,6 +284,28 @@ async def extract_and_store(
             observability.record_outcome(tool, "extracted_zero_facts")
             return ExtractOutcome(ok=True, facts_stored=0)
 
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+        safe_tool = tool.replace("/", "_")
+
+        # Build every candidate fact file BEFORE any disk or indexer
+        # interaction: the extractor (typically an LLM) can reassemble or
+        # normalize sensitive content that evaded the input scan above, so
+        # the actual bytes to be persisted are scanned too. Any hit skips
+        # the whole batch terminally — no partial writes, matching the
+        # per-call-terminal ``privacy_skip`` contract.
+        candidates = [
+            (fact, format_fact_md(fact, server, tool, arguments))
+            for fact in facts[: ext_cfg.max_facts]
+        ]
+        if any(contains_sensitive_content(md) for _, md in candidates):
+            logger.info(
+                "Fact persistence skipped for %s/%s: extracted content matches a privacy pattern",
+                server,
+                tool,
+            )
+            observability.record_outcome(tool, "privacy_skip")
+            return ExtractOutcome(ok=True, facts_stored=0)
+
         memory_dir = ext_cfg.memory_dir.expanduser().resolve()
         memory_dir.mkdir(parents=True, exist_ok=True)
         ns = ext_cfg.namespace.format(server=server, tool=tool)
@@ -268,10 +313,7 @@ async def extract_and_store(
         # Dedup: skip facts already in the index
         dedup = ext_cfg.dedup_threshold > 0 and hasattr(index_engine, "is_duplicate")
 
-        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
-        safe_tool = tool.replace("/", "_")
-
-        for i, fact in enumerate(facts[: ext_cfg.max_facts]):
+        for i, (fact, md_content) in enumerate(candidates):
             if dedup and index_engine is not None:
                 try:
                     is_dup = await index_engine.is_duplicate(
@@ -288,7 +330,6 @@ async def extract_and_store(
 
             fname = f"{server}__{safe_tool}__fact__{ts}__{i:02d}.md"
             file_path = memory_dir / fname
-            md_content = format_fact_md(fact, server, tool, arguments)
             # Atomic so a kill between write and index_file leaves no partial.
             atomic_write_text(file_path, md_content, ensure_parent=False)
 

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -1165,10 +1165,10 @@ async def stm_index_stats(
 
     - ``attempts[tool][path]`` per-tool / per-path call counts; path is
       ``extract`` or ``auto_index``. ``__total__`` aggregates across tools.
-    - ``outcomes[tool][label]`` per-tool 4-label outcomes shared across
-      both paths. ``stored`` and ``error`` fire for both; ``dedup_skip``
-      and ``extracted_zero_facts`` only fire for the extract path
-      (auto_index has no extraction or dedup phase).
+    - ``outcomes[tool][label]`` per-tool 5-label outcomes shared across
+      both paths. ``stored``, ``error``, and ``privacy_skip`` fire for
+      both; ``dedup_skip`` and ``extracted_zero_facts`` only fire for the
+      extract path (auto_index has no extraction or dedup phase).
 
     **Quality signal absent by design.** SURFACE has surfacing-feedback;
     INDEX has no equivalent. Adding one would have to choose between
@@ -1219,7 +1219,7 @@ def _format_index_observability_sections(snapshot: dict, *, tool_filter: str | N
     Mirror of ``_format_observability_sections`` for surfacing, but with
     the INDEX shape: ``attempts`` is per-tool / per-path
     (``{tool: {path: count}}``) so operators see the
-    extract / auto_index breakdown; ``outcomes`` is per-tool 4-label.
+    extract / auto_index breakdown; ``outcomes`` is per-tool 5-label.
     No cache section — INDEX has no caching layer.
     """
     attempts: dict[str, dict[str, int]] = snapshot["attempts"]

--- a/tests/test_auto_index_background.py
+++ b/tests/test_auto_index_background.py
@@ -113,6 +113,30 @@ class TestBackgroundAutoIndex:
         finally:
             await mgr.stop()
 
+    async def test_background_privacy_skip_returns_unfootered_response(self, tmp_path):
+        """A secret-bearing response must not get the ``[Indexing…] ·
+        scheduled`` placeholder: the task's privacy gate would decline, so
+        the footer would promise an indexing run that never happens (#453).
+        The manager pre-checks with the same predicate the task uses and
+        returns the un-footered response without scheduling anything."""
+        mgr, indexer = _bg_manager(tmp_path, background=True)
+        mgr._connections["srv"].session.call_tool.return_value = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="config dump: password=hunter2 " * 10)],
+            isError=False,
+        )
+        try:
+            result = await mgr.call_tool("srv", "some_tool", {})
+
+            assert "[Indexing…]" not in result
+            assert "scheduled" not in result
+            assert mgr._background_tasks == set()
+            indexer.index_file.assert_not_awaited()
+            snap = mgr.index_observability.snapshot()
+            assert snap["attempts"]["__total__"] == {"auto_index": 1}
+            assert snap["outcomes"]["__total__"] == {"privacy_skip": 1}
+        finally:
+            await mgr.stop()
+
     async def test_background_drains_on_stop(self, tmp_path):
         """``stop()`` cancels in-flight background indexing tasks via the
         existing extraction drain loop — no new infrastructure."""

--- a/tests/test_index_observability.py
+++ b/tests/test_index_observability.py
@@ -68,23 +68,26 @@ class TestIndexObservabilityCounters:
             "extracted_zero_facts": 1,
         }
 
-    def test_all_four_outcome_labels_independent(self):
-        """The 4-label split must keep each label as a separate slot —
+    def test_all_outcome_labels_independent(self):
+        """The 5-label split must keep each label as a separate slot —
         fusing ``extracted_zero_facts`` into ``stored=0`` would lose the
         signal "extraction fired but produced nothing", which is
         architecturally distinct from "facts existed but were duplicates"
-        (``dedup_skip``) and from "facts existed and were stored"
-        (``stored``)."""
+        (``dedup_skip``), from "facts existed and were stored"
+        (``stored``), and from "content was refused before any write"
+        (``privacy_skip``, #453)."""
         obs = IndexObservability()
         obs.record_outcome("t", "stored")
         obs.record_outcome("t", "dedup_skip")
         obs.record_outcome("t", "extracted_zero_facts")
+        obs.record_outcome("t", "privacy_skip")
         obs.record_outcome("t", "error")
         snap = obs.snapshot()
         assert snap["outcomes"]["t"] == {
             "stored": 1,
             "dedup_skip": 1,
             "extracted_zero_facts": 1,
+            "privacy_skip": 1,
             "error": 1,
         }
 

--- a/tests/test_memory_ops.py
+++ b/tests/test_memory_ops.py
@@ -760,3 +760,50 @@ class TestExtractPrivacyGate:
         )
         assert outcome == ExtractOutcome(ok=True, facts_stored=1)
         assert len(extractor.calls) == 1
+
+    async def test_secret_in_extractor_output_skips_whole_batch(self, config):
+        # The extractor (an LLM) can reassemble or normalize sensitive
+        # content that evaded the input scan — the actual fact markdown is
+        # scanned before any disk or indexer interaction, and one hit skips
+        # the whole batch (per-call-terminal privacy_skip contract).
+        facts = [
+            ExtractedFact(content="A clean fact about flask", category="c", confidence=0.5),
+            ExtractedFact(content="login password=hunter2", category="c", confidence=0.5),
+        ]
+        extractor = FakeExtractor(facts)
+        indexer = FakeIndexer()
+        obs = IndexObservability()
+        outcome = await extract_and_store(
+            indexer,
+            extractor,
+            config,
+            server="gh",
+            tool="read_file",
+            arguments={"path": "clean.txt"},
+            text="ordinary response that passes the input scan",
+            observability=obs,
+        )
+        assert outcome == ExtractOutcome(ok=True, facts_stored=0)
+        assert len(extractor.calls) == 1  # input was clean — extractor ran
+        assert indexer.indexed_paths == []
+        assert indexer.dedup_calls == []  # scan precedes ALL indexer interaction
+        assert not config.memory_dir.exists()  # nothing touched disk
+        snap = obs.snapshot()
+        assert snap["outcomes"]["read_file"] == {"privacy_skip": 1}
+
+    async def test_secret_in_extractor_output_skips_without_indexer_too(self, config):
+        # index_engine=None still writes fact files — the output scan must
+        # gate that path as well.
+        facts = [ExtractedFact(content="token sk-" + "a" * 24, category="c", confidence=0.5)]
+        extractor = FakeExtractor(facts)
+        outcome = await extract_and_store(
+            None,
+            extractor,
+            config,
+            server="gh",
+            tool="read_file",
+            arguments={},
+            text="ordinary response",
+        )
+        assert outcome == ExtractOutcome(ok=True, facts_stored=0)
+        assert not config.memory_dir.exists()

--- a/tests/test_memory_ops.py
+++ b/tests/test_memory_ops.py
@@ -18,6 +18,7 @@ import pytest
 
 from memtomem_stm.proxy.config import AutoIndexConfig, ExtractionConfig
 from memtomem_stm.proxy.extraction import ExtractedFact
+from memtomem_stm.proxy.index_observability import IndexObservability
 from memtomem_stm.proxy.memory_ops import (
     AutoIndexOutcome,
     ExtractOutcome,
@@ -581,3 +582,181 @@ class TestFormatFactMd:
         fact = ExtractedFact(content="Fact", category="c", confidence=0.5)
         md = format_fact_md(fact, "s", "t", {})
         assert "extracted_from: s/t((none))" in md
+
+
+# ── privacy gates (#453) ─────────────────────────────────────────────────
+
+
+class TestAutoIndexPrivacyGate:
+    """Secret-looking content must never be written to the memory dir or
+    indexed into LTM (SECURITY.md exclusion, #453). The gate scans the
+    exact markdown that would be persisted, so arg-borne secrets count."""
+
+    @pytest.fixture
+    def config(self, tmp_path) -> AutoIndexConfig:
+        return AutoIndexConfig(
+            enabled=True,
+            memory_dir=tmp_path / "proxy_index",
+            namespace="proxy-{server}",
+        )
+
+    async def test_secret_text_skips_write_and_index(self, config):
+        indexer = FakeIndexer()
+        obs = IndexObservability()
+        outcome = await auto_index_response(
+            indexer,
+            config,
+            server="gh",
+            tool="read_file",
+            arguments={"path": "deploy.env"},
+            text="DB_PASSWORD=hunter2\nAPI_HOST=internal",
+            agent_summary="env file summary",
+            observability=obs,
+        )
+        assert outcome == AutoIndexOutcome(summary="env file summary", ok=True, chunks_indexed=0)
+        assert indexer.indexed_paths == []
+        # mkdir happens after the gate: nothing of the response touches disk.
+        assert not config.memory_dir.exists()
+        snap = obs.snapshot()
+        assert snap["attempts"]["read_file"] == {"auto_index": 1}
+        assert snap["outcomes"]["read_file"] == {"privacy_skip": 1}
+
+    async def test_secret_in_arguments_skips(self, config):
+        # The persisted markdown embeds the rendered call arguments, so an
+        # arg-borne secret must trip the gate even when the text is clean.
+        indexer = FakeIndexer()
+        outcome = await auto_index_response(
+            indexer,
+            config,
+            server="gh",
+            tool="fetch",
+            arguments={"auth": "password=hunter2"},
+            text="clean response body",
+            agent_summary="summary",
+        )
+        assert outcome.chunks_indexed == 0
+        assert indexer.indexed_paths == []
+        assert not config.memory_dir.exists()
+
+    async def test_email_bearing_text_skips_persistence(self, config):
+        # Persistence gates scan the full DEFAULT_PATTERNS (credentials +
+        # PII): per the #461 split, an email is fine to show an external
+        # summarizer but not fine to store, so STORAGE consumers keep the
+        # union while ACTION gates (LLM routing) use credentials only.
+        indexer = FakeIndexer()
+        outcome = await auto_index_response(
+            indexer,
+            config,
+            server="gh",
+            tool="fetch",
+            arguments={},
+            text="maintainer contact: dev@example.com",
+            agent_summary="summary",
+        )
+        assert outcome.chunks_indexed == 0
+        assert indexer.indexed_paths == []
+
+    async def test_secret_in_context_query_skips(self, config):
+        # The agent-intent section persists context_query verbatim.
+        indexer = FakeIndexer()
+        outcome = await auto_index_response(
+            indexer,
+            config,
+            server="gh",
+            tool="fetch",
+            arguments={},
+            text="clean response body",
+            agent_summary="summary",
+            context_query="log in with password=hunter2 and retry",
+        )
+        assert outcome.chunks_indexed == 0
+        assert indexer.indexed_paths == []
+
+    async def test_clean_text_still_indexes_and_counts_stored(self, config):
+        indexer = FakeIndexer()
+        obs = IndexObservability()
+        outcome = await auto_index_response(
+            indexer,
+            config,
+            server="gh",
+            tool="read_file",
+            arguments={"path": "src/app.py"},
+            text="ordinary file contents",
+            agent_summary="summary",
+            observability=obs,
+        )
+        assert outcome.ok and outcome.chunks_indexed == 3
+        assert len(indexer.indexed_paths) == 1
+        snap = obs.snapshot()
+        assert snap["outcomes"]["read_file"] == {"stored": 1}
+
+
+class TestExtractPrivacyGate:
+    """The extraction gate fires before ``extractor.extract`` so the
+    (possibly remote) extraction LLM never sees secret-bearing text, and
+    no fact file is persisted (#453)."""
+
+    @pytest.fixture
+    def config(self, tmp_path) -> ExtractionConfig:
+        return ExtractionConfig(
+            enabled=True,
+            memory_dir=tmp_path / "facts",
+            namespace="facts-{server}",
+            max_facts=10,
+            dedup_threshold=0.92,
+        )
+
+    async def test_secret_text_skips_extractor_entirely(self, config):
+        extractor = FakeExtractor([ExtractedFact(content="f", category="c", confidence=0.5)])
+        indexer = FakeIndexer()
+        obs = IndexObservability()
+        outcome = await extract_and_store(
+            indexer,
+            extractor,
+            config,
+            server="gh",
+            tool="read_file",
+            arguments={"path": "x"},
+            text="creds: api_key: zzz-123",
+            observability=obs,
+        )
+        assert outcome == ExtractOutcome(ok=True, facts_stored=0)
+        assert extractor.calls == []  # the extractor (and its LLM) never ran
+        assert indexer.indexed_paths == []
+        assert not config.memory_dir.exists()
+        snap = obs.snapshot()
+        assert snap["attempts"]["read_file"] == {"extract": 1}
+        assert snap["outcomes"]["read_file"] == {"privacy_skip": 1}
+
+    async def test_secret_in_arguments_skips(self, config):
+        # ``format_fact_md`` embeds the rendered arguments in every fact
+        # file, so arg-borne secrets are part of the scanned value.
+        extractor = FakeExtractor([ExtractedFact(content="f", category="c", confidence=0.5)])
+        indexer = FakeIndexer()
+        outcome = await extract_and_store(
+            indexer,
+            extractor,
+            config,
+            server="gh",
+            tool="fetch",
+            arguments={"auth": "password=hunter2"},
+            text="clean response body",
+        )
+        assert outcome == ExtractOutcome(ok=True, facts_stored=0)
+        assert extractor.calls == []
+        assert indexer.indexed_paths == []
+
+    async def test_clean_text_still_extracts(self, config):
+        extractor = FakeExtractor([ExtractedFact(content="A fact", category="c", confidence=0.5)])
+        indexer = FakeIndexer()
+        outcome = await extract_and_store(
+            indexer,
+            extractor,
+            config,
+            server="gh",
+            tool="read_file",
+            arguments={"path": "src/app.py"},
+            text="ordinary response",
+        )
+        assert outcome == ExtractOutcome(ok=True, facts_stored=1)
+        assert len(extractor.calls) == 1


### PR DESCRIPTION
Part of #453 (auto-index + extraction-persistence legs; the cache leg is #460).

## Summary

- `index_content_matches_privacy()` — a shared predicate scanning every caller-controlled field that reaches the persisted markdown (server/tool names, rendered arguments, agent intent, response text; the static scaffolding cannot match). Used by both in-function gates **and** the manager's background pre-check so they can never diverge.
- `auto_index_response()` gates on the predicate before anything touches disk; on a hit it records `privacy_skip`, logs at info (server/tool only, never content), and returns the agent summary unchanged.
- **Background auto-index pre-checks in the manager** before composing the `[Indexing…] · scheduled` footer: a secret-bearing response gets the un-footered response, no task is scheduled, and the same attempt + `privacy_skip` counters are recorded — the footer never promises an indexing run the task's gate would decline.
- `extract_and_store()` gates twice: the input scan runs before `extractor.extract()` (the possibly-remote extraction LLM never sees the content), and **every candidate fact markdown is built and scanned before any disk/dedup/index interaction** — the extractor can reassemble sensitive content that evaded the input scan. One hit terminally skips the whole batch (no partial writes), including the `index_engine=None` file-write path.
- `_render_args()` shared by the markdown builders and the gates; `privacy_skip` joins the `IndexOutcome` label set (per call, terminal, fires from both paths) — `stm_index_stats` renders labels dynamically, so only docstrings change there.

## Pattern-set choice (post-#461)

Persistence gates scan the full `DEFAULT_PATTERNS` (credentials + PII), per the #461 storage-vs-action split: an email is fine to show an external summarizer but not fine to store. Pinned by a dedicated email test. The action-side gate for the extraction LLM call itself (credentials-only, mirroring compression routing) is #454 and lands separately.

## Reachability

Both legs are gated on `index_engine` (#288) and therefore inert in the standalone `mms` server today — this implements the documented SECURITY.md contract for embedding hosts and any future index-engine wiring.

## Behavior change

For deployments with an index engine wired: secret-bearing responses (or calls whose arguments/intent carry secrets) no longer produce LTM chunks or fact files; background mode returns the response without the scheduled footer instead of scheduling a doomed task; operators see `privacy_skip` in `stm_index_stats`. No schema or API change — `AutoIndexOutcome`/`ExtractOutcome` shapes are unchanged (`ok=True`, zero counts on skip).

## Verification

- `uv run pytest -m "not ollama"` — 3166 passed, 3 skipped (11 new tests)
- `uv run ruff check src tests && uv run ruff format --check src` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)