### PR TITLE
fix(extraction): scan for credentials before the extraction LLM call

### DIFF
--- a/src/memtomem_stm/proxy/extraction.py
+++ b/src/memtomem_stm/proxy/extraction.py
@@ -208,6 +208,27 @@ class FactExtractor:
             return []
         if strategy == ExtractionStrategy.HEURISTIC:
             return _extract_heuristic(truncated, max_facts=self._cfg.max_facts)
+
+        # #454: same action gate as the LLM compression route (#289, credential
+        # set per #461) — a credential-bearing response must not cross the
+        # provider trust boundary. The scan runs on the UNSLICED text: slicing
+        # to max_input_chars can split a credential at the boundary so the
+        # truncated text no longer matches a pattern while a near-complete
+        # secret prefix still ships. Sitting before the strategy dispatch it
+        # covers both LLM-bound strategies (LLM and HYBRID). Heuristic
+        # extraction runs locally instead; persistence of its output is
+        # separately gated in memory_ops (#462 scans the extraction input and
+        # every candidate fact file before disk). Operators disable per-config
+        # when the provider is local/trusted (``privacy_scan_enabled=False``).
+        if self._llm_cfg.privacy_scan_enabled and contains_sensitive_content(
+            text, CREDENTIAL_PATTERNS
+        ):
+            logger.info(
+                "Sensitive content detected, skipping LLM extraction (provider=%s)",
+                self._llm_cfg.provider.value,
+            )
+            return _extract_heuristic(truncated, max_facts=self._cfg.max_facts)
+
         if strategy == ExtractionStrategy.HYBRID:
             return await self._extract_hybrid(truncated, server=server, tool=tool)
 
@@ -215,22 +236,12 @@ class FactExtractor:
         return await self._extract_llm(truncated, server=server, tool=tool)
 
     async def _extract_llm(self, text: str, *, server: str, tool: str) -> list[ExtractedFact]:
-        """LLM-based extraction with circuit breaker and fallback."""
+        """LLM-based extraction with circuit breaker and fallback.
+
+        Callers must route through :meth:`extract` — the credential action
+        gate lives there, scanning the pre-truncation text (#454).
+        """
         if self._client is None:
-            return _extract_heuristic(text, max_facts=self._cfg.max_facts)
-        if self._llm_cfg.privacy_scan_enabled and contains_sensitive_content(
-            text, CREDENTIAL_PATTERNS
-        ):
-            # #454: same action gate as the LLM compression route (#289,
-            # credential set per #461) — a credential-bearing response must
-            # not cross the provider trust boundary. Heuristic extraction
-            # runs locally instead; persistence of its output is separately
-            # gated in memory_ops. Operators disable per-config when the
-            # provider is local/trusted (``privacy_scan_enabled=False``).
-            logger.info(
-                "Sensitive content detected, skipping LLM extraction (provider=%s)",
-                self._llm_cfg.provider.value,
-            )
             return _extract_heuristic(text, max_facts=self._cfg.max_facts)
         if self._cb.is_open:
             logger.debug("Extraction circuit open, falling back to heuristic")

--- a/src/memtomem_stm/proxy/extraction.py
+++ b/src/memtomem_stm/proxy/extraction.py
@@ -17,6 +17,7 @@ from memtomem_stm.proxy.config import (
     ExtractionStrategy,
     LLMProvider,
 )
+from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS, contains_sensitive_content
 from memtomem_stm.utils.circuit_breaker import CircuitBreaker
 from memtomem_stm.utils.numeric import safe_float
 
@@ -216,6 +217,20 @@ class FactExtractor:
     async def _extract_llm(self, text: str, *, server: str, tool: str) -> list[ExtractedFact]:
         """LLM-based extraction with circuit breaker and fallback."""
         if self._client is None:
+            return _extract_heuristic(text, max_facts=self._cfg.max_facts)
+        if self._llm_cfg.privacy_scan_enabled and contains_sensitive_content(
+            text, CREDENTIAL_PATTERNS
+        ):
+            # #454: same action gate as the LLM compression route (#289,
+            # credential set per #461) — a credential-bearing response must
+            # not cross the provider trust boundary. Heuristic extraction
+            # runs locally instead; persistence of its output is separately
+            # gated in memory_ops. Operators disable per-config when the
+            # provider is local/trusted (``privacy_scan_enabled=False``).
+            logger.info(
+                "Sensitive content detected, skipping LLM extraction (provider=%s)",
+                self._llm_cfg.provider.value,
+            )
             return _extract_heuristic(text, max_facts=self._cfg.max_facts)
         if self._cb.is_open:
             logger.debug("Extraction circuit open, falling back to heuristic")

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -20,6 +20,7 @@ from memtomem_stm.proxy.extraction import (
     _extract_heuristic,
     _parse_facts_json,
 )
+from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS, contains_sensitive_content
 
 
 # ---------------------------------------------------------------------------
@@ -405,6 +406,24 @@ class TestFactExtractorLLM:
 
         call_api.assert_not_awaited()
         assert isinstance(facts, list)
+
+    async def test_privacy_scan_runs_before_truncation(self):
+        # A credential split at the max_input_chars boundary must still fire
+        # the gate: slicing leaves 15 of the AKIA key's 16 trailing chars, so
+        # the truncated text matches no pattern while a near-complete secret
+        # prefix would ship. The scan must see the pre-truncation text.
+        cfg = ExtractionConfig(enabled=True, min_response_chars=10, max_input_chars=30)
+        extractor = FactExtractor(cfg)
+        text = "x" * 10 + " AKIA" + "A" * 16
+        # Pin the repro shape itself — if either assert breaks, the test no
+        # longer exercises the boundary split and must be reconstructed.
+        assert not contains_sensitive_content(text[:30], CREDENTIAL_PATTERNS)
+        assert contains_sensitive_content(text, CREDENTIAL_PATTERNS)
+
+        with patch.object(extractor, "_call_api", new_callable=AsyncMock) as call_api:
+            await extractor.extract(text, server="s", tool="t")
+
+        call_api.assert_not_awaited()
 
     async def test_hybrid_merges_llm_and_heuristic(self):
         cfg = ExtractionConfig(

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -342,6 +342,70 @@ class TestFactExtractorLLM:
 
         assert extractor._cb.state == "open"
 
+    async def test_privacy_scan_blocks_call_api_for_credentials(self):
+        # #454: action gate — a credential-bearing response must never reach
+        # the provider; heuristic extraction runs locally instead.
+        cfg = ExtractionConfig(enabled=True, min_response_chars=10)
+        extractor = FactExtractor(cfg)
+
+        with patch.object(extractor, "_call_api", new_callable=AsyncMock) as call_api:
+            text = "creds: password=hunter2\nDecision: rotate the key now. " + "x" * 50
+            facts = await extractor.extract(text, server="s", tool="t")
+
+        call_api.assert_not_awaited()
+        # Heuristic fallback still produced local facts (the Decision line).
+        assert any(f.category == "decision" for f in facts)
+
+    async def test_privacy_scan_is_credentials_only(self):
+        # Emails are PII, not credentials (#461): fine to SHOW the provider,
+        # not fine to persist. The action gate must not fire on an email
+        # alone — persistence-side blocking is memory_ops' job.
+        cfg = ExtractionConfig(enabled=True, min_response_chars=10)
+        extractor = FactExtractor(cfg)
+
+        mock_response = json.dumps([{"content": "f", "category": "c", "confidence": 0.9}])
+        with patch.object(
+            extractor, "_call_api", new_callable=AsyncMock, return_value=mock_response
+        ) as call_api:
+            await extractor.extract("contact dev@example.com " * 10, server="s", tool="t")
+
+        call_api.assert_awaited_once()
+
+    async def test_privacy_scan_disabled_reaches_call_api(self):
+        cfg = ExtractionConfig(
+            enabled=True,
+            min_response_chars=10,
+            llm=LLMCompressorConfig(
+                provider=LLMProvider.OLLAMA,
+                model="qwen3:4b",
+                privacy_scan_enabled=False,
+            ),
+        )
+        extractor = FactExtractor(cfg)
+
+        mock_response = json.dumps([{"content": "f", "category": "c", "confidence": 0.9}])
+        with patch.object(
+            extractor, "_call_api", new_callable=AsyncMock, return_value=mock_response
+        ) as call_api:
+            await extractor.extract("password=hunter2 " * 10, server="s", tool="t")
+
+        call_api.assert_awaited_once()
+
+    async def test_hybrid_privacy_scan_blocks_call_api(self):
+        # HYBRID routes through _extract_llm too — the gate covers it.
+        cfg = ExtractionConfig(
+            enabled=True,
+            strategy=ExtractionStrategy.HYBRID,
+            min_response_chars=10,
+        )
+        extractor = FactExtractor(cfg)
+
+        with patch.object(extractor, "_call_api", new_callable=AsyncMock) as call_api:
+            facts = await extractor.extract("api_key: zzz-secret " * 10, server="s", tool="t")
+
+        call_api.assert_not_awaited()
+        assert isinstance(facts, list)
+
     async def test_hybrid_merges_llm_and_heuristic(self):
         cfg = ExtractionConfig(
             enabled=True,


### PR DESCRIPTION
Closes #454.

## Summary

`FactExtractor` now mirrors the LLM-compression action gate: when `privacy_scan_enabled` (default on, via the shared `LLMCompressorConfig`) and the response text matches `CREDENTIAL_PATTERNS`, the provider call is skipped with an info log and heuristic extraction runs locally instead. The gate sits in `extract()` **before the `max_input_chars` slice** and before the strategy dispatch, so it scans the full pre-truncation text and covers both LLM-bound strategies (LLM and HYBRID); the provider still receives only the truncated text. As in `LLMCompressor.compress`, the gate precedes the circuit-breaker check.

## Review R1 fixes

- **Blocker — slice-before-scan bypass**: the first revision scanned inside `_extract_llm()`, i.e. after `extract()` had truncated to `max_input_chars`. A credential straddling the boundary shipped a near-complete secret prefix that no longer matched any pattern (`max_input_chars=30`, `"x"*10 + " AKIA" + "A"*16` → the truncated text holds AKIA + 15 of the key's 16 chars, unmatched). The gate now scans the unsliced text; the regression test pins the boundary-split shape itself (sliced text must NOT match, full text must) so a future pattern change cannot quietly turn the test vacuous.
- **Major — persistence claim ahead of its base**: the comment citing memory_ops persistence gating predated #462 on this branch's old base. Rebased onto main with #462 merged; the comment now cites what #462 actually scans (extraction input + every candidate fact file before disk).

## Pattern-set choice (post-#461)

Credentials only — this is an ACTION gate ("may this text be sent to an external provider?"), so it uses `CREDENTIAL_PATTERNS`, exactly like compression routing after #461. An email alone does **not** block the provider call (pinned by test); persistence of extracted output is the STORAGE side and is gated separately in memory_ops (#462, full `DEFAULT_PATTERNS`).

## Reachability

Inert in the standalone `mms` server today (#288, no `index_engine` wired) — and in the wired manager path, the #462 input gate already blocks secret-bearing text before the extractor runs. This PR hardens the `FactExtractor` API boundary itself: embedding hosts and direct library users get the same provider-trust-boundary guarantee the compression route has, instead of silently diverging from it.

## Tests

- credential-bearing text → `_call_api` never awaited, heuristic facts still produced locally
- credential split at the `max_input_chars` boundary → gate still fires (scan-before-slice regression)
- email-only text → `_call_api` awaited (credentials-only pin)
- `privacy_scan_enabled=False` → `_call_api` awaited (operator opt-out honored)
- HYBRID strategy → gate covers it

## Verification

- `uv run pytest -m "not ollama"` — 3198 passed, 3 skipped (5 new tests)
- `uv run ruff check src tests && uv run ruff format --check src` — clean
- `uv run mypy src/memtomem_stm/proxy/extraction.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
