### PR TITLE
fix(memory-ops): slug server/tool in persisted filenames, private dir and file modes

### DIFF
--- a/src/memtomem_stm/proxy/memory_ops.py
+++ b/src/memtomem_stm/proxy/memory_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -30,6 +31,23 @@ def _render_args(arguments: dict[str, Any]) -> str:
     value and the persisted value can never diverge.
     """
     return ", ".join(f"{k}={v!r}" for k, v in arguments.items()) if arguments else "(none)"
+
+
+_PATH_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _path_slug(name: str) -> str:
+    """Collapse a server/tool name into one filesystem-safe path component.
+
+    Server keys and tool names come from trusted config / import flows, but
+    a hand-edited config can carry path separators (or a bare ``..``) that
+    make the write target under ``memory_dir`` unpredictable (#456). The
+    slug keeps ``[A-Za-z0-9._-]`` and replaces everything else with ``_``:
+    with separators gone, dots cannot climb directories, and the composed
+    ``{server}__{tool}__{ts}`` filename never collapses to ``.`` or ``..``.
+    Empty input becomes ``_`` so the filename keeps its field structure.
+    """
+    return _PATH_SLUG_RE.sub("_", name) or "_"
 
 
 def index_content_matches_privacy(
@@ -166,8 +184,7 @@ async def auto_index_response(
     memory_dir = ai_cfg.memory_dir.expanduser().resolve()
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
-    safe_tool = tool.replace("/", "_")
-    fname = f"{server}__{safe_tool}__{ts}.md"
+    fname = f"{_path_slug(server)}__{_path_slug(tool)}__{ts}.md"
     file_path = memory_dir / fname
 
     args_str = _render_args(arguments)
@@ -198,10 +215,15 @@ async def auto_index_response(
         f"## Content\n\n{text}\n"
     )
 
-    memory_dir.mkdir(parents=True, exist_ok=True)
+    # 0o700 dir / 0o600 files: indexed responses are user conversation
+    # content under ``~/.memtomem``, private to the user like the SQLite
+    # stores (#458). The dir mode only applies at creation, so the file
+    # mode is set explicitly too — a pre-existing permissive memory_dir
+    # must not leave fresh response files at the umask default (#456).
+    memory_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     # Atomic so the auto-indexer (called next) can't observe a partial file
     # if the writer is killed mid-flush. The mkdir above ensured memory_dir.
-    atomic_write_text(file_path, md_content, ensure_parent=False)
+    atomic_write_text(file_path, md_content, ensure_parent=False, mode=0o600)
 
     ns = ai_cfg.namespace.format(server=server, tool=tool)
 
@@ -285,7 +307,7 @@ async def extract_and_store(
             return ExtractOutcome(ok=True, facts_stored=0)
 
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
-        safe_tool = tool.replace("/", "_")
+        safe_server, safe_tool = _path_slug(server), _path_slug(tool)
 
         # Build every candidate fact file BEFORE any disk or indexer
         # interaction: the extractor (typically an LLM) can reassemble or
@@ -307,7 +329,8 @@ async def extract_and_store(
             return ExtractOutcome(ok=True, facts_stored=0)
 
         memory_dir = ext_cfg.memory_dir.expanduser().resolve()
-        memory_dir.mkdir(parents=True, exist_ok=True)
+        # Same 0o700 dir / 0o600 file policy as auto_index_response (#456).
+        memory_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         ns = ext_cfg.namespace.format(server=server, tool=tool)
 
         # Dedup: skip facts already in the index
@@ -328,10 +351,10 @@ async def extract_and_store(
                 except Exception:
                     pass  # on dedup failure, proceed with indexing
 
-            fname = f"{server}__{safe_tool}__fact__{ts}__{i:02d}.md"
+            fname = f"{safe_server}__{safe_tool}__fact__{ts}__{i:02d}.md"
             file_path = memory_dir / fname
             # Atomic so a kill between write and index_file leaves no partial.
-            atomic_write_text(file_path, md_content, ensure_parent=False)
+            atomic_write_text(file_path, md_content, ensure_parent=False, mode=0o600)
 
             if index_engine is None:
                 continue

--- a/tests/test_memory_ops.py
+++ b/tests/test_memory_ops.py
@@ -211,6 +211,46 @@ class TestAutoIndexResponse:
         assert "/" not in written_path.name
         assert "ns_inner" in written_path.name
 
+    async def test_server_with_path_separators_is_sanitized_in_filename(self, config):
+        """The server key is interpolated into the filename too (#456). A
+        hand-edited config can hold separators or ``..``; the slug must
+        keep the write target inside ``memory_dir``."""
+        indexer = FakeIndexer()
+        await auto_index_response(
+            indexer,
+            config,
+            server="../../tmp/evil",
+            tool="t",
+            arguments={},
+            text="body",
+            agent_summary="sum",
+        )
+        written_path, _ = indexer.indexed_paths[0]
+        assert written_path.parent == config.memory_dir.expanduser().resolve()
+        assert written_path.name.startswith(".._.._tmp_evil__t__")
+        assert written_path.exists()
+
+    async def test_memory_dir_and_response_files_are_private(self, config):
+        """0o700 dir / 0o600 files (#456): indexed responses are user
+        conversation content, private like the SQLite stores (#458). The
+        file mode is exact (chmod ignores umask); the dir assert pins the
+        security property — no group/other bits — because mkdir's mode is
+        masked by the process umask."""
+        indexer = FakeIndexer()
+        await auto_index_response(
+            indexer,
+            config,
+            server="s",
+            tool="t",
+            arguments={},
+            text="body",
+            agent_summary="sum",
+        )
+        memory_dir = config.memory_dir.expanduser().resolve()
+        assert memory_dir.stat().st_mode & 0o077 == 0
+        written_path, _ = indexer.indexed_paths[0]
+        assert written_path.stat().st_mode & 0o777 == 0o600
+
 
 # ── compose_index_footer ─────────────────────────────────────────────────
 
@@ -319,6 +359,46 @@ class TestExtractAndStore:
         for path, _ in indexer.indexed_paths:
             content = path.read_text(encoding="utf-8")
             assert any(fact.content in content for fact in facts)
+
+    async def test_server_with_path_separators_is_sanitized_in_fact_filenames(self, config):
+        """Fact filenames interpolate the server key too (#456) — the same
+        slug as auto_index_response keeps writes inside ``memory_dir``."""
+        extractor = FakeExtractor([self._fact("one insight")])
+        indexer = FakeIndexer()
+
+        await extract_and_store(
+            indexer,
+            extractor,
+            config,
+            server="../../tmp/evil",
+            tool="ns/inner",
+            arguments={},
+            text="long response text",
+        )
+
+        written_path, _ = indexer.indexed_paths[0]
+        assert written_path.parent == config.memory_dir.expanduser().resolve()
+        assert written_path.name.startswith(".._.._tmp_evil__ns_inner__fact__")
+
+    async def test_fact_dir_and_files_are_private(self, config):
+        """Same 0o700 dir / 0o600 file policy as auto_index_response (#456)."""
+        extractor = FakeExtractor([self._fact("one insight")])
+        indexer = FakeIndexer()
+
+        await extract_and_store(
+            indexer,
+            extractor,
+            config,
+            server="gh",
+            tool="read_file",
+            arguments={},
+            text="long response text",
+        )
+
+        memory_dir = config.memory_dir.expanduser().resolve()
+        assert memory_dir.stat().st_mode & 0o077 == 0
+        written_path, _ = indexer.indexed_paths[0]
+        assert written_path.stat().st_mode & 0o777 == 0o600
 
     async def test_dedup_skips_duplicates(self, config):
         facts = [

--- a/tests/test_memory_ops.py
+++ b/tests/test_memory_ops.py
@@ -11,6 +11,7 @@ touched.
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -28,6 +29,13 @@ from memtomem_stm.proxy.memory_ops import (
     format_fact_md,
 )
 from memtomem_stm.proxy.protocols import IndexResult
+
+# The #456 mode tests assert POSIX bits; the traversal/slug tests stay
+# cross-platform (same split as test_sqlite_private / test_utils_fileio).
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX 0o700/0o600 modes are unenforceable on Windows; chmod only toggles read-only",
+)
 
 
 # ── Stubs ────────────────────────────────────────────────────────────────
@@ -230,6 +238,7 @@ class TestAutoIndexResponse:
         assert written_path.name.startswith(".._.._tmp_evil__t__")
         assert written_path.exists()
 
+    @_skip_on_windows
     async def test_memory_dir_and_response_files_are_private(self, config):
         """0o700 dir / 0o600 files (#456): indexed responses are user
         conversation content, private like the SQLite stores (#458). The
@@ -380,6 +389,7 @@ class TestExtractAndStore:
         assert written_path.parent == config.memory_dir.expanduser().resolve()
         assert written_path.name.startswith(".._.._tmp_evil__ns_inner__fact__")
 
+    @_skip_on_windows
     async def test_fact_dir_and_files_are_private(self, config):
         """Same 0o700 dir / 0o600 file policy as auto_index_response (#456)."""
         extractor = FakeExtractor([self._fact("one insight")])


### PR DESCRIPTION
Closes #456.

## Summary

Two hardening fixes for the markdown persistence paths in `memory_ops.py`, completing the security-audit drive (#453–#456):

1. **Filename slug for `server` and `tool`.** `auto_index_response` sanitized `/` in the tool name but interpolated the server key raw into `f"{server}__{safe_tool}__{ts}.md"`; the fact-file name in `extract_and_store` had the same shape. A shared `_path_slug()` now keeps `[A-Za-z0-9._-]` and replaces everything else with `_` for both fields at both sites — with separators gone, dots cannot climb, and the composed name never collapses to `.` or `..`, so the write target always stays inside `memory_dir`.
2. **Private modes.** Both `memory_dir.mkdir(...)` calls get `mode=0o700` (matching every SQLite store parent after #458), and both `atomic_write_text(...)` calls get `mode=0o600`.

## Why the file mode too (not just the dir, as the issue proposed)

Same reasoning `utils/sqlite_private.py` documents for the DB files: `mkdir(mode=0o700)` only applies when the directory is **created** — a `memory_dir` that already exists permissive (created by an older version at the umask default) would leave fresh markdown files world-readable. The persisted content is the user's tool-response/conversation data; `atomic_write_text` already supports `mode=` (chmod on the temp before the rename, so the file is never observable permissive). One extra argument per call site closes the gap completely.

## Behavior change

- New auto-index/fact markdown files are `0o600`; `memory_dir` is created `0o700`. Pre-existing files and dirs are not re-chmod'd (creation-time policy, like #458's mkdir half — the md-file population is unbounded, and unlike SQLite sidecars there is no single fixed path to correct at open).
- Filenames change **only** for server/tool names containing characters outside `[A-Za-z0-9._-]` (previously only `/` in `tool` was replaced). For well-formed names the filenames are byte-identical. Nothing parses these filenames back (verified: no consumer splits on `__`).

## Reachability

Low severity as triaged in #456: server keys come from trusted config/import flows, auto-index is opt-in, and the path is inert in the standalone `mms` server (#288, no `index_engine`). This hardens against hand-edited configs.

## Tests

- server `"../../tmp/evil"` → file lands **inside** `memory_dir` with the slugged name, both for auto-index and fact files
- fresh `memory_dir` has no group/other bits (umask-proof assert); written files are exactly `0o600` — POSIX-only via the repo's `_skip_on_windows` idiom (NTFS doesn't enforce mode bits); the traversal tests stay cross-platform
- existing `tool` slash test unchanged (slug is a superset of the old replace)

## Verification

- `uv run pytest -m "not ollama"` — 3197 passed, 3 skipped (4 new tests)
- `uv run ruff check src tests && uv run ruff format --check src` — clean
- `uv run mypy src/memtomem_stm/proxy/memory_ops.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

