### PR TITLE
feat(proxy): opt-in selection/execution telemetry JSONL sink (#467)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ A second tier of management lets you decide *which MCP servers a given project s
 | [Compression](https://github.com/memtomem/memtomem-stm/blob/main/docs/compression.md) | All 10 strategies — pick the right one for your content |
 | [Caching](https://github.com/memtomem/memtomem-stm/blob/main/docs/caching.md) | Skip repeated work with response caching |
 | [Configuration](https://github.com/memtomem/memtomem-stm/blob/main/docs/configuration.md) | Tune settings without touching code |
+| [Selection telemetry](https://github.com/memtomem/memtomem-stm/blob/main/docs/selection-telemetry.md) | Opt-in JSONL log of tool selection + execution outcomes |
 | [CLI](https://github.com/memtomem/memtomem-stm/blob/main/docs/cli.md) | CLI commands, host sync, hooks, daemon, and MCP tools |
 
 STM advertises four model-facing MCP tools by default. Eight observability and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,9 +298,24 @@ Full example with all options:
   "progressive_reads": {
     "enabled": true,
     "db_path": "~/.memtomem/stm_feedback.db"
+  },
+  "selection_telemetry": {
+    "enabled": false,
+    "path": "~/.memtomem/stm_selection_log.jsonl",
+    "sample_rate": 1.0,
+    "max_bytes": 50000000,
+    "max_backups": 3
   }
 }
 ```
+
+`selection_telemetry` (off by default) appends one `selection` + one
+`execution` JSONL record per proxied call — which tool the client picked out
+of the advertised candidate set, and how the call went. The schema, the
+redaction policy (no raw arguments, results, or error text ever reach the
+log), and the replay-join contract are documented in
+[selection-telemetry.md](selection-telemetry.md). The flag is read at
+startup, like `metrics.enabled` — toggling it requires a restart.
 
 ### Token-equivalent budgets (CJK / non-Latin workloads)
 

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -23,11 +23,14 @@ Off by default — it is a new disk write path, so the operator opts in:
 ```
 
 The flag is read at startup (like `metrics.enabled`); toggling it requires a
-restart. Files are created `0600` with a `0700` parent directory. When the
-log reaches `max_bytes` it rotates (`log → log.1 → … → log.N`, oldest
-dropped; `max_backups: 0` truncates instead). `sample_rate` keeps the given
-fraction of calls and applies to the selection+execution pair atomically, so
-sampling never produces orphan halves.
+restart. Files are created `0600`; the parent directory is created `0700`
+(a pre-existing parent keeps its mode, matching the other STM stores — the
+file mode alone guards the content). When the log reaches `max_bytes` it
+rotates (`log → log.1 → … → log.N`, oldest dropped; `max_backups: 0`
+truncates instead). `sample_rate` keeps the given fraction of calls and
+applies to the selection+execution pair atomically — and a selection whose
+write failed also skips its execution event — so neither sampling nor write
+failures produce orphan halves.
 
 ## Schema v1
 

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -1,0 +1,96 @@
+# Selection Telemetry
+
+Append-only JSONL log of tool selection and execution outcomes (#467). The
+proxy sits in the call path, so it can record what an advisory analyzer never
+sees: which tool the client model actually called, out of which advertised
+candidate set, and how the call went. This log is the substrate for offline
+replay/eval (#468) and later learning stages (#469/#470), and the landing
+zone for hard-filter reject reasons once the STM-native selector ships
+(#465).
+
+Off by default — it is a new disk write path, so the operator opts in:
+
+```json
+{
+  "selection_telemetry": {
+    "enabled": true,
+    "path": "~/.memtomem/stm_selection_log.jsonl",
+    "sample_rate": 1.0,
+    "max_bytes": 50000000,
+    "max_backups": 3
+  }
+}
+```
+
+The flag is read at startup (like `metrics.enabled`); toggling it requires a
+restart. Files are created `0600` with a `0700` parent directory. When the
+log reaches `max_bytes` it rotates (`log → log.1 → … → log.N`, oldest
+dropped; `max_backups: 0` truncates instead). `sample_rate` keeps the given
+fraction of calls and applies to the selection+execution pair atomically, so
+sampling never produces orphan halves.
+
+## Schema v1
+
+One JSON object per line, keys sorted, every record self-describing via
+`schema_version` (bumped on any shape change — the exact key sets are pinned
+by `tests/test_selection_log.py`) and `ranker_version` (`"v0-passthrough"`
+today: no in-proxy ranking exists, the client model picks from the full
+advertised set, so replay tooling can treat this version as the unranked
+baseline).
+
+### `selection` — one per proxied call
+
+| field | v1 value |
+|---|---|
+| `selection_id` | joins the paired `execution` record |
+| `trace_id` | joins `proxy_metrics.db` for per-stage diagnostics |
+| `server`, `selected_tool` | prefixed name, same vocabulary as `candidate_tools` |
+| `candidate_tools`, `candidate_count` | what the proxy last advertised (`get_proxy_tools()` snapshot) |
+| `reject_reasons` | `{}` until the #465 hard filter populates it (tool → reason) |
+| `candidate_features`, `graph_generation` | reserved `null` until toolgraph#13/#15 integration |
+| `args_sha256`, `args_chars` | canonical-JSON hash + length of the call arguments |
+| `ts` | unix seconds |
+
+### `execution` — paired outcome
+
+| field | v1 value |
+|---|---|
+| `selection_id`, `trace_id`, `server`, `selected_tool` | mirror the paired selection |
+| `ok` | `true`/`false` |
+| `latency_ms` | proxy-side wall time for the full pipeline (what the agent experienced) |
+| `error_type` | exception class name only; the typed category stays in `proxy_metrics.db` |
+| `retry_count`, `cost`, `cache_hit` | reserved `null` in v0 |
+
+### `feedback` — schema pinned, no emitter yet
+
+`selection_id`, optional `trace_id`, `user_corrected`, `operator_override`.
+Nothing in the proxy produces this signal today; emitters arrive with their
+signal sources (e.g. an operator-facing rating tool).
+
+## Redaction policy
+
+Redaction is **structural**, not filter-based: no field ever carries raw
+arguments, results, prompts, resource URIs, or error message strings.
+Argument payloads appear only as a sha256 over their canonical JSON plus a
+char count; error detail beyond the exception class name lives in
+`proxy_metrics.db` and is reachable through the `trace_id` join instead of
+being duplicated into this log.
+
+As a backstop (the storage-gating rule from `proxy/privacy.py`, mirroring
+the never-persist-secrets behavior of #460/#462), every serialized line is
+screened with `contains_sensitive_content` before persisting and dropped —
+and counted — on a match. A false positive costs one telemetry record,
+never data. Backstop drops are per-record, so an `execution` whose paired
+`selection` was dropped can appear alone: replay tooling must treat
+`selection_id` joins as left-outer.
+
+## Replay joins
+
+- `selection.selection_id = execution.selection_id` — outcome per selection
+  (left-outer; see above).
+- `*.trace_id = proxy_metrics.trace_id` — full per-stage diagnostics
+  (compression strategy, typed error category, stage timings) without
+  duplicating them into the telemetry log.
+
+Telemetry failures never propagate to proxied calls: write errors are
+counted (`write_errors`) and logged, and the call proceeds untouched.

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -529,6 +529,28 @@ class ProgressiveReadsConfig(BaseModel):
     db_path: Path = Path("~/.memtomem/stm_feedback.db")
 
 
+class SelectionTelemetryConfig(BaseModel):
+    """Configuration for tool-selection telemetry (#467).
+
+    When enabled, the proxy appends one ``selection`` + one ``execution``
+    JSONL record per proxied call to ``path`` (schema and redaction policy
+    in ``proxy/selection_log.py``). Off by default: it is a new disk write
+    path, so the operator opts in explicitly. The flag is read at startup
+    (lifespan wiring, like ``metrics.enabled``) — toggling it requires a
+    restart, not a hot-reload.
+    """
+
+    enabled: bool = False
+    path: Path = Path("~/.memtomem/stm_selection_log.jsonl")
+    sample_rate: float = Field(default=1.0, ge=0.0, le=1.0)
+    """Fraction of calls recorded; applies to the selection+execution pair
+    atomically so the log never contains orphan halves."""
+    max_bytes: int = Field(default=50_000_000, gt=0)
+    """Rotate the log when it reaches this size."""
+    max_backups: int = Field(default=3, ge=0)
+    """Rotated files kept (``.1`` … ``.N``); ``0`` truncates instead."""
+
+
 # Static context window sizes (tokens) for known model families.
 # Used by ProxyConfig.effective_max_result_chars() to scale compression budget.
 # Prefix-matched: "claude-sonnet-4-20250514" matches "claude-sonnet-4".
@@ -661,6 +683,7 @@ class ProxyConfig(BaseModel):
         default_factory=CompressionFeedbackConfig
     )
     progressive_reads: ProgressiveReadsConfig = Field(default_factory=ProgressiveReadsConfig)
+    selection_telemetry: SelectionTelemetryConfig = Field(default_factory=SelectionTelemetryConfig)
 
     @model_validator(mode="after")
     def _check_nonempty_upstream_prefixes(self) -> Self:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from memtomem_stm.proxy.pending_store import PendingStore
     from memtomem_stm.proxy.protocols import FileIndexer
     from memtomem_stm.proxy.relevance import RelevanceScorer
+    from memtomem_stm.proxy.selection_log import SelectionTelemetryLog
     from memtomem_stm.surfacing.engine import SurfacingEngine
     from memtomem_stm.surfacing.observability import SkipReason
 
@@ -150,6 +151,7 @@ class ProxyManager:
         cache: ProxyCache | None = None,
         env_overrides: dict[str, Any] | None = None,
         progressive_reads_tracker: ProgressiveReadsTracker | None = None,
+        selection_log: SelectionTelemetryLog | None = None,
     ) -> None:
         self._config_loader = ProxyConfigLoader(config.config_path, env_overrides=env_overrides)
         self._config_loader.seed(config)
@@ -158,6 +160,12 @@ class ProxyManager:
         self._surfacing_engine = surfacing_engine
         self._cache = cache
         self._progressive_reads_tracker = progressive_reads_tracker
+        self._selection_log = selection_log
+        # Snapshot of the prefixed tool names last returned by
+        # ``get_proxy_tools()`` — the candidate set the client model picked
+        # from, recorded in selection telemetry (#467). Empty until the
+        # first advertisement.
+        self._advertised_tools: list[str] = []
         self._connections: dict[str, UpstreamConnection] = {}
         self._stack: AsyncExitStack | None = None
         self._selective_compressor: SelectiveCompressor | None = None
@@ -509,6 +517,7 @@ class ProxyManager:
                         annotations=getattr(t, "annotations", None),
                     )
                 )
+        self._advertised_tools = [info.prefixed_name for info in result]
         return result
 
     @staticmethod
@@ -1200,12 +1209,18 @@ class ProxyManager:
             raise KeyError(f"Unknown upstream server: '{server}'")
         if trace_id is None:
             trace_id = uuid.uuid4().hex[:16]
+        # Selection telemetry (#467): the prefixed name shares the
+        # ``candidate_tools`` vocabulary, so replay tooling can match the
+        # selected tool against the advertised set verbatim.
+        selected_tool = f"{self._connections[server].config.prefix}__{tool}"
+        selection_id = self._log_selection(server, selected_tool, arguments, trace_id)
+        started = _time.perf_counter()
         with traced(
             "proxy_call",
             metadata={"server": server, "tool": tool, "trace_id": trace_id},
         ):
             try:
-                return await self._call_tool_guarded(server, tool, arguments, trace_id=trace_id)
+                result = await self._call_tool_guarded(server, tool, arguments, trace_id=trace_id)
             except Exception as exc:
                 # Upstream/transport/timeout/protocol errors are already
                 # recorded inside _call_tool_inner via record_error(); a raise
@@ -1246,7 +1261,78 @@ class ProxyManager:
                             pipeline_category.value,
                             exc_info=True,
                         )
+                self._log_execution(
+                    selection_id,
+                    server,
+                    selected_tool,
+                    trace_id,
+                    started,
+                    ok=False,
+                    error_type=type(exc).__name__,
+                )
                 raise
+            self._log_execution(selection_id, server, selected_tool, trace_id, started, ok=True)
+            return result
+
+    def _log_selection(
+        self,
+        server: str,
+        selected_tool: str,
+        arguments: dict[str, Any],
+        trace_id: str,
+    ) -> str | None:
+        """Emit the selection-telemetry event for one proxied call (#467).
+
+        Returns ``None`` when telemetry is disabled, the call was sampled
+        out, or the write failed — the caller then skips the paired
+        execution event so the log never contains orphan halves. A
+        telemetry failure must never affect the proxied call.
+        """
+        if self._selection_log is None:
+            return None
+        try:
+            return self._selection_log.log_selection(
+                server=server,
+                selected_tool=selected_tool,
+                candidate_tools=self._advertised_tools,
+                arguments=arguments,
+                trace_id=trace_id,
+            )
+        except Exception:
+            logger.debug("Selection telemetry write failed", exc_info=True)
+            return None
+
+    def _log_execution(
+        self,
+        selection_id: str | None,
+        server: str,
+        selected_tool: str,
+        trace_id: str,
+        started: float,
+        *,
+        ok: bool,
+        error_type: str | None = None,
+    ) -> None:
+        """Emit the execution-outcome event paired to ``selection_id``.
+
+        ``error_type`` is the exception class name only; the typed error
+        category and message live in ``proxy_metrics.db``, joinable via
+        ``trace_id`` — telemetry never duplicates (or leaks) error text.
+        """
+        if self._selection_log is None or selection_id is None:
+            return
+        try:
+            self._selection_log.log_execution(
+                selection_id=selection_id,
+                trace_id=trace_id,
+                server=server,
+                selected_tool=selected_tool,
+                ok=ok,
+                latency_ms=(_time.perf_counter() - started) * 1000.0,
+                error_type=error_type,
+            )
+        except Exception:
+            logger.debug("Execution telemetry write failed", exc_info=True)
 
     async def _call_tool_guarded(
         self,

--- a/src/memtomem_stm/proxy/selection_log.py
+++ b/src/memtomem_stm/proxy/selection_log.py
@@ -45,14 +45,18 @@ char count. As a belt-and-suspenders backstop (the storage-gating rule from
 ``privacy.py``), every serialized line is screened with
 ``contains_sensitive_content`` before persisting and dropped (counted) on a
 match, mirroring the never-persist-secrets rule from #460/#462. Files are
-created ``0o600`` with a ``0o700`` parent (#458).
+created ``0o600`` (#458); the parent directory is created ``0o700``, but a
+pre-existing parent's mode is left untouched — the same posture as every
+other STM store (``MetricsStore``, ``memory_ops`` #456/#464): ``mkdir`` mode
+applies at creation time only, and the file mode alone guards the content.
 
-Sampling applies to the whole selection+execution pair at selection time —
-``log_selection`` returning ``None`` means the call is sampled out and the
-caller skips the execution event, so sampling never produces orphan halves.
-Redaction drops, by contrast, are per-record (never-persist beats pairing):
-an execution whose paired selection was dropped can appear alone, so replay
-tooling must treat ``selection_id`` joins as left-outer.
+Sampling and write failures apply to the whole selection+execution pair at
+selection time — ``log_selection`` returning ``None`` means the call was
+sampled out or its record never reached disk, and the caller skips the
+execution event, so neither produces orphan halves. Redaction drops, by
+contrast, are per-record (never-persist beats pairing): an execution whose
+paired selection was dropped can appear alone, so replay tooling must treat
+``selection_id`` joins as left-outer.
 """
 
 from __future__ import annotations
@@ -137,11 +141,12 @@ class SelectionTelemetryLog:
         return self._path
 
     def initialize(self) -> None:
-        """Create the log file privately (0600 file, 0700 parent).
+        """Create the log file privately (0600 file; parent created 0700).
 
-        Also tightens a pre-existing file left at a permissive mode by an
+        Also tightens a pre-existing *file* left at a permissive mode by an
         older run or umask — same rationale as
-        ``sqlite_private.ensure_private_db_files``.
+        ``sqlite_private.ensure_private_db_files``. A pre-existing *parent
+        directory* keeps its mode (see module docstring).
         """
         self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
@@ -178,7 +183,7 @@ class SelectionTelemetryLog:
             return None
         selection_id = uuid.uuid4().hex
         canonical = _canonical_args(arguments)
-        self._append(
+        appended = self._append(
             {
                 "schema_version": SCHEMA_VERSION,
                 "ranker_version": RANKER_VERSION,
@@ -197,7 +202,12 @@ class SelectionTelemetryLog:
                 "args_chars": len(canonical),
             }
         )
-        return selection_id
+        # A write failure means the selection never reached disk — report
+        # ``None`` so the caller skips the paired execution event rather
+        # than persisting an orphan half (a transient failure could let the
+        # execution write succeed). An intentional redaction drop still
+        # returns the id: that is the documented left-outer case.
+        return selection_id if appended else None
 
     def log_execution(
         self,
@@ -259,7 +269,14 @@ class SelectionTelemetryLog:
             return False
         return self._rng.random() < self._sample_rate
 
-    def _append(self, record: dict[str, Any]) -> None:
+    def _append(self, record: dict[str, Any]) -> bool:
+        """Persist one record; ``False`` only on a write failure.
+
+        An intentional redaction drop returns ``True`` — the record was
+        consumed, not failed — so ``log_selection`` keeps the documented
+        left-outer pairing semantics, while a write failure tells it that
+        nothing reached disk and the pair must be skipped.
+        """
         line = json.dumps(record, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
         # Structural redaction means no payload text should ever be here;
         # this screen is the storage-gating backstop (full DEFAULT_PATTERNS
@@ -272,7 +289,7 @@ class SelectionTelemetryLog:
             logger.warning(
                 "Dropped a selection-telemetry record that matched a sensitive-content pattern"
             )
-            return
+            return True
         data = (line + "\n").encode("utf-8")
         # Synchronous file append on the asyncio event loop: while it runs,
         # every runnable coroutine stalls — other in-flight proxied calls
@@ -300,6 +317,8 @@ class SelectionTelemetryLog:
                     )
                 else:
                     logger.debug("Selection telemetry write failed", exc_info=True)
+                return False
+        return True
 
     def _rotate_if_needed_locked(self) -> None:
         """Size-based rotation: ``log → log.1 → … → log.N``, oldest dropped.

--- a/src/memtomem_stm/proxy/selection_log.py
+++ b/src/memtomem_stm/proxy/selection_log.py
@@ -1,0 +1,324 @@
+"""Append-only JSONL sink for tool-selection telemetry (#467).
+
+The proxy is the one component in the call path, so it can record what an
+advisory analyzer never sees: which tool the client model actually called,
+out of which advertised candidate set, and how the call went. This log is
+the substrate for offline replay/eval (#468) and every later learning stage
+(#469/#470) — and for the STM-native hard filter (#465), whose reject
+reasons land in the ``reject_reasons`` field once it exists.
+
+Schema v1 — three event types, every record self-describing via
+``schema_version`` + ``ranker_version``; one JSON object per line, keys
+sorted, so a replay harness can stream-parse and diff runs:
+
+``selection``
+    ``selection_id`` (joins the paired ``execution`` row), ``trace_id``
+    (joins ``proxy_metrics.db`` for full per-stage diagnostics),
+    ``server``, ``selected_tool`` (prefixed name, same vocabulary as
+    ``candidate_tools``), ``candidate_tools`` (what the proxy last
+    advertised — today the client model does the selecting),
+    ``candidate_count``, ``reject_reasons`` (tool → reason; empty until
+    the #465 hard filter populates it), ``candidate_features`` /
+    ``graph_generation`` (reserved ``null`` until toolgraph#13/#15),
+    ``args_sha256`` + ``args_chars`` (canonical-JSON hash — see
+    redaction below), ``ts``.
+
+``execution``
+    ``selection_id`` / ``trace_id`` / ``server`` / ``selected_tool``
+    mirroring the paired selection, ``ok``, ``latency_ms`` (proxy-side
+    wall time for the full pipeline, what the agent experienced),
+    ``error_type`` (exception class name; the *typed* error category
+    stays in ``proxy_metrics.db``, joinable via ``trace_id`` — not
+    duplicated here), ``retry_count`` / ``cost`` / ``cache_hit``
+    (reserved ``null`` in v0), ``ts``.
+
+``feedback``
+    ``selection_id`` (+ optional ``trace_id``), ``user_corrected``,
+    ``operator_override``, ``ts``. Schema is pinned here and by tests,
+    but nothing in the proxy emits it yet — emitters arrive with their
+    signal sources (e.g. an operator-facing rating tool).
+
+Redaction policy is structural, not filter-based: no field ever carries
+raw arguments, results, prompts, resource URIs, or error message strings —
+argument payloads appear only as a sha256 over their canonical JSON plus a
+char count. As a belt-and-suspenders backstop (the storage-gating rule from
+``privacy.py``), every serialized line is screened with
+``contains_sensitive_content`` before persisting and dropped (counted) on a
+match, mirroring the never-persist-secrets rule from #460/#462. Files are
+created ``0o600`` with a ``0o700`` parent (#458).
+
+Sampling applies to the whole selection+execution pair at selection time —
+``log_selection`` returning ``None`` means the call is sampled out and the
+caller skips the execution event, so sampling never produces orphan halves.
+Redaction drops, by contrast, are per-record (never-persist beats pairing):
+an execution whose paired selection was dropped can appear alone, so replay
+tooling must treat ``selection_id`` joins as left-outer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import random
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from memtomem_stm.proxy.privacy import contains_sensitive_content
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+# Bump when the selection-scoring logic changes. v0 records no ranking at
+# all — the client model picks from the full advertised set — so replay
+# tooling can treat this version as the unranked baseline.
+RANKER_VERSION = "v0-passthrough"
+
+
+def _canonical_args(arguments: dict[str, Any] | None) -> str:
+    """Serialize call arguments deterministically for hashing.
+
+    ``default=str`` keeps non-JSON-native values (e.g. Path) from raising —
+    the output is only ever hashed, never persisted, so a lossy fallback
+    rendering is fine as long as it is stable.
+    """
+    return json.dumps(
+        arguments or {},
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+class SelectionTelemetryLog:
+    """Append-only JSONL writer with rotation, sampling, and redaction.
+
+    Write failures never propagate: a telemetry problem must not break the
+    proxied call it accounts for. Failures are counted (``write_errors``)
+    and logged at WARNING once per process, DEBUG thereafter.
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        max_bytes: int = 50_000_000,
+        max_backups: int = 3,
+        sample_rate: float = 1.0,
+        rng: random.Random | None = None,
+    ) -> None:
+        self._path = Path(path).expanduser()
+        self._max_bytes = max_bytes
+        self._max_backups = max_backups
+        self._sample_rate = sample_rate
+        # Injectable for deterministic sampling tests; rates 0.0 / 1.0
+        # short-circuit and never consult it.
+        self._rng = rng or random.Random()
+        # Writers share the lock defensively, same posture as MetricsStore:
+        # callers are asyncio single-thread today, but the guard makes the
+        # store ready for an off-loop move without a rewrite.
+        self._lock = threading.Lock()
+        self._warned_write_failure = False
+        # Counters are part of the observable contract (wire-in tests
+        # snapshot them); mutate only under ``self._lock``.
+        self.events_written = 0
+        self.events_sampled_out = 0
+        self.redaction_drops = 0
+        self.write_errors = 0
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def initialize(self) -> None:
+        """Create the log file privately (0600 file, 0700 parent).
+
+        Also tightens a pre-existing file left at a permissive mode by an
+        older run or umask — same rationale as
+        ``sqlite_private.ensure_private_db_files``.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        os.close(fd)
+        try:
+            self._path.chmod(0o600)
+        except OSError:
+            pass
+
+    def close(self) -> None:
+        """No-op — the file is opened per append so rotation never holds a
+        stale descriptor. Exists so lifespan teardown can treat every store
+        uniformly."""
+
+    # ── event emitters ───────────────────────────────────────────────────
+
+    def log_selection(
+        self,
+        *,
+        server: str,
+        selected_tool: str,
+        candidate_tools: list[str],
+        arguments: dict[str, Any] | None,
+        trace_id: str | None,
+    ) -> str | None:
+        """Record a selection event; returns its ``selection_id``.
+
+        Returns ``None`` when the call is sampled out — the caller must then
+        skip ``log_execution`` so pairs stay atomic.
+        """
+        if not self._sampled_in():
+            with self._lock:
+                self.events_sampled_out += 1
+            return None
+        selection_id = uuid.uuid4().hex
+        canonical = _canonical_args(arguments)
+        self._append(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "ranker_version": RANKER_VERSION,
+                "event": "selection",
+                "ts": time.time(),
+                "selection_id": selection_id,
+                "trace_id": trace_id,
+                "server": server,
+                "selected_tool": selected_tool,
+                "candidate_tools": list(candidate_tools),
+                "candidate_count": len(candidate_tools),
+                "reject_reasons": {},
+                "candidate_features": None,
+                "graph_generation": None,
+                "args_sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+                "args_chars": len(canonical),
+            }
+        )
+        return selection_id
+
+    def log_execution(
+        self,
+        *,
+        selection_id: str,
+        trace_id: str | None,
+        server: str,
+        selected_tool: str,
+        ok: bool,
+        latency_ms: float,
+        error_type: str | None = None,
+    ) -> None:
+        self._append(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "ranker_version": RANKER_VERSION,
+                "event": "execution",
+                "ts": time.time(),
+                "selection_id": selection_id,
+                "trace_id": trace_id,
+                "server": server,
+                "selected_tool": selected_tool,
+                "ok": ok,
+                "latency_ms": round(latency_ms, 3),
+                "error_type": error_type,
+                "retry_count": None,
+                "cost": None,
+                "cache_hit": None,
+            }
+        )
+
+    def log_feedback(
+        self,
+        *,
+        selection_id: str,
+        trace_id: str | None = None,
+        user_corrected: bool | None = None,
+        operator_override: bool | None = None,
+    ) -> None:
+        self._append(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "ranker_version": RANKER_VERSION,
+                "event": "feedback",
+                "ts": time.time(),
+                "selection_id": selection_id,
+                "trace_id": trace_id,
+                "user_corrected": user_corrected,
+                "operator_override": operator_override,
+            }
+        )
+
+    # ── internals ────────────────────────────────────────────────────────
+
+    def _sampled_in(self) -> bool:
+        if self._sample_rate >= 1.0:
+            return True
+        if self._sample_rate <= 0.0:
+            return False
+        return self._rng.random() < self._sample_rate
+
+    def _append(self, record: dict[str, Any]) -> None:
+        line = json.dumps(record, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+        # Structural redaction means no payload text should ever be here;
+        # this screen is the storage-gating backstop (full DEFAULT_PATTERNS
+        # per the privacy.py contract) against a secret smuggled through a
+        # field nobody expected to carry one — e.g. an upstream tool *name*.
+        # A false positive costs one dropped telemetry record, never data.
+        if contains_sensitive_content(line):
+            with self._lock:
+                self.redaction_drops += 1
+            logger.warning(
+                "Dropped a selection-telemetry record that matched a sensitive-content pattern"
+            )
+            return
+        data = (line + "\n").encode("utf-8")
+        # Synchronous file append on the asyncio event loop: while it runs,
+        # every runnable coroutine stalls — other in-flight proxied calls
+        # included. Accepted for the current local single-MCP-client
+        # deployment (same contract as MetricsStore.record): a small
+        # O_APPEND write is far cheaper than the upstream call it accounts
+        # for. Multi-client serving is the reopen trigger to move this
+        # off-loop; writers already serialize on ``self._lock``.
+        with self._lock:
+            try:
+                self._rotate_if_needed_locked()
+                fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+                try:
+                    os.write(fd, data)
+                finally:
+                    os.close(fd)
+                self.events_written += 1
+            except OSError:
+                self.write_errors += 1
+                if not self._warned_write_failure:
+                    self._warned_write_failure = True
+                    logger.warning(
+                        "Selection telemetry write failed — proxied calls unaffected",
+                        exc_info=True,
+                    )
+                else:
+                    logger.debug("Selection telemetry write failed", exc_info=True)
+
+    def _rotate_if_needed_locked(self) -> None:
+        """Size-based rotation: ``log → log.1 → … → log.N``, oldest dropped.
+
+        Renames preserve the 0600 mode; the fresh file is recreated 0600 by
+        the ``os.open`` in ``_append``. With ``max_backups == 0`` the file
+        is simply truncated by deletion (append recreates it).
+        """
+        try:
+            size = self._path.stat().st_size
+        except OSError:
+            return
+        if size < self._max_bytes:
+            return
+        if self._max_backups <= 0:
+            self._path.unlink(missing_ok=True)
+            return
+        for i in range(self._max_backups - 1, 0, -1):
+            src = self._path.with_name(f"{self._path.name}.{i}")
+            if src.exists():
+                src.replace(self._path.with_name(f"{self._path.name}.{i + 1}"))
+        self._path.replace(self._path.with_name(f"{self._path.name}.1"))

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -103,8 +103,10 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
     # Shared state — populated only when proxy is enabled
     from memtomem_stm.proxy.cache import ProxyCache
     from memtomem_stm.proxy.metrics_store import MetricsStore
+    from memtomem_stm.proxy.selection_log import SelectionTelemetryLog
 
     metrics_store: MetricsStore | None = None
+    selection_log: SelectionTelemetryLog | None = None
     proxy_cache: ProxyCache | None = None
     surfacing_engine: SurfacingEngine | None = None
     mcp_adapter = None
@@ -162,6 +164,27 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
                         exc_info=True,
                     )
                     progressive_reads_tracker = None
+
+            # Selection/execution telemetry (#467) — append-only JSONL log
+            # of which tool the client picked from the advertised set and
+            # how the call went. Opt-in; read at startup like
+            # ``metrics.enabled`` (no hot-reload).
+            if config.proxy.selection_telemetry.enabled:
+                try:
+                    st_cfg = config.proxy.selection_telemetry
+                    selection_log = SelectionTelemetryLog(
+                        st_cfg.path,
+                        max_bytes=st_cfg.max_bytes,
+                        max_backups=st_cfg.max_backups,
+                        sample_rate=st_cfg.sample_rate,
+                    )
+                    selection_log.initialize()
+                except Exception:
+                    logger.warning(
+                        "Selection telemetry init failed — telemetry disabled",
+                        exc_info=True,
+                    )
+                    selection_log = None
 
             # Surfacing engine — LTM access is always remote-only via the
             # MCP client adapter. The adapter spawns (or connects to) a
@@ -267,6 +290,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             cache=proxy_cache,
             env_overrides=proxy_env_overrides,
             progressive_reads_tracker=progressive_reads_tracker,
+            selection_log=selection_log,
         )
 
         if config.proxy.enabled:
@@ -324,6 +348,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             (feedback_tracker, "feedback_tracker"),
             (compression_feedback_tracker, "compression_feedback_tracker"),
             (progressive_reads_tracker, "progressive_reads_tracker"),
+            (selection_log, "selection_log"),
         ]:
             if resource is not None:
                 try:

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -178,6 +178,7 @@ _PROXY_MANAGER_EXPECTED_KWARGS = frozenset(
         "cache",
         "env_overrides",
         "progressive_reads_tracker",
+        "selection_log",
     }
 )
 

--- a/tests/test_selection_log.py
+++ b/tests/test_selection_log.py
@@ -1,0 +1,445 @@
+"""Tests for the selection-telemetry JSONL sink (#467).
+
+Covers the acceptance criteria: stable versioned schema (exact key sets
+pinned per event type), structural redaction (no raw argument text ever
+reaches disk) plus the sensitive-line backstop, sampling and rotation
+config, private file modes (#458), and the ProxyManager wire-in with
+counter snapshots.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ProxyConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
+from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.selection_log import (
+    RANKER_VERSION,
+    SCHEMA_VERSION,
+    SelectionTelemetryLog,
+    _canonical_args,
+)
+
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX 0o700/0o600 modes are unenforceable on Windows; chmod only toggles read-only",
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_log(tmp_path: Path, **kwargs) -> SelectionTelemetryLog:
+    log = SelectionTelemetryLog(tmp_path / "sel" / "log.jsonl", **kwargs)
+    log.initialize()
+    return log
+
+
+def _read_events(log: SelectionTelemetryLog) -> list[dict]:
+    if not log.path.exists():
+        return []
+    return [json.loads(line) for line in log.path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _log_pair(log: SelectionTelemetryLog) -> str | None:
+    sid = log.log_selection(
+        server="srv",
+        selected_tool="test__tool",
+        candidate_tools=["test__tool", "test__other"],
+        arguments={"q": "hello"},
+        trace_id="t" * 16,
+    )
+    if sid is not None:
+        log.log_execution(
+            selection_id=sid,
+            trace_id="t" * 16,
+            server="srv",
+            selected_tool="test__tool",
+            ok=True,
+            latency_ms=12.345,
+        )
+    return sid
+
+
+# ── Schema stability ─────────────────────────────────────────────────────
+
+
+SELECTION_KEYS = {
+    "schema_version",
+    "ranker_version",
+    "event",
+    "ts",
+    "selection_id",
+    "trace_id",
+    "server",
+    "selected_tool",
+    "candidate_tools",
+    "candidate_count",
+    "reject_reasons",
+    "candidate_features",
+    "graph_generation",
+    "args_sha256",
+    "args_chars",
+}
+
+EXECUTION_KEYS = {
+    "schema_version",
+    "ranker_version",
+    "event",
+    "ts",
+    "selection_id",
+    "trace_id",
+    "server",
+    "selected_tool",
+    "ok",
+    "latency_ms",
+    "error_type",
+    "retry_count",
+    "cost",
+    "cache_hit",
+}
+
+FEEDBACK_KEYS = {
+    "schema_version",
+    "ranker_version",
+    "event",
+    "ts",
+    "selection_id",
+    "trace_id",
+    "user_corrected",
+    "operator_override",
+}
+
+
+class TestSchemaStability:
+    def test_selection_and_execution_key_sets_pinned(self, tmp_path):
+        """Replayability contract: the exact v1 key set per event type.
+
+        Adding/removing/renaming a field must fail here and force a
+        ``SCHEMA_VERSION`` bump decision, not silently change the log.
+        """
+        log = _make_log(tmp_path)
+        sid = _log_pair(log)
+        log.log_feedback(selection_id=sid, user_corrected=True)
+
+        selection, execution, feedback = _read_events(log)
+        assert set(selection) == SELECTION_KEYS
+        assert set(execution) == EXECUTION_KEYS
+        assert set(feedback) == FEEDBACK_KEYS
+        for record in (selection, execution, feedback):
+            assert record["schema_version"] == SCHEMA_VERSION == 1
+            assert record["ranker_version"] == RANKER_VERSION
+
+    def test_pair_shares_selection_id_and_trace_id(self, tmp_path):
+        log = _make_log(tmp_path)
+        sid = _log_pair(log)
+
+        selection, execution = _read_events(log)
+        assert selection["event"] == "selection"
+        assert execution["event"] == "execution"
+        assert selection["selection_id"] == execution["selection_id"] == sid
+        assert selection["trace_id"] == execution["trace_id"] == "t" * 16
+
+    def test_v0_reserved_fields(self, tmp_path):
+        """Reserved-until-later fields are present and null/empty in v0 so
+        the schema doesn't change shape when #465/toolgraph populate them."""
+        log = _make_log(tmp_path)
+        _log_pair(log)
+
+        selection, execution = _read_events(log)
+        assert selection["reject_reasons"] == {}
+        assert selection["candidate_features"] is None
+        assert selection["graph_generation"] is None
+        assert execution["retry_count"] is None
+        assert execution["cost"] is None
+        assert execution["cache_hit"] is None
+
+    def test_lines_are_sorted_key_compact_json(self, tmp_path):
+        log = _make_log(tmp_path)
+        _log_pair(log)
+        first = log.path.read_text(encoding="utf-8").splitlines()[0]
+        assert first == json.dumps(
+            json.loads(first), sort_keys=True, ensure_ascii=False, separators=(",", ":")
+        )
+
+
+# ── Redaction ────────────────────────────────────────────────────────────
+
+
+class TestRedaction:
+    def test_raw_arguments_never_reach_disk(self, tmp_path):
+        """Arguments appear only as sha256 + char count — a secret-bearing
+        payload must not be findable anywhere in the log file."""
+        log = _make_log(tmp_path)
+        secret_args = {
+            "api_key": "sk-" + "a" * 24,
+            "query": "the password: hunter2 must stay out",
+            "nested": {"token": "ghp_" + "b" * 36},
+        }
+        sid = log.log_selection(
+            server="srv",
+            selected_tool="test__tool",
+            candidate_tools=["test__tool"],
+            arguments=secret_args,
+            trace_id=None,
+        )
+        assert sid is not None
+
+        raw = log.path.read_text(encoding="utf-8")
+        assert "hunter2" not in raw
+        assert "sk-" + "a" * 24 not in raw
+        assert "ghp_" not in raw
+
+        (selection,) = _read_events(log)
+        canonical = _canonical_args(secret_args)
+        assert selection["args_sha256"] == hashlib.sha256(canonical.encode()).hexdigest()
+        assert selection["args_chars"] == len(canonical)
+        assert log.events_written == 1
+        assert log.redaction_drops == 0
+
+    def test_args_hash_is_order_independent(self, tmp_path):
+        assert _canonical_args({"a": 1, "b": 2}) == _canonical_args({"b": 2, "a": 1})
+        assert _canonical_args(None) == _canonical_args({}) == "{}"
+
+    def test_sensitive_looking_field_drops_whole_record(self, tmp_path):
+        """Backstop (#460/#462 never-persist rule): a secret smuggled through
+        a field nobody expected — here an upstream tool *name* — drops the
+        record and counts it instead of persisting."""
+        log = _make_log(tmp_path)
+        sid = log.log_selection(
+            server="srv",
+            selected_tool="test__ghp_" + "c" * 36,
+            candidate_tools=[],
+            arguments={},
+            trace_id=None,
+        )
+        # The selection_id is still minted (caller pairing unaffected) but
+        # nothing was persisted.
+        assert sid is not None
+        assert _read_events(log) == []
+        assert log.redaction_drops == 1
+        assert log.events_written == 0
+
+
+# ── Sampling ─────────────────────────────────────────────────────────────
+
+
+class TestSampling:
+    def test_rate_zero_samples_everything_out(self, tmp_path):
+        log = _make_log(tmp_path, sample_rate=0.0)
+        assert _log_pair(log) is None
+        assert _read_events(log) == []
+        assert log.events_sampled_out == 1
+        assert log.events_written == 0
+
+    def test_rate_one_keeps_everything(self, tmp_path):
+        log = _make_log(tmp_path, sample_rate=1.0)
+        assert _log_pair(log) is not None
+        assert len(_read_events(log)) == 2
+        assert log.events_sampled_out == 0
+
+    def test_fractional_rate_is_deterministic_with_seeded_rng(self, tmp_path):
+        log = _make_log(tmp_path, sample_rate=0.5, rng=random.Random(42))
+        decisions = [_log_pair(log) is not None for _ in range(20)]
+        ref = random.Random(42)
+        expected = [ref.random() < 0.5 for _ in range(20)]
+        # Sampled-out pairs consume no rng draw beyond their own; the
+        # sequence of keep/drop decisions must follow the injected rng.
+        assert decisions == expected
+        assert log.events_sampled_out == decisions.count(False)
+
+
+# ── Rotation ─────────────────────────────────────────────────────────────
+
+
+class TestRotation:
+    def test_rotates_at_max_bytes_and_bounds_backups(self, tmp_path):
+        log = _make_log(tmp_path, max_bytes=1, max_backups=2)
+        # Every append rotates first (file already ≥ 1 byte), so N pairs
+        # produce a deep shift chain; only .1 and .2 may survive.
+        for _ in range(4):
+            _log_pair(log)
+
+        base = log.path
+        assert base.exists()
+        assert base.with_name(base.name + ".1").exists()
+        assert base.with_name(base.name + ".2").exists()
+        assert not base.with_name(base.name + ".3").exists()
+        # Nothing was lost to errors — every event landed in some file.
+        assert log.write_errors == 0
+        assert log.events_written == 8
+
+    def test_zero_backups_truncates(self, tmp_path):
+        log = _make_log(tmp_path, max_bytes=1, max_backups=0)
+        for _ in range(3):
+            _log_pair(log)
+        assert not log.path.with_name(log.path.name + ".1").exists()
+        # Each append truncated then wrote: exactly one event remains.
+        assert len(_read_events(log)) == 1
+
+    def test_no_rotation_below_threshold(self, tmp_path):
+        log = _make_log(tmp_path, max_bytes=50_000_000)
+        for _ in range(3):
+            _log_pair(log)
+        assert len(_read_events(log)) == 6
+        assert not log.path.with_name(log.path.name + ".1").exists()
+
+
+# ── File modes / failure isolation ───────────────────────────────────────
+
+
+class TestFilesystemPosture:
+    @_skip_on_windows
+    def test_log_file_created_0600_with_0700_parent(self, tmp_path):
+        log = _make_log(tmp_path)
+        assert log.path.stat().st_mode & 0o777 == 0o600
+        assert log.path.parent.stat().st_mode & 0o777 == 0o700
+
+    @_skip_on_windows
+    def test_initialize_tightens_preexisting_mode(self, tmp_path):
+        path = tmp_path / "log.jsonl"
+        path.touch()
+        path.chmod(0o644)
+        log = SelectionTelemetryLog(path)
+        log.initialize()
+        assert path.stat().st_mode & 0o777 == 0o600
+
+    @_skip_on_windows
+    def test_rotated_backup_stays_0600(self, tmp_path):
+        log = _make_log(tmp_path, max_bytes=1, max_backups=1)
+        _log_pair(log)
+        backup = log.path.with_name(log.path.name + ".1")
+        assert backup.exists()
+        assert backup.stat().st_mode & 0o777 == 0o600
+
+    def test_write_failure_is_swallowed_and_counted(self, tmp_path):
+        target = tmp_path / "dir-not-file"
+        target.mkdir()
+        log = SelectionTelemetryLog(target)  # appending to a directory fails
+        sid = log.log_selection(
+            server="srv",
+            selected_tool="test__tool",
+            candidate_tools=[],
+            arguments={},
+            trace_id=None,
+        )
+        assert sid is not None  # caller contract intact
+        assert log.write_errors == 1
+        assert log.events_written == 0
+
+
+# ── ProxyManager wire-in ─────────────────────────────────────────────────
+
+
+def _text_content(text: str):
+    return SimpleNamespace(type="text", text=text)
+
+
+def _make_result(text: str):
+    return SimpleNamespace(content=[_text_content(text)], isError=False)
+
+
+def _make_manager(tmp_path: Path, **log_kwargs) -> tuple[ProxyManager, SelectionTelemetryLog]:
+    server_cfg = UpstreamServerConfig(
+        prefix="test",
+        compression=CompressionStrategy.NONE,
+        max_retries=0,
+        reconnect_delay_seconds=0.0,
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={"srv": server_cfg},
+        min_result_retention=0.0,
+    )
+    log = _make_log(tmp_path, **log_kwargs)
+    mgr = ProxyManager(proxy_cfg, TokenTracker(), selection_log=log)
+
+    session = AsyncMock()
+    tool = SimpleNamespace(name="tool", description="a tool", inputSchema={"type": "object"})
+    conn = UpstreamConnection(name="srv", config=server_cfg, session=session, tools=[tool])
+    mgr._connections["srv"] = conn
+    return mgr, log
+
+
+class TestManagerWireIn:
+    async def test_success_call_writes_paired_events_with_counters(self, tmp_path):
+        mgr, log = _make_manager(tmp_path)
+        # Advertisement snapshot: candidate_tools comes from the last
+        # get_proxy_tools() result, in prefixed-name vocabulary.
+        infos = mgr.get_proxy_tools()
+        assert [i.prefixed_name for i in infos] == ["test__tool"]
+
+        mgr._connections["srv"].session.call_tool.return_value = _make_result("ok!")
+        result = await mgr.call_tool("srv", "tool", {"q": "x"}, trace_id="deadbeef00000000")
+        assert result == "ok!"
+
+        selection, execution = _read_events(log)
+        assert selection["candidate_tools"] == ["test__tool"]
+        assert selection["selected_tool"] == "test__tool"
+        assert selection["server"] == "srv"
+        assert execution["ok"] is True
+        assert execution["error_type"] is None
+        assert execution["latency_ms"] >= 0
+        assert execution["selection_id"] == selection["selection_id"]
+        assert selection["trace_id"] == execution["trace_id"] == "deadbeef00000000"
+        # Counter snapshot (wire-in contract): exactly one pair, no drops.
+        assert log.events_written == 2
+        assert log.events_sampled_out == 0
+        assert log.write_errors == 0
+
+    async def test_upstream_error_writes_ok_false_execution(self, tmp_path):
+        mgr, log = _make_manager(tmp_path)
+        mgr.get_proxy_tools()
+        mgr._connections["srv"].session.call_tool.side_effect = RuntimeError("boom")
+
+        with pytest.raises(Exception):
+            await mgr.call_tool("srv", "tool", {})
+
+        events = _read_events(log)
+        assert [e["event"] for e in events] == ["selection", "execution"]
+        execution = events[1]
+        assert execution["ok"] is False
+        assert isinstance(execution["error_type"], str) and execution["error_type"]
+        assert log.events_written == 2
+
+    async def test_sampled_out_call_emits_nothing(self, tmp_path):
+        mgr, log = _make_manager(tmp_path, sample_rate=0.0)
+        mgr.get_proxy_tools()
+        mgr._connections["srv"].session.call_tool.return_value = _make_result("ok!")
+
+        result = await mgr.call_tool("srv", "tool", {})
+        assert result == "ok!"
+        assert _read_events(log) == []
+        assert log.events_sampled_out == 1
+        assert log.events_written == 0
+
+    async def test_no_selection_log_is_default_noop(self, tmp_path):
+        """Default construction (no selection_log kwarg) keeps the call
+        path telemetry-free — the existing-manager-tests invariant."""
+        server_cfg = UpstreamServerConfig(
+            prefix="test", compression=CompressionStrategy.NONE, max_retries=0
+        )
+        proxy_cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={"srv": server_cfg},
+        )
+        mgr = ProxyManager(proxy_cfg, TokenTracker())
+        session = AsyncMock()
+        session.call_tool.return_value = _make_result("ok!")
+        mgr._connections["srv"] = UpstreamConnection(
+            name="srv", config=server_cfg, session=session, tools=[]
+        )
+        assert await mgr.call_tool("srv", "tool", {}) == "ok!"

--- a/tests/test_selection_log.py
+++ b/tests/test_selection_log.py
@@ -336,7 +336,9 @@ class TestFilesystemPosture:
             arguments={},
             trace_id=None,
         )
-        assert sid is not None  # caller contract intact
+        # Nothing reached disk, so the caller must skip the paired
+        # execution event — write failures never produce orphan halves.
+        assert sid is None
         assert log.write_errors == 1
         assert log.events_written == 0
 
@@ -424,6 +426,31 @@ class TestManagerWireIn:
         assert result == "ok!"
         assert _read_events(log) == []
         assert log.events_sampled_out == 1
+        assert log.events_written == 0
+
+    async def test_selection_write_failure_skips_execution_event(self, tmp_path):
+        """A failed selection write must not leave an orphan execution
+        record: the pair is skipped atomically. ``write_errors == 2``
+        would mean the execution write was still attempted."""
+        server_cfg = UpstreamServerConfig(
+            prefix="test", compression=CompressionStrategy.NONE, max_retries=0
+        )
+        proxy_cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={"srv": server_cfg},
+        )
+        broken_dir = tmp_path / "log-as-dir"
+        broken_dir.mkdir()
+        log = SelectionTelemetryLog(broken_dir)  # every append fails
+        mgr = ProxyManager(proxy_cfg, TokenTracker(), selection_log=log)
+        session = AsyncMock()
+        session.call_tool.return_value = _make_result("ok!")
+        mgr._connections["srv"] = UpstreamConnection(
+            name="srv", config=server_cfg, session=session, tools=[]
+        )
+
+        assert await mgr.call_tool("srv", "tool", {}) == "ok!"
+        assert log.write_errors == 1
         assert log.events_written == 0
 
     async def test_no_selection_log_is_default_noop(self, tmp_path):

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1208,6 +1208,7 @@ class TestLifespan:
             mock_cfg.proxy.metrics.enabled = False
             mock_cfg.proxy.compression_feedback.enabled = False
             mock_cfg.proxy.progressive_reads.enabled = False
+            mock_cfg.proxy.selection_telemetry.enabled = False
             mock_cfg.proxy.cache.enabled = False
             mock_cfg.surfacing = MagicMock()
             mock_cfg.surfacing.enabled = True
@@ -1258,6 +1259,7 @@ class TestLifespan:
             mock_cfg.proxy.metrics.enabled = False
             mock_cfg.proxy.compression_feedback.enabled = False
             mock_cfg.proxy.progressive_reads.enabled = False
+            mock_cfg.proxy.selection_telemetry.enabled = False
             mock_cfg.proxy.cache.enabled = False
             mock_cfg.surfacing = MagicMock()
             mock_cfg.surfacing.enabled = True


### PR DESCRIPTION
Closes #467 (Stage 3 of the tool-selection track).

## What

An append-only JSONL telemetry sink recording, per proxied call, a `selection` event (which tool the client model called, out of which advertised candidate set) and a paired `execution` event (ok/error, proxy-side latency). New module `proxy/selection_log.py`, config block `proxy.selection_telemetry`, wired in `ProxyManager.call_tool` and the server lifespan. **Off by default** — it is a new disk write path, so the operator opts in explicitly.

## Why now

The proxy is the only component in the call path; nothing persisted selection outcomes until now. Offline eval (#468) and the learning stages (#469/#470) are gated on these logs existing and accumulating, and the STM-native hard filter (#465) needs a place for its reject reasons to land. This also opens toolgraph#16's design gate (a real consumer producing selection logs).

## Schema v1 (stable + versioned — acceptance)

- One JSON object per line, keys sorted; every record carries `schema_version` (exact per-event key sets are **pinned by tests** — any shape change fails `test_selection_and_execution_key_sets_pinned` and forces a version-bump decision) and `ranker_version` (`"v0-passthrough"`: no in-proxy ranking exists yet, so this marks the unranked baseline for replay comparisons).
- `selection_id` joins the pair; `trace_id` joins `proxy_metrics.db` for typed error categories and stage timings instead of duplicating them into the log.
- Reserved-null fields (`reject_reasons`, `candidate_features`, `graph_generation`, `retry_count`, `cost`, `cache_hit`) keep the v1 shape stable when #465 / toolgraph#13/#15 populate them.
- `feedback` event (`user_corrected` / `operator_override`) is schema-pinned with an emitter-less `log_feedback` API — nothing in the proxy produces that signal today; emitters arrive with their signal sources.

## Redaction (acceptance)

Structural, not filter-based: no field ever carries raw arguments, results, prompts, resource URIs, or error message strings. Arguments appear only as canonical-JSON sha256 + char count; error detail beyond the exception class name stays in `proxy_metrics.db` behind the `trace_id` join (same reasoning as #462's error-text handling). Backstop: every serialized line is screened with `contains_sensitive_content` (the `privacy.py` storage-gating rule) and dropped + counted on match — the never-persist posture of #460/#462. Files are created `0600` under a `0700` parent (#458); rotation preserves the mode.

## Sampling / rotation (acceptance)

`sample_rate` applies to the selection+execution pair atomically at selection time (no orphan halves from sampling; redaction-backstop drops are per-record by design — documented as a left-outer join contract). Size-based rotation at `max_bytes` keeping `max_backups` files; `0` truncates.

## Behavior change

- New opt-in write path: with `selection_telemetry.enabled = true`, the proxy appends 2 JSONL records per proxied call to `~/.memtomem/stm_selection_log.jsonl` (0600). With the default `enabled = false` there is **no behavior change** — `ProxyManager` takes an optional `selection_log` that defaults to `None` and the call path is telemetry-free.
- The write is a synchronous file append on the event loop, same accepted contract (and same documented reopen trigger) as `MetricsStore.record`.
- Telemetry failures never propagate: write errors are counted and logged, the proxied call proceeds untouched (covered by tests, including append-to-a-directory).

## Tests

- 22 new tests in `tests/test_selection_log.py`: exact key-set pinning per event type, pair `selection_id`/`trace_id` joining, reserved-field nullness, canonical-hash redaction (secret-bearing args unfindable on disk), sensitive-line backstop drop + counter, deterministic seeded-rng sampling, rotation bounds + zero-backup truncation, 0600/0700 modes (POSIX-only, Windows-skipped per repo convention), write-failure isolation, and ProxyManager wire-in with **counter snapshots** (`events_written` / `events_sampled_out` / `write_errors`) on success, upstream-error, sampled-out, and telemetry-disabled paths.
- `tests/test_server_tools.py` lifespan mocks gain `selection_telemetry.enabled = False`; `tests/test_docs_sync.py` allowlists the new `ProxyManager` kwarg.
- Full suite: 3224 passed, 3 skipped (`-m "not ollama"`); `ruff check` + `ruff format --check src` clean.

## Follow-ups (not in this PR)

- Surfacing telemetry counters via `stm_proxy_stats` (operator visibility).
- `cache_hit` population (needs a hit/miss signal at the `call_tool` boundary).
- #465 hard filter writing real `reject_reasons`; #466 ranking stamping a real `ranker_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
