### PR TITLE
feat(proxy): deterministic BM25 tool-relevance ranking into selection telemetry (#466)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,6 +305,10 @@ Full example with all options:
     "sample_rate": 1.0,
     "max_bytes": 50000000,
     "max_backups": 3
+  },
+  "tool_relevance": {
+    "enabled": true,
+    "top_n": 20
   }
 }
 ```
@@ -316,6 +320,12 @@ redaction policy (no raw arguments, results, or error text ever reach the
 log), and the replay-join contract are documented in
 [selection-telemetry.md](selection-telemetry.md). The flag is read at
 startup, like `metrics.enabled` — toggling it requires a restart.
+
+`tool_relevance` ranks the advertised tools against each call's query signal
+(deterministic BM25) and records the result into the selection event's
+`candidate_features` — telemetry input only, exposure never changes. It is
+inert unless `selection_telemetry` is enabled, hot-reloadable, and bounded
+by `top_n`. Details in [selection-telemetry.md](selection-telemetry.md).
 
 ### Token-equivalent budgets (CJK / non-Latin workloads)
 

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -36,10 +36,11 @@ failures produce orphan halves.
 
 One JSON object per line, keys sorted, every record self-describing via
 `schema_version` (bumped on any shape change — the exact key sets are pinned
-by `tests/test_selection_log.py`) and `ranker_version` (`"v0-passthrough"`
-today: no in-proxy ranking exists, the client model picks from the full
-advertised set, so replay tooling can treat this version as the unranked
-baseline).
+by `tests/test_selection_log.py`) and `ranker_version`, a per-call cohort
+marker stamped on both halves of a pair: `"v0-passthrough"` when no ranking
+informed the call (the client model picked from the full advertised set
+unaided — the unranked baseline) and `"v1-bm25-tool-relevance"` when the
+#466 ranking ran (see [Tool-relevance ranking](#tool-relevance-ranking-466-v0)).
 
 ### `selection` — one per proxied call
 
@@ -50,7 +51,8 @@ baseline).
 | `server`, `selected_tool` | prefixed name, same vocabulary as `candidate_tools` |
 | `candidate_tools`, `candidate_count` | what the proxy last advertised (`get_proxy_tools()` snapshot) |
 | `reject_reasons` | `{}` until the #465 hard filter populates it (tool → reason) |
-| `candidate_features`, `graph_generation` | reserved `null` until toolgraph#13/#15 integration |
+| `candidate_features` | ranking output object when #466 ranking ran (shape below); `null` otherwise |
+| `graph_generation` | reserved `null` until toolgraph#13 integration |
 | `args_sha256`, `args_chars` | canonical-JSON hash + length of the call arguments |
 | `ts` | unix seconds |
 
@@ -69,6 +71,45 @@ baseline).
 `selection_id`, optional `trace_id`, `user_corrected`, `operator_override`.
 Nothing in the proxy produces this signal today; emitters arrive with their
 signal sources (e.g. an operator-facing rating tool).
+
+## Tool-relevance ranking (#466 v0)
+
+When `tool_relevance.enabled` (default `true`, inert without
+`selection_telemetry.enabled` — there is nowhere else for the output to go
+in v0), each call's advertised candidate set is ranked against the call's
+query signal and recorded in `candidate_features`:
+
+```json
+{
+  "query_source": "context_query | args",
+  "query_sha256": "…",
+  "query_chars": 42,
+  "ranked_candidates": [
+    {"tool": "gh__create_issue", "rank": 1, "relevance_score": 2.41,
+     "risk_penalty": 0.0, "final_score": 2.41}
+  ]
+}
+```
+
+- **Telemetry input only — exposure never changes.** No `tools/list`
+  reorder, no `list_changed`, no meta-tool. Whether the ranking is worth
+  acting on is what offline replay (#468) decides from these records;
+  dynamic exposure is deferred until that evidence exists.
+- **Deterministic by construction**: BM25 only (the embedding scorer is
+  deliberately excluded — its scores drift across providers/model versions,
+  which would poison replay comparisons), candidates are the *advertised*
+  artifacts (post-truncation description, post-distill schema — what the
+  client actually saw), ties break on the prefixed name, never discovery
+  order. Same inputs → byte-identical output, pinned by
+  `tests/test_tool_relevance.py`.
+- **Query signal**: `_context_query` when the caller attaches one, else the
+  call's top-level string argument values (sorted by key, capped); no
+  signal → no ranking, and the pair keeps the `v0-passthrough` baseline.
+  The raw query never enters the log — `query_source`/sha256/length only.
+- `risk_penalty` is a `0.0` placeholder: no risk table exists in this repo;
+  a real penalty input arrives with #465's STM-native filter signals.
+- `top_n` (default 20) bounds `ranked_candidates`; the full advertised set
+  is already in `candidate_tools`.
 
 ## Redaction policy
 

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -551,6 +551,23 @@ class SelectionTelemetryConfig(BaseModel):
     """Rotated files kept (``.1`` … ``.N``); ``0`` truncates instead."""
 
 
+class ToolRelevanceConfig(BaseModel):
+    """Configuration for per-call tool-relevance ranking (#466 v0).
+
+    Deterministic BM25 ranking of the advertised tool set against the
+    call's query signal, recorded ONLY into selection telemetry
+    (``candidate_features``) — exposure never changes. Inert unless
+    ``selection_telemetry.enabled`` is also on (there is nowhere else for
+    the ranking to go in v0), so the default-on here adds no write path
+    by itself. Read per call via the hot-reloaded proxy config.
+    """
+
+    enabled: bool = True
+    top_n: int = Field(default=20, gt=0)
+    """Ranked candidates recorded per selection event (full advertised
+    set is already in ``candidate_tools``; this bounds the scored list)."""
+
+
 # Static context window sizes (tokens) for known model families.
 # Used by ProxyConfig.effective_max_result_chars() to scale compression budget.
 # Prefix-matched: "claude-sonnet-4-20250514" matches "claude-sonnet-4".
@@ -684,6 +701,7 @@ class ProxyConfig(BaseModel):
     )
     progressive_reads: ProgressiveReadsConfig = Field(default_factory=ProgressiveReadsConfig)
     selection_telemetry: SelectionTelemetryConfig = Field(default_factory=SelectionTelemetryConfig)
+    tool_relevance: ToolRelevanceConfig = Field(default_factory=ToolRelevanceConfig)
 
     @model_validator(mode="after")
     def _check_nonempty_upstream_prefixes(self) -> Self:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -64,6 +64,12 @@ from memtomem_stm.proxy.memory_ops import (
 )
 from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS as PRIVACY_CREDENTIAL_PATTERNS
 from memtomem_stm.proxy.token_estimate import tokens_to_chars
+from memtomem_stm.proxy.tool_relevance import (
+    RANKER_VERSION_BM25,
+    ToolRelevanceRanker,
+    build_candidate_features,
+    derive_query,
+)
 from memtomem_stm.proxy.tool_metadata import (
     convention_suffix,
     distill_schema,
@@ -161,11 +167,13 @@ class ProxyManager:
         self._cache = cache
         self._progressive_reads_tracker = progressive_reads_tracker
         self._selection_log = selection_log
-        # Snapshot of the prefixed tool names last returned by
+        # Snapshots of the advertisement last returned by
         # ``get_proxy_tools()`` — the candidate set the client model picked
-        # from, recorded in selection telemetry (#467). Empty until the
-        # first advertisement.
+        # from: names go into selection telemetry (#467), the full infos
+        # feed tool-relevance ranking (#466). Empty until the first
+        # advertisement.
         self._advertised_tools: list[str] = []
+        self._advertised_infos: list[ProxyToolInfo] = []
         self._connections: dict[str, UpstreamConnection] = {}
         self._stack: AsyncExitStack | None = None
         self._selective_compressor: SelectiveCompressor | None = None
@@ -517,6 +525,7 @@ class ProxyManager:
                         annotations=getattr(t, "annotations", None),
                     )
                 )
+        self._advertised_infos = result
         self._advertised_tools = [info.prefixed_name for info in result]
         return result
 
@@ -1213,7 +1222,10 @@ class ProxyManager:
         # ``candidate_tools`` vocabulary, so replay tooling can match the
         # selected tool against the advertised set verbatim.
         selected_tool = f"{self._connections[server].config.prefix}__{tool}"
-        selection_id = self._log_selection(server, selected_tool, arguments, trace_id)
+        candidate_features, ranker_version = self._rank_candidates(arguments)
+        selection_id = self._log_selection(
+            server, selected_tool, arguments, trace_id, candidate_features, ranker_version
+        )
         started = _time.perf_counter()
         with traced(
             "proxy_call",
@@ -1269,10 +1281,51 @@ class ProxyManager:
                     started,
                     ok=False,
                     error_type=type(exc).__name__,
+                    ranker_version=ranker_version,
                 )
                 raise
-            self._log_execution(selection_id, server, selected_tool, trace_id, started, ok=True)
+            self._log_execution(
+                selection_id,
+                server,
+                selected_tool,
+                trace_id,
+                started,
+                ok=True,
+                ranker_version=ranker_version,
+            )
             return result
+
+    def _rank_candidates(
+        self, arguments: dict[str, Any]
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        """Tool-relevance ranking for one call (#466 v0) — telemetry input only.
+
+        Returns ``(candidate_features, ranker_version)`` for the selection
+        event, or ``(None, None)`` when ranking did not run: telemetry off,
+        ranking disabled, nothing advertised yet, no query signal in the
+        call, or the ranker failed — the event then keeps the
+        unranked-baseline ``ranker_version`` so replay can split cohorts.
+        Runs before the sink's sampling decision, so a sampled-out call
+        wastes one cheap BM25 pass rather than leaking the sampling
+        decision out of the sink.
+        """
+        if self._selection_log is None:
+            return None, None
+        trc = self._config.tool_relevance
+        if not trc.enabled or not self._advertised_infos:
+            return None, None
+        try:
+            derived = derive_query(arguments)
+            if derived is None:
+                return None, None
+            query, source = derived
+            ranked = ToolRelevanceRanker(top_n=trc.top_n).rank(query, self._advertised_infos)
+            if not ranked:
+                return None, None
+            return build_candidate_features(query, source, ranked), RANKER_VERSION_BM25
+        except Exception:
+            logger.debug("Tool-relevance ranking failed", exc_info=True)
+            return None, None
 
     def _log_selection(
         self,
@@ -1280,6 +1333,8 @@ class ProxyManager:
         selected_tool: str,
         arguments: dict[str, Any],
         trace_id: str,
+        candidate_features: dict[str, Any] | None = None,
+        ranker_version: str | None = None,
     ) -> str | None:
         """Emit the selection-telemetry event for one proxied call (#467).
 
@@ -1297,6 +1352,8 @@ class ProxyManager:
                 candidate_tools=self._advertised_tools,
                 arguments=arguments,
                 trace_id=trace_id,
+                candidate_features=candidate_features,
+                ranker_version=ranker_version,
             )
         except Exception:
             logger.debug("Selection telemetry write failed", exc_info=True)
@@ -1312,12 +1369,15 @@ class ProxyManager:
         *,
         ok: bool,
         error_type: str | None = None,
+        ranker_version: str | None = None,
     ) -> None:
         """Emit the execution-outcome event paired to ``selection_id``.
 
         ``error_type`` is the exception class name only; the typed error
         category and message live in ``proxy_metrics.db``, joinable via
         ``trace_id`` — telemetry never duplicates (or leaks) error text.
+        ``ranker_version`` mirrors the paired selection so replay groups
+        both halves under the same cohort.
         """
         if self._selection_log is None or selection_id is None:
             return
@@ -1330,6 +1390,7 @@ class ProxyManager:
                 ok=ok,
                 latency_ms=(_time.perf_counter() - started) * 1000.0,
                 error_type=error_type,
+                ranker_version=ranker_version,
             )
         except Exception:
             logger.debug("Execution telemetry write failed", exc_info=True)

--- a/src/memtomem_stm/proxy/selection_log.py
+++ b/src/memtomem_stm/proxy/selection_log.py
@@ -78,9 +78,12 @@ logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
 
-# Bump when the selection-scoring logic changes. v0 records no ranking at
-# all — the client model picks from the full advertised set — so replay
-# tooling can treat this version as the unranked baseline.
+# Per-record default when no ranking informed the call — the client model
+# picked from the full advertised set unaided — so replay tooling can treat
+# this version as the unranked baseline. Calls where a ranker ran stamp
+# their own version (e.g. ``tool_relevance.RANKER_VERSION_BM25``) on BOTH
+# halves of the pair via the ``ranker_version`` parameter, letting replay
+# split cohorts on this field alone.
 RANKER_VERSION = "v0-passthrough"
 
 
@@ -171,11 +174,16 @@ class SelectionTelemetryLog:
         candidate_tools: list[str],
         arguments: dict[str, Any] | None,
         trace_id: str | None,
+        candidate_features: dict[str, Any] | None = None,
+        ranker_version: str | None = None,
     ) -> str | None:
         """Record a selection event; returns its ``selection_id``.
 
         Returns ``None`` when the call is sampled out — the caller must then
-        skip ``log_execution`` so pairs stay atomic.
+        skip ``log_execution`` so pairs stay atomic. ``candidate_features``
+        is the ranker's output object (#466) — the caller guarantees it
+        carries no raw text, only scores/hashes; ``ranker_version`` stamps
+        which ranker produced it (``None`` = the unranked default).
         """
         if not self._sampled_in():
             with self._lock:
@@ -186,7 +194,7 @@ class SelectionTelemetryLog:
         appended = self._append(
             {
                 "schema_version": SCHEMA_VERSION,
-                "ranker_version": RANKER_VERSION,
+                "ranker_version": ranker_version or RANKER_VERSION,
                 "event": "selection",
                 "ts": time.time(),
                 "selection_id": selection_id,
@@ -196,7 +204,7 @@ class SelectionTelemetryLog:
                 "candidate_tools": list(candidate_tools),
                 "candidate_count": len(candidate_tools),
                 "reject_reasons": {},
-                "candidate_features": None,
+                "candidate_features": candidate_features,
                 "graph_generation": None,
                 "args_sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
                 "args_chars": len(canonical),
@@ -219,11 +227,12 @@ class SelectionTelemetryLog:
         ok: bool,
         latency_ms: float,
         error_type: str | None = None,
+        ranker_version: str | None = None,
     ) -> None:
         self._append(
             {
                 "schema_version": SCHEMA_VERSION,
-                "ranker_version": RANKER_VERSION,
+                "ranker_version": ranker_version or RANKER_VERSION,
                 "event": "execution",
                 "ts": time.time(),
                 "selection_id": selection_id,

--- a/src/memtomem_stm/proxy/tool_relevance.py
+++ b/src/memtomem_stm/proxy/tool_relevance.py
@@ -1,0 +1,136 @@
+"""Deterministic task-relevance ranking over advertised proxy tools (#466 v0).
+
+v0 contract — telemetry input only, never an exposure change: the ranking is
+computed per proxied call from the *advertised* tool snapshot and recorded
+into the #467 selection event's reserved ``candidate_features`` field. It
+does not reorder ``tools/list``, does not emit ``list_changed``, and does not
+gate anything. Whether it is worth acting on is exactly what the offline
+replay stage (#468) decides from these records; dynamic exposure mechanisms
+are deferred until then.
+
+Determinism is an acceptance criterion, so v0 is BM25-only
+(:class:`~memtomem_stm.proxy.relevance.BM25Scorer` — zero dependencies, same
+score for the same inputs forever). The embedding scorer is deliberately not
+offered here: its scores drift across providers/model versions and its
+availability varies, which would make #468 replay comparisons meaningless.
+
+The scored document per candidate is what the client actually saw: the
+prefixed tool name (BM25 heading position, 3x weight) plus the advertised —
+post-truncation, post-distill — description and stable-serialized schema.
+``risk_penalty`` is a ``0.0`` placeholder: no risk table exists in this repo
+(the one in the toolgraph report is not a repo artifact); a real penalty
+input arrives with #465's STM-native filter signals.
+
+Privacy: the derived query is used in memory for scoring only — callers
+persist its sha256/length/source via ``build_candidate_features``, never the
+text, matching the selection log's structural-redaction contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+from memtomem_stm.proxy.relevance import BM25Scorer
+
+if TYPE_CHECKING:
+    from memtomem_stm.proxy.manager import ProxyToolInfo
+
+# Stamped on selection/execution events whose ranking ran; events where it
+# did not (no query signal, ranking disabled, empty candidate set) keep the
+# selection log's "v0-passthrough" default, so replay can split cohorts by
+# this field alone.
+RANKER_VERSION_BM25 = "v1-bm25-tool-relevance"
+
+# Bound the schema text folded into each candidate document. Schemas are
+# advertised (possibly distilled) client-facing artifacts, but a pathological
+# upstream schema should cost bounded scoring work; the cap is deterministic
+# so truncation never varies between identical calls.
+_MAX_SCHEMA_CHARS = 2000
+
+# Bound the args-derived fallback query the same way.
+_MAX_QUERY_CHARS = 512
+
+
+def derive_query(arguments: dict[str, Any] | None) -> tuple[str, str] | None:
+    """Derive the per-call task signal: ``(query, source)`` or ``None``.
+
+    ``_context_query`` — the explicit task text some harnesses attach — wins
+    outright. Otherwise fall back to the call's top-level string argument
+    values, sorted by key for determinism (dict iteration order is caller
+    noise) and capped. No usable signal returns ``None`` and the caller
+    skips ranking entirely rather than ranking against an empty query.
+    """
+    if not arguments:
+        return None
+    ctx = arguments.get("_context_query")
+    if isinstance(ctx, str) and ctx.strip():
+        return ctx[:_MAX_QUERY_CHARS], "context_query"
+    parts = [
+        v.strip()
+        for k, v in sorted(arguments.items())
+        if not k.startswith("_") and isinstance(v, str) and v.strip()
+    ]
+    if not parts:
+        return None
+    return " ".join(parts)[:_MAX_QUERY_CHARS], "args"
+
+
+def _candidate_document(info: ProxyToolInfo) -> tuple[str, str]:
+    """(heading, body) for BM25: name as heading, advertised text as body."""
+    schema_text = json.dumps(info.input_schema or {}, sort_keys=True, separators=(",", ":"))
+    return info.prefixed_name, f"{info.description} {schema_text[:_MAX_SCHEMA_CHARS]}"
+
+
+class ToolRelevanceRanker:
+    """Rank advertised tools against a query, deterministically.
+
+    Ties (including the all-zero scores of a query that matches nothing)
+    break on the prefixed name, never on upstream discovery order — two
+    runs over the same advertised set and query must produce byte-identical
+    ``ranked_candidates``.
+    """
+
+    def __init__(self, *, top_n: int = 20) -> None:
+        self._top_n = top_n
+        self._scorer = BM25Scorer()
+
+    def rank(self, query: str, candidates: list[ProxyToolInfo]) -> list[dict[str, Any]]:
+        if not candidates:
+            return []
+        sections = [_candidate_document(c) for c in candidates]
+        scores = self._scorer.score_sections(query, sections)
+        order = sorted(
+            range(len(candidates)),
+            key=lambda i: (-scores[i], candidates[i].prefixed_name),
+        )
+        return [
+            {
+                "tool": candidates[i].prefixed_name,
+                "rank": rank,
+                "relevance_score": round(scores[i], 6),
+                # Placeholder until a repo-local risk signal exists (#465);
+                # recorded explicitly so replay code never special-cases
+                # its absence.
+                "risk_penalty": 0.0,
+                "final_score": round(scores[i], 6),
+            }
+            for rank, i in enumerate(order[: self._top_n], start=1)
+        ]
+
+
+def build_candidate_features(
+    query: str, query_source: str, ranked: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Assemble the ``candidate_features`` object for the selection event.
+
+    Carries the query only as sha256 + char count + source tag — the raw
+    text never enters the telemetry record.
+    """
+    return {
+        "query_source": query_source,
+        "query_sha256": hashlib.sha256(query.encode("utf-8")).hexdigest(),
+        "query_chars": len(query),
+        "ranked_candidates": ranked,
+    }

--- a/tests/test_selection_log.py
+++ b/tests/test_selection_log.py
@@ -175,6 +175,38 @@ class TestSchemaStability:
             json.loads(first), sort_keys=True, ensure_ascii=False, separators=(",", ":")
         )
 
+    def test_ranker_fields_are_per_call_overridable(self, tmp_path):
+        """#466 wires real values into the reserved seams: the top-level
+        key sets must NOT change — candidate_features is populated, not
+        added, and ranker_version is stamped per record on both halves."""
+        log = _make_log(tmp_path)
+        feats = {"query_source": "args", "query_sha256": "0" * 64, "query_chars": 4,
+                 "ranked_candidates": []}
+        sid = log.log_selection(
+            server="srv",
+            selected_tool="test__tool",
+            candidate_tools=["test__tool"],
+            arguments={},
+            trace_id=None,
+            candidate_features=feats,
+            ranker_version="v1-bm25-tool-relevance",
+        )
+        log.log_execution(
+            selection_id=sid,
+            trace_id=None,
+            server="srv",
+            selected_tool="test__tool",
+            ok=True,
+            latency_ms=1.0,
+            ranker_version="v1-bm25-tool-relevance",
+        )
+        selection, execution = _read_events(log)
+        assert set(selection) == SELECTION_KEYS
+        assert set(execution) == EXECUTION_KEYS
+        assert selection["candidate_features"] == feats
+        assert selection["ranker_version"] == "v1-bm25-tool-relevance"
+        assert execution["ranker_version"] == "v1-bm25-tool-relevance"
+
 
 # ── Redaction ────────────────────────────────────────────────────────────
 

--- a/tests/test_tool_relevance.py
+++ b/tests/test_tool_relevance.py
@@ -1,0 +1,249 @@
+"""Tests for deterministic tool-relevance ranking (#466 v0).
+
+Pins the acceptance criteria: deterministic, reproducible ranking given the
+same inputs (byte-identical ``ranked_candidates``, alphabetical tie-break,
+no dependence on upstream discovery order), the privacy posture (raw query
+text never enters telemetry — sha256/length/source only), and the v0
+boundary (ranking is telemetry input via ``candidate_features``; exposure
+never changes).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ProxyConfig,
+    ToolRelevanceConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager, ProxyToolInfo, UpstreamConnection
+from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.selection_log import SelectionTelemetryLog
+from memtomem_stm.proxy.tool_relevance import (
+    RANKER_VERSION_BM25,
+    ToolRelevanceRanker,
+    build_candidate_features,
+    derive_query,
+)
+
+FEATURES_KEYS = {"query_source", "query_sha256", "query_chars", "ranked_candidates"}
+RANKED_ENTRY_KEYS = {"tool", "rank", "relevance_score", "risk_penalty", "final_score"}
+
+
+def _info(name: str, description: str, schema: dict | None = None) -> ProxyToolInfo:
+    return ProxyToolInfo(
+        prefixed_name=f"test__{name}",
+        description=description,
+        input_schema=schema or {"type": "object"},
+        server="srv",
+        original_name=name,
+    )
+
+
+CANDIDATES = [
+    _info(
+        "send_message",
+        "Send a message to a Slack channel",
+        {"type": "object", "properties": {"channel": {"type": "string"}}},
+    ),
+    _info("read_file", "Read a file from the local filesystem"),
+    _info("create_issue", "Create a GitHub issue in a repository"),
+]
+
+
+# ── derive_query ─────────────────────────────────────────────────────────
+
+
+class TestDeriveQuery:
+    def test_context_query_wins(self):
+        q = derive_query({"_context_query": "deploy the service", "path": "/tmp/x"})
+        assert q == ("deploy the service", "context_query")
+
+    def test_fallback_joins_string_values_sorted_by_key(self):
+        q = derive_query({"b": "world", "a": "hello", "n": 3, "flag": True})
+        assert q == ("hello world", "args")
+
+    def test_underscore_keys_excluded_from_fallback(self):
+        assert derive_query({"_private": "secret hint", "q": "real"}) == ("real", "args")
+
+    def test_no_signal_returns_none(self):
+        assert derive_query(None) is None
+        assert derive_query({}) is None
+        assert derive_query({"n": 3, "flag": False}) is None
+        assert derive_query({"blank": "   "}) is None
+
+    def test_query_is_capped(self):
+        q = derive_query({"text": "x" * 10_000})
+        assert q is not None and len(q[0]) == 512
+
+
+# ── ToolRelevanceRanker ──────────────────────────────────────────────────
+
+
+class TestRanker:
+    def test_relevant_tool_ranks_first(self):
+        ranked = ToolRelevanceRanker().rank("send a slack message to the channel", CANDIDATES)
+        assert ranked[0]["tool"] == "test__send_message"
+        assert ranked[0]["rank"] == 1
+        assert ranked[0]["relevance_score"] > ranked[-1]["relevance_score"]
+
+    def test_byte_identical_across_runs(self):
+        a = ToolRelevanceRanker().rank("read the config file", CANDIDATES)
+        b = ToolRelevanceRanker().rank("read the config file", CANDIDATES)
+        assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+    def test_no_match_ties_break_alphabetically_not_by_discovery_order(self):
+        # Query shares no token with any candidate → all scores equal (0).
+        ranked = ToolRelevanceRanker().rank("zzz qqq", list(reversed(CANDIDATES)))
+        assert [r["tool"] for r in ranked] == [
+            "test__create_issue",
+            "test__read_file",
+            "test__send_message",
+        ]
+
+    def test_top_n_caps_output(self):
+        ranked = ToolRelevanceRanker(top_n=2).rank("file", CANDIDATES)
+        assert len(ranked) == 2
+        assert [r["rank"] for r in ranked] == [1, 2]
+
+    def test_entry_shape_pinned(self):
+        """Per-candidate key set is replay contract — a change here must be
+        a deliberate decision, mirrored in docs/selection-telemetry.md."""
+        ranked = ToolRelevanceRanker().rank("slack", CANDIDATES)
+        for entry in ranked:
+            assert set(entry) == RANKED_ENTRY_KEYS
+            assert entry["risk_penalty"] == 0.0
+            assert entry["final_score"] == entry["relevance_score"]
+
+    def test_empty_candidates(self):
+        assert ToolRelevanceRanker().rank("anything", []) == []
+
+
+# ── build_candidate_features ─────────────────────────────────────────────
+
+
+class TestFeatures:
+    def test_shape_and_hash(self):
+        ranked = ToolRelevanceRanker().rank("slack", CANDIDATES)
+        feats = build_candidate_features("send to slack", "context_query", ranked)
+        assert set(feats) == FEATURES_KEYS
+        assert feats["query_sha256"] == hashlib.sha256(b"send to slack").hexdigest()
+        assert feats["query_chars"] == len("send to slack")
+
+    def test_raw_query_never_in_features(self):
+        feats = build_candidate_features("hunter2 secret task", "context_query", [])
+        assert "hunter2" not in json.dumps(feats)
+
+
+# ── ProxyManager wire-in ─────────────────────────────────────────────────
+
+
+def _make_result(text: str):
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=text)], isError=False)
+
+
+def _make_manager(
+    tmp_path: Path, *, relevance_enabled: bool = True
+) -> tuple[ProxyManager, SelectionTelemetryLog]:
+    server_cfg = UpstreamServerConfig(
+        prefix="test",
+        compression=CompressionStrategy.NONE,
+        max_retries=0,
+        reconnect_delay_seconds=0.0,
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={"srv": server_cfg},
+        tool_relevance=ToolRelevanceConfig(enabled=relevance_enabled),
+    )
+    log = SelectionTelemetryLog(tmp_path / "log.jsonl")
+    log.initialize()
+    mgr = ProxyManager(proxy_cfg, TokenTracker(), selection_log=log)
+
+    tools = [
+        SimpleNamespace(
+            name="send_message",
+            description="Send a message to a Slack channel",
+            inputSchema={"type": "object", "properties": {"channel": {"type": "string"}}},
+        ),
+        SimpleNamespace(
+            name="read_file",
+            description="Read a file from the local filesystem",
+            inputSchema={"type": "object"},
+        ),
+    ]
+    session = AsyncMock()
+    session.call_tool.return_value = _make_result("ok!")
+    mgr._connections["srv"] = UpstreamConnection(
+        name="srv", config=server_cfg, session=session, tools=tools
+    )
+    mgr.get_proxy_tools()  # advertise → snapshot names + infos
+    return mgr, log
+
+
+def _events(log: SelectionTelemetryLog) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in log.path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+
+
+class TestManagerWireIn:
+    async def test_ranked_call_populates_features_and_version_on_both_events(self, tmp_path):
+        mgr, log = _make_manager(tmp_path)
+        query = "send a slack message to the alerts channel"
+        await mgr.call_tool("srv", "send_message", {"_context_query": query})
+
+        selection, execution = _events(log)
+        assert selection["ranker_version"] == RANKER_VERSION_BM25
+        assert execution["ranker_version"] == RANKER_VERSION_BM25
+        feats = selection["candidate_features"]
+        assert set(feats) == FEATURES_KEYS
+        assert feats["query_source"] == "context_query"
+        assert feats["query_sha256"] == hashlib.sha256(query.encode()).hexdigest()
+        assert feats["ranked_candidates"][0]["tool"] == "test__send_message"
+        assert {r["tool"] for r in feats["ranked_candidates"]} == {
+            "test__send_message",
+            "test__read_file",
+        }
+        # Privacy: the raw query text exists nowhere in the log file.
+        assert query not in log.path.read_text(encoding="utf-8")
+        # Exposure unchanged: ranking never reorders the advertised snapshot.
+        assert selection["candidate_tools"] == ["test__send_message", "test__read_file"]
+
+    async def test_no_query_signal_keeps_unranked_baseline(self, tmp_path):
+        mgr, log = _make_manager(tmp_path)
+        await mgr.call_tool("srv", "read_file", {})
+
+        selection, execution = _events(log)
+        assert selection["candidate_features"] is None
+        assert selection["ranker_version"] == "v0-passthrough"
+        assert execution["ranker_version"] == "v0-passthrough"
+
+    async def test_disabled_config_keeps_unranked_baseline(self, tmp_path):
+        mgr, log = _make_manager(tmp_path, relevance_enabled=False)
+        await mgr.call_tool("srv", "read_file", {"_context_query": "read the file"})
+
+        selection, _ = _events(log)
+        assert selection["candidate_features"] is None
+        assert selection["ranker_version"] == "v0-passthrough"
+
+    async def test_upstream_error_still_mirrors_ranker_version(self, tmp_path):
+        import pytest
+
+        mgr, log = _make_manager(tmp_path)
+        mgr._connections["srv"].session.call_tool.side_effect = RuntimeError("boom")
+
+        with pytest.raises(Exception):
+            await mgr.call_tool("srv", "send_message", {"_context_query": "send slack"})
+
+        selection, execution = _events(log)
+        assert execution["ok"] is False
+        assert selection["ranker_version"] == execution["ranker_version"] == RANKER_VERSION_BM25


### PR DESCRIPTION
Implements the v0 of #466 per the design decision recorded on the issue (in-repo BM25-only scorer; telemetry-only ranking — option (c)). Does **not** close #466: the issue stays open as the umbrella for the stage-2 exposure mechanisms (`list_changed` / meta-tool), which are gated on #468 replay evidence.

## What

New `proxy/tool_relevance.py`: a deterministic per-call ranker over the advertised tool snapshot, recorded into the #467 selection event's reserved `candidate_features` field, with `ranker_version` stamped per call (`"v1-bm25-tool-relevance"` on both halves of the pair when ranking ran; `"v0-passthrough"` baseline otherwise). Config block `tool_relevance` (`enabled` default `true`, `top_n` default 20) — **inert unless `selection_telemetry.enabled`**, so it adds no write path by itself; hot-reloadable (read per call from the proxy config).

## Why this shape

- **Telemetry input only — exposure never changes.** No `tools/list` reorder, no `list_changed` bet (client support unverifiable today), no meta-tool. #468 offline replay decides from these records whether ranking is worth acting on; acting on it is stage 2.
- **Deterministic by construction** (the acceptance criterion): BM25 only — the embedding scorer is deliberately excluded because its scores drift across providers/model versions, which would poison replay comparisons. Candidates are scored exactly as the client saw them (prefixed name as BM25 heading at 3× weight; advertised post-truncation description + stable-serialized post-distill schema as body). Ties — including the all-zero case — break on the prefixed name, never upstream discovery order: same inputs → byte-identical `ranked_candidates`.
- **Query signal**: `_context_query` when present, else top-level string argument values (sorted by key for determinism, underscore-prefixed keys excluded, capped at 512 chars). No signal → no ranking → pair keeps the unranked baseline, giving replay a natural cohort split.
- **`risk_penalty: 0.0` placeholder**: correction to the issue body — no risk table exists in this repo (it lives in the toolgraph report). Recorded explicitly so replay code never special-cases its absence; a real penalty input arrives with #465's STM-native filter signals.

## Schema impact (none structural)

Populating reserved `candidate_features` is the designed-for path, so `schema_version` stays **1** — top-level key sets are unchanged (re-pinned by tests). `ranker_version` was always per-record; it now varies per call and is mirrored on the paired execution event so replay groups both halves into the same cohort. The `candidate_features` object's own key set and the per-candidate entry shape are pinned by `tests/test_tool_relevance.py` as a replay contract.

## Privacy

The raw query is used in memory for scoring only; telemetry carries `query_source` + sha256 + char count. The existing line-level `contains_sensitive_content` backstop screens the whole record (features included) before persisting. Wire-in test asserts the raw query text appears nowhere in the log file.

## Behavior change

With `selection_telemetry.enabled = true` (still off by default), selection events now carry a populated `candidate_features` object and a per-call `ranker_version`, and each proxied call with a query signal spends one in-process BM25 pass over the advertised tool set (zero I/O, zero network; runs before the sink's sampling decision, so a sampled-out call wastes one cheap pass rather than leaking the sampling decision out of the sink). With telemetry off — the default — there is no behavior change; ranking failures degrade to the unranked baseline and never affect the proxied call.

## Tests

18 new (17 in `tests/test_tool_relevance.py` + 1 sink-level): query derivation (context-query precedence, sorted-key fallback, underscore exclusion, no-signal → None, cap), byte-identical reruns, alphabetical tie-break against reversed discovery order, `top_n` cap, pinned entry/feature key sets, sha256 correctness, raw-query-absent-from-disk, and manager wire-in for ranked / no-signal / disabled / upstream-error paths (ranker_version mirrored on both events). Full suite: 3242 passed, 3 skipped (`-m "not ollama"`); `ruff check` + `ruff format --check src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)