### PR TITLE
feat(proxy): STM-native tool-eligibility hard filter at exposure time (#465)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,6 +263,9 @@ Full example with all options:
         "search_code": {
           "compression": "selective",
           "max_result_chars": 8000
+        },
+        "delete_repository": {
+          "expose_in_profiles": ["explore"]
         }
       }
     }
@@ -309,6 +312,13 @@ Full example with all options:
   "tool_relevance": {
     "enabled": true,
     "top_n": 20
+  },
+  "exposure": {
+    "profile": "strict",
+    "health_window_hours": 24.0,
+    "health_min_calls": 5,
+    "health_error_rate_threshold": 0.95,
+    "review_risk_penalty": 0.5
   }
 }
 ```
@@ -326,6 +336,24 @@ startup, like `metrics.enabled` — toggling it requires a restart.
 `candidate_features` — telemetry input only, exposure never changes. It is
 inert unless `selection_telemetry` is enabled, hot-reloadable, and bounded
 by `top_n`. Details in [selection-telemetry.md](selection-telemetry.md).
+
+`exposure` configures the tool-exposure hard filter: at advertisement time
+the proxy rejects tools that are config-hidden, scoped out of the active
+profile via `expose_in_profiles` (per-upstream or per-tool — tool wins),
+structurally broken (composed name over the 64-char MCP limit, duplicate
+composed names), or — under the `strict` profile — flagged by a signal:
+credential-looking text in the tool's description/schema, or a
+consistently-failing recent history in `proxy_metrics.db`
+(`health_error_rate_threshold` over `health_min_calls`+ calls within
+`health_window_hours`; only upstream-attributable errors count). Under
+`review`, signal-flagged tools stay advertised but carry
+`review_risk_penalty` in tool-relevance telemetry; under `explore`, signal
+rules are off. Health is evaluated once at startup, so the advertised set
+is stable for the session — a health-hidden tool is re-evaluated at the
+next restart and returns once its failures age out of the window. Reject
+reasons land in each selection event's `reject_reasons` when
+`selection_telemetry` is enabled; see
+[selection-telemetry.md](selection-telemetry.md) for the reason vocabulary.
 
 ### Token-equivalent budgets (CJK / non-Latin workloads)
 

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -134,16 +134,23 @@ reason code`:
 | `config_hidden` | per-tool `hidden: true` override | all |
 | `profile_excluded` | `expose_in_profiles` does not include the active profile | all |
 | `name_overflow` | composed client-side name exceeds the 64-char MCP limit | all |
-| `duplicate_name` | composed name already claimed by an earlier eligible tool | all |
 | `sensitive_metadata` | credential-pattern match in the tool's description/schema | rejects under `strict`; demotes under `review` |
 | `unhealthy` | upstream-attributable error rate over the recent metrics window crossed the threshold | rejects under `strict`; demotes under `review` |
 
 Reason codes are the only #465 payload in the log — no tool metadata, no
-error text — so the redaction policy below is untouched. A rejected tool
-never appears in `candidate_tools` or `ranked_candidates`: ranking runs
-over the filter's eligible output and can never resurrect a reject
-(pinned by `tests/test_tool_eligibility.py`). The codes are additive
-vocabulary: replay tooling should treat unknown codes as opaque.
+error text — so the redaction policy below is untouched. `reject_reasons`
+keys are **disjoint from `candidate_tools` by construction**: an entry
+means that composed name was withheld from the client entirely. Same-named
+duplicate occurrences (a pathological state — composed-name uniqueness is
+normally guaranteed by config validation plus the connect-time guard) are
+dropped and logged at WARNING with a `duplicate_name` verdict but never
+recorded here, because the name stays advertised via its first eligible
+occurrence and telemetry must not claim it was both advertised and
+withheld. A rejected tool never appears in `candidate_tools` or
+`ranked_candidates`: ranking runs over the filter's eligible output and
+can never resurrect a reject (both pinned by
+`tests/test_tool_eligibility.py`). The codes are additive vocabulary:
+replay tooling should treat unknown codes as opaque.
 
 ## Redaction policy
 

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -131,6 +131,7 @@ reason code`:
 
 | code | meaning | profiles |
 |---|---|---|
+| `duplicate_name` | composed name carried by more than one discovered tool — the entire ambiguous group is withheld | all |
 | `config_hidden` | per-tool `hidden: true` override | all |
 | `profile_excluded` | `expose_in_profiles` does not include the active profile | all |
 | `name_overflow` | composed client-side name exceeds the 64-char MCP limit | all |
@@ -140,15 +141,15 @@ reason code`:
 Reason codes are the only #465 payload in the log — no tool metadata, no
 error text — so the redaction policy below is untouched. `reject_reasons`
 keys are **disjoint from `candidate_tools` by construction**: an entry
-means that composed name was withheld from the client entirely. Same-named
-duplicate occurrences (a pathological state — config validation rejects
-duplicate upstream prefixes, so this needs a misbehaving upstream or a
-bypassed config) are dropped and logged at WARNING with a `duplicate_name`
-verdict but never recorded here, because the name stays advertised via its
-first eligible occurrence and telemetry must not claim it was both
-advertised and withheld. A rejected tool never appears in `candidate_tools` or
-`ranked_candidates`: ranking runs over the filter's eligible output and
-can never resurrect a reject (both pinned by
+means that composed name was withheld from the client entirely. Ambiguous
+names are never auto-exposed in any profile: upstream calls route by raw
+tool name, so same-named occurrences (a pathological state — config
+validation rejects duplicate upstream prefixes, so this needs a
+misbehaving upstream or a bypassed config) are one callable entity wearing
+several metadata claims, and advertising a "clean" copy would attach
+metadata that does not bind to what executes. A rejected tool never
+appears in `candidate_tools` or `ranked_candidates`: ranking runs over the
+filter's eligible output and can never resurrect a reject (both pinned by
 `tests/test_tool_eligibility.py`). The codes are additive vocabulary:
 replay tooling should treat unknown codes as opaque.
 

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -141,12 +141,12 @@ Reason codes are the only #465 payload in the log — no tool metadata, no
 error text — so the redaction policy below is untouched. `reject_reasons`
 keys are **disjoint from `candidate_tools` by construction**: an entry
 means that composed name was withheld from the client entirely. Same-named
-duplicate occurrences (a pathological state — composed-name uniqueness is
-normally guaranteed by config validation plus the connect-time guard) are
-dropped and logged at WARNING with a `duplicate_name` verdict but never
-recorded here, because the name stays advertised via its first eligible
-occurrence and telemetry must not claim it was both advertised and
-withheld. A rejected tool never appears in `candidate_tools` or
+duplicate occurrences (a pathological state — config validation rejects
+duplicate upstream prefixes, so this needs a misbehaving upstream or a
+bypassed config) are dropped and logged at WARNING with a `duplicate_name`
+verdict but never recorded here, because the name stays advertised via its
+first eligible occurrence and telemetry must not claim it was both
+advertised and withheld. A rejected tool never appears in `candidate_tools` or
 `ranked_candidates`: ranking runs over the filter's eligible output and
 can never resurrect a reject (both pinned by
 `tests/test_tool_eligibility.py`). The codes are additive vocabulary:

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -5,8 +5,9 @@ proxy sits in the call path, so it can record what an advisory analyzer never
 sees: which tool the client model actually called, out of which advertised
 candidate set, and how the call went. This log is the substrate for offline
 replay/eval (#468) and later learning stages (#469/#470), and the landing
-zone for hard-filter reject reasons once the STM-native selector ships
-(#465).
+zone for the STM-native hard filter's reject reasons (#465) — replay sees
+the tools that were withheld from the advertisement, not just the ones in
+it.
 
 Off by default — it is a new disk write path, so the operator opts in:
 
@@ -39,8 +40,11 @@ One JSON object per line, keys sorted, every record self-describing via
 by `tests/test_selection_log.py`) and `ranker_version`, a per-call cohort
 marker stamped on both halves of a pair: `"v0-passthrough"` when no ranking
 informed the call (the client model picked from the full advertised set
-unaided — the unranked baseline) and `"v1-bm25-tool-relevance"` when the
-#466 ranking ran (see [Tool-relevance ranking](#tool-relevance-ranking-466-v0)).
+unaided — the unranked baseline), `"v1-bm25-tool-relevance"` when the #466
+ranking ran (see [Tool-relevance ranking](#tool-relevance-ranking-466-v0)),
+and `"v2-bm25-risk-penalty"` when at least one nonzero #465 risk penalty
+shaped the scores (an all-zero penalty map is v1 math and keeps the v1
+stamp).
 
 ### `selection` — one per proxied call
 
@@ -50,7 +54,7 @@ unaided — the unranked baseline) and `"v1-bm25-tool-relevance"` when the
 | `trace_id` | joins `proxy_metrics.db` for per-stage diagnostics |
 | `server`, `selected_tool` | prefixed name, same vocabulary as `candidate_tools` |
 | `candidate_tools`, `candidate_count` | what the proxy last advertised (`get_proxy_tools()` snapshot) |
-| `reject_reasons` | `{}` until the #465 hard filter populates it (tool → reason) |
+| `reject_reasons` | prefixed tool → reason code for every tool the #465 filter withheld from that advertisement (see [Hard-filter reject reasons](#hard-filter-reject-reasons-465)); `{}` when nothing was rejected |
 | `candidate_features` | ranking output object when #466 ranking ran (shape below); `null` otherwise |
 | `graph_generation` | reserved `null` until toolgraph#13 integration |
 | `args_sha256`, `args_chars` | canonical-JSON hash + length of the call arguments |
@@ -106,10 +110,40 @@ query signal and recorded in `candidate_features`:
   call's top-level string argument values (sorted by key, capped); no
   signal → no ranking, and the pair keeps the `v0-passthrough` baseline.
   The raw query never enters the log — `query_source`/sha256/length only.
-- `risk_penalty` is a `0.0` placeholder: no risk table exists in this repo;
-  a real penalty input arrives with #465's STM-native filter signals.
+- `risk_penalty` is the #465 hard filter's demotion input: under the
+  `review` exposure profile a signal-flagged tool stays advertised but
+  carries the configured penalty, and `final_score = relevance_score *
+  (1 - risk_penalty)` (ordering follows `final_score`). Multiplicative
+  because BM25 scores are unbounded. Penalties are session-stable (health
+  flags are computed once at startup), so records stay deterministic
+  within a session and self-describing across sessions. When any nonzero
+  penalty applied, both pair halves stamp `"v2-bm25-risk-penalty"`.
 - `top_n` (default 20) bounds `ranked_candidates`; the full advertised set
   is already in `candidate_tools`.
+
+## Hard-filter reject reasons (#465)
+
+The exposure filter (`proxy/tool_eligibility.py`, configured by the
+`exposure` block — see [configuration.md](configuration.md)) decides at
+advertisement time which discovered tools the client model gets to see.
+Every withheld tool appears in `reject_reasons` as `prefixed_name →
+reason code`:
+
+| code | meaning | profiles |
+|---|---|---|
+| `config_hidden` | per-tool `hidden: true` override | all |
+| `profile_excluded` | `expose_in_profiles` does not include the active profile | all |
+| `name_overflow` | composed client-side name exceeds the 64-char MCP limit | all |
+| `duplicate_name` | composed name already claimed by an earlier eligible tool | all |
+| `sensitive_metadata` | credential-pattern match in the tool's description/schema | rejects under `strict`; demotes under `review` |
+| `unhealthy` | upstream-attributable error rate over the recent metrics window crossed the threshold | rejects under `strict`; demotes under `review` |
+
+Reason codes are the only #465 payload in the log — no tool metadata, no
+error text — so the redaction policy below is untouched. A rejected tool
+never appears in `candidate_tools` or `ranked_candidates`: ranking runs
+over the filter's eligible output and can never resurrect a reject
+(pinned by `tests/test_tool_eligibility.py`). The codes are additive
+vocabulary: replay tooling should treat unknown codes as opaque.
 
 ## Redaction policy
 

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -197,6 +197,29 @@ class TransportType(StrEnum):
     STREAMABLE_HTTP = "streamable_http"
 
 
+class ExposureProfile(StrEnum):
+    """Operating mode for the tool-exposure hard filter (#465).
+
+    Controls how *signal-based* eligibility rules (runtime health,
+    sensitive-metadata scan) are enforced at tool-advertisement time.
+    Structural rules (composed-name overflow, duplicate names) and explicit
+    config rules (``hidden``, ``expose_in_profiles``) apply in every profile
+    — a profile never overrides what the operator wrote or what would break
+    the client.
+
+    - ``strict`` (default): signal rules hard-reject — flagged tools are not
+      advertised, with the reason recorded in selection telemetry.
+    - ``review``: signal rules demote instead of reject — flagged tools stay
+      advertised but carry a ``risk_penalty`` in tool-relevance telemetry
+      (#466), so an operator can observe what *would* be hidden.
+    - ``explore``: signal rules are off.
+    """
+
+    STRICT = "strict"
+    REVIEW = "review"
+    EXPLORE = "explore"
+
+
 class LLMProvider(StrEnum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
@@ -396,6 +419,16 @@ class ToolOverrideConfig(BaseModel):
     extraction: bool | None = None
     hidden: bool = False
     description_override: str | None = None
+    expose_in_profiles: list[ExposureProfile] | None = None
+    """Exposure profiles in which this tool is advertised (#465).
+
+    ``None`` (default) means every profile. A set list restricts the tool to
+    those profiles — e.g. ``["explore"]`` keeps a destructive admin tool out
+    of production exposure. Overrides the upstream-level
+    ``expose_in_profiles`` when both are set. An empty list is equivalent to
+    ``hidden: true``. This is a visibility constraint only; it does not
+    exempt the tool from signal-based rules in the profiles where it is
+    visible."""
 
 
 class UpstreamServerConfig(BaseModel):
@@ -427,6 +460,11 @@ class UpstreamServerConfig(BaseModel):
     tool_overrides: dict[str, ToolOverrideConfig] = {}
     auto_index: bool | None = None
     extraction: bool | None = None
+    expose_in_profiles: list[ExposureProfile] | None = None
+    """Exposure profiles in which this upstream's tools are advertised
+    (#465). ``None`` (default) means every profile. Per-tool
+    ``expose_in_profiles`` overrides this when set. See
+    ``ToolOverrideConfig.expose_in_profiles``."""
     surfacing_enabled: bool = True
     """Opt this upstream's proxied tool responses in/out of the SURFACE stage
     (proactive memory surfacing). Default ``True`` preserves existing behavior;
@@ -568,6 +606,45 @@ class ToolRelevanceConfig(BaseModel):
     set is already in ``candidate_tools``; this bounds the scored list)."""
 
 
+class ExposureConfig(BaseModel):
+    """Configuration for the STM-native tool-exposure hard filter (#465).
+
+    The filter runs at advertisement time (``ProxyManager.get_proxy_tools``)
+    — the proxy's tool-exposure choke point — and decides which upstream
+    tools the client model gets to see. Rejected tools are not registered;
+    their reject reasons land in selection telemetry (#467,
+    ``reject_reasons``) when it is enabled. Relevance ranking (#466) runs
+    over the filter's *output*, so a hard-rejected tool can never be
+    resurrected by ranking.
+
+    Health signals are evaluated once at proxy startup from the persisted
+    metrics store (``proxy_metrics.db``), so the advertised set is stable
+    for the lifetime of the session — MCP clients are not guaranteed to
+    re-list tools, and a mid-session change would make telemetry lie about
+    what the client saw. A tool hidden for health is re-evaluated at the
+    next startup: once its failures age out of ``health_window_hours`` it
+    is advertised again (startup-grained half-open probing).
+    """
+
+    profile: ExposureProfile = ExposureProfile.STRICT
+    health_window_hours: float = Field(default=24.0, gt=0.0)
+    """Look-back window over ``proxy_metrics.db`` for per-tool health."""
+    health_min_calls: int = Field(default=5, gt=0)
+    """Minimum calls inside the window before health is judged at all —
+    below this the tool is presumed healthy (insufficient evidence)."""
+    health_error_rate_threshold: float = Field(default=0.95, gt=0.0, le=1.0)
+    """Upstream-attributable error rate (transport / timeout / protocol /
+    upstream_error — proxy-internal pipeline errors do not count against
+    the tool) at or above which a tool is flagged unhealthy. The default
+    is deliberately conservative: only consistently failing tools
+    (≥95% of recent calls) are flagged."""
+    review_risk_penalty: float = Field(default=0.5, ge=0.0, le=1.0)
+    """Multiplicative demotion recorded for signal-flagged tools under the
+    ``review`` profile: ``final_score = relevance_score * (1 - penalty)``
+    in tool-relevance telemetry (#466). Exposure itself never changes in
+    ``review``."""
+
+
 # Static context window sizes (tokens) for known model families.
 # Used by ProxyConfig.effective_max_result_chars() to scale compression budget.
 # Prefix-matched: "claude-sonnet-4-20250514" matches "claude-sonnet-4".
@@ -702,6 +779,7 @@ class ProxyConfig(BaseModel):
     progressive_reads: ProgressiveReadsConfig = Field(default_factory=ProgressiveReadsConfig)
     selection_telemetry: SelectionTelemetryConfig = Field(default_factory=SelectionTelemetryConfig)
     tool_relevance: ToolRelevanceConfig = Field(default_factory=ToolRelevanceConfig)
+    exposure: ExposureConfig = Field(default_factory=ExposureConfig)
 
     @model_validator(mode="after")
     def _check_nonempty_upstream_prefixes(self) -> Self:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -304,17 +304,18 @@ class ProxyManager:
                     srv_cfg.compression.value,
                 )
 
-        # Defense-in-depth: prefix uniqueness is the primary check in
-        # ``ProxyConfig._check_unique_upstream_prefixes``. This guard still
-        # runs because ``model_construct()`` and any future config source
-        # could bypass validation, in which case dropping (and logging) the
-        # second-loaded tool prevents two handlers from racing for the same
-        # composed name (whether the registry overwrites or raises is an
-        # implementation detail of the downstream MCP server).
-        seen_prefixed: set[str] = set()
+        # Composed-name uniqueness (prefix uniqueness is validated in
+        # ``ProxyConfig._check_unique_upstream_prefixes``; ``model_construct()``
+        # or a future config source could bypass it) and the 64-char overflow
+        # rule are enforced at EXPOSURE time by the #465 eligibility filter
+        # in ``get_proxy_tools()`` — the single choke point, so the verdicts
+        # reach telemetry and the reconnect path gets the same treatment.
+        # Registration iterates the filter's output, so two handlers can
+        # never race for one composed name. ``_connect_server`` keeps every
+        # discovered tool and only logs guidance.
         for name, cfg in servers.items():
             try:
-                await self._connect_server(name, cfg, seen_prefixed)
+                await self._connect_server(name, cfg)
             except Exception:
                 logger.exception("Failed to connect to upstream server '%s'", name)
 
@@ -348,9 +349,7 @@ class ProxyManager:
                     StdioServerParameters(command=cfg.command, args=cfg.args, env=cfg.env)
                 )
 
-    async def _connect_server(
-        self, name: str, cfg: UpstreamServerConfig, seen_prefixed: set[str]
-    ) -> None:
+    async def _connect_server(self, name: str, cfg: UpstreamServerConfig) -> None:
         if self._stack is None:
             raise RuntimeError("ProxyManager.start() not called")
 
@@ -377,23 +376,22 @@ class ProxyManager:
                 )
             raise
 
-        valid_tools = []
+        # #261 operator guidance, logged at discovery where the config
+        # context is at hand. The tool itself stays in ``conn.tools``: the
+        # actual exclusion happens at exposure time in ``get_proxy_tools()``
+        # (eligibility filter, reason ``name_overflow``), so the verdict is
+        # one choke point and reaches telemetry. Clients (Claude Code,
+        # Antigravity, Anthropic SDK) silently drop tools whose composed
+        # name overflows the 64-char regex — better one withheld tool than
+        # a mystery-missing one.
         for t in result.tools:
-            prefixed = f"{cfg.prefix}__{t.name}"
-            if prefixed in seen_prefixed:
-                logger.warning("Skipping duplicate tool: %s", prefixed)
-                continue
-            # #261: clients (Claude Code, Antigravity, Anthropic SDK) silently
-            # drop tools whose composed name overflows the 64-char regex. We
-            # skip here so the rest of the upstream's catalogue still
-            # registers — better one missing tool than the whole upstream.
             if tool_name_budget.overflows(cfg.prefix, t.name):
                 logger.warning(
-                    "Skipping tool '%s' from upstream '%s': composed client "
-                    "name 'mcp__%s__%s__%s' is %d chars, exceeds the %d-char "
-                    "MCP limit. Shorten the '%s' prefix in stm_proxy.json, or "
-                    "register STM under 'mms' (3 chars) in your MCP client "
-                    "config to save 9 chars of overhead.",
+                    "Tool '%s' from upstream '%s' will not be advertised: "
+                    "composed client name 'mcp__%s__%s__%s' is %d chars, "
+                    "exceeds the %d-char MCP limit. Shorten the '%s' prefix "
+                    "in stm_proxy.json, or register STM under 'mms' (3 chars) "
+                    "in your MCP client config to save 9 chars of overhead.",
                     t.name,
                     name,
                     tool_name_budget.client_server_name(),
@@ -403,14 +401,11 @@ class ProxyManager:
                     tool_name_budget.TOOL_NAME_LIMIT,
                     cfg.prefix,
                 )
-                continue
-            seen_prefixed.add(prefixed)
-            valid_tools.append(t)
 
         self._connections[name] = UpstreamConnection(
-            name=name, config=cfg, session=session, tools=valid_tools, stack=conn_stack
+            name=name, config=cfg, session=session, tools=list(result.tools), stack=conn_stack
         )
-        logger.info("Connected to '%s' (%s tools)", name, len(valid_tools))
+        logger.info("Connected to '%s' (%s tools)", name, len(result.tools))
 
     async def _reconnect_server(self, name: str) -> None:
         conn = self._connections[name]

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -186,6 +186,7 @@ class ProxyManager:
         self._advertised_infos: list[ProxyToolInfo] = []
         self._advertised_reject_reasons: dict[str, str] = {}
         self._advertised_risk_penalties: dict[str, float] = {}
+        self._advertised_dropped_occurrences: list[tuple[str, str]] = []
         # Health flags for the #465 filter, computed ONCE per start() from
         # the persisted metrics store and held for the session — exposure
         # must not drift between the startup advertisement (what the client
@@ -577,23 +578,28 @@ class ProxyManager:
                 )
 
         verdict = filter_tools(candidates, self._config.exposure, self._unhealthy_tools)
-        if verdict.reject_reasons != self._advertised_reject_reasons:
-            self._log_exposure_rejects(verdict.reject_reasons)
+        if (
+            verdict.reject_reasons != self._advertised_reject_reasons
+            or verdict.dropped_occurrences != self._advertised_dropped_occurrences
+        ):
+            self._log_exposure_rejects(verdict.reject_reasons, verdict.dropped_occurrences)
         self._advertised_infos = verdict.eligible
         self._advertised_tools = [info.prefixed_name for info in verdict.eligible]
         self._advertised_reject_reasons = verdict.reject_reasons
         self._advertised_risk_penalties = verdict.risk_penalties
+        self._advertised_dropped_occurrences = verdict.dropped_occurrences
         return verdict.eligible
 
     @staticmethod
-    def _log_exposure_rejects(reject_reasons: dict[str, str]) -> None:
+    def _log_exposure_rejects(
+        reject_reasons: dict[str, str], dropped_occurrences: list[tuple[str, str]]
+    ) -> None:
         """One line per advertisement *change*, so operators see what was
         withheld and why without per-call noise. Config-driven rejects
         (``hidden``, profile scoping) are the operator's own choices — those
-        log at DEBUG; everything else (structural, signal) is news and logs
-        at WARNING."""
-        if not reject_reasons:
-            return
+        log at DEBUG; everything else (structural rejects, signal rejects,
+        and same-named occurrence drops, which never reach telemetry) is
+        news and logs at WARNING."""
         expected = {REASON_CONFIG_HIDDEN, REASON_PROFILE_EXCLUDED}
         news = {t: r for t, r in reject_reasons.items() if r not in expected}
         if news:
@@ -601,6 +607,13 @@ class ProxyManager:
                 "Exposure filter withheld %d tool(s): %s",
                 len(news),
                 ", ".join(f"{t} ({r})" for t, r in sorted(news.items())),
+            )
+        if dropped_occurrences:
+            logger.warning(
+                "Exposure filter dropped %d same-named tool occurrence(s) "
+                "(name stays advertised via its first eligible occurrence): %s",
+                len(dropped_occurrences),
+                ", ".join(f"{t} ({r})" for t, r in sorted(dropped_occurrences)),
             )
         if len(news) < len(reject_reasons):
             logger.debug(

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -42,6 +42,7 @@ from memtomem_stm.proxy.compression import (
 from memtomem_stm.proxy.config import (
     CleaningConfig,
     CompressionStrategy,
+    ExposureProfile,
     HybridConfig,
     LLMCompressorConfig,
     ProgressiveConfig,
@@ -64,8 +65,16 @@ from memtomem_stm.proxy.memory_ops import (
 )
 from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS as PRIVACY_CREDENTIAL_PATTERNS
 from memtomem_stm.proxy.token_estimate import tokens_to_chars
+from memtomem_stm.proxy.tool_eligibility import (
+    REASON_CONFIG_HIDDEN,
+    REASON_PROFILE_EXCLUDED,
+    ExposureCandidate,
+    compute_health_flags,
+    filter_tools,
+)
 from memtomem_stm.proxy.tool_relevance import (
     RANKER_VERSION_BM25,
+    RANKER_VERSION_BM25_RISK,
     ToolRelevanceRanker,
     build_candidate_features,
     derive_query,
@@ -170,10 +179,19 @@ class ProxyManager:
         # Snapshots of the advertisement last returned by
         # ``get_proxy_tools()`` — the candidate set the client model picked
         # from: names go into selection telemetry (#467), the full infos
-        # feed tool-relevance ranking (#466). Empty until the first
-        # advertisement.
+        # feed tool-relevance ranking (#466), the hard filter's verdict
+        # (#465) rides along as reject reasons + review-profile risk
+        # penalties. Empty until the first advertisement.
         self._advertised_tools: list[str] = []
         self._advertised_infos: list[ProxyToolInfo] = []
+        self._advertised_reject_reasons: dict[str, str] = {}
+        self._advertised_risk_penalties: dict[str, float] = {}
+        # Health flags for the #465 filter, computed ONCE per start() from
+        # the persisted metrics store and held for the session — exposure
+        # must not drift between the startup advertisement (what the client
+        # registered) and later get_proxy_tools() calls (teardown, tests),
+        # or telemetry would lie about the candidate set the client saw.
+        self._unhealthy_tools: frozenset[tuple[str, str]] = frozenset()
         self._connections: dict[str, UpstreamConnection] = {}
         self._stack: AsyncExitStack | None = None
         self._selective_compressor: SelectiveCompressor | None = None
@@ -298,6 +316,25 @@ class ProxyManager:
                 await self._connect_server(name, cfg, seen_prefixed)
             except Exception:
                 logger.exception("Failed to connect to upstream server '%s'", name)
+
+        # #465: evaluate per-tool health once per session, before the first
+        # advertisement. get_proxy_tools() applies this cached snapshot so
+        # the advertised set stays stable for the session; the next start()
+        # re-evaluates (startup-grained half-open probing — see
+        # proxy/tool_eligibility.py). Without a metrics store (metrics
+        # disabled) there is no health signal and the filter runs on
+        # config/structural rules alone.
+        exposure_cfg = self._config.exposure
+        self._unhealthy_tools = compute_health_flags(self.tracker.metrics_store, exposure_cfg)
+        if (
+            self.tracker.metrics_store is None
+            and exposure_cfg.profile is not ExposureProfile.EXPLORE
+        ):
+            logger.info(
+                "Exposure profile '%s' active without a metrics store — "
+                "health-based eligibility signals unavailable",
+                exposure_cfg.profile.value,
+            )
 
     def _open_transport(self, cfg: UpstreamServerConfig):  # noqa: ANN201
         match cfg.transport:
@@ -472,7 +509,18 @@ class ProxyManager:
     _convention_suffix = staticmethod(convention_suffix)
 
     def get_proxy_tools(self) -> list[ProxyToolInfo]:
-        result: list[ProxyToolInfo] = []
+        """Advertise upstream tools, gated by the #465 eligibility filter.
+
+        Builds the would-be advertisement for EVERY discovered tool (hidden
+        ones included — they used to be skipped inline here, and now become
+        structured ``config_hidden`` rejects instead) and hands the set to
+        ``tool_eligibility.filter_tools``, the single exposure choke point.
+        Only the filter's eligible output is returned/registered; the
+        reject reasons and review-profile risk penalties are snapshotted
+        alongside the advertisement so selection telemetry (#467) and
+        relevance ranking (#466) describe exactly this exposure decision.
+        """
+        candidates: list[ExposureCandidate] = []
         global_max_desc = self._config.max_description_chars
         global_strip = self._config.strip_schema_descriptions
 
@@ -482,10 +530,7 @@ class ProxyManager:
             strip = cfg.strip_schema_descriptions or global_strip
 
             for t in conn.tools:
-                # Check per-tool hidden override
                 override = cfg.tool_overrides.get(t.name)
-                if override is not None and override.hidden:
-                    continue
 
                 # Resolve effective compression + hybrid config for convention suffix
                 effective_compression = cfg.compression
@@ -515,19 +560,53 @@ class ProxyManager:
                 if strip:
                     schema = self._distill_schema(schema, True)
 
-                result.append(
-                    ProxyToolInfo(
-                        prefixed_name=f"{cfg.prefix}__{t.name}",
-                        description=desc,
-                        input_schema=schema,
-                        server=conn.name,
-                        original_name=t.name,
-                        annotations=getattr(t, "annotations", None),
+                candidates.append(
+                    ExposureCandidate(
+                        info=ProxyToolInfo(
+                            prefixed_name=f"{cfg.prefix}__{t.name}",
+                            description=desc,
+                            input_schema=schema,
+                            server=conn.name,
+                            original_name=t.name,
+                            annotations=getattr(t, "annotations", None),
+                        ),
+                        raw_description=t.description or "",
+                        raw_schema=t.inputSchema,
+                        server_config=cfg,
                     )
                 )
-        self._advertised_infos = result
-        self._advertised_tools = [info.prefixed_name for info in result]
-        return result
+
+        verdict = filter_tools(candidates, self._config.exposure, self._unhealthy_tools)
+        if verdict.reject_reasons != self._advertised_reject_reasons:
+            self._log_exposure_rejects(verdict.reject_reasons)
+        self._advertised_infos = verdict.eligible
+        self._advertised_tools = [info.prefixed_name for info in verdict.eligible]
+        self._advertised_reject_reasons = verdict.reject_reasons
+        self._advertised_risk_penalties = verdict.risk_penalties
+        return verdict.eligible
+
+    @staticmethod
+    def _log_exposure_rejects(reject_reasons: dict[str, str]) -> None:
+        """One line per advertisement *change*, so operators see what was
+        withheld and why without per-call noise. Config-driven rejects
+        (``hidden``, profile scoping) are the operator's own choices — those
+        log at DEBUG; everything else (structural, signal) is news and logs
+        at WARNING."""
+        if not reject_reasons:
+            return
+        expected = {REASON_CONFIG_HIDDEN, REASON_PROFILE_EXCLUDED}
+        news = {t: r for t, r in reject_reasons.items() if r not in expected}
+        if news:
+            logger.warning(
+                "Exposure filter withheld %d tool(s): %s",
+                len(news),
+                ", ".join(f"{t} ({r})" for t, r in sorted(news.items())),
+            )
+        if len(news) < len(reject_reasons):
+            logger.debug(
+                "Exposure filter applied config rejects: %s",
+                ", ".join(f"{t} ({r})" for t, r in sorted(reject_reasons.items()) if r in expected),
+            )
 
     @staticmethod
     def _create_scorer(config: ProxyConfig) -> RelevanceScorer:
@@ -1319,10 +1398,21 @@ class ProxyManager:
             if derived is None:
                 return None, None
             query, source = derived
-            ranked = ToolRelevanceRanker(top_n=trc.top_n).rank(query, self._advertised_infos)
+            penalties = self._advertised_risk_penalties
+            ranked = ToolRelevanceRanker(top_n=trc.top_n).rank(
+                query, self._advertised_infos, penalties
+            )
             if not ranked:
                 return None, None
-            return build_candidate_features(query, source, ranked), RANKER_VERSION_BM25
+            # The risk-penalty pathway changes the scoring function, so the
+            # cohort stamp must change with it — but only when a penalty
+            # actually shaped the scores (an all-zero map is v1 math).
+            version = (
+                RANKER_VERSION_BM25_RISK
+                if any(p > 0.0 for p in penalties.values())
+                else RANKER_VERSION_BM25
+            )
+            return build_candidate_features(query, source, ranked), version
         except Exception:
             logger.debug("Tool-relevance ranking failed", exc_info=True)
             return None, None
@@ -1354,6 +1444,7 @@ class ProxyManager:
                 trace_id=trace_id,
                 candidate_features=candidate_features,
                 ranker_version=ranker_version,
+                reject_reasons=self._advertised_reject_reasons,
             )
         except Exception:
             logger.debug("Selection telemetry write failed", exc_info=True)

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -186,7 +186,6 @@ class ProxyManager:
         self._advertised_infos: list[ProxyToolInfo] = []
         self._advertised_reject_reasons: dict[str, str] = {}
         self._advertised_risk_penalties: dict[str, float] = {}
-        self._advertised_dropped_occurrences: list[tuple[str, str]] = []
         # Health flags for the #465 filter, computed ONCE per start() from
         # the persisted metrics store and held for the session — exposure
         # must not drift between the startup advertisement (what the client
@@ -405,7 +404,7 @@ class ProxyManager:
         self._connections[name] = UpstreamConnection(
             name=name, config=cfg, session=session, tools=list(result.tools), stack=conn_stack
         )
-        logger.info("Connected to '%s' (%s tools)", name, len(result.tools))
+        logger.info("Connected to '%s' (%s tools discovered)", name, len(result.tools))
 
     async def _reconnect_server(self, name: str) -> None:
         conn = self._connections[name]
@@ -438,7 +437,7 @@ class ProxyManager:
         conn.session = session
         conn.stack = conn_stack
         conn.tools = list(result.tools)
-        logger.info("Reconnected to '%s' (%s tools)", name, len(conn.tools))
+        logger.info("Reconnected to '%s' (%s tools discovered)", name, len(conn.tools))
 
     async def stop(self) -> None:
         # Cancel and drain background tasks (extraction, etc.). Loop until
@@ -573,28 +572,23 @@ class ProxyManager:
                 )
 
         verdict = filter_tools(candidates, self._config.exposure, self._unhealthy_tools)
-        if (
-            verdict.reject_reasons != self._advertised_reject_reasons
-            or verdict.dropped_occurrences != self._advertised_dropped_occurrences
-        ):
-            self._log_exposure_rejects(verdict.reject_reasons, verdict.dropped_occurrences)
+        if verdict.reject_reasons != self._advertised_reject_reasons:
+            self._log_exposure_rejects(verdict.reject_reasons)
         self._advertised_infos = verdict.eligible
         self._advertised_tools = [info.prefixed_name for info in verdict.eligible]
         self._advertised_reject_reasons = verdict.reject_reasons
         self._advertised_risk_penalties = verdict.risk_penalties
-        self._advertised_dropped_occurrences = verdict.dropped_occurrences
         return verdict.eligible
 
     @staticmethod
-    def _log_exposure_rejects(
-        reject_reasons: dict[str, str], dropped_occurrences: list[tuple[str, str]]
-    ) -> None:
+    def _log_exposure_rejects(reject_reasons: dict[str, str]) -> None:
         """One line per advertisement *change*, so operators see what was
         withheld and why without per-call noise. Config-driven rejects
         (``hidden``, profile scoping) are the operator's own choices — those
-        log at DEBUG; everything else (structural rejects, signal rejects,
-        and same-named occurrence drops, which never reach telemetry) is
-        news and logs at WARNING."""
+        log at DEBUG; everything else (structural, signal) is news and logs
+        at WARNING."""
+        if not reject_reasons:
+            return
         expected = {REASON_CONFIG_HIDDEN, REASON_PROFILE_EXCLUDED}
         news = {t: r for t, r in reject_reasons.items() if r not in expected}
         if news:
@@ -602,13 +596,6 @@ class ProxyManager:
                 "Exposure filter withheld %d tool(s): %s",
                 len(news),
                 ", ".join(f"{t} ({r})" for t, r in sorted(news.items())),
-            )
-        if dropped_occurrences:
-            logger.warning(
-                "Exposure filter dropped %d same-named tool occurrence(s) "
-                "(name stays advertised via its first eligible occurrence): %s",
-                len(dropped_occurrences),
-                ", ".join(f"{t} ({r})" for t, r in sorted(dropped_occurrences)),
             )
         if len(news) < len(reject_reasons):
             logger.debug(
@@ -1243,12 +1230,24 @@ class ProxyManager:
             return output
 
     def get_upstream_health(self) -> dict[str, dict]:
-        """Return per-server health: connection status, tool count."""
+        """Return per-server health: connection status, tool counts.
+
+        ``tools`` counts the DISCOVERED catalogue (everything the upstream
+        listed — since #465 ``conn.tools`` is no longer pre-filtered at
+        connect time); ``advertised_tools`` counts how many of them the
+        last advertisement actually exposed, so operators can tell a
+        withheld tool from a missing one. ``advertised_tools`` reflects
+        the most recent ``get_proxy_tools()`` pass — in the server it runs
+        at startup registration, before any health probe can observe it.
+        """
         health: dict[str, dict] = {}
         for name, conn in self._connections.items():
             health[name] = {
                 "connected": conn.session is not None,
                 "tools": len(conn.tools),
+                "advertised_tools": sum(
+                    1 for info in self._advertised_infos if info.server == name
+                ),
             }
         return health
 

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -275,6 +275,16 @@ class TokenTracker:
         self._surface_latencies: deque[float] = deque(maxlen=_LATENCY_WINDOW)
         self._total_latencies: deque[float] = deque(maxlen=_LATENCY_WINDOW)
 
+    @property
+    def metrics_store(self) -> MetricsStore | None:
+        """The persistent store this tracker writes through, if any.
+
+        Read-only access for consumers that need the persisted history
+        (e.g. the #465 exposure health filter) without a second wiring
+        path for the same object.
+        """
+        return self._metrics_store
+
     def record(self, metrics: CallMetrics) -> None:
         self._rps_tracker.record()
         self._total_calls += 1

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -389,6 +389,33 @@ class MetricsStore:
                 )
         return profiles
 
+    def get_tool_error_stats(
+        self, since_seconds: float, error_categories: tuple[str, ...]
+    ) -> dict[tuple[str, str], tuple[int, int]]:
+        """Per ``(server, tool)``: ``(call_count, matching_error_count)``.
+
+        Counts rows inside the look-back window; an error row contributes to
+        ``matching_error_count`` only when its ``error_category`` is in
+        *error_categories* — the tool-exposure health filter (#465) passes
+        the upstream-attributable categories so a proxy-internal pipeline
+        failure never counts against the upstream tool. An empty category
+        tuple therefore yields zero matching errors (calls still counted).
+        ``tool`` keys are raw upstream names, matching ``record()``.
+        """
+        if self._db is None:
+            return {}
+        cutoff = time.time() - since_seconds
+        placeholders = ",".join("?" for _ in error_categories) or "NULL"
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT server, tool, COUNT(*), "
+                "SUM(CASE WHEN is_error = 1 AND error_category IN "
+                f"({placeholders}) THEN 1 ELSE 0 END) "
+                "FROM proxy_metrics WHERE created_at >= ? GROUP BY server, tool",
+                (*error_categories, cutoff),
+            ).fetchall()
+        return {(r[0], r[1]): (r[2], r[3] or 0) for r in rows}
+
     def get_history(self, limit: int = 100) -> list[dict]:
         if self._db is None:
             return []

--- a/src/memtomem_stm/proxy/selection_log.py
+++ b/src/memtomem_stm/proxy/selection_log.py
@@ -4,8 +4,9 @@ The proxy is the one component in the call path, so it can record what an
 advisory analyzer never sees: which tool the client model actually called,
 out of which advertised candidate set, and how the call went. This log is
 the substrate for offline replay/eval (#468) and every later learning stage
-(#469/#470) — and for the STM-native hard filter (#465), whose reject
-reasons land in the ``reject_reasons`` field once it exists.
+(#469/#470) — and the landing zone for the STM-native hard filter's (#465)
+``reject_reasons``, so replay sees the tools that were withheld, not just
+the ones advertised.
 
 Schema v1 — three event types, every record self-describing via
 ``schema_version`` + ``ranker_version``; one JSON object per line, keys
@@ -17,11 +18,13 @@ sorted, so a replay harness can stream-parse and diff runs:
     ``server``, ``selected_tool`` (prefixed name, same vocabulary as
     ``candidate_tools``), ``candidate_tools`` (what the proxy last
     advertised — today the client model does the selecting),
-    ``candidate_count``, ``reject_reasons`` (tool → reason; empty until
-    the #465 hard filter populates it), ``candidate_features`` /
-    ``graph_generation`` (reserved ``null`` until toolgraph#13/#15),
-    ``args_sha256`` + ``args_chars`` (canonical-JSON hash — see
-    redaction below), ``ts``.
+    ``candidate_count``, ``reject_reasons`` (prefixed tool → reason code
+    for every tool the #465 hard filter withheld from that advertisement;
+    ``{}`` when nothing was rejected or the filter never ran — reason
+    vocabulary in ``proxy/tool_eligibility.py``), ``candidate_features``
+    (#466 ranking output) / ``graph_generation`` (reserved ``null`` until
+    toolgraph#13/#15), ``args_sha256`` + ``args_chars`` (canonical-JSON
+    hash — see redaction below), ``ts``.
 
 ``execution``
     ``selection_id`` / ``trace_id`` / ``server`` / ``selected_tool``
@@ -176,6 +179,7 @@ class SelectionTelemetryLog:
         trace_id: str | None,
         candidate_features: dict[str, Any] | None = None,
         ranker_version: str | None = None,
+        reject_reasons: dict[str, str] | None = None,
     ) -> str | None:
         """Record a selection event; returns its ``selection_id``.
 
@@ -184,6 +188,9 @@ class SelectionTelemetryLog:
         is the ranker's output object (#466) — the caller guarantees it
         carries no raw text, only scores/hashes; ``ranker_version`` stamps
         which ranker produced it (``None`` = the unranked default).
+        ``reject_reasons`` is the #465 hard filter's verdict for the
+        advertisement this call selected from — reason codes only, no tool
+        metadata (``None`` records the empty map).
         """
         if not self._sampled_in():
             with self._lock:
@@ -203,7 +210,7 @@ class SelectionTelemetryLog:
                 "selected_tool": selected_tool,
                 "candidate_tools": list(candidate_tools),
                 "candidate_count": len(candidate_tools),
-                "reject_reasons": {},
+                "reject_reasons": dict(reject_reasons) if reject_reasons else {},
                 "candidate_features": candidate_features,
                 "graph_generation": None,
                 "args_sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),

--- a/src/memtomem_stm/proxy/tool_eligibility.py
+++ b/src/memtomem_stm/proxy/tool_eligibility.py
@@ -10,8 +10,9 @@ connect-time duplicate-name skip, the connect-time 64-char overflow skip —
 prefix guidance) and adds profile- and signal-based rules, with every
 rejection recorded as a structured reason instead of (at best) a log line.
 
-Rule vocabulary — one reason code per rejected tool, first matching rule in
-this order wins:
+Rule vocabulary — one reason code per rejected name; the ambiguity
+pre-pass (``duplicate_name``) runs first over the whole candidate set,
+then the remaining rules apply per tool in this order, first match wins:
 
 ``config_hidden``
     ``ToolOverrideConfig.hidden`` — explicit operator intent. Every profile.
@@ -27,15 +28,14 @@ this order wins:
     ``conn.tools``, so connect and reconnect get identical treatment and
     the verdict reaches telemetry on the normal startup path (codex R2).
 ``duplicate_name``
-    The prefixed name is already claimed by an *eligible* tool earlier in
-    the advertisement pass (config order, then upstream catalogue order —
-    first wins). Two handlers must never race for one composed name; the
-    registration loop consumes this filter's output, which makes that
-    impossible by construction. Every profile. Note this verdict is
-    inherently occurrence-level: the NAME stays advertised via its first
-    eligible occurrence, so it appears in ``dropped_occurrences`` (operator
-    log), never in ``reject_reasons`` (telemetry) — see
-    :class:`EligibilityResult`.
+    More than one candidate carries the same composed name, so the ENTIRE
+    group is withheld (ambiguity pre-pass, evaluated before every other
+    rule). Upstream calls route by raw tool name — same-named occurrences
+    are one callable entity wearing several metadata claims, so picking a
+    "winning" occurrence would advertise metadata that does not bind to
+    what executes (codex R3); and two handlers must never race for one
+    composed name. Ambiguous names are never auto-exposed, in any
+    profile — the original #465 regression criterion, verbatim.
 ``sensitive_metadata``
     The tool's metadata (original description, advertised description, raw
     schema) matches a credential pattern (``privacy.CREDENTIAL_PATTERNS``
@@ -64,10 +64,10 @@ Three invariants this module exists to uphold:
   runs over ``EligibilityResult.eligible`` — the filter's output — so a
   rejected tool is structurally outside the ranker's candidate set.
 - **Telemetry never contradicts the advertisement.** ``reject_reasons``
-  keys are disjoint from the eligible names by construction: a name with
-  any advertised occurrence routes its rejected same-named occurrences to
-  ``dropped_occurrences`` (log-only) instead of claiming the name was
-  withheld.
+  keys are disjoint from the eligible names: the ambiguity pre-pass
+  withholds every multi-occurrence name outright, so no name can be both
+  advertised and recorded as withheld (and no advertised metadata can
+  diverge from the callable entity behind the name).
 - **The advertised set is stable for the session.** Health flags are
   computed once at proxy startup (``compute_health_flags``) from the
   persisted metrics store, not per call: MCP clients are not guaranteed to
@@ -87,6 +87,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import Counter
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -155,27 +156,16 @@ class EligibilityResult:
     prefixed name — the same vocabulary as ``candidate_tools`` in selection
     telemetry — and describe NAMES: ``reject_reasons`` only ever names tools
     the client did not get (its key set is disjoint from the eligible names
-    by construction — telemetry must never claim a name was both advertised
-    and withheld), and ``risk_penalties`` only ever names eligible tools
-    (``review``-profile demotions).
-
-    ``dropped_occurrences`` is the occurrence-level remainder: ``(name,
-    reason)`` for each rejected candidate whose composed name is NOT in
-    ``reject_reasons`` — a same-named duplicate of an advertised tool, a
-    same-named sibling rejected by another rule while one occurrence made
-    it through, or the second-plus rejected occurrence of a fully-withheld
-    name. These never reach telemetry (the client's view of that NAME is
-    already described); they exist for operator logging, since silently
-    losing an occurrence is how the old connect-time guards hid anomalies.
-    Empty whenever composed names are unique — the normal case, since
-    config validation rejects duplicate upstream prefixes and an upstream
-    repeating a tool name in one catalogue is itself misbehaving.
+    — telemetry must never claim a name was both advertised and withheld;
+    the ambiguity pre-pass in :func:`filter_tools` withholds every
+    multi-occurrence name outright, so each surviving name has exactly one
+    candidate and the disjointness is structural), and ``risk_penalties``
+    only ever names eligible tools (``review``-profile demotions).
     """
 
     eligible: list[ProxyToolInfo]
     reject_reasons: dict[str, str]
     risk_penalties: dict[str, float]
-    dropped_occurrences: list[tuple[str, str]]
 
 
 def compute_health_flags(
@@ -253,23 +243,37 @@ def filter_tools(
     identical result, independent of call count or wall clock. *unhealthy*
     is the cached startup snapshot from :func:`compute_health_flags`.
     """
+    # ── ambiguity pre-pass (every profile) ───────────────────────────────
+    # A composed name carried by MORE than one candidate is structurally
+    # ambiguous and the whole group is withheld: upstream calls route by
+    # raw tool name (``session.call_tool(tool)``), so same-named
+    # occurrences are one callable entity wearing several metadata claims
+    # — advertising the "clean" copy while a sibling copy carries a
+    # credential or a hidden flag would advertise metadata that does not
+    # bind to what actually executes (codex R3). This also realizes the
+    # issue's regression criterion verbatim: ambiguous names are never
+    # auto-exposed. Withholding the group (rather than first-wins) costs
+    # only the misbehaving-upstream case and removes every
+    # occurrence-vs-name ambiguity downstream.
+    name_counts = Counter(candidate.info.prefixed_name for candidate in candidates)
+
     eligible: list[ProxyToolInfo] = []
+    reject_reasons: dict[str, str] = {}
     risk_penalties: dict[str, float] = {}
-    claimed_names: set[str] = set()
-    # Per-OCCURRENCE verdicts in input order; folded into the name-level
-    # ``reject_reasons`` map after the pass, because whether a rejected
-    # occurrence means "this NAME was withheld" depends on whether some
-    # other occurrence of the same name ended up advertised.
-    occurrence_rejects: list[tuple[str, str]] = []
 
     for candidate in candidates:
         info = candidate.info
         server_cfg = candidate.server_config
         override = server_cfg.tool_overrides.get(info.original_name)
 
+        # ── structural ambiguity (pre-pass verdict, every profile) ───────
+        if name_counts[info.prefixed_name] > 1:
+            reject_reasons[info.prefixed_name] = REASON_DUPLICATE_NAME
+            continue
+
         # ── config rules (every profile) ─────────────────────────────────
         if override is not None and override.hidden:
-            occurrence_rejects.append((info.prefixed_name, REASON_CONFIG_HIDDEN))
+            reject_reasons[info.prefixed_name] = REASON_CONFIG_HIDDEN
             continue
         profiles = (
             override.expose_in_profiles
@@ -277,15 +281,12 @@ def filter_tools(
             else server_cfg.expose_in_profiles
         )
         if profiles is not None and cfg.profile not in profiles:
-            occurrence_rejects.append((info.prefixed_name, REASON_PROFILE_EXCLUDED))
+            reject_reasons[info.prefixed_name] = REASON_PROFILE_EXCLUDED
             continue
 
         # ── structural rules (every profile) ─────────────────────────────
         if tool_name_budget.overflows(server_cfg.prefix, info.original_name):
-            occurrence_rejects.append((info.prefixed_name, REASON_NAME_OVERFLOW))
-            continue
-        if info.prefixed_name in claimed_names:
-            occurrence_rejects.append((info.prefixed_name, REASON_DUPLICATE_NAME))
+            reject_reasons[info.prefixed_name] = REASON_NAME_OVERFLOW
             continue
 
         # ── signal rules (profile-dependent) ─────────────────────────────
@@ -297,35 +298,13 @@ def filter_tools(
                 flagged_reason = REASON_UNHEALTHY
             if flagged_reason is not None:
                 if cfg.profile is ExposureProfile.STRICT:
-                    occurrence_rejects.append((info.prefixed_name, flagged_reason))
+                    reject_reasons[info.prefixed_name] = flagged_reason
                     continue
                 # review: advertise, but demote in ranking telemetry.
                 risk_penalties[info.prefixed_name] = cfg.review_risk_penalty
 
-        # Only fully-eligible tools claim their composed name — a tool
-        # rejected by a later rule must not block a same-named sibling
-        # from being the one that actually registers.
-        claimed_names.add(info.prefixed_name)
         eligible.append(info)
 
-    # Name-level fold. ``reject_reasons`` may only name tools the client
-    # did NOT get — a name some occurrence of which was advertised routes
-    # its rejected occurrences to ``dropped_occurrences`` instead, keeping
-    # ``reject_reasons`` keys disjoint from ``candidate_tools`` by
-    # construction. For a fully-withheld name the first rejected
-    # occurrence's reason wins; later occurrences of the same withheld
-    # name are occurrence drops too (one name, one reason).
-    reject_reasons: dict[str, str] = {}
-    dropped_occurrences: list[tuple[str, str]] = []
-    for name, reason in occurrence_rejects:
-        if name in claimed_names or name in reject_reasons:
-            dropped_occurrences.append((name, reason))
-        else:
-            reject_reasons[name] = reason
-
     return EligibilityResult(
-        eligible=eligible,
-        reject_reasons=reject_reasons,
-        risk_penalties=risk_penalties,
-        dropped_occurrences=dropped_occurrences,
+        eligible=eligible, reject_reasons=reject_reasons, risk_penalties=risk_penalties
     )

--- a/src/memtomem_stm/proxy/tool_eligibility.py
+++ b/src/memtomem_stm/proxy/tool_eligibility.py
@@ -183,8 +183,7 @@ def compute_health_flags(
     flagged = {
         key
         for key, (calls, errors) in stats.items()
-        if calls >= cfg.health_min_calls
-        and (errors / calls) >= cfg.health_error_rate_threshold
+        if calls >= cfg.health_min_calls and (errors / calls) >= cfg.health_error_rate_threshold
     }
     if flagged:
         logger.warning(

--- a/src/memtomem_stm/proxy/tool_eligibility.py
+++ b/src/memtomem_stm/proxy/tool_eligibility.py
@@ -1,0 +1,283 @@
+"""STM-native hard filter for proxy tool exposure (#465).
+
+The proxy is the tool-exposure choke point: ``get_proxy_tools()`` decides
+which upstream tools the client model ever sees. This module is that
+decision, factored into a pure, deterministic pass so it can be tested and
+audited in isolation. It consolidates what used to be three scattered
+exposure guards (the per-tool ``hidden`` override, the connect-time
+duplicate-name skip, the connect-time 64-char overflow skip) and adds
+profile- and signal-based rules, with every rejection recorded as a
+structured reason instead of (at best) a log line.
+
+Rule vocabulary — one reason code per rejected tool, first matching rule in
+this order wins:
+
+``config_hidden``
+    ``ToolOverrideConfig.hidden`` — explicit operator intent. Every profile.
+``profile_excluded``
+    ``expose_in_profiles`` (tool-level wins over upstream-level when both
+    set) does not include the active profile. Every profile.
+``name_overflow``
+    The composed client-side name exceeds the 64-char MCP limit
+    (``tool_name_budget``) — clients silently drop such tools (#261), so
+    advertising one is strictly worse than rejecting it. Every profile.
+    The connect-time skip in ``_connect_server`` remains as
+    defense-in-depth; this exposure-time check also covers the reconnect
+    path, which re-populates ``conn.tools`` without the connect-time guard.
+``duplicate_name``
+    The prefixed name is already claimed by an *eligible* tool earlier in
+    the advertisement pass (config order, then upstream catalogue order —
+    first wins, matching the connect-time guard). Two handlers must never
+    race for one composed name. Every profile.
+``sensitive_metadata``
+    The tool's metadata (original description, advertised description, raw
+    schema) matches a credential pattern (``privacy.CREDENTIAL_PATTERNS``
+    only — not PII, so an email in a contact-info description never trips
+    it). A credential-looking string in tool *metadata* means the upstream
+    is misconfigured at best and hostile at worst; advertising it would
+    paste the match into the client's context on every ``tools/list``.
+    Signal rule: rejects under ``strict``, demotes under ``review``, off
+    under ``explore``.
+``unhealthy``
+    The tool's upstream-attributable error rate (transport / timeout /
+    protocol / upstream_error — proxy-internal pipeline failures never
+    count against the tool) over the recent metrics window crossed the
+    configured threshold with enough samples. Signal rule, like
+    ``sensitive_metadata``.
+
+Profile semantics (``ExposureProfile``): ``strict`` enforces signal rules as
+hard rejects; ``review`` keeps flagged tools advertised but assigns them a
+``risk_penalty`` for tool-relevance telemetry (#466) so the operator can
+observe what strict *would* hide; ``explore`` skips signal rules entirely.
+Config and structural rules apply in every profile.
+
+Two invariants this module exists to uphold:
+
+- **Ranking may never resurrect a hard reject.** Relevance ranking (#466)
+  runs over ``EligibilityResult.eligible`` — the filter's output — so a
+  rejected tool is structurally outside the ranker's candidate set.
+- **The advertised set is stable for the session.** Health flags are
+  computed once at proxy startup (``compute_health_flags``) from the
+  persisted metrics store, not per call: MCP clients are not guaranteed to
+  re-list tools, and a mid-session eligibility change would make selection
+  telemetry lie about the candidate set the client actually saw. A tool
+  hidden for health gets re-evaluated at the next startup; once its
+  failures age out of the window it is advertised again (startup-grained
+  half-open probing — recovery is possible because hiding stops new
+  failures from accruing, and the window forgets old ones).
+
+Reject reasons flow into the selection log's ``reject_reasons`` field
+(#467) via ``ProxyManager``; they are reason *codes* only — no tool
+metadata, no error text — so the telemetry redaction contract is untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from memtomem_stm.proxy import tool_name_budget
+from memtomem_stm.proxy.config import (
+    ExposureConfig,
+    ExposureProfile,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.metrics import ErrorCategory
+from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS, contains_sensitive_content
+
+if TYPE_CHECKING:
+    from memtomem_stm.proxy.manager import ProxyToolInfo
+    from memtomem_stm.proxy.metrics_store import MetricsStore
+
+logger = logging.getLogger(__name__)
+
+# Reject reason codes — the closed vocabulary of the selection log's
+# ``reject_reasons`` values. Adding a code is additive (replay tooling
+# treats unknown codes as opaque); renaming one is a breaking change to
+# recorded history and needs the same care as a schema bump.
+REASON_CONFIG_HIDDEN = "config_hidden"
+REASON_PROFILE_EXCLUDED = "profile_excluded"
+REASON_NAME_OVERFLOW = "name_overflow"
+REASON_DUPLICATE_NAME = "duplicate_name"
+REASON_SENSITIVE_METADATA = "sensitive_metadata"
+REASON_UNHEALTHY = "unhealthy"
+
+# Error categories that count against a TOOL's health. Proxy-side failures
+# (programming, internal_error, lock_timeout) are our bugs, not the
+# upstream's — hiding a tool because the proxy's own pipeline broke would
+# punish the wrong party.
+UPSTREAM_ERROR_CATEGORIES: tuple[str, ...] = (
+    ErrorCategory.TRANSPORT.value,
+    ErrorCategory.TIMEOUT.value,
+    ErrorCategory.PROTOCOL.value,
+    ErrorCategory.UPSTREAM_ERROR.value,
+)
+
+# Bound the schema text scanned for credentials, mirroring the cap used by
+# tool_relevance for scoring documents: a pathological upstream schema
+# should cost bounded work. Credentials embedded beyond the cap are still
+# caught by the selection log's per-line backstop at telemetry time.
+_MAX_SCAN_CHARS = 20_000
+
+
+@dataclass(frozen=True, slots=True)
+class ExposureCandidate:
+    """One tool as it would be advertised, plus the raw artifacts the
+    advertisement was derived from.
+
+    ``info`` carries the advertised (post-truncation, post-distill) view;
+    ``raw_description`` / ``raw_schema`` are the upstream originals, scanned
+    for sensitive metadata because truncation/distillation can only *remove*
+    text — a credential at char 250 of a description truncated at 200 is
+    still a signal the upstream is compromised.
+    """
+
+    info: ProxyToolInfo
+    raw_description: str
+    raw_schema: dict[str, Any] | None
+    server_config: UpstreamServerConfig
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityResult:
+    """Output of one filter pass over an advertisement candidate set.
+
+    ``eligible`` preserves input order (config order, then upstream
+    catalogue order). ``reject_reasons`` and ``risk_penalties`` are keyed by
+    prefixed name — the same vocabulary as ``candidate_tools`` in selection
+    telemetry. A name never appears in both ``eligible`` and
+    ``reject_reasons``; ``risk_penalties`` only ever names eligible tools
+    (``review``-profile demotions).
+    """
+
+    eligible: list[ProxyToolInfo]
+    reject_reasons: dict[str, str]
+    risk_penalties: dict[str, float]
+
+
+def compute_health_flags(
+    metrics_store: MetricsStore | None, cfg: ExposureConfig
+) -> frozenset[tuple[str, str]]:
+    """``(server, raw_tool_name)`` pairs whose recent error rate flags them.
+
+    Reads the persisted metrics store once; call at proxy startup and cache
+    — see the module docstring for why health must not drift mid-session.
+    No store (metrics disabled, or the standalone manager in tests) means no
+    health signal: every tool is presumed healthy. A read failure likewise
+    fails open — exposure must not depend on the health of the metrics DB.
+    """
+    if metrics_store is None:
+        return frozenset()
+    try:
+        stats = metrics_store.get_tool_error_stats(
+            cfg.health_window_hours * 3600.0, UPSTREAM_ERROR_CATEGORIES
+        )
+    except Exception:
+        logger.warning(
+            "Tool health read failed — exposure proceeds without health signals",
+            exc_info=True,
+        )
+        return frozenset()
+    flagged = {
+        key
+        for key, (calls, errors) in stats.items()
+        if calls >= cfg.health_min_calls
+        and (errors / calls) >= cfg.health_error_rate_threshold
+    }
+    if flagged:
+        logger.warning(
+            "Tool health flags (window %.1fh, threshold %.0f%%, min %d calls): %s",
+            cfg.health_window_hours,
+            cfg.health_error_rate_threshold * 100.0,
+            cfg.health_min_calls,
+            ", ".join(sorted(f"{s}/{t}" for s, t in flagged)),
+        )
+    return frozenset(flagged)
+
+
+def _metadata_scan_text(candidate: ExposureCandidate) -> str:
+    """Assemble the metadata text scanned for credential patterns.
+
+    Covers the raw upstream description, the advertised description (which
+    may originate from an operator ``description_override`` rather than the
+    raw text), and the raw schema. Serialization is deterministic
+    (sorted keys) so the same candidate always scans the same text.
+    """
+    try:
+        schema_text = json.dumps(
+            candidate.raw_schema or {}, sort_keys=True, separators=(",", ":"), default=str
+        )
+    except (TypeError, ValueError):  # pragma: no cover - dict from JSON can't cycle
+        schema_text = ""
+    return "\n".join(
+        (candidate.raw_description, candidate.info.description, schema_text[:_MAX_SCAN_CHARS])
+    )
+
+
+def filter_tools(
+    candidates: list[ExposureCandidate],
+    cfg: ExposureConfig,
+    unhealthy: frozenset[tuple[str, str]] = frozenset(),
+) -> EligibilityResult:
+    """Apply the hard-filter rules to one advertisement candidate set.
+
+    Pure and deterministic: same candidates + config + health flags →
+    identical result, independent of call count or wall clock. *unhealthy*
+    is the cached startup snapshot from :func:`compute_health_flags`.
+    """
+    eligible: list[ProxyToolInfo] = []
+    reject_reasons: dict[str, str] = {}
+    risk_penalties: dict[str, float] = {}
+    claimed_names: set[str] = set()
+
+    for candidate in candidates:
+        info = candidate.info
+        server_cfg = candidate.server_config
+        override = server_cfg.tool_overrides.get(info.original_name)
+
+        # ── config rules (every profile) ─────────────────────────────────
+        if override is not None and override.hidden:
+            reject_reasons[info.prefixed_name] = REASON_CONFIG_HIDDEN
+            continue
+        profiles = (
+            override.expose_in_profiles
+            if override is not None and override.expose_in_profiles is not None
+            else server_cfg.expose_in_profiles
+        )
+        if profiles is not None and cfg.profile not in profiles:
+            reject_reasons[info.prefixed_name] = REASON_PROFILE_EXCLUDED
+            continue
+
+        # ── structural rules (every profile) ─────────────────────────────
+        if tool_name_budget.overflows(server_cfg.prefix, info.original_name):
+            reject_reasons[info.prefixed_name] = REASON_NAME_OVERFLOW
+            continue
+        if info.prefixed_name in claimed_names:
+            reject_reasons[info.prefixed_name] = REASON_DUPLICATE_NAME
+            continue
+
+        # ── signal rules (profile-dependent) ─────────────────────────────
+        if cfg.profile is not ExposureProfile.EXPLORE:
+            flagged_reason: str | None = None
+            if contains_sensitive_content(_metadata_scan_text(candidate), CREDENTIAL_PATTERNS):
+                flagged_reason = REASON_SENSITIVE_METADATA
+            elif (info.server, info.original_name) in unhealthy:
+                flagged_reason = REASON_UNHEALTHY
+            if flagged_reason is not None:
+                if cfg.profile is ExposureProfile.STRICT:
+                    reject_reasons[info.prefixed_name] = flagged_reason
+                    continue
+                # review: advertise, but demote in ranking telemetry.
+                risk_penalties[info.prefixed_name] = cfg.review_risk_penalty
+
+        # Only fully-eligible tools claim their composed name — a tool
+        # rejected by a later rule must not block a same-named sibling
+        # from being the one that actually registers.
+        claimed_names.add(info.prefixed_name)
+        eligible.append(info)
+
+    return EligibilityResult(
+        eligible=eligible, reject_reasons=reject_reasons, risk_penalties=risk_penalties
+    )

--- a/src/memtomem_stm/proxy/tool_eligibility.py
+++ b/src/memtomem_stm/proxy/tool_eligibility.py
@@ -3,11 +3,12 @@
 The proxy is the tool-exposure choke point: ``get_proxy_tools()`` decides
 which upstream tools the client model ever sees. This module is that
 decision, factored into a pure, deterministic pass so it can be tested and
-audited in isolation. It consolidates what used to be three scattered
-exposure guards (the per-tool ``hidden`` override, the connect-time
-duplicate-name skip, the connect-time 64-char overflow skip) and adds
-profile- and signal-based rules, with every rejection recorded as a
-structured reason instead of (at best) a log line.
+audited in isolation. It absorbs what used to be three scattered exposure
+guards (the per-tool ``hidden`` override inline in ``get_proxy_tools``, the
+connect-time duplicate-name skip, the connect-time 64-char overflow skip —
+``_connect_server`` now keeps every discovered tool and only logs the #261
+prefix guidance) and adds profile- and signal-based rules, with every
+rejection recorded as a structured reason instead of (at best) a log line.
 
 Rule vocabulary — one reason code per rejected tool, first matching rule in
 this order wins:
@@ -21,14 +22,16 @@ this order wins:
     The composed client-side name exceeds the 64-char MCP limit
     (``tool_name_budget``) — clients silently drop such tools (#261), so
     advertising one is strictly worse than rejecting it. Every profile.
-    The connect-time skip in ``_connect_server`` remains as
-    defense-in-depth; this exposure-time check also covers the reconnect
-    path, which re-populates ``conn.tools`` without the connect-time guard.
+    This filter is the only place such tools are excluded; the connect
+    path logs the prefix-shortening guidance but keeps the tool in
+    ``conn.tools``, so connect and reconnect get identical treatment and
+    the verdict reaches telemetry on the normal startup path (codex R2).
 ``duplicate_name``
     The prefixed name is already claimed by an *eligible* tool earlier in
     the advertisement pass (config order, then upstream catalogue order —
-    first wins, matching the connect-time guard). Two handlers must never
-    race for one composed name. Every profile. Note this verdict is
+    first wins). Two handlers must never race for one composed name; the
+    registration loop consumes this filter's output, which makes that
+    impossible by construction. Every profile. Note this verdict is
     inherently occurrence-level: the NAME stays advertised via its first
     eligible occurrence, so it appears in ``dropped_occurrences`` (operator
     log), never in ``reject_reasons`` (telemetry) — see
@@ -124,12 +127,6 @@ UPSTREAM_ERROR_CATEGORIES: tuple[str, ...] = (
     ErrorCategory.UPSTREAM_ERROR.value,
 )
 
-# Bound the schema text scanned for credentials, mirroring the cap used by
-# tool_relevance for scoring documents: a pathological upstream schema
-# should cost bounded work. Credentials embedded beyond the cap are still
-# caught by the selection log's per-line backstop at telemetry time.
-_MAX_SCAN_CHARS = 20_000
-
 
 @dataclass(frozen=True, slots=True)
 class ExposureCandidate:
@@ -170,8 +167,9 @@ class EligibilityResult:
     name. These never reach telemetry (the client's view of that NAME is
     already described); they exist for operator logging, since silently
     losing an occurrence is how the old connect-time guards hid anomalies.
-    Empty whenever composed names are unique — the normal case, guaranteed
-    by config validation plus the connect-time guard.
+    Empty whenever composed names are unique — the normal case, since
+    config validation rejects duplicate upstream prefixes and an upstream
+    repeating a tool name in one catalogue is itself misbehaving.
     """
 
     eligible: list[ProxyToolInfo]
@@ -226,6 +224,14 @@ def _metadata_scan_text(candidate: ExposureCandidate) -> str:
     may originate from an operator ``description_override`` rather than the
     raw text), and the raw schema. Serialization is deterministic
     (sorted keys) so the same candidate always scans the same text.
+
+    Deliberately UNBOUNDED: this is a security gate, not a scoring
+    document, and unlike payload telemetry there is no downstream backstop
+    for advertisement — whatever passes here goes to the client's context
+    verbatim on every ``tools/list``. The scan runs once per advertisement
+    (not per call), and the advertisement path already serializes the same
+    schema unbounded, so one regex pass over the full text costs nothing
+    the upstream couldn't already inflict (codex R2).
     """
     try:
         schema_text = json.dumps(
@@ -233,9 +239,7 @@ def _metadata_scan_text(candidate: ExposureCandidate) -> str:
         )
     except (TypeError, ValueError):  # pragma: no cover - dict from JSON can't cycle
         schema_text = ""
-    return "\n".join(
-        (candidate.raw_description, candidate.info.description, schema_text[:_MAX_SCAN_CHARS])
-    )
+    return "\n".join((candidate.raw_description, candidate.info.description, schema_text))
 
 
 def filter_tools(

--- a/src/memtomem_stm/proxy/tool_eligibility.py
+++ b/src/memtomem_stm/proxy/tool_eligibility.py
@@ -28,7 +28,11 @@ this order wins:
     The prefixed name is already claimed by an *eligible* tool earlier in
     the advertisement pass (config order, then upstream catalogue order —
     first wins, matching the connect-time guard). Two handlers must never
-    race for one composed name. Every profile.
+    race for one composed name. Every profile. Note this verdict is
+    inherently occurrence-level: the NAME stays advertised via its first
+    eligible occurrence, so it appears in ``dropped_occurrences`` (operator
+    log), never in ``reject_reasons`` (telemetry) — see
+    :class:`EligibilityResult`.
 ``sensitive_metadata``
     The tool's metadata (original description, advertised description, raw
     schema) matches a credential pattern (``privacy.CREDENTIAL_PATTERNS``
@@ -51,11 +55,16 @@ hard rejects; ``review`` keeps flagged tools advertised but assigns them a
 observe what strict *would* hide; ``explore`` skips signal rules entirely.
 Config and structural rules apply in every profile.
 
-Two invariants this module exists to uphold:
+Three invariants this module exists to uphold:
 
 - **Ranking may never resurrect a hard reject.** Relevance ranking (#466)
   runs over ``EligibilityResult.eligible`` — the filter's output — so a
   rejected tool is structurally outside the ranker's candidate set.
+- **Telemetry never contradicts the advertisement.** ``reject_reasons``
+  keys are disjoint from the eligible names by construction: a name with
+  any advertised occurrence routes its rejected same-named occurrences to
+  ``dropped_occurrences`` (log-only) instead of claiming the name was
+  withheld.
 - **The advertised set is stable for the session.** Health flags are
   computed once at proxy startup (``compute_health_flags``) from the
   persisted metrics store, not per call: MCP clients are not guaranteed to
@@ -147,14 +156,28 @@ class EligibilityResult:
     ``eligible`` preserves input order (config order, then upstream
     catalogue order). ``reject_reasons`` and ``risk_penalties`` are keyed by
     prefixed name — the same vocabulary as ``candidate_tools`` in selection
-    telemetry. A name never appears in both ``eligible`` and
-    ``reject_reasons``; ``risk_penalties`` only ever names eligible tools
+    telemetry — and describe NAMES: ``reject_reasons`` only ever names tools
+    the client did not get (its key set is disjoint from the eligible names
+    by construction — telemetry must never claim a name was both advertised
+    and withheld), and ``risk_penalties`` only ever names eligible tools
     (``review``-profile demotions).
+
+    ``dropped_occurrences`` is the occurrence-level remainder: ``(name,
+    reason)`` for each rejected candidate whose composed name is NOT in
+    ``reject_reasons`` — a same-named duplicate of an advertised tool, a
+    same-named sibling rejected by another rule while one occurrence made
+    it through, or the second-plus rejected occurrence of a fully-withheld
+    name. These never reach telemetry (the client's view of that NAME is
+    already described); they exist for operator logging, since silently
+    losing an occurrence is how the old connect-time guards hid anomalies.
+    Empty whenever composed names are unique — the normal case, guaranteed
+    by config validation plus the connect-time guard.
     """
 
     eligible: list[ProxyToolInfo]
     reject_reasons: dict[str, str]
     risk_penalties: dict[str, float]
+    dropped_occurrences: list[tuple[str, str]]
 
 
 def compute_health_flags(
@@ -227,9 +250,13 @@ def filter_tools(
     is the cached startup snapshot from :func:`compute_health_flags`.
     """
     eligible: list[ProxyToolInfo] = []
-    reject_reasons: dict[str, str] = {}
     risk_penalties: dict[str, float] = {}
     claimed_names: set[str] = set()
+    # Per-OCCURRENCE verdicts in input order; folded into the name-level
+    # ``reject_reasons`` map after the pass, because whether a rejected
+    # occurrence means "this NAME was withheld" depends on whether some
+    # other occurrence of the same name ended up advertised.
+    occurrence_rejects: list[tuple[str, str]] = []
 
     for candidate in candidates:
         info = candidate.info
@@ -238,7 +265,7 @@ def filter_tools(
 
         # ── config rules (every profile) ─────────────────────────────────
         if override is not None and override.hidden:
-            reject_reasons[info.prefixed_name] = REASON_CONFIG_HIDDEN
+            occurrence_rejects.append((info.prefixed_name, REASON_CONFIG_HIDDEN))
             continue
         profiles = (
             override.expose_in_profiles
@@ -246,15 +273,15 @@ def filter_tools(
             else server_cfg.expose_in_profiles
         )
         if profiles is not None and cfg.profile not in profiles:
-            reject_reasons[info.prefixed_name] = REASON_PROFILE_EXCLUDED
+            occurrence_rejects.append((info.prefixed_name, REASON_PROFILE_EXCLUDED))
             continue
 
         # ── structural rules (every profile) ─────────────────────────────
         if tool_name_budget.overflows(server_cfg.prefix, info.original_name):
-            reject_reasons[info.prefixed_name] = REASON_NAME_OVERFLOW
+            occurrence_rejects.append((info.prefixed_name, REASON_NAME_OVERFLOW))
             continue
         if info.prefixed_name in claimed_names:
-            reject_reasons[info.prefixed_name] = REASON_DUPLICATE_NAME
+            occurrence_rejects.append((info.prefixed_name, REASON_DUPLICATE_NAME))
             continue
 
         # ── signal rules (profile-dependent) ─────────────────────────────
@@ -266,7 +293,7 @@ def filter_tools(
                 flagged_reason = REASON_UNHEALTHY
             if flagged_reason is not None:
                 if cfg.profile is ExposureProfile.STRICT:
-                    reject_reasons[info.prefixed_name] = flagged_reason
+                    occurrence_rejects.append((info.prefixed_name, flagged_reason))
                     continue
                 # review: advertise, but demote in ranking telemetry.
                 risk_penalties[info.prefixed_name] = cfg.review_risk_penalty
@@ -277,6 +304,24 @@ def filter_tools(
         claimed_names.add(info.prefixed_name)
         eligible.append(info)
 
+    # Name-level fold. ``reject_reasons`` may only name tools the client
+    # did NOT get — a name some occurrence of which was advertised routes
+    # its rejected occurrences to ``dropped_occurrences`` instead, keeping
+    # ``reject_reasons`` keys disjoint from ``candidate_tools`` by
+    # construction. For a fully-withheld name the first rejected
+    # occurrence's reason wins; later occurrences of the same withheld
+    # name are occurrence drops too (one name, one reason).
+    reject_reasons: dict[str, str] = {}
+    dropped_occurrences: list[tuple[str, str]] = []
+    for name, reason in occurrence_rejects:
+        if name in claimed_names or name in reject_reasons:
+            dropped_occurrences.append((name, reason))
+        else:
+            reject_reasons[name] = reason
+
     return EligibilityResult(
-        eligible=eligible, reject_reasons=reject_reasons, risk_penalties=risk_penalties
+        eligible=eligible,
+        reject_reasons=reject_reasons,
+        risk_penalties=risk_penalties,
+        dropped_occurrences=dropped_occurrences,
     )

--- a/src/memtomem_stm/proxy/tool_relevance.py
+++ b/src/memtomem_stm/proxy/tool_relevance.py
@@ -17,9 +17,19 @@ availability varies, which would make #468 replay comparisons meaningless.
 The scored document per candidate is what the client actually saw: the
 prefixed tool name (BM25 heading position, 3x weight) plus the advertised —
 post-truncation, post-distill — description and stable-serialized schema.
-``risk_penalty`` is a ``0.0`` placeholder: no risk table exists in this repo
-(the one in the toolgraph report is not a repo artifact); a real penalty
-input arrives with #465's STM-native filter signals.
+
+``risk_penalty`` is the #465 hard filter's demotion input (``review``
+profile flags a tool instead of rejecting it): ``final_score =
+relevance_score * (1 - risk_penalty)`` and the ordering follows
+``final_score``, so a flagged tool sinks without leaving the record.
+Multiplicative because BM25 scores are unbounded — an absolute penalty
+would mean nothing across queries. Calls where any nonzero penalty applied
+stamp :data:`RANKER_VERSION_BM25_RISK` so replay can split cohorts; the
+penalties themselves are session-stable (health flags are computed once at
+startup), making records deterministic within a session and self-describing
+across sessions (each candidate carries the penalty that shaped its score).
+A hard-rejected tool never reaches this module at all — ranking runs over
+the filter's output, so it can never resurrect a reject.
 
 Privacy: the derived query is used in memory for scoring only — callers
 persist its sha256/length/source via ``build_candidate_features``, never the
@@ -30,6 +40,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from memtomem_stm.proxy.relevance import BM25Scorer
@@ -42,6 +53,13 @@ if TYPE_CHECKING:
 # selection log's "v0-passthrough" default, so replay can split cohorts by
 # this field alone.
 RANKER_VERSION_BM25 = "v1-bm25-tool-relevance"
+
+# Stamped instead of RANKER_VERSION_BM25 when at least one candidate carried
+# a nonzero risk penalty — the scoring function then differs from plain v1
+# (final_score = relevance * (1 - penalty)), and replay must not pool the
+# two. With an all-zero penalty map the math degenerates to v1 exactly, so
+# such calls keep the v1 stamp.
+RANKER_VERSION_BM25_RISK = "v2-bm25-risk-penalty"
 
 # Bound the schema text folded into each candidate document. Schemas are
 # advertised (possibly distilled) client-facing artifacts, but a pathological
@@ -96,25 +114,38 @@ class ToolRelevanceRanker:
         self._top_n = top_n
         self._scorer = BM25Scorer()
 
-    def rank(self, query: str, candidates: list[ProxyToolInfo]) -> list[dict[str, Any]]:
+    def rank(
+        self,
+        query: str,
+        candidates: list[ProxyToolInfo],
+        risk_penalties: Mapping[str, float] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Rank *candidates* against *query*; order follows ``final_score``.
+
+        *risk_penalties* maps prefixed names to the #465 filter's demotion
+        for tools flagged-but-advertised (``review`` profile); absent tools
+        carry ``0.0`` and the math degenerates to plain relevance order.
+        """
         if not candidates:
             return []
+        penalties = risk_penalties or {}
         sections = [_candidate_document(c) for c in candidates]
         scores = self._scorer.score_sections(query, sections)
+        finals = [
+            scores[i] * (1.0 - penalties.get(c.prefixed_name, 0.0))
+            for i, c in enumerate(candidates)
+        ]
         order = sorted(
             range(len(candidates)),
-            key=lambda i: (-scores[i], candidates[i].prefixed_name),
+            key=lambda i: (-finals[i], candidates[i].prefixed_name),
         )
         return [
             {
                 "tool": candidates[i].prefixed_name,
                 "rank": rank,
                 "relevance_score": round(scores[i], 6),
-                # Placeholder until a repo-local risk signal exists (#465);
-                # recorded explicitly so replay code never special-cases
-                # its absence.
-                "risk_penalty": 0.0,
-                "final_score": round(scores[i], 6),
+                "risk_penalty": round(penalties.get(candidates[i].prefixed_name, 0.0), 6),
+                "final_score": round(finals[i], 6),
             }
             for rank, i in enumerate(order[: self._top_n], start=1)
         ]

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -652,7 +652,10 @@ async def stm_proxy_health(
     lines = ["Upstream Server Health", "====================="]
     for name, info in health.items():
         status = "connected" if info["connected"] else "DISCONNECTED"
-        lines.append(f"  {name}: {status} ({info['tools']} tools)")
+        lines.append(
+            f"  {name}: {status} "
+            f"({info['tools']} tools discovered, {info['advertised_tools']} advertised)"
+        )
 
     surfacing = app.surfacing_engine
     if surfacing is not None:

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -85,7 +85,7 @@ class TestStart:
             }
         )
 
-        async def _conditional_connect(name, cfg, seen):
+        async def _conditional_connect(name, cfg):
             if name == "bad":
                 raise ConnectionError("unreachable")
 
@@ -227,7 +227,7 @@ class TestConnectTimeout:
             patch("memtomem_stm.proxy.manager.ClientSession", return_value=mock_session),
         ):
             with _pt.raises(asyncio.TimeoutError):
-                await mgr._connect_server("slow", cfg, set())
+                await mgr._connect_server("slow", cfg)
 
     async def test_start_logs_timeout_and_continues(self, caplog):
         """start() catches TimeoutError from _connect_server and continues."""
@@ -238,7 +238,7 @@ class TestConnectTimeout:
             }
         )
 
-        async def _conditional_connect(name, cfg, seen):
+        async def _conditional_connect(name, cfg):
             if name == "slow":
                 raise asyncio.TimeoutError()
 
@@ -276,23 +276,25 @@ class TestConnectServerCleanup:
             patch("memtomem_stm.proxy.manager.ClientSession", return_value=mock_session),
         ):
             with _pt.raises(RuntimeError, match="catalog failed"):
-                await mgr._connect_server("bad", cfg, set())
+                await mgr._connect_server("bad", cfg)
 
         assert "bad" not in mgr._connections
         mock_session.__aexit__.assert_awaited_once()
         mock_transport.__aexit__.assert_awaited_once()
 
 
-# ── tool name overflow skip (#261) ───────────────────────────────────────
+# ── tool name overflow (#261 → exposure-time enforcement via #465) ──────
 
 
 class TestConnectServerOverflowSkip:
-    """Boot-time enforcement: when an upstream returns a tool whose
-    composed name (`mcp__<server>__<prefix>__<tool>`) would exceed the
-    64-char MCP regex, skip *that one tool* and register the rest.
-    Failing the entire upstream would be too aggressive — one bad name
-    shouldn't make every other tool from the same upstream invisible
-    (#261).
+    """When an upstream returns a tool whose composed name
+    (`mcp__<server>__<prefix>__<tool>`) would exceed the 64-char MCP regex,
+    only *that one tool* is withheld and the rest still register — one bad
+    name shouldn't make every other tool from the same upstream invisible
+    (#261). Since #465 the enforcement point is the exposure-time
+    eligibility filter (reason ``name_overflow``, visible to telemetry):
+    ``_connect_server`` keeps every discovered tool in ``conn.tools`` and
+    only logs the prefix-shortening guidance.
     """
 
     async def _stub_session(self, tool_names: list[str]) -> AsyncMock:
@@ -323,11 +325,12 @@ class TestConnectServerOverflowSkip:
         transport.__aexit__ = AsyncMock(return_value=False)
         return transport
 
-    async def test_overflowing_tool_is_skipped_others_register(self, caplog, monkeypatch) -> None:
+    async def test_overflowing_tool_is_withheld_others_register(self, caplog, monkeypatch) -> None:
         """Mixed catalogue: a 40-char tool with the original ``docs_langchain``
         prefix (14 chars) overflows the 64-char limit, while a short tool from
-        the same upstream fits. Expect: short tool registered, long tool
-        logged + skipped, manager keeps running."""
+        the same upstream fits. Expect: both tools kept in ``conn.tools``,
+        guidance logged at connect, and the long tool withheld at exposure
+        with a ``name_overflow`` reject on the normal startup path."""
         monkeypatch.delenv("MMS_CLIENT_SERVER_NAME", raising=False)
 
         cfg = UpstreamServerConfig(prefix="docs_langchain")
@@ -351,11 +354,19 @@ class TestConnectServerOverflowSkip:
             patch("memtomem_stm.proxy.manager.ClientSession", return_value=session),
             caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"),
         ):
-            await mgr._connect_server("docs", cfg, set())
+            await mgr._connect_server("docs", cfg)
 
-        # Short tool registered, long tool not registered.
-        registered = [t.name for t in mgr._connections["docs"].tools]
-        assert registered == ["search"]
+        # Discovery keeps the full catalogue; exclusion is the filter's job.
+        discovered = [t.name for t in mgr._connections["docs"].tools]
+        assert discovered == ["search", "query_docs_filesystem_docs_by_lang_chain"]
+        # The first advertisement withholds the overflowing tool, with the
+        # verdict recorded for selection telemetry (#465 / codex R2: the
+        # structural reject must be observable on the NORMAL startup path).
+        advertised = [info.prefixed_name for info in mgr.get_proxy_tools()]
+        assert advertised == ["docs_langchain__search"]
+        assert mgr._advertised_reject_reasons == {
+            "docs_langchain__query_docs_filesystem_docs_by_lang_chain": "name_overflow"
+        }
         # Warning identifies the overflowing tool by name + composed length.
         warning_text = caplog.text
         assert "query_docs_filesystem_docs_by_lang_chain" in warning_text
@@ -367,7 +378,8 @@ class TestConnectServerOverflowSkip:
 
     async def test_short_prefix_lets_long_tool_through(self, caplog, monkeypatch) -> None:
         """With the recommended ``lc`` prefix the same long tool fits
-        (composed = 61 chars), so the skip path doesn't fire."""
+        (composed = 61 chars), so neither the guidance warning nor the
+        exposure reject fires."""
         monkeypatch.delenv("MMS_CLIENT_SERVER_NAME", raising=False)
 
         cfg = UpstreamServerConfig(prefix="lc")
@@ -386,9 +398,10 @@ class TestConnectServerOverflowSkip:
             patch("memtomem_stm.proxy.manager.ClientSession", return_value=session),
             caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"),
         ):
-            await mgr._connect_server("docs", cfg, set())
+            await mgr._connect_server("docs", cfg)
 
-        registered = [t.name for t in mgr._connections["docs"].tools]
-        assert registered == ["query_docs_filesystem_docs_by_lang_chain"]
-        # No skip-warning in the log — no overflow happened.
-        assert "Skipping tool" not in caplog.text
+        advertised = [info.prefixed_name for info in mgr.get_proxy_tools()]
+        assert advertised == ["lc__query_docs_filesystem_docs_by_lang_chain"]
+        assert mgr._advertised_reject_reasons == {}
+        # No overflow guidance in the log — no overflow happened.
+        assert "will not be advertised" not in caplog.text

--- a/tests/test_selection_log.py
+++ b/tests/test_selection_log.py
@@ -167,6 +167,24 @@ class TestSchemaStability:
         assert execution["cost"] is None
         assert execution["cache_hit"] is None
 
+    def test_reject_reasons_are_per_call_populatable(self, tmp_path):
+        """#465 wires the hard filter's verdict into the reserved seam: the
+        top-level key set must NOT change — reject_reasons is populated,
+        not added — and omitting it keeps the v0 empty-map default."""
+        log = _make_log(tmp_path)
+        rejects = {"test__hidden": "config_hidden", "test__flaky": "unhealthy"}
+        log.log_selection(
+            server="srv",
+            selected_tool="test__tool",
+            candidate_tools=["test__tool"],
+            arguments={},
+            trace_id=None,
+            reject_reasons=rejects,
+        )
+        (selection,) = _read_events(log)
+        assert set(selection) == SELECTION_KEYS
+        assert selection["reject_reasons"] == rejects
+
     def test_lines_are_sorted_key_compact_json(self, tmp_path):
         log = _make_log(tmp_path)
         _log_pair(log)

--- a/tests/test_selection_log.py
+++ b/tests/test_selection_log.py
@@ -198,8 +198,12 @@ class TestSchemaStability:
         key sets must NOT change — candidate_features is populated, not
         added, and ranker_version is stamped per record on both halves."""
         log = _make_log(tmp_path)
-        feats = {"query_source": "args", "query_sha256": "0" * 64, "query_chars": 4,
-                 "ranked_candidates": []}
+        feats = {
+            "query_source": "args",
+            "query_sha256": "0" * 64,
+            "query_chars": 4,
+            "ranked_candidates": [],
+        }
         sid = log.log_selection(
             server="srv",
             selected_tool="test__tool",

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -223,7 +223,10 @@ class TestHealth:
         assert "No upstream servers configured" in result
 
     async def test_with_servers(self):
-        """Reports connection status for each server."""
+        """Reports connection status with discovered vs advertised counts —
+        since #465 the discovered catalogue can exceed what the eligibility
+        filter actually exposed, and operators must be able to tell a
+        withheld tool from a missing one."""
         pm = _make_proxy_manager()
         conn = UpstreamConnection(
             name="srv",
@@ -234,7 +237,7 @@ class TestHealth:
         pm._connections["srv"] = conn
         ctx = _make_ctx(proxy_manager=pm)
         result = await stm_proxy_health(ctx=ctx)
-        assert "srv: connected (2 tools)" in result
+        assert "srv: connected (2 tools discovered, 0 advertised)" in result
 
     @staticmethod
     def _proxy_enabled_config() -> STMConfig:
@@ -1295,9 +1298,7 @@ class TestLifespan:
         with (
             patch("memtomem_stm.server.STMConfig") as MockConfig,
             patch("memtomem_stm.server.ProxyManager", return_value=mock_pm_instance),
-            patch(
-                "memtomem_stm.server.ProxyConfig.load_from_file", return_value=None
-            ) as mock_load,
+            patch("memtomem_stm.server.ProxyConfig.load_from_file", return_value=None) as mock_load,
         ):
             mock_cfg = MockConfig.return_value
             mock_cfg.proxy = MagicMock()

--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -146,23 +146,41 @@ class TestStructuralRules:
             assert result.reject_reasons == {f"test__{long_name}": REASON_NAME_OVERFLOW}
 
     def test_duplicate_name_first_wins(self):
+        # The advertised NAME must never also be claimed withheld:
+        # the duplicate occurrence is a log-only drop, not a telemetry
+        # reject (codex R1 — reject_reasons keys ⊥ candidate_tools).
         cfg = _server_cfg()
         first = _cand("dup", cfg, desc="first copy")
         second = _cand("dup", cfg, desc="second copy")
         result = filter_tools([first, second], STRICT)
         assert result.eligible == [first.info]
-        assert result.reject_reasons == {"test__dup": REASON_DUPLICATE_NAME}
+        assert result.reject_reasons == {}
+        assert result.dropped_occurrences == [("test__dup", REASON_DUPLICATE_NAME)]
 
     def test_rejected_tool_does_not_claim_its_name(self):
         # The first copy is signal-rejected (credential in metadata); the
         # clean second copy must be the one advertised, not dropped as a
-        # duplicate of a tool that never got exposed.
+        # duplicate of a tool that never got exposed — and since the name
+        # IS advertised, the flagged occurrence is a drop, not a reject.
         cfg = _server_cfg()
         flagged = _cand("dup", cfg, raw_desc="api_key=sk-" + "a" * 24)
         clean = _cand("dup", cfg, desc="clean copy")
         result = filter_tools([flagged, clean], STRICT)
         assert result.eligible == [clean.info]
-        assert result.reject_reasons == {"test__dup": REASON_SENSITIVE_METADATA}
+        assert result.reject_reasons == {}
+        assert result.dropped_occurrences == [("test__dup", REASON_SENSITIVE_METADATA)]
+
+    def test_fully_withheld_name_keeps_first_reason(self):
+        # Every occurrence of the name is rejected → the NAME was withheld:
+        # reject_reasons carries the first occurrence's reason, the second
+        # occurrence is an occurrence-level drop (one name, one reason).
+        cfg = _server_cfg(tool_overrides={"dup": ToolOverrideConfig(hidden=True)})
+        hidden_a = _cand("dup", cfg)
+        hidden_b = _cand("dup", cfg)
+        result = filter_tools([hidden_a, hidden_b], STRICT)
+        assert result.eligible == []
+        assert result.reject_reasons == {"test__dup": REASON_CONFIG_HIDDEN}
+        assert result.dropped_occurrences == [("test__dup", REASON_CONFIG_HIDDEN)]
 
 
 # ── signal rules: sensitive metadata ─────────────────────────────────────
@@ -277,6 +295,24 @@ class TestResultInvariants:
         for exposure in (STRICT, REVIEW, EXPLORE):
             result = self._mixed_result(exposure)
             assert set(_names(result)).isdisjoint(result.reject_reasons)
+            # Unique composed names (the normal case) → no occurrence drops.
+            assert result.dropped_occurrences == []
+
+    def test_disjointness_holds_with_same_named_occurrences(self):
+        """Telemetry must never claim a name was both advertised and
+        withheld, whichever occurrence survives in whichever profile."""
+        cfg = _server_cfg()
+        cands = [
+            _cand("dup", cfg, raw_desc="api_key=sk-" + "c" * 24),  # signal-flagged
+            _cand("dup", cfg, desc="clean copy"),
+            _cand("dup", cfg, desc="clean again"),  # duplicate of whoever claimed
+        ]
+        for exposure in (STRICT, REVIEW, EXPLORE):
+            result = filter_tools(cands, exposure)
+            assert len(_names(result)) == 1  # exactly one occurrence advertised
+            assert set(result.reject_reasons).isdisjoint(_names(result))
+            assert result.reject_reasons == {}  # name advertised → never withheld
+            assert len(result.dropped_occurrences) == 2
 
     def test_penalties_only_name_eligible_tools(self):
         for exposure in (STRICT, REVIEW, EXPLORE):

--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -145,42 +145,40 @@ class TestStructuralRules:
             assert _names(result) == ["test__ok"]
             assert result.reject_reasons == {f"test__{long_name}": REASON_NAME_OVERFLOW}
 
-    def test_duplicate_name_first_wins(self):
-        # The advertised NAME must never also be claimed withheld:
-        # the duplicate occurrence is a log-only drop, not a telemetry
-        # reject (codex R1 — reject_reasons keys ⊥ candidate_tools).
+    def test_duplicate_name_withholds_the_whole_group(self):
+        # A composed name carried by 2+ candidates is one callable entity
+        # wearing several metadata claims (upstream calls route by raw
+        # name), so no occurrence may be advertised — ambiguous names are
+        # never auto-exposed, the original #465 regression criterion.
         cfg = _server_cfg()
         first = _cand("dup", cfg, desc="first copy")
         second = _cand("dup", cfg, desc="second copy")
-        result = filter_tools([first, second], STRICT)
-        assert result.eligible == [first.info]
-        assert result.reject_reasons == {}
-        assert result.dropped_occurrences == [("test__dup", REASON_DUPLICATE_NAME)]
+        for exposure in (STRICT, REVIEW, EXPLORE):
+            result = filter_tools([first, second], exposure)
+            assert result.eligible == []
+            assert result.reject_reasons == {"test__dup": REASON_DUPLICATE_NAME}
 
-    def test_rejected_tool_does_not_claim_its_name(self):
-        # The first copy is signal-rejected (credential in metadata); the
-        # clean second copy must be the one advertised, not dropped as a
-        # duplicate of a tool that never got exposed — and since the name
-        # IS advertised, the flagged occurrence is a drop, not a reject.
+    def test_clean_copy_cannot_launder_a_flagged_sibling(self):
+        # codex R3 attack: list `dup` once with a credential and once
+        # clean. Advertising the clean copy would attach clean metadata to
+        # a callable whose upstream-side identity also matched a credential
+        # — the group is structurally ambiguous and fully withheld, with
+        # the ambiguity (not the signal) as the recorded reason.
         cfg = _server_cfg()
         flagged = _cand("dup", cfg, raw_desc="api_key=sk-" + "a" * 24)
         clean = _cand("dup", cfg, desc="clean copy")
         result = filter_tools([flagged, clean], STRICT)
-        assert result.eligible == [clean.info]
-        assert result.reject_reasons == {}
-        assert result.dropped_occurrences == [("test__dup", REASON_SENSITIVE_METADATA)]
-
-    def test_fully_withheld_name_keeps_first_reason(self):
-        # Every occurrence of the name is rejected → the NAME was withheld:
-        # reject_reasons carries the first occurrence's reason, the second
-        # occurrence is an occurrence-level drop (one name, one reason).
-        cfg = _server_cfg(tool_overrides={"dup": ToolOverrideConfig(hidden=True)})
-        hidden_a = _cand("dup", cfg)
-        hidden_b = _cand("dup", cfg)
-        result = filter_tools([hidden_a, hidden_b], STRICT)
         assert result.eligible == []
-        assert result.reject_reasons == {"test__dup": REASON_CONFIG_HIDDEN}
-        assert result.dropped_occurrences == [("test__dup", REASON_CONFIG_HIDDEN)]
+        assert result.reject_reasons == {"test__dup": REASON_DUPLICATE_NAME}
+
+    def test_ambiguity_prepass_precedes_config_rules(self):
+        # Even an operator-hidden name stays duplicate_name when duplicated:
+        # the pre-pass runs before every per-tool rule, so the verdict
+        # names the structural problem, not whichever rule fired first.
+        cfg = _server_cfg(tool_overrides={"dup": ToolOverrideConfig(hidden=True)})
+        result = filter_tools([_cand("dup", cfg), _cand("dup", cfg)], STRICT)
+        assert result.eligible == []
+        assert result.reject_reasons == {"test__dup": REASON_DUPLICATE_NAME}
 
 
 # ── signal rules: sensitive metadata ─────────────────────────────────────
@@ -310,24 +308,24 @@ class TestResultInvariants:
         for exposure in (STRICT, REVIEW, EXPLORE):
             result = self._mixed_result(exposure)
             assert set(_names(result)).isdisjoint(result.reject_reasons)
-            # Unique composed names (the normal case) → no occurrence drops.
-            assert result.dropped_occurrences == []
 
     def test_disjointness_holds_with_same_named_occurrences(self):
         """Telemetry must never claim a name was both advertised and
-        withheld, whichever occurrence survives in whichever profile."""
+        withheld — a multi-occurrence name is withheld outright in every
+        profile (one callable entity, several metadata claims), so the
+        disjointness is structural."""
         cfg = _server_cfg()
         cands = [
             _cand("dup", cfg, raw_desc="api_key=sk-" + "c" * 24),  # signal-flagged
             _cand("dup", cfg, desc="clean copy"),
-            _cand("dup", cfg, desc="clean again"),  # duplicate of whoever claimed
+            _cand("dup", cfg, desc="clean again"),
+            _cand("unique", cfg),
         ]
         for exposure in (STRICT, REVIEW, EXPLORE):
             result = filter_tools(cands, exposure)
-            assert len(_names(result)) == 1  # exactly one occurrence advertised
+            assert _names(result) == ["test__unique"]
+            assert result.reject_reasons == {"test__dup": REASON_DUPLICATE_NAME}
             assert set(result.reject_reasons).isdisjoint(_names(result))
-            assert result.reject_reasons == {}  # name advertised → never withheld
-            assert len(result.dropped_occurrences) == 2
 
     def test_penalties_only_name_eligible_tools(self):
         for exposure in (STRICT, REVIEW, EXPLORE):

--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -5,23 +5,33 @@ recorded, rule precedence is stable, the profile ladder behaves
 (``strict`` rejects / ``review`` demotes via ``risk_penalties`` /
 ``explore`` ignores signal rules), structural and config rules apply in
 every profile, health flags come from upstream-attributable errors only,
-and the whole pass is deterministic and side-effect-free.
+and the whole pass is deterministic and side-effect-free. The manager
+wire-in section pins the cross-issue contract: reject reasons land in
+selection telemetry (#467), review penalties land in relevance ranking
+(#466), and a hard-rejected tool can never be resurrected by ranking.
 """
 
 from __future__ import annotations
 
+import json
 import time
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 from memtomem_stm.proxy.config import (
+    CompressionStrategy,
     ExposureConfig,
     ExposureProfile,
+    ProxyConfig,
     ToolOverrideConfig,
     UpstreamServerConfig,
 )
-from memtomem_stm.proxy.manager import ProxyToolInfo
-from memtomem_stm.proxy.metrics import CallMetrics, ErrorCategory
+from memtomem_stm.proxy.manager import ProxyManager, ProxyToolInfo, UpstreamConnection
+from memtomem_stm.proxy.metrics import CallMetrics, ErrorCategory, TokenTracker
 from memtomem_stm.proxy.metrics_store import MetricsStore
+from memtomem_stm.proxy.selection_log import SelectionTelemetryLog
 from memtomem_stm.proxy.tool_eligibility import (
     REASON_CONFIG_HIDDEN,
     REASON_DUPLICATE_NAME,
@@ -34,6 +44,7 @@ from memtomem_stm.proxy.tool_eligibility import (
     compute_health_flags,
     filter_tools,
 )
+from memtomem_stm.proxy.tool_relevance import RANKER_VERSION_BM25_RISK
 
 
 def _server_cfg(prefix: str = "test", **kwargs: Any) -> UpstreamServerConfig:
@@ -108,9 +119,7 @@ class TestConfigRules:
         # Server restricts to explore; the tool-level list re-admits strict.
         cfg = _server_cfg(
             expose_in_profiles=[ExposureProfile.EXPLORE],
-            tool_overrides={
-                "a": ToolOverrideConfig(expose_in_profiles=[ExposureProfile.STRICT])
-            },
+            tool_overrides={"a": ToolOverrideConfig(expose_in_profiles=[ExposureProfile.STRICT])},
         )
         result = filter_tools([_cand("a", cfg), _cand("b", cfg)], STRICT)
         assert _names(result) == ["test__a"]
@@ -413,3 +422,147 @@ class TestGetToolErrorStats:
     def test_uninitialized_store_returns_empty(self, tmp_path):
         store = MetricsStore(tmp_path / "metrics.db")
         assert store.get_tool_error_stats(3600.0, UPSTREAM_ERROR_CATEGORIES) == {}
+
+
+# ── ProxyManager wire-in ─────────────────────────────────────────────────
+
+
+def _make_result(text: str):
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=text)], isError=False)
+
+
+def _make_manager(
+    tmp_path: Path,
+    *,
+    exposure: ExposureConfig | None = None,
+    tool_overrides: dict[str, ToolOverrideConfig] | None = None,
+    unhealthy: frozenset[tuple[str, str]] = frozenset(),
+) -> tuple[ProxyManager, SelectionTelemetryLog]:
+    server_cfg = UpstreamServerConfig(
+        prefix="test",
+        compression=CompressionStrategy.NONE,
+        max_retries=0,
+        reconnect_delay_seconds=0.0,
+        tool_overrides=tool_overrides or {},
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={"srv": server_cfg},
+        exposure=exposure or ExposureConfig(),
+    )
+    log = SelectionTelemetryLog(tmp_path / "log.jsonl")
+    log.initialize()
+    mgr = ProxyManager(proxy_cfg, TokenTracker(), selection_log=log)
+
+    tools = [
+        SimpleNamespace(
+            name="send_message",
+            description="Send a message to a Slack channel",
+            inputSchema={"type": "object", "properties": {"channel": {"type": "string"}}},
+        ),
+        SimpleNamespace(
+            name="read_file",
+            description="Read a file from the local filesystem",
+            inputSchema={"type": "object"},
+        ),
+    ]
+    session = AsyncMock()
+    session.call_tool.return_value = _make_result("ok!")
+    mgr._connections["srv"] = UpstreamConnection(
+        name="srv", config=server_cfg, session=session, tools=tools
+    )
+    mgr._unhealthy_tools = unhealthy
+    mgr.get_proxy_tools()  # advertise → snapshot eligibility verdict
+    return mgr, log
+
+
+def _events(log: SelectionTelemetryLog) -> list[dict]:
+    return [json.loads(line) for line in log.path.read_text(encoding="utf-8").splitlines() if line]
+
+
+class TestManagerWireIn:
+    async def test_hidden_reject_reaches_telemetry_and_never_ranks(self, tmp_path):
+        """The resurrection invariant end-to-end: a hard-rejected tool is
+        absent from exposure, absent from candidate_tools, absent from
+        ranked_candidates — present only in reject_reasons."""
+        mgr, log = _make_manager(
+            tmp_path, tool_overrides={"read_file": ToolOverrideConfig(hidden=True)}
+        )
+        assert [i.prefixed_name for i in mgr.get_proxy_tools()] == ["test__send_message"]
+
+        await mgr.call_tool("srv", "send_message", {"_context_query": "read a file"})
+        selection, _execution = _events(log)
+        assert selection["candidate_tools"] == ["test__send_message"]
+        assert selection["reject_reasons"] == {"test__read_file": REASON_CONFIG_HIDDEN}
+        ranked = selection["candidate_features"]["ranked_candidates"]
+        assert {r["tool"] for r in ranked} == {"test__send_message"}
+
+    async def test_unhealthy_strict_rejected_and_recorded(self, tmp_path):
+        mgr, log = _make_manager(tmp_path, unhealthy=frozenset({("srv", "read_file")}))
+        mgr.get_proxy_tools()
+        assert mgr._advertised_tools == ["test__send_message"]
+
+        await mgr.call_tool("srv", "send_message", {})
+        selection, _execution = _events(log)
+        assert selection["reject_reasons"] == {"test__read_file": REASON_UNHEALTHY}
+
+    async def test_review_penalty_flows_into_ranking_and_version(self, tmp_path):
+        mgr, log = _make_manager(
+            tmp_path,
+            exposure=ExposureConfig(profile=ExposureProfile.REVIEW, review_risk_penalty=0.5),
+            unhealthy=frozenset({("srv", "read_file")}),
+        )
+        mgr.get_proxy_tools()
+        # review: still advertised, nothing rejected.
+        assert mgr._advertised_tools == ["test__send_message", "test__read_file"]
+
+        await mgr.call_tool("srv", "read_file", {"_context_query": "read the file"})
+        selection, execution = _events(log)
+        assert selection["reject_reasons"] == {}
+        assert selection["ranker_version"] == RANKER_VERSION_BM25_RISK
+        assert execution["ranker_version"] == RANKER_VERSION_BM25_RISK
+        entry = next(
+            r
+            for r in selection["candidate_features"]["ranked_candidates"]
+            if r["tool"] == "test__read_file"
+        )
+        assert entry["risk_penalty"] == 0.5
+        assert entry["final_score"] == round(entry["relevance_score"] * 0.5, 6)
+        clean = next(
+            r
+            for r in selection["candidate_features"]["ranked_candidates"]
+            if r["tool"] == "test__send_message"
+        )
+        assert clean["risk_penalty"] == 0.0
+        assert clean["final_score"] == clean["relevance_score"]
+
+    async def test_strict_without_flags_keeps_v1_version(self, tmp_path):
+        mgr, log = _make_manager(tmp_path)
+        await mgr.call_tool("srv", "read_file", {"_context_query": "read the file"})
+        (selection, _execution) = _events(log)
+        assert selection["ranker_version"] == "v1-bm25-tool-relevance"
+        assert selection["reject_reasons"] == {}
+
+    async def test_advertisement_is_stable_across_calls(self, tmp_path):
+        """Teardown calls get_proxy_tools() again — same session state must
+        produce the identical advertisement and verdict."""
+        mgr, _log = _make_manager(tmp_path, unhealthy=frozenset({("srv", "read_file")}))
+        first = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        rejects = dict(mgr._advertised_reject_reasons)
+        second = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        assert first == second
+        assert mgr._advertised_reject_reasons == rejects
+
+    async def test_start_computes_health_flags_from_metrics_store(self, tmp_path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        for _ in range(5):
+            _record(store, "broken", error=ErrorCategory.UPSTREAM_ERROR)
+        cfg = ProxyConfig(config_path=tmp_path / "proxy.json", upstream_servers={})
+        mgr = ProxyManager(cfg, TokenTracker(metrics_store=store))
+        await mgr.start()
+        try:
+            assert mgr._unhealthy_tools == frozenset({("srv", "broken")})
+        finally:
+            await mgr.stop()
+            store.close()

--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -1,0 +1,415 @@
+"""Tests for the STM-native tool-exposure hard filter (#465).
+
+Pins the acceptance criteria: every reject reason code fires and is
+recorded, rule precedence is stable, the profile ladder behaves
+(``strict`` rejects / ``review`` demotes via ``risk_penalties`` /
+``explore`` ignores signal rules), structural and config rules apply in
+every profile, health flags come from upstream-attributable errors only,
+and the whole pass is deterministic and side-effect-free.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from memtomem_stm.proxy.config import (
+    ExposureConfig,
+    ExposureProfile,
+    ToolOverrideConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyToolInfo
+from memtomem_stm.proxy.metrics import CallMetrics, ErrorCategory
+from memtomem_stm.proxy.metrics_store import MetricsStore
+from memtomem_stm.proxy.tool_eligibility import (
+    REASON_CONFIG_HIDDEN,
+    REASON_DUPLICATE_NAME,
+    REASON_NAME_OVERFLOW,
+    REASON_PROFILE_EXCLUDED,
+    REASON_SENSITIVE_METADATA,
+    REASON_UNHEALTHY,
+    UPSTREAM_ERROR_CATEGORIES,
+    ExposureCandidate,
+    compute_health_flags,
+    filter_tools,
+)
+
+
+def _server_cfg(prefix: str = "test", **kwargs: Any) -> UpstreamServerConfig:
+    return UpstreamServerConfig(prefix=prefix, **kwargs)
+
+
+def _cand(
+    name: str,
+    server_cfg: UpstreamServerConfig,
+    *,
+    desc: str = "Reads project data",
+    raw_desc: str | None = None,
+    schema: dict[str, Any] | None = None,
+    server: str = "srv",
+) -> ExposureCandidate:
+    schema = schema if schema is not None else {"type": "object"}
+    return ExposureCandidate(
+        info=ProxyToolInfo(
+            prefixed_name=f"{server_cfg.prefix}__{name}",
+            description=desc,
+            input_schema=schema,
+            server=server,
+            original_name=name,
+        ),
+        raw_description=raw_desc if raw_desc is not None else desc,
+        raw_schema=schema,
+        server_config=server_cfg,
+    )
+
+
+def _names(result) -> list[str]:
+    return [info.prefixed_name for info in result.eligible]
+
+
+STRICT = ExposureConfig(profile=ExposureProfile.STRICT)
+REVIEW = ExposureConfig(profile=ExposureProfile.REVIEW)
+EXPLORE = ExposureConfig(profile=ExposureProfile.EXPLORE)
+
+
+# ── config rules ─────────────────────────────────────────────────────────
+
+
+class TestConfigRules:
+    def test_hidden_override_rejected_in_every_profile(self):
+        cfg = _server_cfg(tool_overrides={"a": ToolOverrideConfig(hidden=True)})
+        cands = [_cand("a", cfg), _cand("b", cfg)]
+        for exposure in (STRICT, REVIEW, EXPLORE):
+            result = filter_tools(cands, exposure)
+            assert _names(result) == ["test__b"]
+            assert result.reject_reasons == {"test__a": REASON_CONFIG_HIDDEN}
+
+    def test_tool_profiles_list_excludes_other_profiles(self):
+        cfg = _server_cfg(
+            tool_overrides={
+                "danger": ToolOverrideConfig(expose_in_profiles=[ExposureProfile.EXPLORE])
+            }
+        )
+        cands = [_cand("danger", cfg)]
+        for exposure in (STRICT, REVIEW):
+            result = filter_tools(cands, exposure)
+            assert result.eligible == []
+            assert result.reject_reasons == {"test__danger": REASON_PROFILE_EXCLUDED}
+        assert _names(filter_tools(cands, EXPLORE)) == ["test__danger"]
+
+    def test_server_profiles_apply_to_all_its_tools(self):
+        cfg = _server_cfg(expose_in_profiles=[ExposureProfile.STRICT])
+        result = filter_tools([_cand("a", cfg), _cand("b", cfg)], REVIEW)
+        assert result.eligible == []
+        assert set(result.reject_reasons.values()) == {REASON_PROFILE_EXCLUDED}
+
+    def test_tool_profiles_override_server_profiles(self):
+        # Server restricts to explore; the tool-level list re-admits strict.
+        cfg = _server_cfg(
+            expose_in_profiles=[ExposureProfile.EXPLORE],
+            tool_overrides={
+                "a": ToolOverrideConfig(expose_in_profiles=[ExposureProfile.STRICT])
+            },
+        )
+        result = filter_tools([_cand("a", cfg), _cand("b", cfg)], STRICT)
+        assert _names(result) == ["test__a"]
+        assert result.reject_reasons == {"test__b": REASON_PROFILE_EXCLUDED}
+
+    def test_empty_profiles_list_hides_everywhere(self):
+        cfg = _server_cfg(tool_overrides={"a": ToolOverrideConfig(expose_in_profiles=[])})
+        for exposure in (STRICT, REVIEW, EXPLORE):
+            result = filter_tools([_cand("a", cfg)], exposure)
+            assert result.reject_reasons == {"test__a": REASON_PROFILE_EXCLUDED}
+
+
+# ── structural rules ─────────────────────────────────────────────────────
+
+
+class TestStructuralRules:
+    def test_name_overflow_rejected_in_every_profile(self):
+        cfg = _server_cfg()
+        long_name = "x" * 60  # 21 overhead + 4 prefix + 60 ≫ 64
+        cands = [_cand(long_name, cfg), _cand("ok", cfg)]
+        for exposure in (STRICT, REVIEW, EXPLORE):
+            result = filter_tools(cands, exposure)
+            assert _names(result) == ["test__ok"]
+            assert result.reject_reasons == {f"test__{long_name}": REASON_NAME_OVERFLOW}
+
+    def test_duplicate_name_first_wins(self):
+        cfg = _server_cfg()
+        first = _cand("dup", cfg, desc="first copy")
+        second = _cand("dup", cfg, desc="second copy")
+        result = filter_tools([first, second], STRICT)
+        assert result.eligible == [first.info]
+        assert result.reject_reasons == {"test__dup": REASON_DUPLICATE_NAME}
+
+    def test_rejected_tool_does_not_claim_its_name(self):
+        # The first copy is signal-rejected (credential in metadata); the
+        # clean second copy must be the one advertised, not dropped as a
+        # duplicate of a tool that never got exposed.
+        cfg = _server_cfg()
+        flagged = _cand("dup", cfg, raw_desc="api_key=sk-" + "a" * 24)
+        clean = _cand("dup", cfg, desc="clean copy")
+        result = filter_tools([flagged, clean], STRICT)
+        assert result.eligible == [clean.info]
+        assert result.reject_reasons == {"test__dup": REASON_SENSITIVE_METADATA}
+
+
+# ── signal rules: sensitive metadata ─────────────────────────────────────
+
+
+class TestSensitiveMetadata:
+    CRED_DESC = "Call with api_key= to authenticate"
+
+    def test_credential_in_description_rejected_under_strict(self):
+        result = filter_tools([_cand("a", _server_cfg(), raw_desc=self.CRED_DESC)], STRICT)
+        assert result.eligible == []
+        assert result.reject_reasons == {"test__a": REASON_SENSITIVE_METADATA}
+
+    def test_credential_in_raw_schema_rejected_under_strict(self):
+        schema = {
+            "type": "object",
+            "properties": {"token": {"type": "string", "default": "ghp_" + "a" * 36}},
+        }
+        result = filter_tools([_cand("a", _server_cfg(), schema=schema)], STRICT)
+        assert result.reject_reasons == {"test__a": REASON_SENSITIVE_METADATA}
+
+    def test_credential_only_in_truncated_tail_still_caught(self):
+        # The advertised description was truncated before the credential;
+        # the scan runs over the RAW description, so it still fires.
+        raw = ("benign text " * 50) + "password=hunter2hunter2"
+        cand = _cand("a", _server_cfg(), desc=raw[:80], raw_desc=raw)
+        result = filter_tools([cand], STRICT)
+        assert result.reject_reasons == {"test__a": REASON_SENSITIVE_METADATA}
+
+    def test_email_is_not_a_credential(self):
+        # PII patterns are deliberately excluded — a contact email in a
+        # description must not hide the tool.
+        result = filter_tools(
+            [_cand("a", _server_cfg(), desc="Maintained by ops@example.com")], STRICT
+        )
+        assert result.eligible != []
+        assert result.reject_reasons == {}
+
+    def test_review_demotes_instead_of_rejecting(self):
+        result = filter_tools([_cand("a", _server_cfg(), raw_desc=self.CRED_DESC)], REVIEW)
+        assert _names(result) == ["test__a"]
+        assert result.reject_reasons == {}
+        assert result.risk_penalties == {"test__a": REVIEW.review_risk_penalty}
+
+    def test_explore_ignores_signal(self):
+        result = filter_tools([_cand("a", _server_cfg(), raw_desc=self.CRED_DESC)], EXPLORE)
+        assert _names(result) == ["test__a"]
+        assert result.reject_reasons == {}
+        assert result.risk_penalties == {}
+
+
+# ── signal rules: health ─────────────────────────────────────────────────
+
+
+class TestHealthRule:
+    def test_unhealthy_rejected_under_strict(self):
+        cfg = _server_cfg()
+        result = filter_tools(
+            [_cand("bad", cfg), _cand("good", cfg)],
+            STRICT,
+            unhealthy=frozenset({("srv", "bad")}),
+        )
+        assert _names(result) == ["test__good"]
+        assert result.reject_reasons == {"test__bad": REASON_UNHEALTHY}
+
+    def test_unhealthy_demoted_under_review(self):
+        custom = ExposureConfig(profile=ExposureProfile.REVIEW, review_risk_penalty=0.25)
+        result = filter_tools(
+            [_cand("bad", _server_cfg())], custom, unhealthy=frozenset({("srv", "bad")})
+        )
+        assert _names(result) == ["test__bad"]
+        assert result.risk_penalties == {"test__bad": 0.25}
+
+    def test_unhealthy_ignored_under_explore(self):
+        result = filter_tools(
+            [_cand("bad", _server_cfg())], EXPLORE, unhealthy=frozenset({("srv", "bad")})
+        )
+        assert result.risk_penalties == {}
+        assert result.reject_reasons == {}
+
+    def test_health_keyed_by_server_and_raw_name(self):
+        # Same bare tool name on a different connection stays exposed.
+        result = filter_tools(
+            [_cand("bad", _server_cfg(), server="other")],
+            STRICT,
+            unhealthy=frozenset({("srv", "bad")}),
+        )
+        assert _names(result) == ["test__bad"]
+
+
+# ── result invariants ────────────────────────────────────────────────────
+
+
+class TestResultInvariants:
+    def _mixed_result(self, exposure: ExposureConfig):
+        cfg = _server_cfg(
+            tool_overrides={
+                "hidden": ToolOverrideConfig(hidden=True),
+                "scoped": ToolOverrideConfig(expose_in_profiles=[ExposureProfile.EXPLORE]),
+            }
+        )
+        cands = [
+            _cand("hidden", cfg),
+            _cand("scoped", cfg),
+            _cand("creds", cfg, raw_desc="secret_key: sk-" + "b" * 30),
+            _cand("flaky", cfg),
+            _cand("ok", cfg),
+        ]
+        return filter_tools(cands, exposure, unhealthy=frozenset({("srv", "flaky")}))
+
+    def test_eligible_and_rejected_are_disjoint(self):
+        for exposure in (STRICT, REVIEW, EXPLORE):
+            result = self._mixed_result(exposure)
+            assert set(_names(result)).isdisjoint(result.reject_reasons)
+
+    def test_penalties_only_name_eligible_tools(self):
+        for exposure in (STRICT, REVIEW, EXPLORE):
+            result = self._mixed_result(exposure)
+            assert set(result.risk_penalties) <= set(_names(result))
+
+    def test_deterministic_across_runs(self):
+        a = self._mixed_result(STRICT)
+        b = self._mixed_result(STRICT)
+        assert _names(a) == _names(b)
+        assert a.reject_reasons == b.reject_reasons
+        assert a.risk_penalties == b.risk_penalties
+
+    def test_strict_full_verdict(self):
+        result = self._mixed_result(STRICT)
+        assert _names(result) == ["test__ok"]
+        assert result.reject_reasons == {
+            "test__hidden": REASON_CONFIG_HIDDEN,
+            "test__scoped": REASON_PROFILE_EXCLUDED,
+            "test__creds": REASON_SENSITIVE_METADATA,
+            "test__flaky": REASON_UNHEALTHY,
+        }
+
+    def test_review_keeps_signal_flagged_tools_with_penalties(self):
+        result = self._mixed_result(REVIEW)
+        assert _names(result) == ["test__creds", "test__flaky", "test__ok"]
+        assert result.risk_penalties == {
+            "test__creds": REVIEW.review_risk_penalty,
+            "test__flaky": REVIEW.review_risk_penalty,
+        }
+
+
+# ── compute_health_flags ─────────────────────────────────────────────────
+
+
+def _record(
+    store: MetricsStore,
+    tool: str,
+    *,
+    error: ErrorCategory | None = None,
+    server: str = "srv",
+) -> None:
+    store.record(
+        CallMetrics(
+            server=server,
+            tool=tool,
+            original_chars=10,
+            compressed_chars=10,
+            is_error=error is not None,
+            error_category=error,
+        )
+    )
+
+
+class TestComputeHealthFlags:
+    def _store(self, tmp_path) -> MetricsStore:
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        return store
+
+    def test_consistently_failing_tool_flagged(self, tmp_path):
+        store = self._store(tmp_path)
+        for _ in range(5):
+            _record(store, "bad", error=ErrorCategory.UPSTREAM_ERROR)
+        for _ in range(5):
+            _record(store, "good")
+        assert compute_health_flags(store, STRICT) == frozenset({("srv", "bad")})
+
+    def test_below_min_calls_is_presumed_healthy(self, tmp_path):
+        store = self._store(tmp_path)
+        for _ in range(4):  # default health_min_calls = 5
+            _record(store, "sparse", error=ErrorCategory.TIMEOUT)
+        assert compute_health_flags(store, STRICT) == frozenset()
+
+    def test_below_threshold_not_flagged(self, tmp_path):
+        store = self._store(tmp_path)
+        for _ in range(9):
+            _record(store, "flaky", error=ErrorCategory.TRANSPORT)
+        _record(store, "flaky")  # 90% < default 95%
+        assert compute_health_flags(store, STRICT) == frozenset()
+
+    def test_proxy_internal_errors_do_not_count(self, tmp_path):
+        store = self._store(tmp_path)
+        for _ in range(10):
+            _record(store, "victim", error=ErrorCategory.INTERNAL_ERROR)
+        assert compute_health_flags(store, STRICT) == frozenset()
+
+    def test_old_failures_age_out_of_window(self, tmp_path):
+        store = self._store(tmp_path)
+        for _ in range(10):
+            _record(store, "recovered", error=ErrorCategory.UPSTREAM_ERROR)
+        # Rewind the rows beyond the window so a restart re-admits the tool.
+        assert store._db is not None
+        store._db.execute(
+            "UPDATE proxy_metrics SET created_at = ?",
+            (time.time() - STRICT.health_window_hours * 3600.0 - 60.0,),
+        )
+        store._db.commit()
+        assert compute_health_flags(store, STRICT) == frozenset()
+
+    def test_no_store_means_no_flags(self):
+        assert compute_health_flags(None, STRICT) == frozenset()
+
+    def test_store_read_failure_fails_open(self, tmp_path):
+        store = self._store(tmp_path)
+        store.close()  # closed store returns {} rather than raising
+
+        class Exploding:
+            def get_tool_error_stats(self, *a, **k):
+                raise RuntimeError("disk on fire")
+
+        assert compute_health_flags(Exploding(), STRICT) == frozenset()
+
+
+# ── MetricsStore.get_tool_error_stats ────────────────────────────────────
+
+
+class TestGetToolErrorStats:
+    def test_counts_calls_and_matching_errors(self, tmp_path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        _record(store, "t", error=ErrorCategory.UPSTREAM_ERROR)
+        _record(store, "t", error=ErrorCategory.INTERNAL_ERROR)  # not upstream-attributable
+        _record(store, "t")
+        stats = store.get_tool_error_stats(3600.0, UPSTREAM_ERROR_CATEGORIES)
+        assert stats == {("srv", "t"): (3, 1)}
+
+    def test_window_excludes_old_rows(self, tmp_path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        _record(store, "t", error=ErrorCategory.TIMEOUT)
+        assert store._db is not None
+        store._db.execute("UPDATE proxy_metrics SET created_at = created_at - 7200")
+        store._db.commit()
+        assert store.get_tool_error_stats(3600.0, UPSTREAM_ERROR_CATEGORIES) == {}
+
+    def test_empty_categories_count_no_errors(self, tmp_path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        _record(store, "t", error=ErrorCategory.UPSTREAM_ERROR)
+        assert store.get_tool_error_stats(3600.0, ()) == {("srv", "t"): (1, 0)}
+
+    def test_uninitialized_store_returns_empty(self, tmp_path):
+        store = MetricsStore(tmp_path / "metrics.db")
+        assert store.get_tool_error_stats(3600.0, UPSTREAM_ERROR_CATEGORIES) == {}

--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -210,6 +210,21 @@ class TestSensitiveMetadata:
         result = filter_tools([cand], STRICT)
         assert result.reject_reasons == {"test__a": REASON_SENSITIVE_METADATA}
 
+    def test_credential_deep_in_large_schema_still_caught(self):
+        # The scan is a security gate with no downstream backstop on the
+        # advertisement path (telemetry never carries the schema), so it
+        # must NOT be length-capped: a credential buried past any cap in a
+        # huge raw schema still rejects (codex R2).
+        schema = {
+            "type": "object",
+            "properties": {
+                f"field_{i:04d}": {"type": "string", "description": "x" * 40} for i in range(400)
+            }
+            | {"zzz_last": {"type": "string", "default": "ghp_" + "a" * 36}},
+        }
+        result = filter_tools([_cand("a", _server_cfg(), schema=schema)], STRICT)
+        assert result.reject_reasons == {"test__a": REASON_SENSITIVE_METADATA}
+
     def test_email_is_not_a_credential(self):
         # PII patterns are deliberately excluded — a contact email in a
         # description must not hide the tool.

--- a/tests/test_tool_relevance.py
+++ b/tests/test_tool_relevance.py
@@ -124,6 +124,36 @@ class TestRanker:
     def test_empty_candidates(self):
         assert ToolRelevanceRanker().rank("anything", []) == []
 
+    def test_risk_penalty_demotes_by_final_score(self):
+        """#465 review-profile demotion: order follows final_score =
+        relevance * (1 - penalty), and both inputs stay in the record."""
+        query = "send a slack message to the channel"
+        baseline = ToolRelevanceRanker().rank(query, CANDIDATES)
+        assert baseline[0]["tool"] == "test__send_message"
+
+        ranked = ToolRelevanceRanker().rank(
+            query, CANDIDATES, risk_penalties={"test__send_message": 1.0}
+        )
+        flagged = next(r for r in ranked if r["tool"] == "test__send_message")
+        assert flagged["rank"] > 1  # fully penalized → sinks below the rest
+        assert flagged["risk_penalty"] == 1.0
+        assert flagged["final_score"] == 0.0
+        assert flagged["relevance_score"] == baseline[0]["relevance_score"]
+        # Unflagged candidates are untouched: penalty 0, final == relevance.
+        for entry in ranked:
+            if entry["tool"] != "test__send_message":
+                assert entry["risk_penalty"] == 0.0
+                assert entry["final_score"] == entry["relevance_score"]
+
+    def test_zero_penalty_map_is_identical_to_no_map(self):
+        query = "read the config file"
+        a = ToolRelevanceRanker().rank(query, CANDIDATES)
+        b = ToolRelevanceRanker().rank(query, CANDIDATES, risk_penalties={})
+        c = ToolRelevanceRanker().rank(
+            query, CANDIDATES, risk_penalties={"test__read_file": 0.0}
+        )
+        assert json.dumps(a) == json.dumps(b) == json.dumps(c)
+
 
 # ── build_candidate_features ─────────────────────────────────────────────
 

--- a/tests/test_tool_relevance.py
+++ b/tests/test_tool_relevance.py
@@ -149,9 +149,7 @@ class TestRanker:
         query = "read the config file"
         a = ToolRelevanceRanker().rank(query, CANDIDATES)
         b = ToolRelevanceRanker().rank(query, CANDIDATES, risk_penalties={})
-        c = ToolRelevanceRanker().rank(
-            query, CANDIDATES, risk_penalties={"test__read_file": 0.0}
-        )
+        c = ToolRelevanceRanker().rank(query, CANDIDATES, risk_penalties={"test__read_file": 0.0})
         assert json.dumps(a) == json.dumps(b) == json.dumps(c)
 
 
@@ -218,11 +216,7 @@ def _make_manager(
 
 
 def _events(log: SelectionTelemetryLog) -> list[dict]:
-    return [
-        json.loads(line)
-        for line in log.path.read_text(encoding="utf-8").splitlines()
-        if line
-    ]
+    return [json.loads(line) for line in log.path.read_text(encoding="utf-8").splitlines() if line]
 
 
 class TestManagerWireIn:


### PR DESCRIPTION
## Summary

Implements the re-scoped, STM-native stage of #465: a deterministic hard filter at the proxy's tool-exposure choke point (`get_proxy_tools()`), built entirely from signals the proxy already owns — no toolgraph dependency. **Issue #465 stays open after this merge** as the umbrella for the optional toolgraph `eligible_tools` provider stage (gated on toolgraph#15/#13 landing).

New module `proxy/tool_eligibility.py` absorbs what used to be three scattered exposure guards (per-tool `hidden` skip inline in `get_proxy_tools`, connect-time duplicate-name skip, connect-time 64-char-overflow skip) into one pure, auditable pass, and adds profile- and signal-based rules. `_connect_server` now keeps every discovered tool and only logs the #261 prefix guidance — the filter is the single exclusion point, so every verdict reaches telemetry on the normal startup path and connect/reconnect get identical treatment.

## Rule vocabulary (one reason per withheld name)

| code | rule | profiles |
|---|---|---|
| `duplicate_name` | composed name carried by >1 discovered tool — the **entire ambiguous group** is withheld (ambiguity pre-pass, runs before every other rule; upstream calls route by raw name, so same-named occurrences are one callable entity wearing several metadata claims — a "clean" copy must not launder a flagged sibling) | all |
| `config_hidden` | per-tool `hidden: true` | all |
| `profile_excluded` | `expose_in_profiles` (per-upstream / per-tool, tool wins) excludes the active profile | all |
| `name_overflow` | composed client name > 64-char MCP limit (#261) | all |
| `sensitive_metadata` | credential pattern (CREDENTIAL_PATTERNS only, not PII) in raw description / advertised description / **full** raw schema (unbounded scan — security gate, no downstream backstop on the advertisement path) | strict rejects; review demotes |
| `unhealthy` | upstream-attributable error rate (transport/timeout/protocol/upstream_error only) ≥ 0.95 over ≥ 5 calls in a 24h `proxy_metrics.db` window | strict rejects; review demotes |

Profile ladder (`exposure.profile`, default `strict`): **strict** = signal rules hard-reject; **review** = signal-flagged tools stay advertised but carry `review_risk_penalty` in #466 ranking telemetry (observe what strict would hide); **explore** = signal rules off. Config/structural rules apply in every profile.

**Telemetry never contradicts the advertisement:** `reject_reasons` keys are disjoint from `candidate_tools` structurally — the ambiguity pre-pass withholds every multi-occurrence name outright, so each surviving name has exactly one candidate and an entry always means "this name was withheld entirely".

## Track integration

- **#467**: the advertisement's reject map rides into every selection event's `reject_reasons` (schema v1 key set unchanged — the field was reserved for exactly this; pinned by tests).
- **#466**: review-profile penalties feed `ToolRelevanceRanker` — `final_score = relevance_score * (1 - risk_penalty)`, ordering follows `final_score`, and calls shaped by a nonzero penalty stamp `v2-bm25-risk-penalty` on both pair halves (all-zero map keeps the v1 stamp, since the math degenerates to v1 exactly).
- **Invariant**: ranking can never resurrect a hard reject — it runs over the filter's eligible output; pinned end-to-end by a wire-in test (rejected tool absent from `candidate_tools` and `ranked_candidates`, present only in `reject_reasons`).

## Design decisions

- **Health is evaluated once per `start()`** from the persisted metrics store and cached: MCP clients aren't guaranteed to re-list tools, and mid-session exposure drift would make telemetry lie about the candidate set the client saw. A health-hidden tool re-qualifies at the next startup once its failures age out of the window (startup-grained half-open probing).
- **Proxy-internal failures never count against a tool's health** (`internal_error`/`lock_timeout`/`programming` excluded) — hiding a tool because our pipeline broke would punish the wrong party.
- **Sensitive-metadata scan runs over the RAW description/schema** (truncation only removes text) plus the advertised description (covers operator `description_override`), with no length cap.
- **Registration-race safety without the connect-time guard**: the FastMCP registration loop consumes the filter's output, which is unique by construction.
- **Operators can tell withheld from missing**: `get_upstream_health` reports `tools` (discovered) and `advertised_tools`; `stm_proxy_health` renders "N tools discovered, M advertised"; rejects log once per advertisement change (WARNING for structural/signal, DEBUG for the operator's own config choices).

## Behavior change

Default profile is `strict`, so two classes of tools that were advertised before can now be withheld **without any config change**:

1. **Consistently failing tools** — ≥ 95% upstream-attributable errors over ≥ 5 calls within the last 24h (deliberately conservative; requires `metrics.enabled`, which is the default). These tools were failing nearly every call anyway; hiding them is the feature.
2. **Tools with credential-looking metadata** — e.g. a description containing `api_key=`-style text or a provider-prefixed token. Suspicious by definition; advertising one pastes the match into the client context on every `tools/list`.

Additionally: same-named duplicate groups are now withheld entirely (previously first-listed copy won — see rule table for why that was unsafe); `hidden`-tool rejects (previously silent) now appear in `reject_reasons` telemetry when `selection_telemetry` is enabled; `conn.tools` / health tool counts now reflect the full discovered catalogue (exclusion happens at exposure, not discovery). Escape hatches: switch `exposure.profile` to `review`/`explore`, tune health thresholds, or scope tools with `expose_in_profiles`.

## Review

Codex 4 rounds: R1 NEEDS-FIX (Major: duplicate-name telemetry could contradict the advertised set → occurrence/name fold) → R2 NEEDS-FIX (Majors: connect-time skips bypassed the filter on the normal startup path → single choke point; 20k schema-scan cap → unbounded) → R3 NEEDS-FIX (Major: first-eligible-wins let a clean copy launder a flagged same-named sibling → ambiguity pre-pass withholds the whole group, which also deleted the R1 fold as unnecessary; Minor: discovered-vs-advertised counts) → **R4 SHIP** (no findings).

## Tests

- `tests/test_tool_eligibility.py` (new, 45 tests): every reason code, the ambiguity pre-pass (incl. the R3 laundering attack and precedence over config rules), the profile matrix, disjointness invariants, deep-schema credential regression, health-flag computation from a real metrics store (window aging, category filtering, fail-open), `get_tool_error_stats`, and the ProxyManager wire-in (telemetry + ranking + resurrection invariant + session stability + `start()` health snapshot).
- Extended: `test_selection_log.py`, `test_tool_relevance.py`, `test_proxy_manager_lifecycle.py` (#261 contract moved to exposure time), `test_server_tools.py` (health rendering).
- Full suite: **3288 passed** (`-m "not ollama"`), ruff clean, mypy delta-clean (8 pre-existing errors untouched). CI green on all jobs.

## Follow-ups (not in this PR)

- Surface reject counts / current verdict via `stm_proxy_stats` or `mms status` (recorded #467 follow-up).
- Per-tool profile *evaluation* override (false-positive escape hatch finer than the global profile switch) — wait-for-signal.
- toolgraph `eligible_tools` as an optional feature provider once toolgraph#15/#13 land — plugs into this filter as an additional rule source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)