### PR TITLE
feat(cli): capture origin provenance at import, redact it from --json (#475)

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -14,6 +15,7 @@ import sys
 import tomllib
 from collections.abc import Iterator
 from contextlib import AsyncExitStack, contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -30,6 +32,7 @@ from memtomem_stm.mms.import_hosts import (
     _is_self_reference,
     _read_json_safely,
 )
+from memtomem_stm.mms.state import utc_now_iso
 from memtomem_stm.proxy import tool_name_budget
 from memtomem_stm.utils.fileio import atomic_write_text
 from memtomem_stm.utils.redact import redact_exception_text, redact_url_userinfo
@@ -514,6 +517,28 @@ def version() -> None:
     click.echo(f"memtomem-stm {pkg_version('memtomem-stm')}")
 
 
+def _redacted_servers_json(servers: dict[str, Any]) -> dict[str, Any]:
+    """Server map for ``--json`` output with ``origin.original`` stripped (#475).
+
+    ``origin.original`` is the verbatim host entry an import captured and may
+    carry secrets (``env`` / ``headers``), so the machine-readable outputs
+    must not dump it. The summary keys (``source`` kinds, ``pruned`` flags,
+    ``imported_at``) stay, plus ``has_original`` so scripts can tell a
+    redacted block from one that never captured an original. Human output is
+    unaffected — it only prints selected fields. (Entries' own ``env`` is
+    exposed here as before — pre-existing surface, out of scope per #475.)
+    """
+    redacted: dict[str, Any] = {}
+    for name, cfg in servers.items():
+        if isinstance(cfg, dict) and isinstance(cfg.get("origin"), dict):
+            origin = dict(cfg["origin"])
+            origin["has_original"] = isinstance(origin.pop("original", None), dict)
+            redacted[name] = {**cfg, "origin": origin}
+        else:
+            redacted[name] = cfg
+    return redacted
+
+
 @cli.command()
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
@@ -540,7 +565,7 @@ def status(config_path: str, *, as_json: bool = False) -> None:
                 {
                     "config_path": str(resolved),
                     "enabled": enabled,
-                    "servers": servers,
+                    "servers": _redacted_servers_json(servers),
                 },
                 indent=2,
                 ensure_ascii=False,
@@ -598,7 +623,7 @@ def list_servers(config_path: str, *, as_json: bool = False) -> None:
     if as_json:
         click.echo(
             json.dumps(
-                {"config_path": str(resolved), "servers": servers},
+                {"config_path": str(resolved), "servers": _redacted_servers_json(servers)},
                 indent=2,
                 ensure_ascii=False,
             )
@@ -1097,41 +1122,83 @@ def _normalize_client_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
     return entry
 
 
+# One definition of the source-client locations the import flow can read,
+# keeping three consumers in lockstep (#475): the discovery labels below,
+# the removal hint (`_source_removal_hint`), and the prune writer
+# (`_prune_from_source`). ``kind`` is the machine-readable identifier
+# persisted in ``origin.source.kind`` (see ``UpstreamOrigin`` in
+# ``proxy/config.py``); ``claude_scope`` is the ``claude mcp remove -s``
+# scope for shell-out sources, ``None`` marking the one source (Claude
+# Desktop) handled by direct JSON edit instead.
+@dataclass(frozen=True)
+class _SourceSpec:
+    label: str
+    kind: str
+    claude_scope: str | None
+
+
+_SOURCE_SPECS: tuple[_SourceSpec, ...] = (
+    _SourceSpec(".mcp.json (project)", "mcp-json", "project"),
+    _SourceSpec("Claude Code (user)", "claude-user", "user"),
+    _SourceSpec("Claude Code (project)", "claude-project", "local"),
+    _SourceSpec("Claude Desktop", "claude-desktop", None),
+)
+_SOURCE_BY_LABEL: dict[str, _SourceSpec] = {spec.label: spec for spec in _SOURCE_SPECS}
+
+
 def _discover_candidates(cwd: Path) -> list[dict[str, Any]]:
     """Scan known MCP-client configs and return importable candidates.
 
-    Each candidate dict is ``{name, source, entry}`` where ``entry`` is an
-    already-normalized STM upstream-server entry (sans prefix). The first
-    source to claim a name wins; later duplicates are dropped with a
-    ``duplicate_in`` note so the UI can indicate the overlap.
+    Each candidate dict is ``{name, source, entry, raw, source_ref}`` where
+    ``entry`` is an already-normalized STM upstream-server entry (sans
+    prefix), ``raw`` is the **verbatim** host entry (normalization is lossy —
+    the original is what ``mms eject`` restores, #475), and ``source_ref``
+    is the structured ``{kind, path?}`` record persisted as
+    ``origin.source``. The first source to claim a name wins; later
+    duplicates are dropped with a ``duplicate_in`` label note for the UI
+    plus a structured ``duplicates`` record (``{label, source_ref, raw}``)
+    so provenance and the prune backup log can address every source.
     """
-    sources: list[tuple[str, dict[str, Any]]] = []
+    sources: list[tuple[_SourceSpec, str | None, dict[str, Any]]] = []
 
     # 1. Project-scope ``.mcp.json`` in cwd (Claude Code project config).
-    proj = _read_json_safely(cwd / ".mcp.json")
+    mcp_json_path = cwd / ".mcp.json"
+    proj = _read_json_safely(mcp_json_path)
     if proj and isinstance(proj.get("mcpServers"), dict):
-        sources.append((".mcp.json (project)", proj["mcpServers"]))
+        sources.append(
+            (
+                _SOURCE_BY_LABEL[".mcp.json (project)"],
+                str(mcp_json_path.resolve()),
+                proj["mcpServers"],
+            )
+        )
 
     # 2. Claude Code ~/.claude.json user-scope + per-project entries.
     cc = _read_json_safely(Path("~/.claude.json").expanduser())
     if cc:
         if isinstance(cc.get("mcpServers"), dict):
-            sources.append(("Claude Code (user)", cc["mcpServers"]))
+            sources.append((_SOURCE_BY_LABEL["Claude Code (user)"], None, cc["mcpServers"]))
         projects = cc.get("projects")
         if isinstance(projects, dict):
             # Match on resolved cwd so we don't duplicate entries across sibling projects.
             resolved_cwd = str(cwd.resolve())
             proj_entry = projects.get(resolved_cwd)
             if isinstance(proj_entry, dict) and isinstance(proj_entry.get("mcpServers"), dict):
-                sources.append(("Claude Code (project)", proj_entry["mcpServers"]))
+                sources.append(
+                    (
+                        _SOURCE_BY_LABEL["Claude Code (project)"],
+                        resolved_cwd,
+                        proj_entry["mcpServers"],
+                    )
+                )
 
     # 3. Claude Desktop (macOS path only; non-macOS → file absent → skipped).
     desktop = _read_json_safely(_desktop_config_path())
     if desktop and isinstance(desktop.get("mcpServers"), dict):
-        sources.append(("Claude Desktop", desktop["mcpServers"]))
+        sources.append((_SOURCE_BY_LABEL["Claude Desktop"], None, desktop["mcpServers"]))
 
     seen: dict[str, dict[str, Any]] = {}
-    for source_label, servers in sources:
+    for spec, src_path, servers in sources:
         if not isinstance(servers, dict):
             continue
         for name, raw in servers.items():
@@ -1140,11 +1207,58 @@ def _discover_candidates(cwd: Path) -> list[dict[str, Any]]:
             entry = _normalize_client_entry(raw)
             if entry is None or _is_self_reference(entry):
                 continue
+            source_ref: dict[str, Any] = {"kind": spec.kind}
+            if src_path is not None:
+                source_ref["path"] = src_path
             if name in seen:
-                seen[name].setdefault("duplicate_in", []).append(source_label)
+                seen[name].setdefault("duplicate_in", []).append(spec.label)
+                seen[name].setdefault("duplicates", []).append(
+                    {"label": spec.label, "source_ref": source_ref, "raw": copy.deepcopy(raw)}
+                )
                 continue
-            seen[name] = {"name": name, "source": source_label, "entry": entry}
+            seen[name] = {
+                "name": name,
+                "source": spec.label,
+                "entry": entry,
+                "raw": copy.deepcopy(raw),
+                "source_ref": source_ref,
+            }
     return list(seen.values())
+
+
+def _build_origin(cand: dict[str, Any], imported_at: str) -> dict[str, Any] | None:
+    """Build the per-entry ``origin`` provenance block for an import (#475).
+
+    Returns ``None`` when the candidate carries no verbatim ``raw`` /
+    ``source_ref`` (hand-constructed candidates) — a partial block could not
+    drive a faithful restore, so none is written.
+
+    Construction goes through the ``UpstreamOrigin`` pydantic model so the
+    shape the CLI writes cannot drift from the schema the server documents
+    (``proxy/config.py``). ``pruned`` / ``pruned_at`` stay at their defaults
+    here; the prune writers update them per source (PR2 of #475).
+    """
+    raw = cand.get("raw")
+    source_ref = cand.get("source_ref")
+    if not isinstance(raw, dict) or not isinstance(source_ref, dict):
+        return None
+
+    # Deferred import: ``proxy.config`` materializes the full pydantic model
+    # tree, which only the two import commands need — keep it off the CLI's
+    # cold-start path.
+    from memtomem_stm.proxy.config import OriginSource, UpstreamOrigin
+
+    origin = UpstreamOrigin(
+        source=OriginSource(**source_ref),
+        duplicates=[
+            OriginSource(**dup["source_ref"])
+            for dup in cand.get("duplicates") or []
+            if isinstance(dup.get("source_ref"), dict)
+        ],
+        imported_at=imported_at,
+        original=raw,
+    )
+    return origin.model_dump(mode="json", exclude_none=True)
 
 
 def _format_candidate_detail(entry: dict[str, Any]) -> str:
@@ -1161,19 +1275,17 @@ def _source_removal_hint(name: str, source: str) -> str:
     from the client that originated it.
 
     STM never edits source client configs itself — the hint is copy-paste
-    only. Scope-label mapping matches the ``claude mcp remove -s`` flag:
-    ``Claude Code (project)`` is the per-project entry in ``~/.claude.json``,
-    which the Claude Code CLI calls ``local``.
+    only. Scope-label mapping comes from ``_SOURCE_SPECS`` and matches the
+    ``claude mcp remove -s`` flag: ``Claude Code (project)`` is the
+    per-project entry in ``~/.claude.json``, which the Claude Code CLI calls
+    ``local``.
     """
-    if source == "Claude Code (user)":
-        return f"claude mcp remove {name} -s user"
-    if source == "Claude Code (project)":
-        return f"claude mcp remove {name} -s local"
-    if source == ".mcp.json (project)":
-        return f"claude mcp remove {name} -s project"
-    if source == "Claude Desktop":
-        return f"# Edit {_desktop_config_path()} and remove '{name}' under mcpServers."
-    return f"# Remove '{name}' from {source}."
+    spec = _SOURCE_BY_LABEL.get(source)
+    if spec is None:
+        return f"# Remove '{name}' from {source}."
+    if spec.claude_scope is not None:
+        return f"claude mcp remove {name} -s {spec.claude_scope}"
+    return f"# Edit {_desktop_config_path()} and remove '{name}' under mcpServers."
 
 
 def _print_source_removal_hints(imported_candidates: list[dict[str, Any]]) -> None:
@@ -1273,19 +1385,17 @@ def _desktop_json_remove_entry(name: str) -> tuple[bool, str | None]:
 def _prune_from_source(name: str, source: str) -> tuple[bool, str | None]:
     """Dispatch the prune action per source label used by ``_discover_candidates``.
 
-    Scope-label mapping matches :func:`_source_removal_hint` — the remediation
-    hint and the prune writer agree on which ``claude mcp remove -s <scope>``
-    flag maps to which label. Unknown sources are refused rather than guessed.
+    Scope-label mapping comes from the same ``_SOURCE_SPECS`` table as
+    :func:`_source_removal_hint` — the remediation hint and the prune writer
+    cannot disagree on which ``claude mcp remove -s <scope>`` flag maps to
+    which label. Unknown sources are refused rather than guessed.
     """
-    if source == "Claude Code (user)":
-        return _claude_mcp_remove(name, "user")
-    if source == "Claude Code (project)":
-        return _claude_mcp_remove(name, "local")
-    if source == ".mcp.json (project)":
-        return _claude_mcp_remove(name, "project")
-    if source == "Claude Desktop":
-        return _desktop_json_remove_entry(name)
-    return (False, f"unknown source label: {source}")
+    spec = _SOURCE_BY_LABEL.get(source)
+    if spec is None:
+        return (False, f"unknown source label: {source}")
+    if spec.claude_scope is not None:
+        return _claude_mcp_remove(name, spec.claude_scope)
+    return _desktop_json_remove_entry(name)
 
 
 def _prune_imported_candidates(
@@ -1727,6 +1837,7 @@ def _add_from_clients(
     # suggestions don't collide with prior registrations.
     used_prefixes: set[str] = {p for srv_cfg in servers.values() if (p := srv_cfg.get("prefix"))}
     imported: dict[str, dict[str, Any]] = {}
+    imported_at = utc_now_iso()
     click.echo("")
     for idx in picks:
         cand = new_candidates[idx]
@@ -1735,6 +1846,9 @@ def _add_from_clients(
         prefix = _prompt_prefix(default=suggested)
         used_prefixes.add(prefix)
         entry = {"prefix": prefix, **cand["entry"]}
+        origin = _build_origin(cand, imported_at)
+        if origin is not None:
+            entry["origin"] = origin
         imported[cand["name"]] = entry
 
     if validate:
@@ -1940,6 +2054,7 @@ def init(
 
         click.echo("")
         used_prefixes: set[str] = set()
+        imported_at = utc_now_iso()
         for idx in picks:
             cand = candidates[idx]
             click.echo(_hdr(f"Configuring '{cand['name']}'"))
@@ -1947,6 +2062,9 @@ def init(
             prefix = _prompt_prefix(default=suggested)
             used_prefixes.add(prefix)
             entry = {"prefix": prefix, **cand["entry"]}
+            origin = _build_origin(cand, imported_at)
+            if origin is not None:
+                entry["origin"] = origin
             imported[cand["name"]] = entry
             imported_candidates.append(cand)
     else:

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -431,6 +431,44 @@ class ToolOverrideConfig(BaseModel):
     visible."""
 
 
+class OriginSource(BaseModel):
+    """One host-config location an imported upstream entry came from (#475)."""
+
+    kind: str
+    """Machine-readable source kind: ``claude-user`` / ``claude-project`` /
+    ``mcp-json`` / ``claude-desktop``. Kept in lockstep with the CLI's shared
+    source table (``cli/proxy.py``); a plain ``str`` rather than an enum so a
+    config written by a newer CLI with a new kind still validates here."""
+    path: str | None = None
+    """Filesystem anchor for path-scoped kinds: the resolved project dir for
+    ``claude-project``, the ``.mcp.json`` path for ``mcp-json``."""
+    pruned: bool = False
+    """``True`` once this source's host entry was removed by a prune writer.
+    Per-source rather than per-entry because prune permits partial failure
+    across the primary source and its duplicates."""
+    pruned_at: str | None = None
+
+
+class UpstreamOrigin(BaseModel):
+    """Import provenance for an upstream entry (#475).
+
+    Written by the CLI import paths (``mms init`` / ``mms add --import``) so
+    the entry can later be restored to its host config verbatim (``mms
+    eject``). The proxy runtime never reads it — the field exists here to
+    document the schema and give the CLI a validated constructor.
+
+    ``original`` is the verbatim host entry and may contain secrets
+    (``env`` / ``headers``); CLI ``--json`` outputs must strip it (see the
+    redacted serializer in ``cli/proxy.py``) rather than dumping it.
+    """
+
+    schema_version: int = 1
+    source: OriginSource
+    duplicates: list[OriginSource] = []
+    imported_at: str | None = None
+    original: dict[str, Any] | None = None
+
+
 class UpstreamServerConfig(BaseModel):
     command: str = ""
     args: list[str] = []
@@ -507,6 +545,12 @@ class UpstreamServerConfig(BaseModel):
     """
     max_description_chars: int = Field(default=200, gt=0)
     strip_schema_descriptions: bool = False
+    origin: UpstreamOrigin | None = None
+    """Import provenance (#475) — see :class:`UpstreamOrigin`. CLI-owned
+    metadata: the server validates the shape but never reads it at runtime.
+    Older binaries that predate the field ignore it via pydantic's default
+    ``extra="ignore"``; the CLI's raw-dict load/save preserves it through
+    every config mutation."""
 
     @model_validator(mode="after")
     def _check_ordering(self) -> Self:

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -46,6 +46,33 @@ def _cfg_args(config: Path) -> list[str]:
     return ["--config", str(config)]
 
 
+def _config_with_origin() -> dict:
+    """Config payload with one origin-bearing entry (secret in
+    ``origin.original.env``) and one plain entry — shared by the
+    ``status --json`` / ``list --json`` redaction tests (#475)."""
+    return {
+        "enabled": True,
+        "upstream_servers": {
+            "gh": {
+                "prefix": "gh",
+                "transport": "stdio",
+                "command": "npx",
+                "origin": {
+                    "schema_version": 1,
+                    "source": {"kind": "claude-user", "pruned": False},
+                    "duplicates": [{"kind": "claude-desktop", "pruned": False}],
+                    "imported_at": "2026-06-11T05:00:00Z",
+                    "original": {
+                        "command": "npx",
+                        "env": {"GITHUB_TOKEN": "ghp_supersecret"},
+                    },
+                },
+            },
+            "plain": {"prefix": "pl", "command": "uvx"},
+        },
+    }
+
+
 # ── version command ─────────────────────────────────────────────────────
 
 
@@ -381,6 +408,27 @@ class TestStatus:
         data = json.loads(result.output)
         assert data["error"] == "config_not_found"
 
+    def test_json_redacts_origin_original(self, runner, config):
+        """``origin.original`` is the verbatim host entry and may carry
+        secrets — ``status --json`` must emit only the provenance summary
+        plus ``has_original`` (#475)."""
+        config.write_text(json.dumps(_config_with_origin()), encoding="utf-8")
+        result = runner.invoke(cli, ["status", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        origin = json.loads(result.output)["servers"]["gh"]["origin"]
+        assert "original" not in origin
+        assert origin["has_original"] is True
+        assert "ghp_supersecret" not in result.output
+        # Summary keys survive — scripts can still read provenance.
+        assert origin["source"] == {"kind": "claude-user", "pruned": False}
+        assert origin["duplicates"] == [{"kind": "claude-desktop", "pruned": False}]
+        assert origin["imported_at"] == "2026-06-11T05:00:00Z"
+        # Redaction is output-only: the config file keeps the original.
+        on_disk = json.loads(config.read_text(encoding="utf-8"))
+        assert on_disk["upstream_servers"]["gh"]["origin"]["original"]["env"] == {
+            "GITHUB_TOKEN": "ghp_supersecret"
+        }
+
     def test_shows_server_details(self, runner, config):
         config.write_text(
             json.dumps(
@@ -511,6 +559,19 @@ class TestListServers:
         data = json.loads(result.output)
         assert data["error"] == "config_not_found"
         assert str(config) in data["path"]
+
+    def test_json_redacts_origin_original(self, runner, config):
+        """Same redaction contract as ``status --json`` (#475) — entries
+        without an origin pass through byte-identical."""
+        config.write_text(json.dumps(_config_with_origin()), encoding="utf-8")
+        result = runner.invoke(cli, ["list", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        servers = json.loads(result.output)["servers"]
+        assert "original" not in servers["gh"]["origin"]
+        assert servers["gh"]["origin"]["has_original"] is True
+        assert "ghp_supersecret" not in result.output
+        assert servers["plain"] == {"prefix": "pl", "command": "uvx"}
+        assert "origin" not in servers["plain"]
 
 
 # ── add command — validation paths ───────────────────────────────────────
@@ -1455,6 +1516,62 @@ class TestInitDiscoverySources:
         fs = next(c for c in cands if c["name"] == "filesystem")
         assert fs["source"] == "Claude Code (user)"
         assert fs["entry"]["transport"] == "stdio"
+        # Origin capture (#475): verbatim raw + structured source ref.
+        assert fs["raw"] == {"command": "npx", "args": ["-y", "@fs"]}
+        assert fs["source_ref"] == {"kind": "claude-user"}
+
+    def test_discovers_claude_code_project_scope_with_path(self, tmp_path, monkeypatch):
+        """Per-project entries in ``~/.claude.json`` carry the resolved cwd in
+        ``source_ref.path`` — ``mms eject`` restores via ``claude mcp add-json
+        -s local``, which resolves the project by cwd (#475)."""
+        from memtomem_stm.cli.proxy import _discover_candidates
+
+        home, cwd, _ = self._setup_home(tmp_path, monkeypatch)
+        (home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "projects": {
+                        str(cwd.resolve()): {
+                            "mcpServers": {"proj-tool": {"command": "node", "args": ["a.js"]}}
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cands = _discover_candidates(cwd)
+        assert len(cands) == 1
+        assert cands[0]["source"] == "Claude Code (project)"
+        assert cands[0]["source_ref"] == {
+            "kind": "claude-project",
+            "path": str(cwd.resolve()),
+        }
+        assert cands[0]["raw"] == {"command": "node", "args": ["a.js"]}
+
+    def test_raw_is_verbatim_where_normalization_is_lossy(self, tmp_path, monkeypatch):
+        """``_normalize_client_entry`` drops HTTP ``headers``, dangerous env
+        keys, and unknown fields. ``raw`` must keep all of them — it is the
+        restore payload for ``mms eject`` (#475)."""
+        from memtomem_stm.cli.proxy import _discover_candidates
+
+        home, cwd, _ = self._setup_home(tmp_path, monkeypatch)
+        raw_entry = {
+            "type": "http",
+            "url": "https://api.example/mcp",
+            "headers": {"Authorization": "Bearer tok"},
+            "unknown_host_field": True,
+        }
+        (home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"api": raw_entry}}),
+            encoding="utf-8",
+        )
+
+        cands = _discover_candidates(cwd)
+        assert len(cands) == 1
+        assert cands[0]["raw"] == raw_entry
+        assert "headers" not in cands[0]["entry"]
+        assert "unknown_host_field" not in cands[0]["entry"]
 
     def test_discovers_desktop_config(self, tmp_path, monkeypatch):
         from memtomem_stm.cli.proxy import _discover_candidates
@@ -1482,6 +1599,10 @@ class TestInitDiscoverySources:
         cands = _discover_candidates(cwd)
         assert len(cands) == 1
         assert cands[0]["source"] == ".mcp.json (project)"
+        assert cands[0]["source_ref"] == {
+            "kind": "mcp-json",
+            "path": str((cwd / ".mcp.json").resolve()),
+        }
 
     def test_dedupes_by_name_priority(self, tmp_path, monkeypatch):
         """Same name in multiple sources → first-priority wins, others
@@ -1506,6 +1627,21 @@ class TestInitDiscoverySources:
         assert len(cands) == 1
         assert cands[0]["entry"]["command"] == "a"  # .mcp.json wins
         assert cands[0]["duplicate_in"] == ["Claude Code (user)", "Claude Desktop"]
+        # Structured duplicate records (#475): every losing source keeps its
+        # kind + verbatim raw so origin.duplicates and the prune backup log
+        # (PR2) can address each source individually.
+        assert cands[0]["duplicates"] == [
+            {
+                "label": "Claude Code (user)",
+                "source_ref": {"kind": "claude-user"},
+                "raw": {"command": "b"},
+            },
+            {
+                "label": "Claude Desktop",
+                "source_ref": {"kind": "claude-desktop"},
+                "raw": {"command": "c"},
+            },
+        ]
 
     def test_skips_self_reference(self, tmp_path, monkeypatch):
         """Imports of STM (``mms``) or LTM (``memtomem-server``, either as
@@ -1965,6 +2101,203 @@ class _FakeClaudeResult:
         self.returncode = returncode
         self.stdout = ""
         self.stderr = stderr
+
+
+class TestImportOriginCapture:
+    """Both import paths (``mms init`` + ``mms add --import``) persist an
+    ``origin`` provenance block per imported entry (#475 PR1): structured
+    source kind(s), import timestamp, and the **verbatim** host entry — the
+    restore payload for ``mms eject``. Manual entries get none.
+
+    ``_run_mcp_integration`` / ``_handle_source_prune`` are stubbed as in
+    ``TestInitImportFlow`` — this class is about what gets persisted, not the
+    post-save steps."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_post_save(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_run_mcp_integration", lambda *_a, **_kw: None)
+        monkeypatch.setattr(proxy_mod, "_handle_source_prune", lambda *_a, **_kw: None)
+
+    def _stub_candidates(self, monkeypatch, candidates):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: candidates)
+
+    @staticmethod
+    def _github_candidate() -> dict:
+        """Full discovery-shaped candidate: lossy-normalized entry + verbatim
+        raw (keeps the env secret + a field normalization drops) + one
+        duplicate source."""
+        return {
+            "name": "github",
+            "source": "Claude Code (user)",
+            "entry": {
+                "transport": "stdio",
+                "command": "npx",
+                "args": ["-y", "@gh"],
+                "compression": "auto",
+                "max_result_chars": 8000,
+            },
+            "raw": {
+                "command": "npx",
+                "args": ["-y", "@gh"],
+                "env": {"GITHUB_TOKEN": "ghp_secret"},
+                "host_only_field": True,
+            },
+            "source_ref": {"kind": "claude-user"},
+            "duplicate_in": ["Claude Desktop"],
+            "duplicates": [
+                {
+                    "label": "Claude Desktop",
+                    "source_ref": {"kind": "claude-desktop"},
+                    "raw": {"command": "npx", "args": ["-y", "@gh"]},
+                }
+            ],
+        }
+
+    def _assert_origin_block(self, entry: dict, cand: dict) -> None:
+        origin = entry["origin"]
+        assert origin["schema_version"] == 1
+        assert origin["source"] == {"kind": "claude-user", "pruned": False}
+        assert origin["duplicates"] == [{"kind": "claude-desktop", "pruned": False}]
+        # Verbatim deep-equality — normalization loss must not leak into the
+        # provenance copy.
+        assert origin["original"] == cand["raw"]
+        assert origin["imported_at"].endswith("Z")
+        # Lockstep pin: what the CLI wrote validates against the schema the
+        # server documents.
+        from memtomem_stm.proxy.config import UpstreamOrigin
+
+        assert UpstreamOrigin.model_validate(origin).source.kind == "claude-user"
+
+    def test_init_import_writes_origin_block(self, runner, config, monkeypatch):
+        cand = self._github_candidate()
+        self._stub_candidates(monkeypatch, [cand])
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        self._assert_origin_block(data["upstream_servers"]["github"], cand)
+
+    def test_add_import_writes_origin_block(self, runner, config, monkeypatch):
+        config.write_text(json.dumps({"enabled": True, "upstream_servers": {}}), encoding="utf-8")
+        cand = self._github_candidate()
+        self._stub_candidates(monkeypatch, [cand])
+        result = runner.invoke(
+            cli,
+            ["add", "--import", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        self._assert_origin_block(data["upstream_servers"]["github"], cand)
+
+    def test_candidate_without_raw_gets_no_origin(self, runner, config, monkeypatch):
+        """A candidate that never captured a verbatim raw (hand-constructed)
+        produces no origin block at all — a partial block could not drive a
+        faithful restore."""
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "legacy",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                }
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "origin" not in data["upstream_servers"]["legacy"]
+
+    def test_manual_init_flow_writes_no_origin(self, runner, config, no_discovery):
+        """Origin is import-only provenance — the manual prompt flow has no
+        host entry to record."""
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="filesystem\nfs\nstdio\nnpx\n-y @fs\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "origin" not in data["upstream_servers"]["filesystem"]
+
+    def test_init_roundtrip_preserves_verbatim_original_from_real_files(
+        self, tmp_path, monkeypatch, runner
+    ):
+        """End-to-end through real discovery (no stubs): host file → init →
+        config. ``origin.original`` deep-equals the host entry including
+        fields the STM entry drops."""
+        home = tmp_path / "home"
+        home.mkdir()
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        set_home(monkeypatch, home)
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_desktop_config_path", lambda: home / "no_desktop.json")
+        host_entry = {
+            "command": "npx",
+            "args": ["-y", "@gh"],
+            "env": {"GITHUB_TOKEN": "ghp_secret", "LD_PRELOAD": "/evil.so"},
+        }
+        (home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"github": host_entry}}), encoding="utf-8"
+        )
+        monkeypatch.chdir(cwd)
+
+        config = tmp_path / "stm_proxy.json"
+        result = runner.invoke(
+            cli,
+            ["init", "--no-validate", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config.read_text(encoding="utf-8"))
+        entry = data["upstream_servers"]["github"]
+        assert entry["origin"]["original"] == host_entry
+        assert entry["origin"]["source"] == {"kind": "claude-user", "pruned": False}
+        # The dangerous env key is filtered from the *active* entry (forward
+        # import) but kept verbatim in the provenance copy — eject restores
+        # what the host originally had (#475 §7).
+        assert "LD_PRELOAD" not in (entry.get("env") or {})
+
+    def test_other_cli_commands_preserve_origin(self, runner, config, monkeypatch):
+        """The CLI's raw-dict load/save passthrough keeps origin intact across
+        unrelated mutations (``mms surfacing``, ``mms remove`` of a sibling)."""
+        cand = self._github_candidate()
+        self._stub_candidates(monkeypatch, [cand])
+        runner.invoke(cli, ["init", "--no-validate", *_cfg_args(config)], input="all\n\n")
+        runner.invoke(
+            cli,
+            ["add", "other", "--prefix", "ot", "--command", "uvx", *_cfg_args(config)],
+        )
+        before = json.loads(config.read_text(encoding="utf-8"))
+        origin_before = before["upstream_servers"]["github"]["origin"]
+
+        result = runner.invoke(cli, ["surfacing", "github", "off", *_cfg_args(config)])
+        assert result.exit_code == 0, result.output
+        result = runner.invoke(cli, ["remove", "other", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0, result.output
+
+        after = json.loads(config.read_text(encoding="utf-8"))
+        assert after["upstream_servers"]["github"]["origin"] == origin_before
+        assert after["upstream_servers"]["github"]["surfacing_enabled"] is False
 
 
 class TestInitMcpRegistration:

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -12,9 +12,11 @@ from memtomem_stm.proxy.config import (
     HybridConfig,
     LLMCompressorConfig,
     LLMProvider,
+    OriginSource,
     ProxyConfig,
     RelevanceScorerConfig,
     SelectiveConfig,
+    UpstreamOrigin,
     UpstreamServerConfig,
 )
 from memtomem_stm.surfacing.config import SurfacingConfig
@@ -94,6 +96,68 @@ class TestProxyNumericConstraints:
     def test_hybrid_defaults_are_valid(self) -> None:
         cfg = HybridConfig()
         assert cfg.min_head_chars <= cfg.head_chars
+
+
+class TestUpstreamOrigin:
+    """`origin` import-provenance block (#475) — schema documented server-side.
+
+    The proxy runtime never reads `origin`; these pins exist so the shape the
+    CLI import paths write keeps validating here (the CLI constructs it via
+    this model) and so compat with configs written by newer/older versions
+    cannot silently regress.
+    """
+
+    _FULL_ORIGIN = {
+        "schema_version": 1,
+        "source": {"kind": "claude-user", "pruned": False},
+        "duplicates": [
+            {"kind": "claude-desktop", "pruned": False},
+            {"kind": "mcp-json", "path": "/proj/.mcp.json", "pruned": False},
+        ],
+        "imported_at": "2026-06-11T05:00:00Z",
+        "original": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-github"],
+            "env": {"GITHUB_TOKEN": "ghp_x"},
+        },
+    }
+
+    def test_full_origin_block_validates_on_upstream_entry(self) -> None:
+        cfg = UpstreamServerConfig(prefix="gh", command="npx", origin=self._FULL_ORIGIN)
+        assert cfg.origin is not None
+        assert cfg.origin.source.kind == "claude-user"
+        assert cfg.origin.source.pruned is False
+        assert [d.kind for d in cfg.origin.duplicates] == ["claude-desktop", "mcp-json"]
+        assert cfg.origin.duplicates[1].path == "/proj/.mcp.json"
+        # Verbatim original survives validation untouched — it is what
+        # `mms eject` restores.
+        assert cfg.origin.original == self._FULL_ORIGIN["original"]
+
+    def test_origin_defaults(self) -> None:
+        origin = UpstreamOrigin(source=OriginSource(kind="claude-user"))
+        assert origin.schema_version == 1
+        assert origin.duplicates == []
+        assert origin.source.pruned is False
+        assert origin.source.pruned_at is None
+        assert origin.original is None
+
+    def test_unknown_origin_keys_ignored_for_forward_compat(self) -> None:
+        """A config written by a newer CLI (schema_version bump adding keys,
+        or a new source kind) must still load in this server — pydantic's
+        default ``extra="ignore"`` is the compat mechanism (#475)."""
+        block = {
+            "schema_version": 2,
+            "source": {"kind": "some-future-host", "pruned": False, "new_field": 1},
+            "future_top_level": {"x": 1},
+        }
+        cfg = UpstreamServerConfig(prefix="gh", command="npx", origin=block)
+        assert cfg.origin is not None
+        assert cfg.origin.schema_version == 2
+        assert cfg.origin.source.kind == "some-future-host"
+
+    def test_entry_without_origin_still_valid(self) -> None:
+        cfg = UpstreamServerConfig(prefix="gh", command="npx")
+        assert cfg.origin is None
 
 
 class TestSurfacingLtmTransportConfig:


### PR DESCRIPTION
PR1 of 4 for #475 (round-trip transition: origin provenance, prune backup log, `mms eject`). PR2 (backup log + per-source `pruned` + write lock) and PR3 (`mms eject` core) build on the data captured here; PR1/PR2 do not depend on the `claude mcp add-json` expressiveness probe gating PR3.

## What

- **Candidate raw capture** — `_discover_candidates` now keeps the **verbatim** host entry (`raw`) and a structured `{kind, path?}` source ref per candidate, for the primary source and every duplicate. Normalization is lossy (HTTP `headers` not imported, dangerous env keys filtered, client `type` folded into the transport enum), so the host entry cannot be reconstructed from the STM entry — the verbatim copy is the only faithful restore payload.
- **Shared source table** — discovery labels, `_source_removal_hint`, and `_prune_from_source` previously repeated the same label literals in three places. They now read one `_SOURCE_SPECS` table (label ↔ `kind` ↔ `claude mcp remove -s` scope), so the mapping that `origin.source.kind` persists cannot drift from what the prune writers act on.
- **Origin block on both import paths** (`mms init`, `mms add --import`):

  ```jsonc
  "origin": {
    "schema_version": 1,
    "source": { "kind": "claude-user", "pruned": false },
    "duplicates": [ { "kind": "claude-desktop", "pruned": false } ],
    "imported_at": "2026-06-11T05:00:00Z",
    "original": { /* verbatim host entry */ }
  }
  ```

  Stored inline in the entry: the CLI load/save path is raw-dict passthrough, so every existing command (`add`, `remove`, `surfacing`, …) preserves it with no migration. `pruned` stays `false` in this PR — the per-source updates land with the backup log (PR2).
- **`UpstreamServerConfig.origin`** — validated optional field documenting the schema server-side. The proxy runtime never reads it; the CLI constructs the block *through* the model (`UpstreamOrigin` / `OriginSource`), so the written shape cannot drift from the documented one. Older binaries ignore the field via pydantic's default `extra="ignore"`, and since the server never writes the config back there is no loss path.
- **Redacted `--json` serializer** — ships in the same PR as capture (separating them would leave a vulnerable in-between state): `mms status --json` / `mms list --json` previously dumped the raw `upstream_servers` dict, which would leak `origin.original`'s verbatim `env`/`headers`. The serializer keeps the provenance summary and replaces `original` with a `has_original` flag. Redaction is output-only; the file keeps the original (0600, unchanged exposure).

## Behavior change

- Imported entries in `stm_proxy.json` gain an `origin` block, including a **verbatim copy of the host entry's `env`** (the file was already the secret-bearing surface, written `0600`; no new exposure class).
- `mms status --json` / `mms list --json` output for origin-bearing entries changes shape: `origin.original` is never emitted; `origin.has_original` appears instead. Entries without `origin` (manual adds, pre-existing configs) are byte-identical to before.
- Manual entry paths (`mms add NAME`, init's manual prompt flow) intentionally get no origin block.
- Note: these `--json` paths already expose each entry's own `env` today — pre-existing surface, called out in #475 as out of scope for this PR.

## Tests

- Discovery: verbatim `raw` kept where normalization is lossy (headers / unknown fields / dangerous env keys); structured `source_ref` per kind incl. `path` for `claude-project` (resolved cwd) and `mcp-json` (file path); structured per-source `duplicates` records.
- Both import paths persist the origin block; end-to-end round-trip from real sandbox host files pins `origin.original` deep-equals the host entry (incl. an `LD_PRELOAD` key that the active entry filters); the saved block re-validates against `UpstreamOrigin` (CLI↔server lockstep pin).
- Compat: full block validates on `UpstreamServerConfig`; unknown origin keys / future source kinds ignored (`extra="ignore"` pin); entries without origin unaffected.
- Preservation: `mms surfacing` / `mms remove` of a sibling leave the block untouched (raw-dict passthrough pin).
- Redaction: `status --json` + `list --json` emit no `original` and no secret value, keep summary keys + `has_original`, and don't write back; origin-less entries pass through unchanged.
- `uv run pytest -m "not ollama"`: 3302 passed, 3 skipped. `ruff check` / `ruff format --check src` clean; `mypy src` unchanged from main (8 pre-existing errors in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)