### PR TITLE
feat(cli): prune backup log, per-source pruned status, config write lock (#475)

### DIFF
--- a/src/memtomem_stm/cli/_write_lock.py
+++ b/src/memtomem_stm/cli/_write_lock.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, TypeVar
 
 import click
@@ -18,6 +19,27 @@ import click
 from memtomem_stm.mms import state
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+def stm_config_lock_path() -> Path:
+    """Cross-process write lock for the proxy-config domain (#475 PR2).
+
+    Guards every ``stm_proxy.json`` mutator plus the prune backup log
+    (``pruned_upstreams.json``) — both live under ``~/.memtomem``, and the
+    backup-log append is a read-modify-write that shares its span with
+    config mutations, so one lock covers the domain. Deliberately a single
+    fixed path rather than a per-``--config`` sidecar: two processes
+    pruning different configs still append to the one shared backup log.
+    Resolved at call time so monkeypatched ``HOME`` works in tests
+    (mirrors ``state.mms_home``).
+    """
+    return Path.home() / ".memtomem" / ".stm_proxy.lock"
+
+
+_CONFIG_LOCK_HOLDER_HINT = (
+    "another `mms` command appears to be mutating the proxy config "
+    "(possibly waiting at its confirmation prompt)"
+)
 
 
 def with_write_lock(f: F) -> F:
@@ -47,3 +69,43 @@ def with_write_lock(f: F) -> F:
             raise click.ClickException(str(exc)) from exc
 
     return wrapper  # type: ignore[return-value]
+
+
+def with_config_write_lock(
+    *, skip: Callable[[dict[str, Any]], bool] | None = None
+) -> Callable[[F], F]:
+    """Run a Click command callback under the proxy-config write lock (#475 PR2).
+
+    Same shape as :func:`with_write_lock` but over
+    :func:`stm_config_lock_path`, serializing every ``stm_proxy.json``
+    mutator (``add``/``init``/``remove``/``surfacing``/``prune``) so an
+    unlocked command holding a stale load can't save over a locked one's
+    result — e.g. resurrect an entry a concurrent ``mms eject`` just
+    removed. Like the mms lock, the span covers the ENTIRE command
+    including TTY prompts; releasing around a prompt would re-open the
+    stale-load window.
+
+    ``skip`` receives the callback kwargs and returns ``True`` for
+    invocations that never write (``prune --dry-run``, ``surfacing`` with
+    no state argument) — those run unlocked, mirroring the mms ``--plan``
+    skip. A factory rather than a bare decorator because the skip
+    predicate differs per command.
+    """
+
+    def decorate(f: F) -> F:
+        @functools.wraps(f)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            enabled = skip is None or not skip(kwargs)
+            try:
+                with state.write_lock(
+                    enabled=enabled,
+                    lock_path=stm_config_lock_path(),
+                    holder_hint=_CONFIG_LOCK_HOLDER_HINT,
+                ):
+                    return f(*args, **kwargs)
+            except state.WriteLockTimeout as exc:
+                raise click.ClickException(str(exc)) from exc
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorate

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -21,6 +21,7 @@ from typing import Any, TextIO
 
 import click
 
+from memtomem_stm.cli._write_lock import with_config_write_lock
 from memtomem_stm.cli.daemon_cmd import daemon_group as _daemon_group
 from memtomem_stm.cli.hook_cmd import hook_command as _hook_command
 from memtomem_stm.cli.mms_host import host_group as _mms_host_group
@@ -856,6 +857,7 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
     "via STM. Default: interactive prompt on TTY, skip on non-TTY. Only "
     "valid with --from-clients/--import.",
 )
+@with_config_write_lock()
 def add(
     name: str | None,
     config_path: str,
@@ -1398,26 +1400,165 @@ def _prune_from_source(name: str, source: str) -> tuple[bool, str | None]:
     return _desktop_json_remove_entry(name)
 
 
+_PRUNED_BACKUP_SCHEMA_VERSION = 1
+
+
+def _pruned_backup_path() -> Path:
+    """Append-only backup log of pruned host originals (#475 PR2).
+
+    Deliberately a fixed user-wide path rather than ``--config``-relative:
+    the log records host-side deletions, which exist independently of
+    whichever proxy config drove them. Resolved at call time so
+    monkeypatched ``HOME`` works in tests (mirrors ``state.mms_home``).
+    """
+    return Path.home() / ".memtomem" / "pruned_upstreams.json"
+
+
+def _append_pruned_backup(
+    name: str, source_ref: dict[str, Any], original: dict[str, Any], pruned_at: str
+) -> tuple[bool, str | None]:
+    """Append one verbatim host entry to the prune backup log.
+
+    Runs BEFORE the host delete (backup-before-delete): a crash between the
+    two leaves a stale row — harmless, the log is advisory — while the
+    reverse order would destroy the only verbatim copy of an entry that has
+    no ``origin`` block (pre-#475 imports, manual adds). Returns
+    ``(ok, error_message_or_None)``; on failure the caller must SKIP the
+    delete for the same reason.
+
+    A corrupt or wrong-shape existing log refuses the append rather than
+    clobbering it — the log is a last-resort recovery source, so destroying
+    prior rows to record a new one would invert its purpose. Rows are never
+    deduped or rewritten: it is a chronological event record.
+    """
+    path = _pruned_backup_path()
+    data: dict[str, Any] = {"schema_version": _PRUNED_BACKUP_SCHEMA_VERSION, "entries": []}
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            return (False, f"backup log {path} is unreadable ({exc}) — move it aside and retry")
+        if not isinstance(loaded, dict) or not isinstance(loaded.get("entries"), list):
+            return (
+                False,
+                f"backup log {path} has an unexpected shape — move it aside and retry",
+            )
+        data = loaded
+    data["entries"].append(
+        {
+            "name": name,
+            "source": source_ref,
+            "original": original,
+            "pruned_at": pruned_at,
+        }
+    )
+    # 0600 like ``stm_proxy.json`` (``_save``): ``original`` carries verbatim
+    # host env/headers, secrets included.
+    try:
+        atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n", mode=0o600)
+    except OSError as exc:
+        return (False, f"backup log write failed: {exc}")
+    return (True, None)
+
+
+def _candidate_source_records(
+    cand: dict[str, Any],
+) -> list[tuple[str, dict[str, Any] | None, dict[str, Any] | None]]:
+    """``(label, source_ref, raw)`` for every source registering this candidate.
+
+    Primary source first, then ``duplicate_in`` order — the exact label
+    sequence the prune loop has always acted on (pinned by
+    ``test_duplicate_in_sources_all_pruned``). ``source_ref`` / ``raw``
+    come from the structured ``duplicates`` records discovery captures
+    (#475 PR1); both are ``None`` for old-shape candidates, where there is
+    nothing verbatim to back up or match against an origin row.
+    """
+    records: list[tuple[str, dict[str, Any] | None, dict[str, Any] | None]] = [
+        (cand["source"], cand.get("source_ref"), cand.get("raw"))
+    ]
+    by_label = {
+        dup.get("label"): dup for dup in cand.get("duplicates") or [] if isinstance(dup, dict)
+    }
+    for label in cand.get("duplicate_in") or []:
+        dup = by_label.get(label) or {}
+        records.append((label, dup.get("source_ref"), dup.get("raw")))
+    return records
+
+
 def _prune_imported_candidates(
     imported_candidates: list[dict[str, Any]],
+    *,
+    pruned_at: str,
 ) -> tuple[list[tuple[str, str]], list[tuple[str, str, str]]]:
     """Prune each imported candidate from every source that registered it.
 
     A single candidate can show up in multiple sources (primary ``source``
     plus ``duplicate_in``) — all are pruned so the dual-path collapses.
+    Per source, the verbatim host entry is appended to the backup log
+    *before* the delete runs (see :func:`_append_pruned_backup` for the
+    ordering rationale); an append failure fails that source's prune
+    outright and the delete is skipped.
+
     Returns ``(pruned, failed)`` where ``pruned`` is ``[(name, source), ...]``
     and ``failed`` is ``[(name, source, error), ...]``.
     """
     pruned: list[tuple[str, str]] = []
     failed: list[tuple[str, str, str]] = []
     for cand in imported_candidates:
-        for src in [cand["source"], *(cand.get("duplicate_in") or [])]:
+        for src, source_ref, raw in _candidate_source_records(cand):
+            if isinstance(raw, dict) and isinstance(source_ref, dict):
+                ok, err = _append_pruned_backup(cand["name"], source_ref, raw, pruned_at)
+                if not ok:
+                    failed.append((cand["name"], src, err or "backup log append failed"))
+                    continue
             ok, err = _prune_from_source(cand["name"], src)
             if ok:
                 pruned.append((cand["name"], src))
             else:
                 failed.append((cand["name"], src, err or "unknown error"))
     return pruned, failed
+
+
+def _mark_pruned_sources(
+    servers: dict[str, Any],
+    candidates: list[dict[str, Any]],
+    pruned: list[tuple[str, str]],
+    pruned_at: str,
+) -> bool:
+    """Flip per-source ``origin`` ``pruned``/``pruned_at`` for successful prunes.
+
+    Matches each pruned ``(name, source-label)`` against the entry's
+    ``origin.source`` / ``origin.duplicates`` rows by structured
+    ``(kind, path)`` — not by label, which is a human string the origin
+    block deliberately doesn't store. Prune permits partial failure across
+    sources, so only rows whose writer succeeded flip; a failed duplicate
+    keeps ``pruned: false`` and stays visible to ``mms eject`` (PR3).
+    Returns ``True`` when anything changed so the caller knows to save.
+    """
+    refs: dict[tuple[str, str], dict[str, Any]] = {}
+    for cand in candidates:
+        for label, source_ref, _raw in _candidate_source_records(cand):
+            if isinstance(source_ref, dict):
+                refs[(cand["name"], label)] = source_ref
+    changed = False
+    for name, label in pruned:
+        ref = refs.get((name, label))
+        if ref is None:
+            continue
+        entry = servers.get(name)
+        origin = entry.get("origin") if isinstance(entry, dict) else None
+        if not isinstance(origin, dict):
+            continue
+        for row in (origin.get("source"), *(origin.get("duplicates") or [])):
+            if not isinstance(row, dict):
+                continue
+            if row.get("kind") != ref.get("kind") or row.get("path") != ref.get("path"):
+                continue
+            if not row.get("pruned"):
+                row["pruned"] = True
+                row["pruned_at"] = pruned_at
+                changed = True
+    return changed
 
 
 def _confirm_prune_prompt(imported_candidates: list[dict[str, Any]]) -> bool:
@@ -1450,6 +1591,8 @@ def _handle_source_prune(
     imported_candidates: list[dict[str, Any]],
     *,
     prune: bool,
+    config_path: Path,
+    data: dict[str, Any],
 ) -> None:
     """Post-import prune + reporting.
 
@@ -1464,6 +1607,13 @@ def _handle_source_prune(
     per-entry warning plus the manual-command fallback for the failed rows
     only, so the user always has a path forward even if the writer is
     degraded.
+
+    ``config_path`` / ``data`` are the already-saved import — callers MUST
+    have saved the origin-bearing entries before invoking this
+    (save-import-first, #475): ① import saved with ``pruned: false`` →
+    ② backup append + host delete per source → ③ the per-source ``pruned``
+    metadata save below. Any crash point leaves the entry restorable; even
+    a failed ③ only loses the metadata flip, never the origin or backup.
     """
     if not imported_candidates:
         return
@@ -1479,7 +1629,13 @@ def _handle_source_prune(
         _print_source_removal_hints(imported_candidates)
         return
 
-    pruned, failed = _prune_imported_candidates(imported_candidates)
+    pruned_at = utc_now_iso()
+    pruned, failed = _prune_imported_candidates(imported_candidates, pruned_at=pruned_at)
+    servers = data.get("upstream_servers")
+    if isinstance(servers, dict) and _mark_pruned_sources(
+        servers, imported_candidates, pruned, pruned_at
+    ):
+        _save(config_path, data)
     _report_prune_results(pruned, failed)
 
 
@@ -1876,7 +2032,9 @@ def _add_from_clients(
     # surfacing. ``_handle_source_prune`` picks between the --prune flag,
     # the interactive prompt (TTY), and the hint-only fallback (non-TTY /
     # user declined).
-    _handle_source_prune([new_candidates[i] for i in picks], prune=prune)
+    _handle_source_prune(
+        [new_candidates[i] for i in picks], prune=prune, config_path=config_path, data=data
+    )
 
 
 # Token-aware budget presets keyed by primary content language. KO is the
@@ -1987,6 +2145,7 @@ def _prompt_language() -> str:
         "'en' on non-TTY callers."
     ),
 )
+@with_config_write_lock()
 def init(
     config_path: str,
     no_validate: bool,
@@ -2198,7 +2357,9 @@ def init(
     # * non-TTY + no flag → skip; fall through to the #203 hint-only warning.
     # Matches ``mms add --import --prune`` semantics via ``_handle_source_prune``.
     if imported_candidates:
-        _handle_source_prune(imported_candidates, prune=prune_originals)
+        _handle_source_prune(
+            imported_candidates, prune=prune_originals, config_path=path, data=data
+        )
 
 
 @cli.command()
@@ -2249,6 +2410,7 @@ def register(config_path: str, mcp_mode: str | None) -> None:
 @click.argument("name")
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation.")
+@with_config_write_lock()
 def remove(name: str, config_path: str, yes: bool) -> None:
     """Remove an upstream MCP server from the proxy configuration."""
     path = Path(config_path)
@@ -2279,6 +2441,7 @@ def remove(name: str, config_path: str, yes: bool) -> None:
 @click.argument("name")
 @click.argument("state", type=click.Choice(["on", "off"]), required=False)
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
+@with_config_write_lock(skip=lambda kwargs: kwargs.get("state") is None)
 def surfacing(name: str, state: str | None, config_path: str) -> None:
     """Toggle proactive memory surfacing for an upstream server.
 
@@ -2348,6 +2511,7 @@ def surfacing(name: str, state: str | None, config_path: str) -> None:
     is_flag=True,
     help="Print what would be pruned; no writes.",
 )
+@with_config_write_lock(skip=lambda kwargs: bool(kwargs.get("dry_run")))
 def prune(
     names: tuple[str, ...],
     config_path: str,
@@ -2449,7 +2613,14 @@ def prune(
         click.echo("Aborted. No changes made.")
         return
 
-    pruned, failed = _prune_imported_candidates(dual)
+    pruned_at = utc_now_iso()
+    pruned, failed = _prune_imported_candidates(dual, pruned_at=pruned_at)
+    # Same step-③ metadata save as the inline import path: flip the matching
+    # per-source ``origin`` rows for entries that have one. The save only
+    # happens when a row actually flipped — entries without origin leave the
+    # config untouched (the backup rows above are their only record).
+    if _mark_pruned_sources(upstreams, dual, pruned, pruned_at):
+        _save(resolved, data)
     if _report_prune_results(pruned, failed):
         sys.exit(1)
 

--- a/src/memtomem_stm/mms/state.py
+++ b/src/memtomem_stm/mms/state.py
@@ -134,14 +134,25 @@ class CorruptedConfig(MmsConfigError):
         self.reason = reason
 
 
+_REGISTRY_LOCK_HOLDER_HINT = (
+    "another `mms host sync --apply` or `mms import --apply` appears to be "
+    "running (possibly waiting at its confirmation prompt)"
+)
+"""Default :class:`WriteLockTimeout` attribution — names the registry/sidecar
+mutators that hold the default ``~/.mms/.lock``. Locks over other domains
+(the proxy-config lock, #475 PR2) pass their own hint so the operator is
+pointed at the right family of commands."""
+
+
 class WriteLockTimeout(MmsConfigError):
     """Another process held the mms write lock past the acquisition timeout."""
 
-    def __init__(self, path: Path, timeout: float) -> None:
+    def __init__(
+        self, path: Path, timeout: float, holder_hint: str = _REGISTRY_LOCK_HOLDER_HINT
+    ) -> None:
         super().__init__(
             f"timed out after {timeout:.0f}s waiting for the mms write lock ({path}) — "
-            "another `mms host sync --apply` or `mms import --apply` appears to be "
-            "running (possibly waiting at its confirmation prompt). Retry after it "
+            f"{holder_hint}. Retry after it "
             "finishes; the lock releases automatically when that process exits."
         )
         self.path = path
@@ -161,7 +172,13 @@ _WRITE_LOCK_POLL_SECONDS = 0.05
 
 
 @contextmanager
-def write_lock(*, enabled: bool = True, timeout: float | None = None) -> Iterator[None]:
+def write_lock(
+    *,
+    enabled: bool = True,
+    timeout: float | None = None,
+    lock_path: Path | None = None,
+    holder_hint: str | None = None,
+) -> Iterator[None]:
     """Hold the cross-process mms write lock for a load→mutate→save span.
 
     ``mms host sync --apply`` and ``mms import --apply`` both read the
@@ -183,12 +200,19 @@ def write_lock(*, enabled: bool = True, timeout: float | None = None) -> Iterato
     No-ops when ``enabled`` is False (``--plan`` runs read but never write)
     and on Windows (no ``fcntl``; single-user CLI, the lock is best-effort
     hardening there, not a correctness guarantee).
+
+    ``lock_path`` / ``holder_hint`` generalize the mechanism beyond the
+    ``~/.mms`` registry domain (#475 PR2): the proxy-config CLI serializes
+    its ``stm_proxy.json`` + prune-backup-log mutators under a separate
+    ``~/.memtomem`` lock file with its own timeout attribution. Defaults
+    keep the original registry/sidecar behavior.
     """
     if not enabled or fcntl is None:
         yield
         return
     wait = WRITE_LOCK_TIMEOUT_SECONDS if timeout is None else timeout
-    lock_path = write_lock_path()
+    if lock_path is None:
+        lock_path = write_lock_path()
     lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
     try:
@@ -203,7 +227,9 @@ def write_lock(*, enabled: bool = True, timeout: float | None = None) -> Iterato
                 # surface as the same timeout — the operator action is
                 # identical either way.
                 if time.monotonic() >= deadline:
-                    raise WriteLockTimeout(lock_path, wait) from None
+                    if holder_hint is None:
+                        raise WriteLockTimeout(lock_path, wait) from None
+                    raise WriteLockTimeout(lock_path, wait, holder_hint) from None
                 time.sleep(_WRITE_LOCK_POLL_SECONDS)
         try:
             yield

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -30,6 +30,25 @@ from helpers import set_home
 _FAKE_SERVER = Path(__file__).resolve().parents[1] / "_fake_memtomem_server.py"
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_home(monkeypatch, tmp_path: Path) -> Path:
+    """Repoint ``$HOME`` at a sandbox for every test in this module.
+
+    The mutating commands acquire the cross-process write lock at
+    ``~/.memtomem/.stm_proxy.lock`` and prune appends to
+    ``~/.memtomem/pruned_upstreams.json`` (#475 PR2) — both resolved via
+    ``Path.home()`` at call time, so without this the suite would write
+    into the developer's real home (violating the module contract above).
+    Tests that build their own sandbox home still win: class/function
+    fixtures run after module-level autouse ones. Named ``hermetic-home``
+    so tests that ``mkdir`` their own ``tmp_path / "home"`` don't collide.
+    """
+    home = tmp_path / "hermetic-home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    return home
+
+
 @pytest.fixture
 def config(tmp_path: Path) -> Path:
     """Fresh config path inside a tmp dir — never collides with $HOME."""
@@ -3929,6 +3948,621 @@ class TestPruneCommand:
         assert "could not remove 1 direct registration" in result.output
         assert "boom" in result.output
         assert "claude mcp remove docs-langchain -s user" in result.output
+
+
+# ── prune backup log + per-source pruned metadata (#475 PR2) ─────────────
+
+
+def _backup_log_path(home: Path) -> Path:
+    return home / ".memtomem" / "pruned_upstreams.json"
+
+
+def _read_backup_log(home: Path) -> dict:
+    return json.loads(_backup_log_path(home).read_text(encoding="utf-8"))
+
+
+def _user_candidate(name: str = "alpha", *, secret: str = "tok_secret") -> dict:
+    """Discovery-shaped candidate from Claude Code (user) with verbatim raw.
+
+    ``raw`` deliberately differs from ``entry`` (env secret + a field
+    normalization drops) so verbatim-copy assertions can't pass by accident.
+    """
+    return {
+        "name": name,
+        "source": "Claude Code (user)",
+        "entry": {"transport": "stdio", "command": "npx", "args": ["-y", f"@{name}"]},
+        "raw": {
+            "command": "npx",
+            "args": ["-y", f"@{name}"],
+            "env": {"TOKEN": secret},
+            "host_only_field": True,
+        },
+        "source_ref": {"kind": "claude-user"},
+    }
+
+
+class TestPruneBackupLog:
+    """Every prune path appends the verbatim host entry to
+    ``~/.memtomem/pruned_upstreams.json`` BEFORE the host delete runs
+    (#475 PR2). The log is the only recovery source for entries without an
+    ``origin`` block, so backup-before-delete is the load-bearing order and
+    a failed append must skip the delete."""
+
+    def _stub_candidates(self, monkeypatch, candidates):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: candidates)
+
+    def _seed_config(self, config: Path, servers: dict) -> None:
+        config.write_text(
+            json.dumps({"enabled": True, "upstream_servers": servers}, indent=2),
+            encoding="utf-8",
+        )
+
+    @pytest.fixture
+    def fake_claude(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        state: dict = {"calls": [], "script": []}
+
+        def fake_run(cmd, timeout=5):
+            state["calls"].append(list(cmd))
+            if state["script"]:
+                nxt = state["script"].pop(0)
+                if isinstance(nxt, Exception):
+                    raise nxt
+                return nxt
+            return _FakeClaudeResult(returncode=0)
+
+        monkeypatch.setattr(proxy_mod, "_run_claude_mcp", fake_run)
+        return state
+
+    def test_import_prune_appends_verbatim_row_per_source(
+        self, runner, config, monkeypatch, fake_claude, _hermetic_home
+    ):
+        """`add --import --prune` writes one row per pruned source — primary
+        and duplicate each with their OWN verbatim raw — at 0600."""
+        import stat as stat_mod
+
+        cand = _user_candidate("github")
+        cand["duplicate_in"] = ["Claude Code (project)"]
+        cand["duplicates"] = [
+            {
+                "label": "Claude Code (project)",
+                "source_ref": {"kind": "claude-project", "path": "/proj"},
+                "raw": {"command": "npx", "args": ["-y", "@github"], "type": "stdio"},
+            }
+        ]
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, [cand])
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        log_path = _backup_log_path(_hermetic_home)
+        assert stat_mod.S_IMODE(log_path.stat().st_mode) == 0o600
+        log = _read_backup_log(_hermetic_home)
+        assert log["schema_version"] == 1
+        assert [(r["name"], r["source"], r["original"]) for r in log["entries"]] == [
+            ("github", {"kind": "claude-user"}, cand["raw"]),
+            (
+                "github",
+                {"kind": "claude-project", "path": "/proj"},
+                cand["duplicates"][0]["raw"],
+            ),
+        ]
+        assert all(r["pruned_at"] for r in log["entries"])
+
+    def test_backup_log_accumulates_across_runs(
+        self, runner, config, monkeypatch, fake_claude, _hermetic_home
+    ):
+        """Append-only: a second prune run adds rows, never rewrites."""
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, [_user_candidate("one")])
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        self._stub_candidates(monkeypatch, [_user_candidate("two")])
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        log = _read_backup_log(_hermetic_home)
+        assert [r["name"] for r in log["entries"]] == ["one", "two"]
+
+    def test_crash_between_append_and_delete_keeps_row_and_host_entry(
+        self, runner, config, tmp_path, monkeypatch, _hermetic_home
+    ):
+        """Backup-before-delete pin (RFC acceptance): crash AFTER the append
+        but BEFORE the host delete → the backup row exists and the host file
+        still holds the entry. The reverse order would leave neither."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        desktop_path = tmp_path / "claude_desktop_config.json"
+        desktop_entry = {"command": "npx", "args": ["-y", "@d"], "env": {"K": "v"}}
+        desktop_path.write_text(
+            json.dumps({"mcpServers": {"crashy": desktop_entry}}, indent=2),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(proxy_mod, "_desktop_config_path", lambda: desktop_path)
+
+        cand = {
+            "name": "crashy",
+            "source": "Claude Desktop",
+            "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@d"]},
+            "raw": dict(desktop_entry),
+            "source_ref": {"kind": "claude-desktop"},
+        }
+        self._seed_config(config, {"crashy": {"prefix": "cr", **cand["entry"]}})
+        self._stub_candidates(monkeypatch, [cand])
+
+        def boom(name, source):
+            raise RuntimeError("simulated crash between backup append and host delete")
+
+        monkeypatch.setattr(proxy_mod, "_prune_from_source", boom)
+
+        result = runner.invoke(cli, ["prune", "--all", "--yes", *_cfg_args(config)])
+        assert isinstance(result.exception, RuntimeError)
+
+        # Row landed before the crash...
+        log = _read_backup_log(_hermetic_home)
+        assert [(r["name"], r["original"]) for r in log["entries"]] == [
+            ("crashy", desktop_entry)
+        ]
+        # ...and the host entry survived untouched.
+        host = json.loads(desktop_path.read_text(encoding="utf-8"))
+        assert host["mcpServers"]["crashy"] == desktop_entry
+
+    def test_failed_delete_leaves_stale_row_and_pruned_false(
+        self, runner, config, monkeypatch, fake_claude, _hermetic_home
+    ):
+        """A failed host delete leaves the already-appended row in place
+        (stale, harmless — the log is advisory) and must NOT flip the
+        origin row's ``pruned`` flag."""
+        cand = _user_candidate("flaky")
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, [cand])
+        fake_claude["script"] = [_FakeClaudeResult(returncode=1, stderr="nope")]
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        log = _read_backup_log(_hermetic_home)
+        assert [r["name"] for r in log["entries"]] == ["flaky"]
+
+        saved = json.loads(config.read_text(encoding="utf-8"))
+        origin = saved["upstream_servers"]["flaky"]["origin"]
+        assert origin["source"]["pruned"] is False
+        assert "pruned_at" not in origin["source"]
+
+    def test_corrupt_backup_log_refuses_append_and_skips_delete(
+        self, runner, config, tmp_path, monkeypatch, _hermetic_home
+    ):
+        """A corrupt log is never clobbered (it's the last-resort recovery
+        source) — the append fails, and the host delete is SKIPPED so the
+        original keeps existing somewhere."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        log_path = _backup_log_path(_hermetic_home)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("{not json", encoding="utf-8")
+
+        desktop_path = tmp_path / "claude_desktop_config.json"
+        desktop_entry = {"command": "npx", "args": ["-y", "@d"]}
+        desktop_path.write_text(
+            json.dumps({"mcpServers": {"keep": desktop_entry}}), encoding="utf-8"
+        )
+        monkeypatch.setattr(proxy_mod, "_desktop_config_path", lambda: desktop_path)
+
+        cand = {
+            "name": "keep",
+            "source": "Claude Desktop",
+            "entry": {"transport": "stdio", "command": "npx", "args": ["-y", "@d"]},
+            "raw": dict(desktop_entry),
+            "source_ref": {"kind": "claude-desktop"},
+        }
+        self._seed_config(config, {"keep": {"prefix": "k", **cand["entry"]}})
+        self._stub_candidates(monkeypatch, [cand])
+
+        result = runner.invoke(cli, ["prune", "--all", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 1
+        assert "move it aside" in result.output
+
+        # No clobber, no delete.
+        assert log_path.read_text(encoding="utf-8") == "{not json"
+        host = json.loads(desktop_path.read_text(encoding="utf-8"))
+        assert "keep" in host["mcpServers"]
+
+    def test_old_shape_candidate_without_raw_prunes_without_backup(
+        self, runner, config, monkeypatch, fake_claude, _hermetic_home
+    ):
+        """Candidates lacking verbatim ``raw`` (pre-#475 shape) still prune —
+        there is just nothing to back up. Pins backward compatibility for
+        the hand-constructed-candidate paths."""
+        self._seed_config(config, {})
+        self._stub_candidates(
+            monkeypatch,
+            [
+                {
+                    "name": "legacy",
+                    "source": "Claude Code (user)",
+                    "entry": {"transport": "stdio", "command": "npx"},
+                }
+            ],
+        )
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert "Removed from source client(s)" in result.output
+        assert not _backup_log_path(_hermetic_home).exists()
+
+
+class TestPerSourcePrunedMetadata:
+    """Successful prunes flip the matching ``origin`` row's per-source
+    ``pruned``/``pruned_at`` (#475 PR2) — a single ``pruned`` boolean would
+    misreport partial failure across primary + duplicate sources."""
+
+    def _stub_candidates(self, monkeypatch, candidates):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: candidates)
+
+    def _seed_config(self, config: Path, servers: dict) -> None:
+        config.write_text(
+            json.dumps({"enabled": True, "upstream_servers": servers}, indent=2),
+            encoding="utf-8",
+        )
+
+    @pytest.fixture
+    def fake_claude(self, monkeypatch):
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        state: dict = {"calls": [], "script": []}
+
+        def fake_run(cmd, timeout=5):
+            state["calls"].append(list(cmd))
+            if state["script"]:
+                nxt = state["script"].pop(0)
+                if isinstance(nxt, Exception):
+                    raise nxt
+                return nxt
+            return _FakeClaudeResult(returncode=0)
+
+        monkeypatch.setattr(proxy_mod, "_run_claude_mcp", fake_run)
+        return state
+
+    def test_inline_import_prune_marks_origin_source(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        cand = _user_candidate("github")
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, [cand])
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        saved = json.loads(config.read_text(encoding="utf-8"))
+        origin = saved["upstream_servers"]["github"]["origin"]
+        assert origin["source"]["pruned"] is True
+        assert origin["source"]["pruned_at"]
+        # The verbatim restore payload must survive the metadata save.
+        assert origin["original"] == cand["raw"]
+
+    def test_partial_failure_marks_only_successful_source(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """Primary (claude-user) succeeds, duplicate (claude-desktop, file
+        missing) fails → only the primary row flips."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(
+            proxy_mod, "_desktop_config_path", lambda: Path("/nonexistent/desktop.json")
+        )
+        cand = _user_candidate("github")
+        cand["duplicate_in"] = ["Claude Desktop"]
+        cand["duplicates"] = [
+            {
+                "label": "Claude Desktop",
+                "source_ref": {"kind": "claude-desktop"},
+                "raw": {"command": "npx", "args": ["-y", "@github"]},
+            }
+        ]
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, [cand])
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        saved = json.loads(config.read_text(encoding="utf-8"))
+        origin = saved["upstream_servers"]["github"]["origin"]
+        assert origin["source"]["pruned"] is True
+        assert origin["duplicates"] == [{"kind": "claude-desktop", "pruned": False}]
+
+    def test_standalone_prune_updates_origin_and_saves(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """``mms prune`` (post-hoc) flips the origin row of an entry imported
+        earlier, matching by structured ``(kind, path)``."""
+        cand = _user_candidate("github")
+        entry = {
+            "prefix": "gh",
+            **cand["entry"],
+            "origin": {
+                "schema_version": 1,
+                "source": {"kind": "claude-user", "pruned": False},
+                "duplicates": [],
+                "imported_at": "2026-06-11T00:00:00+00:00",
+                "original": cand["raw"],
+            },
+        }
+        self._seed_config(config, {"github": entry})
+        self._stub_candidates(monkeypatch, [cand])
+
+        result = runner.invoke(cli, ["prune", "github", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0, result.output
+
+        saved = json.loads(config.read_text(encoding="utf-8"))
+        origin = saved["upstream_servers"]["github"]["origin"]
+        assert origin["source"]["pruned"] is True
+        assert origin["source"]["pruned_at"]
+        assert origin["original"] == cand["raw"]
+
+    def test_standalone_prune_without_origin_leaves_config_untouched(
+        self, runner, config, monkeypatch, fake_claude
+    ):
+        """No origin row to flip → no config rewrite (byte-identical)."""
+        cand = _user_candidate("github")
+        self._seed_config(config, {"github": {"prefix": "gh", **cand["entry"]}})
+        before = config.read_text(encoding="utf-8")
+        self._stub_candidates(monkeypatch, [cand])
+
+        result = runner.invoke(cli, ["prune", "github", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0, result.output
+        assert config.read_text(encoding="utf-8") == before
+
+    def test_metadata_save_failure_leaves_origin_and_backup_restorable(
+        self, runner, config, monkeypatch, fake_claude, _hermetic_home
+    ):
+        """Save-import-first order pin (RFC acceptance): the import (with
+        origin, ``pruned: false``) is saved BEFORE any host delete, so a
+        step-③ metadata-save failure still leaves the entry restorable —
+        origin on disk + backup row appended + host delete done."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        cand = _user_candidate("github")
+        self._seed_config(config, {})
+        self._stub_candidates(monkeypatch, [cand])
+
+        real_save = proxy_mod._save
+        calls = {"n": 0}
+
+        def flaky_save(path, data):
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                raise OSError("disk full at metadata save")
+            real_save(path, data)
+
+        monkeypatch.setattr(proxy_mod, "_save", flaky_save)
+
+        result = runner.invoke(
+            cli,
+            ["add", "--from-clients", "--prune", *_cfg_args(config)],
+            input="all\n\n",
+        )
+        assert isinstance(result.exception, OSError)
+        assert calls["n"] == 2  # import save succeeded, metadata save crashed
+
+        # Step-① save survived: origin (with verbatim original) is on disk.
+        saved = json.loads(config.read_text(encoding="utf-8"))
+        origin = saved["upstream_servers"]["github"]["origin"]
+        assert origin["original"] == cand["raw"]
+        assert origin["source"]["pruned"] is False
+        # Step ② ran: backup row appended and host delete executed.
+        log = _read_backup_log(_hermetic_home)
+        assert [r["name"] for r in log["entries"]] == ["github"]
+        assert ["claude", "mcp", "remove", "github", "-s", "user"] in fake_claude["calls"]
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="flock is POSIX-only; write_lock is documented as a no-op on Windows",
+)
+class TestConfigWriteLock:
+    """Every ``stm_proxy.json`` mutator runs under the cross-process
+    ``~/.memtomem/.stm_proxy.lock`` (#475 PR2). Locking only prune/eject
+    would leave a hole: an unlocked ``add`` holding a stale load could save
+    over a locked command's result. Read paths and ``--dry-run`` skip it."""
+
+    @staticmethod
+    def _hold_lock(home: Path):
+        """Hold the config lock through a raw fd, as a foreign process would."""
+        import fcntl
+        from contextlib import contextmanager
+
+        @contextmanager
+        def held():
+            lock = home / ".memtomem" / ".stm_proxy.lock"
+            lock.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(lock, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                yield
+            finally:
+                os.close(fd)
+
+        return held()
+
+    @pytest.fixture(autouse=True)
+    def _fast_timeout(self, monkeypatch):
+        from memtomem_stm.mms import state as mms_state
+
+        monkeypatch.setattr(mms_state, "WRITE_LOCK_TIMEOUT_SECONDS", 0.2)
+
+    def _seed(self, config: Path) -> None:
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {"srv": {"prefix": "s", "command": "npx"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["add", "other", "--prefix", "o", "--command", "npx"],
+            ["remove", "srv", "--yes"],
+            ["surfacing", "srv", "off"],
+            ["prune", "--all", "--yes"],
+            ["init"],
+        ],
+        ids=["add", "remove", "surfacing-write", "prune", "init"],
+    )
+    def test_mutators_fail_cleanly_when_lock_held(
+        self, runner, config, argv, _hermetic_home
+    ):
+        self._seed(config)
+        if argv == ["init"]:
+            # init aborts on an existing config before doing anything; give
+            # it a fresh path so it reaches the lock acquisition.
+            cfg_args = ["--config", str(config.parent / "fresh.json")]
+        else:
+            cfg_args = _cfg_args(config)
+        with self._hold_lock(_hermetic_home):
+            result = runner.invoke(cli, [*argv, *cfg_args])
+        assert result.exit_code == 1
+        assert "timed out" in result.output
+        assert "mutating the proxy config" in result.output
+
+    def test_read_and_dry_run_paths_skip_lock(
+        self, runner, config, monkeypatch, _hermetic_home
+    ):
+        """`surfacing NAME` (read) and `prune --dry-run` never write, so a
+        held lock must not block them — mirrors the mms ``--plan`` skip."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        self._seed(config)
+        monkeypatch.setattr(proxy_mod, "_discover_candidates", lambda _cwd: [])
+        with self._hold_lock(_hermetic_home):
+            read = runner.invoke(cli, ["surfacing", "srv", *_cfg_args(config)])
+            dry = runner.invoke(cli, ["prune", "--all", "--dry-run", *_cfg_args(config)])
+        assert read.exit_code == 0, read.output
+        assert "surfacing for 'srv': on" in read.output
+        assert dry.exit_code == 0, dry.output
+
+    def test_concurrent_prunes_serialize_and_lose_no_backup_rows(
+        self, config, monkeypatch, _hermetic_home
+    ):
+        """Two concurrent prune spans serialize on the lock: the second's
+        backup append happens strictly after the first's host delete
+        finishes, so the read-modify-write log append can't lose rows."""
+        import threading
+
+        from memtomem_stm.cli import proxy as proxy_mod
+        from memtomem_stm.mms import state as mms_state
+
+        # Override this class's 0.2s `_fast_timeout`: t2 must keep polling
+        # while t1 deliberately parks inside its span.
+        monkeypatch.setattr(mms_state, "WRITE_LOCK_TIMEOUT_SECONDS", 10.0)
+
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {
+                        "alpha": {"prefix": "a", "command": "npx", "args": ["-y", "@alpha"]},
+                        "beta": {"prefix": "b", "command": "npx", "args": ["-y", "@beta"]},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            proxy_mod,
+            "_discover_candidates",
+            lambda _cwd: [_user_candidate("alpha"), _user_candidate("beta")],
+        )
+
+        t1_in_span = threading.Event()
+        release_t1 = threading.Event()
+        events: list[str] = []
+        events_lock = threading.Lock()
+
+        def fake_remove(name, scope):
+            with events_lock:
+                events.append(f"remove:{name}")
+            if name == "alpha":
+                t1_in_span.set()
+                assert release_t1.wait(timeout=10)
+            return (True, None)
+
+        monkeypatch.setattr(proxy_mod, "_claude_mcp_remove", fake_remove)
+
+        prune_cb = cli.commands["prune"].callback
+        errors: list[BaseException] = []
+
+        def run(name: str) -> None:
+            try:
+                prune_cb(
+                    names=(name,),
+                    config_path=str(config),
+                    all_servers=False,
+                    assume_yes=True,
+                    dry_run=False,
+                )
+            except BaseException as exc:  # noqa: BLE001 — surfaced via `errors`
+                errors.append(exc)
+
+        t1 = threading.Thread(target=run, args=("alpha",))
+        t2 = threading.Thread(target=run, args=("beta",))
+        t1.start()
+        assert t1_in_span.wait(timeout=10)
+        t2.start()
+        # t1 is parked inside its host delete, still holding the lock; give
+        # t2 time to reach acquisition. It must not have appended: its whole
+        # span waits on the lock.
+        t2.join(timeout=0.5)
+        assert t2.is_alive(), "t2 must block on the lock while t1 holds it"
+        log = _read_backup_log(_hermetic_home)
+        assert [r["name"] for r in log["entries"]] == ["alpha"]
+
+        release_t1.set()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+        assert not t1.is_alive() and not t2.is_alive()
+        assert errors == []
+        assert events == ["remove:alpha", "remove:beta"]
+
+        log = _read_backup_log(_hermetic_home)
+        assert [r["name"] for r in log["entries"]] == ["alpha", "beta"]
 
 
 # ── init --prune-originals integration ───────────────────────────────────

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -4044,7 +4044,8 @@ class TestPruneBackupLog:
         assert result.exit_code == 0, result.output
 
         log_path = _backup_log_path(_hermetic_home)
-        assert stat_mod.S_IMODE(log_path.stat().st_mode) == 0o600
+        if sys.platform != "win32":  # chmod is a near-no-op on Windows
+            assert stat_mod.S_IMODE(log_path.stat().st_mode) == 0o600
         log = _read_backup_log(_hermetic_home)
         assert log["schema_version"] == 1
         assert [(r["name"], r["source"], r["original"]) for r in log["entries"]] == [

--- a/tests/mms/test_write_lock.py
+++ b/tests/mms/test_write_lock.py
@@ -144,6 +144,49 @@ def test_disabled_lock_ignores_a_held_lock(sandbox_home):
 
 
 # ---------------------------------------------------------------------------
+# Generalized seam — lock_path / holder_hint parameterization (#475 PR2)
+# ---------------------------------------------------------------------------
+
+
+def test_custom_lock_path_creates_that_file_with_0600(sandbox_home):
+    custom = sandbox_home / ".memtomem" / ".stm_proxy.lock"
+    with state.write_lock(lock_path=custom):
+        pass
+    assert custom.is_file()
+    assert stat.S_IMODE(custom.stat().st_mode) == 0o600
+    # The default registry lock must not be touched by a custom-path span.
+    assert not (sandbox_home / ".mms" / ".lock").exists()
+
+
+def test_custom_holder_hint_lands_in_timeout_message(sandbox_home):
+    custom = sandbox_home / ".memtomem" / ".stm_proxy.lock"
+    custom.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(custom, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(state.WriteLockTimeout) as exc_info:
+            with state.write_lock(
+                lock_path=custom, holder_hint="a proxy-config writer", timeout=0.1
+            ):
+                pytest.fail("acquisition must not succeed while held")
+    finally:
+        os.close(fd)
+    msg = str(exc_info.value)
+    assert str(custom) in msg
+    assert "a proxy-config writer" in msg
+    assert "mms host sync --apply" not in msg  # default attribution replaced
+
+
+def test_registry_and_custom_locks_are_independent(sandbox_home):
+    """Holding the registry lock must not block a custom-path span — the
+    two domains (mms registry vs proxy config) serialize separately."""
+    custom = sandbox_home / ".memtomem" / ".stm_proxy.lock"
+    with _hold_lock(sandbox_home):
+        with state.write_lock(lock_path=custom, timeout=0.1):
+            pass  # enters immediately: different file, different flock
+
+
+# ---------------------------------------------------------------------------
 # CLI wiring — both mutating commands acquire; --plan never does
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
PR2 of the #475 round-trip plan (PR1: #476). Prune is the destructive half of the host↔STM transition: today it deletes host originals with no record anywhere, and every `stm_proxy.json` mutator runs an unserialized read-modify-write span.

## What

### 1. Backup log for pruned originals — backup-before-delete

Every prune path (inline `mms add --import --prune` / `mms init --prune-originals` prompt+flag paths, and standalone `mms prune`) appends the **verbatim host entry** (captured by PR1's discovery `raw`) to `~/.memtomem/pruned_upstreams.json` (`0600`, append-only, `schema_version: 1`) **before** the host delete runs:

- Crash between append and delete → harmless stale row; the reverse order would destroy the only verbatim copy of an entry that has no `origin` block (pre-#475 imports, manual adds).
- A failed append **fails that source's prune and skips the delete** — proceeding would delete the only copy un-backed-up.
- A corrupt/wrong-shape existing log is never clobbered (it is the last-resort recovery source); the error tells the operator to move it aside.
- One row per pruned source: primary and each `duplicate_in` source get their own verbatim raw.

### 2. Per-source `pruned` status

Successful prunes flip the matching `origin.source` / `origin.duplicates` row to `pruned: true` + `pruned_at`, matched by structured `(kind, path)` — not by the human source label, which the origin block deliberately doesn't store. Per-source rather than per-entry because prune permits partial failure across primary + duplicate sources; a failed duplicate stays `pruned: false` and visible to `mms eject` (PR3).

The import flow keeps its existing save-then-prune order as an explicit **save-import-first invariant**: ① import saved with origin (`pruned: false`) → ② per source: backup append → host delete → ③ per-source pruned metadata save. Every crash point leaves the entry restorable; a failed ③ only loses the metadata flip, never the origin or backup (pinned by test).

### 3. Cross-process write lock for all config mutators

All `stm_proxy.json` mutators (`add`, `init`, `remove`, `surfacing <name> on|off`, `prune`) now run under one `~/.memtomem/.stm_proxy.lock`, generalizing the mms registry lock seam (`state.write_lock` gains `lock_path` / `holder_hint` params; CLI glue mirrors `with_write_lock`). Locking only the prune path would leave a hole: an unlocked `add` holding a stale load could save over a locked command's result and resurrect a removed entry. The span covers the entire command including TTY prompts (mms precedent — releasing around the prompt re-opens the stale-load window). Read paths, `surfacing <name>` (no state arg), and `prune --dry-run` skip the lock (mms `--plan` precedent). The lock is deliberately one fixed path rather than per-`--config`: two processes pruning different configs still share the one backup log.

## Behavior change

- `mms prune` now **writes** `stm_proxy.json` (per-source `pruned` metadata) when a pruned entry carries an `origin` block — previously it never touched the STM config. Entries without origin leave the config byte-identical.
- All prune paths create/append `~/.memtomem/pruned_upstreams.json` (`0600`), which may contain secrets verbatim (same exposure class as `stm_proxy.json` itself, same file mode).
- Mutating commands can now fail with a clean `Error: timed out … waiting for the mms write lock` (exit 1) if another mutator holds the lock past 10s — previously they would silently interleave.
- A backup-log append failure now blocks that source's host delete (reported through the existing non-fatal per-source failure path, exit 1 from `mms prune`).

## Tests

RFC acceptance criteria pinned: 0600 perms; append accumulation across runs; per-duplicate-source rows with their own raws; crash simulation between append and delete (row exists + host entry intact); failed delete → stale row + `pruned` not flipped; corrupt log → no clobber + delete skipped; old-shape candidates (no `raw`) still prune without backup; save-import-first order (step-③ save failure leaves origin + backup row + delete done); per-source flip on partial failure; standalone `mms prune` flips origin and leaves origin-less configs byte-identical; lock timeout → clean error for all five mutators; read/dry-run paths run unlocked; two concurrent prune spans serialize with no backup-row loss; `lock_path`/`holder_hint` parameterization + lock-domain independence.

Also: CLI tests now sandbox `$HOME` module-wide (autouse fixture) — the lock and backup log resolve via `Path.home()` at call time, and without it the suite would write into the developer's real home, violating the module's "no real home directory is touched" contract.

`uv run ruff check src` + `format --check` clean; full suite 3323 passed / 3 skipped; `mypy src` errors are pre-existing in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)