### PR TITLE
feat(cli): mms eject — restore imported upstreams to their host config (#475)

### DIFF
--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -170,8 +170,16 @@ def _save(config_path: Path, data: dict[str, Any]) -> None:
 # visible.
 
 
-def _run_claude_mcp(cmd: list[str], timeout: int = 5) -> subprocess.CompletedProcess[str]:
-    """Invoke the ``claude`` CLI — isolated so tests replace a single seam."""
+def _run_claude_mcp(
+    cmd: list[str], timeout: int = 5, cwd: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the ``claude`` CLI — isolated so tests replace a single seam.
+
+    ``cwd`` exists for ``claude mcp add-json -s local`` (eject, #475 PR3):
+    the local scope resolves its ``~/.claude.json`` ``projects.<path>`` slot
+    from the process cwd, so the restore must run from the recorded origin
+    path or it lands in the wrong project.
+    """
     # ``encoding="utf-8"`` is explicit so non-ASCII bytes from the child don't
     # hit the platform default codec (cp1252/cp949 on Windows). See #302 P0.
     return subprocess.run(
@@ -181,6 +189,7 @@ def _run_claude_mcp(cmd: list[str], timeout: int = 5) -> subprocess.CompletedPro
         encoding="utf-8",
         errors="replace",
         timeout=timeout,
+        cwd=cwd,
     )
 
 
@@ -1146,6 +1155,7 @@ _SOURCE_SPECS: tuple[_SourceSpec, ...] = (
     _SourceSpec("Claude Desktop", "claude-desktop", None),
 )
 _SOURCE_BY_LABEL: dict[str, _SourceSpec] = {spec.label: spec for spec in _SOURCE_SPECS}
+_SOURCE_BY_KIND: dict[str, _SourceSpec] = {spec.kind: spec for spec in _SOURCE_SPECS}
 
 
 def _discover_candidates(cwd: Path) -> list[dict[str, Any]]:
@@ -2622,6 +2632,722 @@ def prune(
     if _mark_pruned_sources(upstreams, dual, pruned, pruned_at):
         _save(resolved, data)
     if _report_prune_results(pruned, failed):
+        sys.exit(1)
+
+
+# ── eject command (#475 PR3) ───────────────────────────────────────────────
+#
+# Reverse of the import(+prune) forward path: write the entry back to its
+# host config (``origin.original`` verbatim when captured), then remove it
+# from STM. Order invariant: host write FIRST, STM removal SECOND — every
+# failure mode degrades to dual registration (visible, recoverable), never
+# to a server registered nowhere. Like prune, this is an explicit opt-in
+# writer; discovery itself stays read-only (#202/#226 lineage).
+
+
+def _denormalize_client_entry(entry: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Reconstruct a host-config entry from an STM upstream entry.
+
+    Degraded inverse of :func:`_normalize_client_entry` for entries without
+    an ``origin.original`` (manual ``mms add``, pre-#475 imports). Forward
+    normalization is lossy — HTTP ``headers`` are never imported and
+    ``_DANGEROUS_ENV_KEYS`` are filtered — so the reconstruction cannot
+    recover those; the returned warnings name what may be missing. STM-only
+    fields (prefix, compression, budgets, ...) are dropped by construction:
+    the host entry is built from the transport-identifying fields alone.
+    """
+    transport = entry.get("transport", "stdio")
+    warnings: list[str] = []
+    if transport == "stdio":
+        payload: dict[str, Any] = {"type": "stdio", "command": entry.get("command", "")}
+        args = entry.get("args")
+        if isinstance(args, list) and args:
+            payload["args"] = [str(a) for a in args]
+        env = entry.get("env")
+        if isinstance(env, dict) and env:
+            payload["env"] = {str(k): str(v) for k, v in env.items()}
+        warnings.append("env keys filtered at import time (LD_PRELOAD etc.) are not recoverable")
+    else:
+        # STM calls streamable HTTP ``streamable_http``; host configs and the
+        # claude CLI call it ``http`` (``_normalize_client_entry`` accepts both).
+        payload = {
+            "type": "sse" if transport == "sse" else "http",
+            "url": entry.get("url", ""),
+        }
+        headers = entry.get("headers")
+        if isinstance(headers, dict) and headers:
+            payload["headers"] = {str(k): str(v) for k, v in headers.items()}
+        else:
+            warnings.append("HTTP headers are not captured by import — the restored entry has none")
+    return payload, warnings
+
+
+def _parse_eject_to(value: str) -> tuple[_SourceSpec, str | None]:
+    """Parse ``--to kind[:PATH]`` into a source spec + resolved path.
+
+    User-supplied paths are resolved here (relative paths, ``~``) — unlike
+    ``origin.source.path``, which is used exactly as recorded because the
+    claude CLI keyed it (already realpath'd; re-deriving could relocate the
+    restore). Raises :class:`click.UsageError` on an unknown kind or a path
+    on a kind that doesn't take one.
+    """
+    kind, _, path_part = value.partition(":")
+    spec = _SOURCE_BY_KIND.get(kind)
+    if spec is None:
+        kinds = " | ".join(s.kind for s in _SOURCE_SPECS)
+        raise click.UsageError(f"--to must be one of: {kinds} (got {value!r})")
+    if kind == "claude-project":
+        return spec, str(Path(path_part or ".").expanduser().resolve())
+    if kind == "mcp-json":
+        return spec, str(Path(path_part or ".mcp.json").expanduser().resolve())
+    if path_part:
+        raise click.UsageError(f"--to {kind} does not take a :PATH suffix")
+    return spec, None
+
+
+def _read_host_servers(kind: str, path: str | None) -> dict[str, Any] | None:
+    """Read-only ``mcpServers`` map for one host target; ``None`` when absent.
+
+    Same backing files as :func:`_discover_candidates`. Eject's no-clobber
+    pre-check and post-write verify both read the host config directly
+    rather than parsing ``claude mcp get`` output — the latter has no
+    machine-readable contract, and a parse drift could false-pass the
+    verify or leak secret values through diagnostics.
+    """
+    if kind == "mcp-json":
+        data = _read_json_safely(Path(path)) if path else None
+    elif kind == "claude-desktop":
+        data = _read_json_safely(_desktop_config_path())
+    elif kind == "claude-user":
+        data = _read_json_safely(Path("~/.claude.json").expanduser())
+    elif kind == "claude-project":
+        cc = _read_json_safely(Path("~/.claude.json").expanduser())
+        projects = cc.get("projects") if cc else None
+        candidate = projects.get(path) if isinstance(projects, dict) else None
+        data = candidate if isinstance(candidate, dict) else None
+    else:
+        return None
+    if not isinstance(data, dict):
+        return None
+    servers = data.get("mcpServers")
+    return servers if isinstance(servers, dict) else None
+
+
+def _host_existing_entry(kind: str, path: str | None, name: str) -> dict[str, Any] | None:
+    servers = _read_host_servers(kind, path)
+    entry = servers.get(name) if servers else None
+    return entry if isinstance(entry, dict) else None
+
+
+def _payload_secret_keys(payload: dict[str, Any]) -> list[str]:
+    """``env`` / ``headers`` keys whose values classify as secrets.
+
+    Reuses the ``mms import`` classifier so the two flows agree on what
+    counts as a credential. Decides whether the ``claude mcp add-json``
+    shell-out would put a secret on argv (visible in the process list) —
+    the §7 gate that ``--yes`` must never bypass.
+    """
+    from memtomem_stm.mms.secrets import classify_env
+
+    found: list[str] = []
+    for section in ("env", "headers"):
+        block = payload.get(section)
+        if not isinstance(block, dict):
+            continue
+        text = {str(k): str(v) for k, v in block.items()}
+        for key, cls in classify_env(text).items():
+            if cls.is_secret:
+                found.append(f"{section}.{key}")
+    return found
+
+
+def _dict_diff_paths(
+    expected: dict[str, Any], actual: dict[str, Any], prefix: str = ""
+) -> list[str]:
+    """Dotted paths where ``actual`` deviates from ``expected`` (post-write verify)."""
+    paths: list[str] = []
+    for key in expected.keys() | actual.keys():
+        dotted = f"{prefix}{key}"
+        if key not in actual:
+            paths.append(f"{dotted} (dropped)")
+        elif key not in expected:
+            paths.append(f"{dotted} (added)")
+        elif isinstance(expected[key], dict) and isinstance(actual[key], dict):
+            paths.extend(_dict_diff_paths(expected[key], actual[key], prefix=f"{dotted}."))
+        elif expected[key] != actual[key]:
+            paths.append(f"{dotted} (changed)")
+    return sorted(paths)
+
+
+def _json_config_set_entry(
+    path: Path, name: str, entry: dict[str, Any], *, default_mode: int
+) -> tuple[bool, str | None]:
+    """Set ``mcpServers[name]`` in a plain JSON host config, atomic write.
+
+    Restore counterpart of :func:`_desktop_json_remove_entry`; also the
+    ``.mcp.json`` writer (direct edit by design — argv non-exposure plus
+    writing exactly the recorded path, where ``claude mcp add-json -s
+    project`` would resolve by cwd). A corrupt existing file refuses the
+    write rather than clobbering — restoring one entry must not destroy a
+    config the user can still fix by hand. An existing file keeps its mode
+    (a restore shouldn't change permissions); ``default_mode`` only applies
+    to newly created files.
+    """
+    existing: dict[str, Any] = {}
+    if path.exists():
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return (False, f"read error: {exc}")
+        try:
+            loaded = json.loads(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            return (False, f"parse error: {exc} — fix or move {path} aside and retry")
+        if not isinstance(loaded, dict):
+            return (False, f"{path} top-level is not an object")
+        existing = loaded
+        try:
+            default_mode = path.stat().st_mode & 0o777
+        except OSError:
+            pass
+    servers = existing.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = {}
+        existing["mcpServers"] = servers
+    servers[name] = entry
+    try:
+        atomic_write_text(
+            path,
+            json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
+            mode=default_mode,
+        )
+    except OSError as exc:
+        return (False, f"write error: {exc}")
+    return (True, None)
+
+
+def _claude_mcp_add_json(
+    name: str, payload: dict[str, Any], scope: str, cwd: str | None = None
+) -> tuple[bool, str | None]:
+    """Shell out to ``claude mcp add-json <name> '<json>' -s <scope>``.
+
+    Returns ``(ok, error_message_or_None)`` — non-fatal failure contract
+    matching :func:`_claude_mcp_remove`, so eject leaves the STM entry put
+    and prints the manual command instead of aborting the run. ``cwd`` is
+    set for the ``local`` scope only (see :func:`_run_claude_mcp`).
+    """
+    cmd = ["claude", "mcp", "add-json", name, json.dumps(payload, ensure_ascii=False)]
+    cmd += ["-s", scope]
+    try:
+        result = _run_claude_mcp(cmd, cwd=cwd)
+    except FileNotFoundError:
+        return (False, "`claude` CLI not on PATH")
+    except subprocess.TimeoutExpired:
+        return (False, "`claude mcp add-json` timed out")
+    except OSError as exc:
+        return (False, f"OS error invoking `claude`: {exc}")
+    if result.returncode != 0:
+        msg = (result.stderr or result.stdout or "").strip()
+        return (False, msg or f"`claude mcp add-json` exited {result.returncode}")
+    return (True, None)
+
+
+def _eject_manual_hint(name: str, kind: str, path: str | None, payload: dict[str, Any]) -> str:
+    """Copy-paste restore fallback when a host writer fails or is declined.
+
+    Prints the full restore JSON (secrets included) — terminal output for
+    the operator's own paste-back, per the RFC fallback UX; this is not the
+    argv-exposure surface the secret gate covers.
+    """
+    payload_json = json.dumps(payload, ensure_ascii=False)
+    if kind == "claude-user":
+        return f"claude mcp add-json {name} {shlex.quote(payload_json)} -s user"
+    if kind == "claude-project":
+        return (
+            f"cd {shlex.quote(path or '.')} && "
+            f"claude mcp add-json {name} {shlex.quote(payload_json)} -s local"
+        )
+    target = path if kind == "mcp-json" else str(_desktop_config_path())
+    return f'# Edit {target} and add under mcpServers: "{name}": {payload_json}'
+
+
+@dataclass
+class _EjectPlan:
+    """Resolved restore action for one entry (or the reason it can't run)."""
+
+    name: str
+    kind: str = ""
+    path: str | None = None
+    payload: dict[str, Any] | None = None
+    verbatim: bool = False
+    skip_write: bool = False
+    overwrite: bool = False
+    needs_secret_confirm: bool = False
+    warnings: list[str] | None = None
+    pruned_duplicates: list[str] | None = None
+    error: str | None = None
+
+
+def _latest_backup_row(name: str) -> dict[str, Any] | None:
+    """Most recent prune-backup row for ``name``, or None.
+
+    Suggestion source only (RFC §4.2): eject never auto-adopts a backup row
+    — it may be stale relative to what the host had last — so the caller
+    prints it and asks the user to re-run with ``--to`` after checking.
+    """
+    path = _pruned_backup_path()
+    data = _read_json_safely(path)
+    entries = data.get("entries") if data else None
+    if not isinstance(entries, list):
+        return None
+    for row in reversed(entries):
+        if isinstance(row, dict) and row.get("name") == name:
+            return row
+    return None
+
+
+def _resolve_eject_plan(
+    name: str,
+    entry: Any,
+    to_spec: tuple[_SourceSpec, str | None] | None,
+    *,
+    force: bool,
+    allow_argv_secrets: bool,
+) -> _EjectPlan:
+    """Decide target, payload, and guards for one entry — no writes.
+
+    Implements RFC #475 §4.3 steps 1–3 plus the secret gate's non-TTY
+    branch. TTY secret confirmation is deferred to execution time so the
+    prompt sits next to the write it authorizes.
+    """
+    if not isinstance(entry, dict):
+        return _EjectPlan(name=name, error="entry is not an object — fix the config by hand")
+    if _is_self_reference(entry):
+        return _EjectPlan(name=name, error="refusing to eject STM's own registration")
+
+    origin = entry.get("origin") if isinstance(entry.get("origin"), dict) else None
+    source = origin.get("source") if origin and isinstance(origin.get("source"), dict) else None
+    warnings: list[str] = []
+
+    # Step 1 — target: origin.source wins; --to is the escape hatch for
+    # origin-less entries or a vanished origin path.
+    kind = path = None
+    no_origin = "no usable origin recorded"
+    if source and source.get("kind") in _SOURCE_BY_KIND:
+        kind = source["kind"]
+        path = source.get("path") if isinstance(source.get("path"), str) else None
+    if kind == "claude-project" and (path is None or not Path(path).is_dir()):
+        no_origin = f"origin project directory no longer exists: {path}"
+        kind = path = None
+    if kind == "mcp-json" and (path is None or not Path(path).parent.is_dir()):
+        no_origin = f"origin .mcp.json directory no longer exists: {path}"
+        kind = path = None
+    if kind is None:
+        if to_spec is None:
+            row = _latest_backup_row(name)
+            if row is not None:
+                src = row.get("source") or {}
+                hint = src.get("kind", "?") if isinstance(src, dict) else "?"
+                return _EjectPlan(
+                    name=name,
+                    error=(
+                        f"{no_origin} — the prune backup log has a row "
+                        f"for '{name}' (kind={hint}, pruned_at={row.get('pruned_at')}); "
+                        "verify it is current, then re-run with --to"
+                    ),
+                )
+            return _EjectPlan(
+                name=name,
+                error=f"{no_origin} — pass --to to choose a restore target",
+            )
+        spec, to_path = to_spec
+        kind, path = spec.kind, to_path
+        if kind == "claude-project" and (path is None or not Path(path).is_dir()):
+            return _EjectPlan(name=name, error=f"--to project directory does not exist: {path}")
+
+    # Step 2 — payload: verbatim original first; reconstructed otherwise.
+    original = origin.get("original") if origin else None
+    if isinstance(original, dict):
+        payload: dict[str, Any] = copy.deepcopy(original)
+        verbatim = True
+        normalized = _normalize_client_entry(original)
+        if normalized is not None:
+            stm_sig = _server_signature(entry)
+            orig_sig = _server_signature(normalized)
+            if stm_sig is not None and orig_sig is not None and stm_sig != orig_sig:
+                warnings.append(
+                    "STM entry was modified after import — restoring the original "
+                    "host entry as imported (STM-side changes are not carried over)"
+                )
+    else:
+        payload, loss = _denormalize_client_entry(entry)
+        verbatim = False
+        warnings.append("no verbatim original captured — restoring a reconstructed entry")
+        warnings.extend(loss)
+
+    # Step 3 — no-clobber guard against the live host config.
+    skip_write = overwrite = False
+    existing = _host_existing_entry(kind, path, name)
+    if existing is not None:
+        existing_norm = _normalize_client_entry(existing)
+        payload_norm = _normalize_client_entry(payload)
+        existing_sig = _server_signature(existing_norm) if existing_norm else None
+        payload_sig = _server_signature(payload_norm) if payload_norm else None
+        if existing_sig is not None and payload_sig is not None:
+            if existing_sig == payload_sig:
+                skip_write = True
+            elif force:
+                overwrite = True
+            else:
+                return _EjectPlan(
+                    name=name,
+                    error=(
+                        f"a different '{name}' already exists in the target "
+                        "(command/url mismatch) — pass --force to overwrite it"
+                    ),
+                )
+        # A missing signature on either side is NEVER an idempotent match:
+        # full structural equality is the only skip condition (#475 R1 M1).
+        elif existing == payload:
+            skip_write = True
+        elif force:
+            overwrite = True
+        else:
+            return _EjectPlan(
+                name=name,
+                error=(
+                    f"the target already has '{name}' and its identity can't be "
+                    "compared (no command/url signature) — pass --force to overwrite"
+                ),
+            )
+
+    # Secret gate (§7) — shell-out scopes only, and only when a write will
+    # actually run. --yes never bypasses this; --allow-argv-secrets is the
+    # single override for both TTY and non-TTY.
+    needs_secret_confirm = False
+    spec = _SOURCE_BY_KIND[kind]
+    shell_out = spec.kind in ("claude-user", "claude-project")
+    if shell_out and not skip_write and not allow_argv_secrets:
+        secret_keys = _payload_secret_keys(payload)
+        if secret_keys:
+            if not _should_use_tui():
+                return _EjectPlan(
+                    name=name,
+                    error=(
+                        f"payload carries secret-classified values ({', '.join(secret_keys)}) "
+                        "that `claude mcp add-json` would expose on argv — pass "
+                        "--allow-argv-secrets to proceed (--yes does not cover this)"
+                    ),
+                )
+            needs_secret_confirm = True
+            warnings.append(
+                f"secret-classified values on argv if confirmed: {', '.join(secret_keys)}"
+            )
+
+    pruned_dups: list[str] = []
+    for dup in (origin.get("duplicates") or []) if origin else []:
+        if isinstance(dup, dict) and dup.get("pruned"):
+            label_spec = _SOURCE_BY_KIND.get(dup.get("kind", ""))
+            pruned_dups.append(label_spec.label if label_spec else str(dup.get("kind")))
+
+    return _EjectPlan(
+        name=name,
+        kind=kind,
+        path=path,
+        payload=payload,
+        verbatim=verbatim,
+        skip_write=skip_write,
+        overwrite=overwrite,
+        needs_secret_confirm=needs_secret_confirm,
+        warnings=warnings,
+        pruned_duplicates=pruned_dups,
+    )
+
+
+def _eject_host_write(plan: _EjectPlan) -> tuple[bool, str | None]:
+    """Dispatch the host write for one resolved plan (RFC §4.1 writer table)."""
+    assert plan.payload is not None
+    spec = _SOURCE_BY_KIND[plan.kind]
+    if plan.kind in ("claude-user", "claude-project"):
+        scope = spec.claude_scope or "user"
+        cwd = plan.path if plan.kind == "claude-project" else None
+        if plan.overwrite:
+            # `claude mcp add-json` has no overwrite flag (same probe lineage
+            # as `claude mcp add`, cli/proxy.py:274) — remove-then-add.
+            ok, err = _claude_mcp_remove(plan.name, scope)
+            if not ok:
+                return (False, f"--force pre-remove failed: {err}")
+        return _claude_mcp_add_json(plan.name, plan.payload, scope, cwd=cwd)
+    # ``plan.path`` is always set for mcp-json by plan resolution (the
+    # preflight rejected pathless targets); mypy can't see that invariant.
+    target = Path(plan.path or "") if plan.kind == "mcp-json" else _desktop_config_path()
+    # .mcp.json is a shared project file (0644 precedent in
+    # _write_mcp_json_for_stm); the Desktop config carries secrets (0600).
+    default_mode = 0o644 if plan.kind == "mcp-json" else 0o600
+    return _json_config_set_entry(target, plan.name, plan.payload, default_mode=default_mode)
+
+
+def _eject_verify(plan: _EjectPlan) -> list[str]:
+    """Post-write verify: re-read the host config, deep-compare to the payload.
+
+    Returns the list of deviating paths (empty = verbatim restore). The
+    claude CLI re-serializes through its own schema and silently drops
+    unknown fields (probed on 2.1.173), so a clean `add-json` exit does not
+    prove the verbatim-restore contract held — only re-reading the backing
+    file does. A `None` read (entry not where expected) reports as a full
+    mismatch rather than crashing.
+    """
+    assert plan.payload is not None
+    actual = _host_existing_entry(plan.kind, plan.path, plan.name)
+    if actual is None:
+        return ["<entry not found at the expected host location after write>"]
+    return _dict_diff_paths(plan.payload, actual)
+
+
+@cli.command()
+@click.argument("names", nargs=-1, required=True)
+@click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
+@click.option(
+    "--to",
+    "to_target",
+    default=None,
+    metavar="TARGET",
+    help=(
+        "Restore target for entries without a usable origin: claude-user | "
+        "claude-project[:PATH] | mcp-json[:PATH] | claude-desktop. Entries "
+        "with a recorded origin ignore this."
+    ),
+)
+@click.option(
+    "--keep",
+    is_flag=True,
+    help="Restore to the host but keep the STM entry (dual registration).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite a same-name host entry whose identity differs.",
+)
+@click.option(
+    "--allow-argv-secrets",
+    "allow_argv_secrets",
+    is_flag=True,
+    help=(
+        "Permit `claude mcp add-json` shell-outs whose payload carries "
+        "secret-classified values (argv is visible in the process list). "
+        "The only override for the secret gate — --yes does not bypass it."
+    ),
+)
+@click.option(
+    "--accept-schema-loss",
+    "accept_schema_loss",
+    is_flag=True,
+    help=(
+        "Proceed with STM removal even when the restored host entry does not "
+        "structurally match the original (the claude CLI strips fields it "
+        "does not know). Default is to keep the STM entry and fail."
+    ),
+)
+@click.option("--dry-run", "dry_run", is_flag=True, help="Print the plan; no writes.")
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the confirm prompt (scripts / CI / non-TTY callers).",
+)
+@with_config_write_lock(skip=lambda kwargs: bool(kwargs.get("dry_run")))
+def eject(
+    names: tuple[str, ...],
+    config_path: str,
+    to_target: str | None,
+    keep: bool,
+    force: bool,
+    allow_argv_secrets: bool,
+    accept_schema_loss: bool,
+    dry_run: bool,
+    assume_yes: bool,
+) -> None:
+    """Restore imported upstream(s) to their host MCP client, then remove from STM.
+
+    Reverse of ``mms add --import --prune``: writes the verbatim host entry
+    captured at import time (``origin.original``) back to where it came
+    from, verifies the restore against the host config, and only then
+    removes the STM entry. Any failure leaves the server registered in at
+    least one place — worst case is dual registration, never disappearance.
+    """
+    path = Path(config_path)
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        click.echo(f"{_err('Error:')} config not found at {resolved}.", err=True)
+        click.echo("  Run `mms init` first.", err=True)
+        sys.exit(1)
+
+    data = _load(resolved)
+    servers: dict[str, Any] = data.get("upstream_servers", {})
+    missing = [n for n in names if n not in servers]
+    if missing:
+        click.echo(f"{_err('Error:')} not configured: {', '.join(missing)}.", err=True)
+        sys.exit(1)
+
+    to_spec = _parse_eject_to(to_target) if to_target else None
+    plans = [
+        _resolve_eject_plan(
+            n, servers[n], to_spec, force=force, allow_argv_secrets=allow_argv_secrets
+        )
+        for n in names
+    ]
+
+    # Plan display — every entry, actionable or not, before any consent.
+    click.echo(_hdr(f"Eject plan ({len(plans)} entr{'y' if len(plans) == 1 else 'ies'}):"))
+    for plan in plans:
+        if plan.error:
+            click.echo(f"  {plan.name}: {_bad('cannot eject')} — {plan.error}")
+            continue
+        spec = _SOURCE_BY_KIND[plan.kind]
+        where = f"{spec.label}" + (f" [{plan.path}]" if plan.path else "")
+        action = (
+            "already present — skip write"
+            if plan.skip_write
+            else ("overwrite" if plan.overwrite else "restore")
+        )
+        body = "verbatim original" if plan.verbatim else "reconstructed entry"
+        click.echo(f"  {plan.name}: {action} → {where}  ({body})")
+        for w in plan.warnings or []:
+            click.echo(f"    {_warn('warning:')} {w}")
+        if plan.pruned_duplicates:
+            click.echo(
+                f"    {_warn('note:')} also pruned from {', '.join(plan.pruned_duplicates)} — "
+                "not restored here; originals remain in "
+                f"{_pruned_backup_path()} (restore manually if needed)"
+            )
+
+    errors = [p for p in plans if p.error]
+    actionable = [p for p in plans if not p.error]
+
+    if dry_run:
+        click.echo("")
+        click.echo(f"{_ok('Dry run:')} no writes performed.")
+        if errors:
+            sys.exit(1)
+        return
+
+    if not actionable:
+        sys.exit(1)
+
+    if assume_yes:
+        proceed = True
+    elif _should_use_tui():
+        click.echo("")
+        verb = (
+            "Restore to host(s) and keep in STM?"
+            if keep
+            else "Restore to host(s) and remove from STM?"
+        )
+        proceed = click.confirm(verb, default=False)
+    else:
+        click.echo(
+            f"{_err('Error:')} no TTY; pass --yes to confirm (or --dry-run to preview).",
+            err=True,
+        )
+        sys.exit(1)
+    if not proceed:
+        click.echo("Aborted. No changes made.")
+        return
+
+    restored: list[_EjectPlan] = []
+    failed: list[tuple[_EjectPlan, str]] = []
+    config_changed = False
+    for plan in actionable:
+        assert plan.payload is not None
+        if plan.needs_secret_confirm:
+            ok = click.confirm(
+                f"  '{plan.name}': pass the secret value(s) above on `claude` argv "
+                "(visible in the process list while it runs)?",
+                default=False,
+            )
+            if not ok:
+                failed.append((plan, "secret gate declined"))
+                continue
+
+        wrote = False
+        if not plan.skip_write:
+            ok, err = _eject_host_write(plan)
+            if not ok:
+                failed.append((plan, err or "host write failed"))
+                continue
+            wrote = True
+
+        if wrote:
+            mismatches = _eject_verify(plan)
+            if mismatches:
+                detail = ", ".join(mismatches)
+                if not accept_schema_loss:
+                    failed.append(
+                        (
+                            plan,
+                            "restored host entry does not match the original "
+                            f"({detail}) — the host now has the stripped copy and the "
+                            "STM entry is kept (dual registration); re-run with "
+                            "--accept-schema-loss to remove from STM anyway",
+                        )
+                    )
+                    continue
+                click.echo(
+                    f"  {_warn('Warning:')} '{plan.name}' restored with schema loss: {detail}",
+                    err=True,
+                )
+
+        if not keep:
+            del servers[plan.name]
+            config_changed = True
+        restored.append(plan)
+
+    if config_changed:
+        _save(resolved, data)
+
+    if restored:
+        click.echo("")
+        if keep:
+            click.echo(f"{_ok('Restored to host (kept in STM):')}")
+        else:
+            click.echo(f"{_ok('Restored to host and removed from STM:')}")
+        for plan in restored:
+            spec = _SOURCE_BY_KIND[plan.kind]
+            click.echo(f"  {plan.name} — {spec.label}")
+        if keep:
+            click.echo(
+                f"{_warn('Note:')} entries are now dual-registered (direct + via STM). "
+                "Run `mms prune NAME` to collapse back to STM-only routing."
+            )
+
+    if failed:
+        click.echo("")
+        click.echo(f"{_warn('Warning:')} could not eject {len(failed)} entr(ies):", err=True)
+        for plan, err in failed:
+            click.echo(f"  {plan.name}: {err}", err=True)
+        click.echo("", err=True)
+        click.echo("Restore manually (entry remains in STM):", err=True)
+        click.echo(
+            "  (a failing `claude mcp add-json` may also mean the installed claude "
+            "CLI predates json/http support — probed working on 2.1.173)",
+            err=True,
+        )
+        for plan, _err_msg in failed:
+            if plan.payload is not None:
+                click.echo(
+                    f"  {_eject_manual_hint(plan.name, plan.kind, plan.path, plan.payload)}",
+                    err=True,
+                )
+
+    if config_changed and not servers:
+        click.echo("")
+        click.echo(
+            f"{_warn('Note:')} no upstream servers remain. To also remove STM's own "
+            "client registration, run: claude mcp remove memtomem-stm"
+        )
+
+    if failed or errors:
         sys.exit(1)
 
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -1341,15 +1341,22 @@ def _print_source_removal_hints(imported_candidates: list[dict[str, Any]]) -> No
 # put and the user is shown the manual-command fallback.
 
 
-def _claude_mcp_remove(name: str, scope: str) -> tuple[bool, str | None]:
+def _claude_mcp_remove(name: str, scope: str, cwd: str | None = None) -> tuple[bool, str | None]:
     """Shell out to ``claude mcp remove <name> -s <scope>``.
 
     Returns ``(ok, error_message_or_None)``. Treats any non-zero exit or
     subprocess error as a non-fatal failure so the caller can surface the
     manual command instead of aborting the import.
+
+    ``cwd`` matters for ``-s local``: the claude CLI picks the
+    ``~/.claude.json`` project slot from the process cwd, so a remove run
+    from the wrong directory deletes a same-named entry from the wrong
+    project (or nothing). Prune leaves it unset because its discovery
+    matched the current cwd by construction; eject passes the recorded
+    origin path (#475 PR3).
     """
     try:
-        result = _run_claude_mcp(["claude", "mcp", "remove", name, "-s", scope], timeout=5)
+        result = _run_claude_mcp(["claude", "mcp", "remove", name, "-s", scope], timeout=5, cwd=cwd)
     except FileNotFoundError:
         return (False, "`claude` CLI not on PATH")
     except subprocess.TimeoutExpired:
@@ -3073,8 +3080,10 @@ def _eject_host_write(plan: _EjectPlan) -> tuple[bool, str | None]:
         cwd = plan.path if plan.kind == "claude-project" else None
         if plan.overwrite:
             # `claude mcp add-json` has no overwrite flag (same probe lineage
-            # as `claude mcp add`, cli/proxy.py:274) — remove-then-add.
-            ok, err = _claude_mcp_remove(plan.name, scope)
+            # as `claude mcp add`, cli/proxy.py:274) — remove-then-add. The
+            # pre-remove needs the same cwd as the add: `-s local` resolves
+            # its project slot from the process cwd on both verbs.
+            ok, err = _claude_mcp_remove(plan.name, scope, cwd=cwd)
             if not ok:
                 return (False, f"--force pre-remove failed: {err}")
         return _claude_mcp_add_json(plan.name, plan.payload, scope, cwd=cwd)
@@ -3088,14 +3097,16 @@ def _eject_host_write(plan: _EjectPlan) -> tuple[bool, str | None]:
 
 
 def _eject_verify(plan: _EjectPlan) -> list[str]:
-    """Post-write verify: re-read the host config, deep-compare to the payload.
+    """Pre-removal verify: re-read the host config, deep-compare to the payload.
 
-    Returns the list of deviating paths (empty = verbatim restore). The
-    claude CLI re-serializes through its own schema and silently drops
-    unknown fields (probed on 2.1.173), so a clean `add-json` exit does not
-    prove the verbatim-restore contract held — only re-reading the backing
-    file does. A `None` read (entry not where expected) reports as a full
-    mismatch rather than crashing.
+    Returns the list of deviating paths (empty = verbatim restore). Runs
+    after a write — the claude CLI re-serializes through its own schema and
+    silently drops unknown fields (probed on 2.1.173), so a clean
+    `add-json` exit does not prove the verbatim-restore contract held —
+    AND on the skipped-write path, where the no-clobber signature match
+    ignores env/headers/unknown fields. Only a host entry deep-equal to
+    the payload may release the STM entry. A `None` read (entry not where
+    expected) reports as a full mismatch rather than crashing.
     """
     assert plan.payload is not None
     actual = _host_existing_entry(plan.kind, plan.path, plan.name)
@@ -3278,25 +3289,31 @@ def eject(
                 continue
             wrote = True
 
-        if wrote:
-            mismatches = _eject_verify(plan)
-            if mismatches:
-                detail = ", ".join(mismatches)
-                if not accept_schema_loss:
-                    failed.append(
-                        (
-                            plan,
-                            "restored host entry does not match the original "
-                            f"({detail}) — the host now has the stripped copy and the "
-                            "STM entry is kept (dual registration); re-run with "
-                            "--accept-schema-loss to remove from STM anyway",
-                        )
+        # Verify on BOTH paths — written and skipped. A same-signature host
+        # entry is not necessarily structurally equal to the original
+        # (signatures ignore env/headers/unknown fields), so removing the
+        # STM entry on signature alone could destroy the only complete copy.
+        # The invariant: STM removal requires a host entry deep-equal to the
+        # payload, or the operator's explicit --accept-schema-loss.
+        mismatches = _eject_verify(plan)
+        if mismatches:
+            detail = ", ".join(mismatches)
+            state = "restored host entry" if wrote else "existing host entry"
+            if not accept_schema_loss:
+                failed.append(
+                    (
+                        plan,
+                        f"{state} does not match the captured original "
+                        f"({detail}) — the STM entry is kept (dual registration); "
+                        "re-run with --accept-schema-loss to remove from STM anyway",
                     )
-                    continue
-                click.echo(
-                    f"  {_warn('Warning:')} '{plan.name}' restored with schema loss: {detail}",
-                    err=True,
                 )
+                continue
+            click.echo(
+                f"  {_warn('Warning:')} '{plan.name}' {state} deviates from the "
+                f"original (schema loss accepted): {detail}",
+                err=True,
+            )
 
         if not keep:
             del servers[plan.name]

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -2345,7 +2345,7 @@ class TestInitMcpRegistration:
 
         state: dict = {"calls": [], "script": []}
 
-        def fake_run(cmd, timeout=5):
+        def fake_run(cmd, timeout=5, cwd=None):
             state["calls"].append(list(cmd))
             if state["script"]:
                 nxt = state["script"].pop(0)
@@ -2817,7 +2817,7 @@ class TestRegisterCommand:
 
         state: dict = {"calls": [], "script": []}
 
-        def fake_run(cmd, timeout=5):
+        def fake_run(cmd, timeout=5, cwd=None):
             state["calls"].append(list(cmd))
             if state["script"]:
                 nxt = state["script"].pop(0)
@@ -3256,7 +3256,7 @@ class TestAddFromClientsPrune:
 
         state: dict = {"calls": [], "script": []}
 
-        def fake_run(cmd, timeout=5):
+        def fake_run(cmd, timeout=5, cwd=None):
             state["calls"].append(list(cmd))
             if state["script"]:
                 nxt = state["script"].pop(0)
@@ -3579,7 +3579,7 @@ class TestPruneCommand:
 
         state: dict = {"calls": [], "script": []}
 
-        def fake_run(cmd, timeout=5):
+        def fake_run(cmd, timeout=5, cwd=None):
             state["calls"].append(list(cmd))
             if state["script"]:
                 nxt = state["script"].pop(0)
@@ -4005,7 +4005,7 @@ class TestPruneBackupLog:
 
         state: dict = {"calls": [], "script": []}
 
-        def fake_run(cmd, timeout=5):
+        def fake_run(cmd, timeout=5, cwd=None):
             state["calls"].append(list(cmd))
             if state["script"]:
                 nxt = state["script"].pop(0)
@@ -4238,7 +4238,7 @@ class TestPerSourcePrunedMetadata:
 
         state: dict = {"calls": [], "script": []}
 
-        def fake_run(cmd, timeout=5):
+        def fake_run(cmd, timeout=5, cwd=None):
             state["calls"].append(list(cmd))
             if state["script"]:
                 nxt = state["script"].pop(0)
@@ -4673,6 +4673,40 @@ class TestEjectCommand:
         assert "--force" in result.output
         assert "demo" in self._stm_servers(config)
 
+    def test_same_signature_different_content_never_releases_stm(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        """A host entry matching by signature (command/args) but NOT
+        structurally (missing env / host-only fields) must not satisfy the
+        verbatim-restore invariant: the write is skipped, but the pre-removal
+        verify keeps the STM entry — signature alone ignores exactly the
+        fields the original exists to preserve (codex R1 Blocker)."""
+        original = {
+            "command": "npx",
+            "args": ["-y", "@demo"],
+            "env": {"PLAIN": "1"},
+            "hostOnly": True,
+        }
+        (_hermetic_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"demo": {"command": "npx", "args": ["-y", "@demo"]}}}),
+            encoding="utf-8",
+        )
+        self._seed_config(config, {"demo": _eject_entry(original=original)})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert fake_claude_host["calls"] == []  # write was skipped...
+        assert "demo" in self._stm_servers(config)  # ...and removal blocked
+        assert "existing host entry does not match" in result.output
+        assert "--accept-schema-loss" in result.output
+
+        accepted = runner.invoke(
+            cli, ["eject", "demo", "--yes", "--accept-schema-loss", *_cfg_args(config)]
+        )
+        assert accepted.exit_code == 0, accepted.output
+        assert "demo" not in self._stm_servers(config)
+
     def test_signature_none_deep_equal_skips(
         self, runner, config, fake_claude_host, _hermetic_home
     ):
@@ -4769,6 +4803,32 @@ class TestEjectCommand:
         assert add["cwd"] == recorded  # verbatim, not str(real)
         assert add["cmd"][-2:] == ["-s", "local"]
         assert "demo" not in self._stm_servers(config)
+
+    def test_force_pre_remove_runs_at_recorded_path_too(
+        self, runner, config, tmp_path, fake_claude_host, _hermetic_home
+    ):
+        """`--force` remove-then-add: BOTH verbs need the recorded cwd —
+        `claude mcp remove -s local` run from elsewhere would delete a
+        same-named entry from the wrong project (codex R1 Blocker). The
+        test process cwd is unrelated to the recorded path by construction."""
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        recorded = str(proj)
+        cc = {
+            "projects": {
+                recorded: {"mcpServers": {"demo": {"command": "other-server"}}},
+            }
+        }
+        (_hermetic_home / ".claude.json").write_text(json.dumps(cc), encoding="utf-8")
+        self._seed_config(config, {"demo": _eject_entry(kind="claude-project", path=recorded)})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", "--force", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        by_verb = {c["cmd"][2]: c for c in fake_claude_host["calls"]}
+        assert set(by_verb) == {"remove", "add-json"}
+        assert by_verb["remove"]["cwd"] == recorded
+        assert by_verb["add-json"]["cwd"] == recorded
 
     def test_claude_project_vanished_path_aborts_entry(self, runner, config, tmp_path):
         gone = str(tmp_path / "deleted-proj")
@@ -5228,7 +5288,7 @@ class TestInitPruneOriginals:
 
         state: dict = {"calls": [], "script": []}
 
-        def fake_run(cmd, timeout=5):
+        def fake_run(cmd, timeout=5, cwd=None):
             state["calls"].append(list(cmd))
             if state["script"]:
                 nxt = state["script"].pop(0)

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -4390,6 +4390,641 @@ class TestPerSourcePrunedMetadata:
         assert ["claude", "mcp", "remove", "github", "-s", "user"] in fake_claude["calls"]
 
 
+# ── mms eject (#475 PR3) ────────────────────────────────────────────────
+
+
+def _eject_entry(
+    *,
+    kind: str = "claude-user",
+    path: str | None = None,
+    original: dict | None = None,
+    duplicates: list[dict] | None = None,
+    command: str = "npx",
+    args: list[str] | None = None,
+) -> dict:
+    """STM config entry with an origin block, shaped like a real import."""
+    if original is None:
+        original = {"command": command, "args": args or ["-y", "@demo"]}
+    source: dict = {"kind": kind, "pruned": True, "pruned_at": "2026-06-11T00:00:00Z"}
+    if path is not None:
+        source["path"] = path
+    return {
+        "prefix": "dm",
+        "transport": "stdio",
+        "command": command,
+        "args": args or ["-y", "@demo"],
+        "origin": {
+            "schema_version": 1,
+            "source": source,
+            "duplicates": duplicates or [],
+            "imported_at": "2026-06-11T00:00:00Z",
+            "original": original,
+        },
+    }
+
+
+class TestEjectCommand:
+    """``mms eject`` restores the verbatim host entry, verifies the restore
+    against the backing host config, and only then removes the STM entry
+    (#475 PR3). Order invariant: host write first, STM removal second —
+    every failure mode is dual registration, never disappearance."""
+
+    def _seed_config(self, config: Path, servers: dict) -> None:
+        config.write_text(
+            json.dumps({"enabled": True, "upstream_servers": servers}, indent=2),
+            encoding="utf-8",
+        )
+
+    def _stm_servers(self, config: Path) -> dict:
+        return json.loads(config.read_text(encoding="utf-8"))["upstream_servers"]
+
+    @pytest.fixture
+    def fake_claude_host(self, monkeypatch, _hermetic_home):
+        """``_run_claude_mcp`` fake that emulates the claude CLI's writes.
+
+        ``add-json`` applies the payload to the hermetic ``~/.claude.json``
+        (user scope to top-level ``mcpServers``, local scope under
+        ``projects[<cwd>]``) so the post-write verify exercises a real
+        re-read. ``strip_keys`` simulates the CLI's schema-strip of unknown
+        fields (probed on 2.1.173); ``write=False`` simulates a clean exit
+        that wrote nowhere we can see (wrong project slot).
+        """
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        state: dict = {"calls": [], "rc": 0, "stderr": "", "strip_keys": [], "write": True}
+
+        def fake_run(cmd, timeout=5, cwd=None):
+            state["calls"].append({"cmd": list(cmd), "cwd": cwd})
+            if state["rc"] != 0:
+                return _FakeClaudeResult(returncode=state["rc"], stderr=state["stderr"])
+            if cmd[:3] == ["claude", "mcp", "add-json"] and state["write"]:
+                name, payload = cmd[3], json.loads(cmd[4])
+                scope = cmd[cmd.index("-s") + 1]
+                for key in state["strip_keys"]:
+                    payload.pop(key, None)
+                cc_path = _hermetic_home / ".claude.json"
+                cc = json.loads(cc_path.read_text(encoding="utf-8")) if cc_path.exists() else {}
+                if scope == "user":
+                    cc.setdefault("mcpServers", {})[name] = payload
+                else:
+                    proj = cc.setdefault("projects", {}).setdefault(cwd, {})
+                    proj.setdefault("mcpServers", {})[name] = payload
+                cc_path.write_text(json.dumps(cc), encoding="utf-8")
+            return _FakeClaudeResult(returncode=0)
+
+        monkeypatch.setattr(proxy_mod, "_run_claude_mcp", fake_run)
+        return state
+
+    def _claude_user_servers(self, home: Path) -> dict:
+        cc = json.loads((home / ".claude.json").read_text(encoding="utf-8"))
+        return cc.get("mcpServers", {})
+
+    # ── round trip + verify ──
+
+    def test_mcp_json_round_trip_deep_equal(self, runner, config, tmp_path):
+        """Direct-edit restore is byte-for-byte the verbatim original —
+        including fields STM's normalization drops (the round-trip
+        invariant the origin block exists to guarantee)."""
+        target = tmp_path / "proj" / ".mcp.json"
+        target.parent.mkdir()
+        original = {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["-y", "@demo"],
+            "env": {"PLAIN": "1"},
+            "hostOnly": True,
+        }
+        self._seed_config(
+            config,
+            {"demo": _eject_entry(kind="mcp-json", path=str(target), original=original)},
+        )
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        written = json.loads(target.read_text(encoding="utf-8"))
+        assert written["mcpServers"]["demo"] == original
+        assert "demo" not in self._stm_servers(config)
+        # Last upstream gone → STM self-deregistration hint.
+        assert "claude mcp remove memtomem-stm" in result.output
+
+    def test_claude_user_shell_out_writes_and_removes(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        original = {"type": "stdio", "command": "npx", "args": ["-y", "@demo"]}
+        self._seed_config(config, {"demo": _eject_entry(original=original)})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        add_calls = [c for c in fake_claude_host["calls"] if c["cmd"][:3][2:] == ["add-json"]]
+        assert len(add_calls) == 1
+        cmd = add_calls[0]["cmd"]
+        assert cmd[3] == "demo"
+        assert json.loads(cmd[4]) == original
+        assert cmd[-2:] == ["-s", "user"]
+        assert self._claude_user_servers(_hermetic_home)["demo"] == original
+        assert "demo" not in self._stm_servers(config)
+
+    def test_desktop_direct_edit_round_trip(self, runner, config, _hermetic_home):
+        from memtomem_stm.mms.import_hosts import _desktop_config_path
+
+        desktop = _desktop_config_path()
+        original = {"command": "npx", "args": ["-y", "@demo"], "env": {"X": "1"}}
+        self._seed_config(config, {"demo": _eject_entry(kind="claude-desktop", original=original)})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        written = json.loads(desktop.read_text(encoding="utf-8"))
+        assert written["mcpServers"]["demo"] == original
+
+    # ── schema-loss hard gate ──
+
+    def test_schema_strip_fails_entry_and_keeps_stm(
+        self, runner, config, fake_claude_host
+    ):
+        """The claude CLI silently drops unknown fields — a clean add-json
+        exit is NOT proof the verbatim contract held. Default: the entry
+        stays in STM (dual registration) and eject fails loudly."""
+        original = {"type": "stdio", "command": "npx", "hostOnly": True}
+        self._seed_config(config, {"demo": _eject_entry(original=original)})
+        fake_claude_host["strip_keys"] = ["hostOnly"]
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "demo" in self._stm_servers(config)
+        assert "hostOnly (dropped)" in result.output
+        assert "--accept-schema-loss" in result.output
+        assert "dual registration" in result.output
+
+    def test_accept_schema_loss_removes_with_warning(
+        self, runner, config, fake_claude_host
+    ):
+        original = {"type": "stdio", "command": "npx", "hostOnly": True}
+        self._seed_config(config, {"demo": _eject_entry(original=original)})
+        fake_claude_host["strip_keys"] = ["hostOnly"]
+
+        result = runner.invoke(
+            cli, ["eject", "demo", "--yes", "--accept-schema-loss", *_cfg_args(config)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "demo" not in self._stm_servers(config)
+        assert "schema loss" in result.output
+
+    def test_clean_exit_but_no_visible_write_fails(self, runner, config, fake_claude_host):
+        """rc=0 with the entry absent from the expected host slot is a full
+        mismatch — the safety net for a CLI writing somewhere unexpected."""
+        self._seed_config(config, {"demo": _eject_entry()})
+        fake_claude_host["write"] = False
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "demo" in self._stm_servers(config)
+        assert "not found at the expected host location" in result.output
+
+    # ── host-write failure / capability message ──
+
+    def test_host_write_failure_keeps_stm_and_prints_fallback(
+        self, runner, config, fake_claude_host
+    ):
+        self._seed_config(config, {"demo": _eject_entry()})
+        fake_claude_host["rc"] = 1
+        fake_claude_host["stderr"] = "unknown command add-json"
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "demo" in self._stm_servers(config)
+        assert "unknown command add-json" in result.output
+        assert "claude mcp add-json demo" in result.output  # manual fallback
+        assert "2.1.173" in result.output  # capability-oriented hint
+
+    # ── no-clobber guard ──
+
+    def test_idempotent_skip_when_host_identical(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        """Same signature already in the target → skip the write, proceed
+        with STM removal (idempotent re-run after a crashed first eject)."""
+        original = {"type": "stdio", "command": "npx", "args": ["-y", "@demo"]}
+        (_hermetic_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"demo": dict(original)}}), encoding="utf-8"
+        )
+        self._seed_config(config, {"demo": _eject_entry(original=original)})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        assert fake_claude_host["calls"] == []  # no shell-out at all
+        assert "demo" not in self._stm_servers(config)
+        assert "skip write" in result.output
+
+    def test_no_clobber_different_entry_requires_force(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        (_hermetic_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"demo": {"command": "other-server"}}}),
+            encoding="utf-8",
+        )
+        self._seed_config(config, {"demo": _eject_entry()})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "--force" in result.output
+        assert fake_claude_host["calls"] == []
+        assert "demo" in self._stm_servers(config)
+
+    def test_force_overwrites_via_remove_then_add(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        (_hermetic_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"demo": {"command": "other-server"}}}),
+            encoding="utf-8",
+        )
+        self._seed_config(config, {"demo": _eject_entry()})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", "--force", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        verbs = [c["cmd"][2] for c in fake_claude_host["calls"]]
+        assert verbs == ["remove", "add-json"]
+        assert "demo" not in self._stm_servers(config)
+
+    def test_signature_none_is_never_an_idempotent_match(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        """No command/url on either side → only full structural equality may
+        skip; anything else aborts (R1 M1 — ``None == None`` must not pass)."""
+        (_hermetic_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"demo": {"broken": "entry"}}}), encoding="utf-8"
+        )
+        self._seed_config(
+            config, {"demo": _eject_entry(original={"type": "stdio", "command": "npx"})}
+        )
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "--force" in result.output
+        assert "demo" in self._stm_servers(config)
+
+    def test_signature_none_deep_equal_skips(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        weird = {"weird": "shape"}
+        (_hermetic_home / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"demo": dict(weird)}}), encoding="utf-8"
+        )
+        self._seed_config(config, {"demo": _eject_entry(original=weird)})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        assert fake_claude_host["calls"] == []
+        assert "demo" not in self._stm_servers(config)
+
+    # ── secret gate (§7) ──
+
+    def test_secret_gate_non_tty_yes_does_not_bypass(
+        self, runner, config, fake_claude_host
+    ):
+        original = {"command": "npx", "env": {"GITHUB_TOKEN": "ghp_secret"}}
+        self._seed_config(config, {"demo": _eject_entry(original=original)})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "--allow-argv-secrets" in result.output
+        assert fake_claude_host["calls"] == []
+        assert "demo" in self._stm_servers(config)
+
+    def test_secret_gate_allow_flag_proceeds(self, runner, config, fake_claude_host):
+        original = {"command": "npx", "env": {"GITHUB_TOKEN": "ghp_secret"}}
+        self._seed_config(config, {"demo": _eject_entry(original=original)})
+
+        result = runner.invoke(
+            cli, ["eject", "demo", "--yes", "--allow-argv-secrets", *_cfg_args(config)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "demo" not in self._stm_servers(config)
+
+    def test_secret_gate_tty_confirm_default_no(
+        self, runner, config, monkeypatch, fake_claude_host
+    ):
+        """TTY path: declining the dedicated secret confirm fails the entry
+        even after the main eject confirm was accepted."""
+        from memtomem_stm.cli import proxy as proxy_mod
+
+        monkeypatch.setattr(proxy_mod, "_should_use_tui", lambda: True)
+        original = {"command": "npx", "env": {"GITHUB_TOKEN": "ghp_secret"}}
+        self._seed_config(config, {"demo": _eject_entry(original=original)})
+
+        result = runner.invoke(cli, ["eject", "demo", *_cfg_args(config)], input="y\nn\n")
+
+        assert result.exit_code == 1
+        assert "secret gate declined" in result.output
+        assert fake_claude_host["calls"] == []
+        assert "demo" in self._stm_servers(config)
+
+    def test_secret_gate_direct_edit_scope_unaffected(self, runner, config, tmp_path):
+        """mcp-json/desktop restores never shell out — no argv exposure, no gate."""
+        target = tmp_path / ".mcp.json"
+        original = {"command": "npx", "env": {"GITHUB_TOKEN": "ghp_secret"}}
+        self._seed_config(
+            config, {"demo": _eject_entry(kind="mcp-json", path=str(target), original=original)}
+        )
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(target.read_text(encoding="utf-8"))["mcpServers"]["demo"] == original
+
+    # ── claude-project cwd rule ──
+
+    def test_claude_project_shell_out_runs_at_recorded_path(
+        self, runner, config, tmp_path, fake_claude_host
+    ):
+        """`-s local` resolves its project slot from the process cwd, and the
+        recorded path is used EXACTLY as written — a symlinked alias must not
+        be resolved away (the claude CLI keyed the slot, not us)."""
+        real = tmp_path / "real-proj"
+        real.mkdir()
+        alias = tmp_path / "alias-proj"
+        alias.symlink_to(real)
+        recorded = str(alias)
+        self._seed_config(
+            config, {"demo": _eject_entry(kind="claude-project", path=recorded)}
+        )
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        add = [c for c in fake_claude_host["calls"] if c["cmd"][2] == "add-json"][0]
+        assert add["cwd"] == recorded  # verbatim, not str(real)
+        assert add["cmd"][-2:] == ["-s", "local"]
+        assert "demo" not in self._stm_servers(config)
+
+    def test_claude_project_vanished_path_aborts_entry(self, runner, config, tmp_path):
+        gone = str(tmp_path / "deleted-proj")
+        self._seed_config(config, {"demo": _eject_entry(kind="claude-project", path=gone)})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "no longer exists" in result.output
+        assert "--to" in result.output
+        assert "demo" in self._stm_servers(config)
+
+    # ── --to / origin-less entries ──
+
+    def test_origin_less_requires_to(self, runner, config):
+        self._seed_config(config, {"plain": {"prefix": "p", "command": "npx"}})
+
+        result = runner.invoke(cli, ["eject", "plain", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "--to" in result.output
+
+    def test_origin_less_suggests_backup_log_row(
+        self, runner, config, _hermetic_home
+    ):
+        log = _hermetic_home / ".memtomem" / "pruned_upstreams.json"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "entries": [
+                        {
+                            "name": "plain",
+                            "source": {"kind": "claude-user"},
+                            "original": {"command": "npx"},
+                            "pruned_at": "2026-06-10T00:00:00Z",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        self._seed_config(config, {"plain": {"prefix": "p", "command": "npx"}})
+
+        result = runner.invoke(cli, ["eject", "plain", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "backup log has a row" in result.output
+        assert "kind=claude-user" in result.output
+
+    def test_to_denormalizes_and_strips_stm_fields(self, runner, config, tmp_path):
+        target = tmp_path / ".mcp.json"
+        self._seed_config(
+            config,
+            {
+                "plain": {
+                    "prefix": "p",
+                    "transport": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "@p"],
+                    "env": {"A": "1"},
+                    "compression": "auto",
+                    "max_result_chars": 8000,
+                }
+            },
+        )
+
+        result = runner.invoke(
+            cli, ["eject", "plain", "--yes", "--to", f"mcp-json:{target}", *_cfg_args(config)]
+        )
+
+        assert result.exit_code == 0, result.output
+        written = json.loads(target.read_text(encoding="utf-8"))["mcpServers"]["plain"]
+        assert written == {"type": "stdio", "command": "npx", "args": ["-y", "@p"], "env": {"A": "1"}}
+        assert "reconstructed" in result.output
+
+    def test_to_usage_errors(self, runner, config):
+        self._seed_config(config, {"plain": {"prefix": "p", "command": "npx"}})
+        bad_kind = runner.invoke(
+            cli, ["eject", "plain", "--yes", "--to", "cursor", *_cfg_args(config)]
+        )
+        assert bad_kind.exit_code == 2
+        assert "--to must be one of" in bad_kind.output
+        bad_path = runner.invoke(
+            cli, ["eject", "plain", "--yes", "--to", "claude-user:/x", *_cfg_args(config)]
+        )
+        assert bad_path.exit_code == 2
+        assert "does not take a :PATH" in bad_path.output
+
+    # ── drift guard / duplicates / --keep ──
+
+    def test_drift_guard_warns_and_restores_original(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        original = {"type": "stdio", "command": "npx", "args": ["-y", "@demo"]}
+        entry = _eject_entry(original=original)
+        entry["args"] = ["-y", "@demo", "--edited-after-import"]
+        self._seed_config(config, {"demo": entry})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        assert "modified after import" in result.output
+        assert self._claude_user_servers(_hermetic_home)["demo"] == original
+
+    def test_pruned_duplicates_reported_not_restored(
+        self, runner, config, fake_claude_host
+    ):
+        self._seed_config(
+            config,
+            {
+                "demo": _eject_entry(
+                    duplicates=[
+                        {"kind": "claude-desktop", "pruned": True, "pruned_at": "x"},
+                        {"kind": "mcp-json", "path": "/p/.mcp.json", "pruned": False},
+                    ]
+                )
+            },
+        )
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        assert "also pruned from Claude Desktop" in result.output
+        assert "pruned_upstreams.json" in result.output
+        # Only the primary restore shell-out — duplicates are not written.
+        assert len([c for c in fake_claude_host["calls"] if c["cmd"][2] == "add-json"]) == 1
+
+    def test_keep_restores_but_retains_stm_entry(
+        self, runner, config, fake_claude_host, _hermetic_home
+    ):
+        self._seed_config(config, {"demo": _eject_entry()})
+
+        result = runner.invoke(cli, ["eject", "demo", "--yes", "--keep", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        assert "demo" in self._claude_user_servers(_hermetic_home)
+        assert "demo" in self._stm_servers(config)
+        assert "dual-registered" in result.output
+        assert "mms prune" in result.output
+
+    # ── command plumbing ──
+
+    def test_dry_run_writes_nothing(self, runner, config, fake_claude_host):
+        self._seed_config(config, {"demo": _eject_entry()})
+
+        result = runner.invoke(cli, ["eject", "demo", "--dry-run", *_cfg_args(config)])
+
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert fake_claude_host["calls"] == []
+        assert "demo" in self._stm_servers(config)
+
+    def test_non_tty_without_yes_exits_1(self, runner, config, fake_claude_host):
+        self._seed_config(config, {"demo": _eject_entry()})
+
+        result = runner.invoke(cli, ["eject", "demo", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "--yes" in result.output
+        assert fake_claude_host["calls"] == []
+
+    def test_self_reference_refused(self, runner, config):
+        entry = _eject_entry(command="memtomem-stm", args=[])
+        entry["origin"]["original"] = {"command": "memtomem-stm"}
+        self._seed_config(config, {"self": entry})
+
+        result = runner.invoke(cli, ["eject", "self", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "STM's own registration" in result.output
+
+    def test_unknown_name_errors(self, runner, config):
+        self._seed_config(config, {"demo": _eject_entry()})
+
+        result = runner.invoke(cli, ["eject", "ghost", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        assert "not configured: ghost" in result.output
+
+    def test_partial_failure_exits_1_but_completes_others(
+        self, runner, config, tmp_path, fake_claude_host
+    ):
+        """One entry failing must not stop the others — per-entry isolation
+        with a non-zero exit, matching the prune reporting convention."""
+        target = tmp_path / ".mcp.json"
+        ok_original = {"command": "npx", "args": ["-y", "@ok"]}
+        self._seed_config(
+            config,
+            {
+                "ok": _eject_entry(kind="mcp-json", path=str(target), original=ok_original),
+                "bad": _eject_entry(),
+            },
+        )
+        fake_claude_host["rc"] = 1
+        fake_claude_host["stderr"] = "boom"
+
+        result = runner.invoke(cli, ["eject", "ok", "bad", "--yes", *_cfg_args(config)])
+
+        assert result.exit_code == 1
+        servers = self._stm_servers(config)
+        assert "ok" not in servers  # succeeded and was removed
+        assert "bad" in servers  # failed and was kept
+        assert json.loads(target.read_text(encoding="utf-8"))["mcpServers"]["ok"] == ok_original
+
+
+class TestDenormalizeClientEntry:
+    """Unit pins for the degraded inverse of ``_normalize_client_entry``."""
+
+    def test_stdio_strips_stm_fields_and_warns_on_env_filter(self):
+        from memtomem_stm.cli.proxy import _denormalize_client_entry
+
+        payload, warnings = _denormalize_client_entry(
+            {
+                "prefix": "p",
+                "transport": "stdio",
+                "command": "npx",
+                "args": ["-y", "@p"],
+                "env": {"A": "1"},
+                "compression": "auto",
+                "max_result_chars": 8000,
+                "surfacing_enabled": False,
+            }
+        )
+        assert payload == {"type": "stdio", "command": "npx", "args": ["-y", "@p"], "env": {"A": "1"}}
+        assert any("filtered at import time" in w for w in warnings)
+
+    def test_streamable_http_maps_to_host_http_type(self):
+        from memtomem_stm.cli.proxy import _denormalize_client_entry
+
+        payload, warnings = _denormalize_client_entry(
+            {"prefix": "p", "transport": "streamable_http", "url": "https://x/mcp"}
+        )
+        assert payload == {"type": "http", "url": "https://x/mcp"}
+        assert any("headers" in w for w in warnings)
+
+    def test_headers_carried_when_present(self):
+        from memtomem_stm.cli.proxy import _denormalize_client_entry
+
+        payload, warnings = _denormalize_client_entry(
+            {
+                "prefix": "p",
+                "transport": "sse",
+                "url": "https://x/sse",
+                "headers": {"Authorization": "Bearer t"},
+            }
+        )
+        assert payload == {
+            "type": "sse",
+            "url": "https://x/sse",
+            "headers": {"Authorization": "Bearer t"},
+        }
+        assert not any("headers" in w for w in warnings)
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="flock is POSIX-only; write_lock is documented as a no-op on Windows",
@@ -4444,8 +5079,9 @@ class TestConfigWriteLock:
             ["surfacing", "srv", "off"],
             ["prune", "--all", "--yes"],
             ["init"],
+            ["eject", "srv", "--yes"],
         ],
-        ids=["add", "remove", "surfacing-write", "prune", "init"],
+        ids=["add", "remove", "surfacing-write", "prune", "init", "eject"],
     )
     def test_mutators_fail_cleanly_when_lock_held(
         self, runner, config, argv, _hermetic_home
@@ -4475,9 +5111,14 @@ class TestConfigWriteLock:
         with self._hold_lock(_hermetic_home):
             read = runner.invoke(cli, ["surfacing", "srv", *_cfg_args(config)])
             dry = runner.invoke(cli, ["prune", "--all", "--dry-run", *_cfg_args(config)])
+            eject_dry = runner.invoke(
+                cli,
+                ["eject", "srv", "--dry-run", "--to", "claude-user", *_cfg_args(config)],
+            )
         assert read.exit_code == 0, read.output
         assert "surfacing for 'srv': on" in read.output
         assert dry.exit_code == 0, dry.output
+        assert eject_dry.exit_code == 0, eject_dry.output
 
     def test_concurrent_prunes_serialize_and_lose_no_backup_rows(
         self, config, monkeypatch, _hermetic_home


### PR DESCRIPTION
Part of #475 (PR3 of 4 — eject core). Follows #476 (origin capture) and #477 (prune backup log + config write lock).

## What

New `mms eject NAME... [--to|--keep|--force|--allow-argv-secrets|--accept-schema-loss|--dry-run|--yes]` command: restores an imported upstream entry back to its host MCP client config (the `origin.original` verbatim payload captured by #476), verifies the restore against the backing host file, and only then removes the STM entry.

## Behavior change

This adds the third opt-in writer to the otherwise read-only source-client contract (after `--prune`/`mms prune`, #226 lineage). Eject writes to host configs: `claude mcp add-json` shell-out for Claude Code user/local scopes, direct atomic JSON edit for `.mcp.json` / Claude Desktop. STM config mutation (entry removal) runs under the #477 cross-process write lock; `--dry-run` skips the lock.

## Design notes (pre-impl gate + review constraints)

The hard gate probe (claude CLI 2.1.173) confirmed `add-json` accepts all 3 transports and preserves `headers` in all 3 scopes — but it silently strips fields outside its schema, and `-s local` keys the project slot by the process cwd (realpath). Hence:

- **Post-write verify** re-reads the backing host config (`~/.claude.json` / `.mcp.json` / Desktop json — never `claude mcp get` output, which has no machine-readable contract) and deep-compares against the payload. A mismatch **fails the entry by default**: the STM entry is kept and the dual registration is reported; `--accept-schema-loss` is the explicit opt-out. A clean `add-json` exit alone does not prove the verbatim-restore contract that `origin.original` exists to provide.
- **cwd rule**: claude-project shell-outs run with `cwd=origin.source.path`, used exactly as recorded (the claude CLI keyed the slot; re-resolving could relocate the restore). Pinned by a symlink regression test.
- **No-clobber**: signature compare against the live host entry; a `None` signature on either side is never an idempotent match — full structural equality only (R1 M1). `--force` = remove-then-add (no overwrite flag in `add-json`).
- **Secret gate (§7)**: env/headers values classified as secrets (`mms/secrets.py`) would land on argv during the shell-out — TTY gets a dedicated confirm (default No), non-TTY requires `--allow-argv-secrets`, and `--yes` never bypasses it. Direct-edit scopes are exempt (no argv).
- **Older CLIs**: any `add-json` failure is non-fatal per entry — STM entry kept, manual fallback command printed, plus a capability hint (add-json/http support probed on 2.1.173).
- **Duplicates**: primary-source restore only (RFC defers `--all-sources`); pruned duplicate rows are listed in the plan with the backup-log location so nothing disappears silently.
- Order invariant: host write FIRST, STM removal SECOND — every failure mode is dual registration, never disappearance.

## Tests

26 new tests (`TestEjectCommand`, `TestDenormalizeClientEntry`, lock parametrize extension): round-trip deep-equal per writer kind, schema-strip hard-fail + `--accept-schema-loss`, clean-exit-no-write safety net, host-write failure keeps STM + fallback hints, idempotent skip, signature-None rules (both branches), secret gate TTY/non-TTY/`--yes`-no-bypass/direct-edit-exempt, cwd verbatim symlink pin, vanished-path abort, `--to` parse/denormalize/STM-field stripping, drift guard, `--keep`, `--dry-run`, partial-failure isolation, self-reference refusal, lock coverage (held-lock timeout + dry-run skip).

Full suite: 3357 passed, 3 skipped. `ruff check`/`format` clean; new code mypy-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)