### PR TITLE
feat(cli): remove eject hint + mms list origin summary + docs (#475)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ mms add filesystem \
 
 `--prefix` is required: it's the namespace under which the upstream server's tools will appear (e.g. `fs__read_file`). Repeat for each MCP server you want to proxy.
 
-If you've already configured MCP servers in Claude Desktop, Claude Code, or a project `.mcp.json`, `mms add --import` (alias `--from-clients`) reuses the init wizard to bulk-select them — skipping anything already registered.
+If you've already configured MCP servers in Claude Desktop, Claude Code, or a project `.mcp.json`, `mms add --import` (alias `--from-clients`) reuses the init wizard to bulk-select them — skipping anything already registered. Moving behind the proxy is reversible: imports capture where each entry came from, and `mms eject NAME` restores it to its host client if you later want to stop proxying it (see [docs/cli.md](https://github.com/memtomem/memtomem-stm/blob/main/docs/cli.md#eject)).
 
 ```bash
 mms list      # show what you've added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,6 +37,7 @@ Options:
 Commands:
   add        Add an upstream MCP server to the proxy configuration.
   daemon     Manage the local surfacing daemon (warm LTM connection for...
+  eject      Restore imported upstream(s) to their host MCP client, then...
   health     Check upstream server connectivity.
   hook       Compress and/or surface for a host's built-in tool call...
   host       Host-config inspection and sync (RFC §7.3).
@@ -180,6 +181,8 @@ Use `--from-clients` (alias `--import`) to bulk-pick additional servers from the
 
 To remove the original direct registrations after a successful import, pass `--prune`. On a TTY you get a `(name, source)` confirm prompt that defaults to **No** before any file edits; in non-TTY callers (CI, scripts) you must pass `--prune` explicitly — the flag never auto-fires on inferred consent. A candidate registered in more than one source client is pruned from every source, not just the one it was imported from. Prune failures are non-fatal: the import stays, and each failed entry prints the exact manual `claude mcp remove` or Claude Desktop edit to retry. `--prune` without `--from-clients` is a usage error rather than a silent no-op.
 
+The import→prune transition is reversible: every import records an `origin` provenance block per entry (the structured source plus the verbatim host entry), and every prune backs the deleted host entry up to `~/.memtomem/pruned_upstreams.json` before removing it. [`mms eject`](#eject) walks the whole path back — it restores the captured host entry to where it came from and removes the entry from STM.
+
 > **Note**: The CLI's `--compression` flag exposes 5 of the 10 strategies. The remaining five (`extract_fields`, `schema_pruning`, `skeleton`, `progressive`, `llm_summary`) are configured by editing `stm_proxy.json` directly. See [Compression Strategies](compression.md).
 
 ### `list`
@@ -192,7 +195,9 @@ Options:
   --json         Output as JSON for scripting.
 ```
 
-Prints the configured upstream servers in a table — name, prefix, transport, compression strategy, and the command (stdio) or URL (SSE / HTTP). Reads the config only; does not probe connectivity (use `mms health` for that). With `--json` the output becomes `{"config_path": ..., "servers": {...}}` for scripting; a missing config file returns `{"error": "config_not_found", "path": ...}` instead of a text fallthrough so callers can branch on shape.
+Prints the configured upstream servers in a table — name, prefix, transport, compression strategy, origin, and the command (stdio) or URL (SSE / HTTP). Reads the config only; does not probe connectivity (use `mms health` for that). With `--json` the output becomes `{"config_path": ..., "servers": {...}}` for scripting; a missing config file returns `{"error": "config_not_found", "path": ...}` instead of a text fallthrough so callers can branch on shape.
+
+The ORIGIN column summarizes import provenance: `-` for entries added manually (or imported before provenance capture), otherwise the recorded source kind (`claude-user`, `claude-project`, `mcp-json`, `claude-desktop`). A trailing `*` marks an entry whose host original was pruned — it now exists only behind STM, and [`mms eject`](#eject) can restore it. In `--json` output the `origin` block appears with `origin.original` redacted (`has_original` tells you whether one was captured) because the verbatim host entry may carry secrets.
 
 ### `remove`
 
@@ -205,6 +210,8 @@ Options:
 ```
 
 Removes an upstream MCP server from the proxy configuration by name. Prompts for confirmation on a TTY unless `-y` or `--yes` is passed.
+
+`remove` only edits the STM config — it never touches host configs. If the entry was imported and every host original was pruned, removing it would leave the server registered **nowhere**, so the command prints a note (before the confirmation prompt) pointing at [`mms eject`](#eject), which restores the host entry instead. The hint is advisory; the removal itself is never blocked.
 
 ### Examples
 
@@ -249,8 +256,12 @@ mms list --json            # machine-readable: {config_path, servers}
 # Show full status
 mms status
 
-# Remove a server
+# Remove a server (STM config only)
 mms remove github
+
+# Stop proxying an imported server WITHOUT losing it: restore the captured
+# host entry to where it came from, then remove it from STM
+mms eject github
 
 # Toggle proactive surfacing for an upstream (persisted in stm_proxy.json)
 mms surfacing context7 off  # `on` to re-enable; omit the state to show it
@@ -278,6 +289,66 @@ Removes direct registrations for STM upstreams that are still registered in a so
 
 Scope selection is explicit by design: pass `--all` to act on every dual-registered upstream, or pass one or more `NAMES` to limit the action. Running `mms prune` with no arguments is a usage error rather than defaulting to "everything" — this is a destructive operation against external config files and the default should be visible.
 
+"Dual-registered" requires both the name **and** the identity to match: the source-client entry must share the STM upstream's `(transport, command, args)` or `(transport, url)` signature. If you've edited either side to point at a different server that happens to share a name, `mms prune` skips it rather than clobbering the unrelated entry.
+
+STM's own config (`stm_proxy.json`) is never modified. Only source-client files change. Failures are surfaced via non-zero exit and the exact manual `claude mcp remove` command for each failed entry, so scripting callers can retry.
+
+Before deleting a host entry, every prune path appends the verbatim entry (with its source and timestamp) to `~/.memtomem/pruned_upstreams.json` (mode `0600`) — backup-before-delete, so a crash mid-prune never loses the only copy. The log is append-only and advisory: [`mms eject`](#eject) suggests it when an entry has no recorded origin, but never restores from it without your confirmation.
+
+```bash
+mms prune --all              # remove every dual-registered upstream (TTY: confirm prompt)
+mms prune --all --yes        # same, skip the prompt (CI / scripts)
+mms prune --all --dry-run    # preview without writes
+mms prune docs-langchain     # target specific upstreams
+```
+
+### `eject`
+
+```
+Usage: mms eject [OPTIONS] NAMES...
+
+Options:
+  --config TEXT         [default: ~/.memtomem/stm_proxy.json]
+  --to TARGET           Restore target for entries without a usable origin:
+                        claude-user | claude-project[:PATH] | mcp-json[:PATH]
+                        | claude-desktop. Entries with a recorded origin
+                        ignore this.
+  --keep                Restore to the host but keep the STM entry (dual
+                        registration).
+  --force               Overwrite a same-name host entry whose identity
+                        differs.
+  --allow-argv-secrets  Permit `claude mcp add-json` shell-outs whose payload
+                        carries secret-classified values (argv is visible in
+                        the process list). The only override for the secret
+                        gate — --yes does not bypass it.
+  --accept-schema-loss  Proceed with STM removal even when the restored host
+                        entry does not structurally match the original (the
+                        claude CLI strips fields it does not know). Default is
+                        to keep the STM entry and fail.
+  --dry-run             Print the plan; no writes.
+  -y, --yes             Skip the confirm prompt (scripts / CI / non-TTY
+                        callers).
+```
+
+The reverse of `mms add --import --prune`: stop proxying a server **without losing it**. Imports capture an `origin` provenance block per entry in `stm_proxy.json` — the structured source (`claude-user`, `claude-project`, `mcp-json`, `claude-desktop`) plus the verbatim host entry as it existed at import time. `eject` writes that original back to where it came from, verifies the restore by re-reading the host config, and only then removes the entry from STM. The order is the safety invariant: host write first, STM removal second — any failure leaves the server registered in at least one place (worst case dual registration, never disappearance).
+
+`origin.original` may carry secrets (`env`, `headers`), so `mms list --json` / `mms status --json` redact it — the summary keys stay, plus `has_original` so scripts can tell a redacted block from one that never captured an original.
+
+Key semantics:
+
+- **Targets.** Entries restore to their recorded origin. Claude Code scopes go through `claude mcp add-json` (the project scope runs at the recorded project path); `.mcp.json` and Claude Desktop are direct atomic JSON edits. Entries without a usable origin (manual `mms add`, imports predating provenance capture, a vanished project directory) need an explicit `--to`; the restore is then a reconstructed entry, with warnings for what import-time normalization lost (filtered env keys, HTTP headers).
+- **No-clobber.** A same-name entry already at the target is compared structurally: identical → idempotent skip; different or not comparable → that entry fails with a hint unless `--force` (which replaces it).
+- **Verified release.** The STM entry is only removed once the host entry deep-equals the restore payload. The claude CLI re-serializes through its own schema and silently drops fields it doesn't know, so a clean `add-json` exit isn't proof; on mismatch the entry stays in STM (dual registration) unless you pass `--accept-schema-loss`.
+- **Secret gate.** Payloads with secret-classified `env`/`headers` values would appear on the `claude` argv (visible in the process list). On a TTY you get an explicit per-entry confirmation; non-TTY callers must pass `--allow-argv-secrets`. `--yes` never bypasses this gate.
+- **Failures are per-entry and non-fatal.** Each failed entry keeps its STM registration and prints an exact manual restore command; the run exits 1 if anything failed. When an entry has no origin, the [prune backup log](#prune) (`~/.memtomem/pruned_upstreams.json`) is suggested as a starting point for `--to` — verify it's current first; eject never auto-adopts it.
+
+```bash
+mms eject github                   # restore to its recorded origin, then remove from STM
+mms eject github --keep            # restore but keep proxying (dual registration)
+mms eject legacy --to claude-user  # no recorded origin: pick the restore target
+mms eject github --dry-run         # preview the per-entry plan; no writes
+```
+
 ### `surfacing`
 
 ```
@@ -288,17 +359,6 @@ Options:
 ```
 
 Toggles `surfacing_enabled` on an upstream in `stm_proxy.json` (default `on`). With no state it prints the current value; `mms status` shows it per server. A running proxy hot-reloads the change without a restart. Because the flag lives in the shared proxy config — not per-client `env` — every MCP client that proxies through this `mms` sees the same scope. When off, surfacing is skipped before the LTM search for every tool on that server (counted as `upstream_disabled` in `stm_surfacing_stats`). For tool-grained or cross-server glob scope, use the `MEMTOMEM_STM_SURFACING__EXCLUDE_TOOLS` env glob instead (matches `server__tool`). See [surfacing.md](surfacing.md#scoping-surfacing-per-upstream).
-
-"Dual-registered" requires both the name **and** the identity to match: the source-client entry must share the STM upstream's `(transport, command, args)` or `(transport, url)` signature. If you've edited either side to point at a different server that happens to share a name, `mms prune` skips it rather than clobbering the unrelated entry.
-
-STM's own config (`stm_proxy.json`) is never modified. Only source-client files change. Failures are surfaced via non-zero exit and the exact manual `claude mcp remove` command for each failed entry, so scripting callers can retry.
-
-```bash
-mms prune --all              # remove every dual-registered upstream (TTY: confirm prompt)
-mms prune --all --yes        # same, skip the prompt (CI / scripts)
-mms prune --all --dry-run    # preview without writes
-mms prune docs-langchain     # target specific upstreams
-```
 
 ### `health`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,7 +197,7 @@ Options:
 
 Prints the configured upstream servers in a table — name, prefix, transport, compression strategy, origin, and the command (stdio) or URL (SSE / HTTP). Reads the config only; does not probe connectivity (use `mms health` for that). With `--json` the output becomes `{"config_path": ..., "servers": {...}}` for scripting; a missing config file returns `{"error": "config_not_found", "path": ...}` instead of a text fallthrough so callers can branch on shape.
 
-The ORIGIN column summarizes import provenance: `-` for entries added manually (or imported before provenance capture), otherwise the recorded source kind (`claude-user`, `claude-project`, `mcp-json`, `claude-desktop`). A trailing `*` marks an entry whose host original was pruned — it now exists only behind STM, and [`mms eject`](#eject) can restore it. In `--json` output the `origin` block appears with `origin.original` redacted (`has_original` tells you whether one was captured) because the verbatim host entry may carry secrets.
+The ORIGIN column summarizes import provenance: `-` for entries added manually (or imported before provenance capture), otherwise the recorded source kind (`claude-user`, `claude-project`, `mcp-json`, `claude-desktop`). A trailing `*` marks an entry whose recorded host sources — the primary origin **and** any duplicate registrations — were all pruned: it now exists only behind STM, and [`mms eject`](#eject) can restore it. The same condition drives the [`mms remove`](#remove) hint, so the two surfaces never disagree about which entries removal would orphan. In `--json` output the `origin` block appears with `origin.original` redacted (`has_original` tells you whether one was captured) because the verbatim host entry may carry secrets.
 
 ### `remove`
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -549,6 +549,25 @@ def _redacted_servers_json(servers: dict[str, Any]) -> dict[str, Any]:
     return redacted
 
 
+def _origin_cell(cfg: Any) -> str:
+    """ORIGIN table cell for one ``mms list`` row (#475 PR4).
+
+    ``-`` for entries without provenance (manual ``mms add``, pre-#475
+    imports); otherwise the recorded ``origin.source.kind`` — the
+    machine-readable identifier, not the human label, so the cell stays
+    within one column and matches what ``--json`` exposes. A trailing ``*``
+    marks a primary source whose host original was pruned (the entry now
+    exists only behind STM); the legend under the table points at
+    ``mms eject``. Unknown kinds print as recorded — the cell is a display
+    of stored provenance, not a validation of it.
+    """
+    origin = cfg.get("origin") if isinstance(cfg, dict) else None
+    source = origin.get("source") if isinstance(origin, dict) else None
+    if not isinstance(source, dict) or not isinstance(source.get("kind"), str):
+        return "-"
+    return source["kind"] + ("*" if source.get("pruned") else "")
+
+
 @cli.command()
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
@@ -649,23 +668,33 @@ def list_servers(config_path: str, *, as_json: bool = False) -> None:
     # COMPRESSION and COMMAND/URL columns out of alignment with the
     # header. ``<16`` fits every Choice value the ``--transport`` flag
     # accepts (``stdio`` / ``sse`` / ``streamable_http``) with at least
-    # one space of padding.
-    click.echo(
-        _hdr(f"{'NAME':<20} {'PREFIX':<10} {'TRANSPORT':<16} {'COMPRESSION':<12} COMMAND / URL")
+    # one space of padding. ORIGIN ``<16`` likewise fits the widest
+    # source kind plus the pruned marker (``claude-desktop*``, 15).
+    header = (
+        f"{'NAME':<20} {'PREFIX':<10} {'TRANSPORT':<16} {'COMPRESSION':<12} "
+        f"{'ORIGIN':<16} COMMAND / URL"
     )
-    click.echo("-" * 80)
+    click.echo(_hdr(header))
+    click.echo("-" * len(header))
+    any_pruned = False
     for name, cfg in servers.items():
         transport = cfg.get("transport", "stdio")
         prefix = cfg.get("prefix", "")
         compression = cfg.get("compression", "auto")
+        origin_cell = _origin_cell(cfg)
+        any_pruned = any_pruned or origin_cell.endswith("*")
         if transport == "stdio":
             cmd = cfg.get("command", "")
             args_str = " ".join(cfg.get("args", []))
             detail = f"{cmd} {args_str}".strip()
         else:
             detail = cfg.get("url", "")
-        click.echo(f"{name:<20} {prefix:<10} {transport:<16} {compression:<12} {detail}")
+        click.echo(
+            f"{name:<20} {prefix:<10} {transport:<16} {compression:<12} {origin_cell:<16} {detail}"
+        )
     click.echo(f"\n{len(servers)} server(s) configured.")
+    if any_pruned:
+        click.echo("* host original pruned — `mms eject NAME` restores it (see `mms eject -h`).")
 
 
 def _render_compression_block(summary: dict[str, Any]) -> None:
@@ -2423,6 +2452,43 @@ def register(config_path: str, mcp_mode: str | None) -> None:
     _run_mcp_integration(_MCP_MODE_TO_CHOICE.get(mcp_mode) if mcp_mode else None)
 
 
+def _remove_eject_hint(name: str, entry: Any) -> str | None:
+    """Eject hint printed before removing an imported entry (#475 PR4).
+
+    Fires only when the recorded provenance says removal would leave the
+    server registered **nowhere**: the primary source was pruned and no
+    un-pruned duplicate source remains. Entries without an ``origin`` block
+    (manual ``mms add``, pre-#475 imports) and entries whose host original
+    still exists get no hint — removing those just stops proxying.
+
+    Advisory only: the flags are as recorded at prune time (a manually
+    re-added host entry isn't detected), and ``mms eject``'s live
+    no-clobber check stays the authoritative guard. The removal itself is
+    never blocked — the hint precedes the confirm prompt so a TTY user can
+    still abort.
+    """
+    if not isinstance(entry, dict):
+        return None
+    origin = entry.get("origin")
+    if not isinstance(origin, dict):
+        return None
+    source = origin.get("source")
+    if not isinstance(source, dict) or not source.get("pruned"):
+        return None
+    duplicates = [d for d in origin.get("duplicates") or [] if isinstance(d, dict)]
+    if any(not d.get("pruned") for d in duplicates):
+        return None
+    kind = source.get("kind")
+    spec = _SOURCE_BY_KIND.get(kind) if isinstance(kind, str) else None
+    label = spec.label if spec else (kind if isinstance(kind, str) else "its host client")
+    return (
+        f"{_warn('Note:')} '{name}' was imported from {label} and the host original "
+        "was pruned —\n"
+        "  removing it from STM leaves it registered nowhere.\n"
+        f"  To restore it to the host instead, run: mms eject {name}"
+    )
+
+
 @cli.command()
 @click.argument("name")
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
@@ -2445,6 +2511,10 @@ def remove(name: str, config_path: str, yes: bool) -> None:
     if name not in servers:
         click.echo(f"{_err('Error:')} server '{name}' not found.", err=True)
         sys.exit(1)
+
+    hint = _remove_eject_hint(name, servers[name])
+    if hint:
+        click.echo(hint)
 
     if not yes:
         click.confirm(f"Remove server '{name}'?", abort=True)

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -561,14 +561,22 @@ def _origin_fully_pruned(origin: Any) -> bool:
     duplicate still registers). Advisory by construction — flags are as
     recorded at prune time; ``mms eject``'s live no-clobber check stays the
     authoritative guard.
+
+    Strict types, not truthiness: the block is pydantic-built by our own
+    writers, so anything else is a hand-edited or corrupt config — e.g.
+    ``"pruned": "false"`` (truthy string) or a non-list ``duplicates`` —
+    and a claim this drives ("registered nowhere") must not rest on it.
+    Malformed provenance answers False (codex R2).
     """
     if not isinstance(origin, dict):
         return False
     source = origin.get("source")
-    if not isinstance(source, dict) or not source.get("pruned"):
+    if not isinstance(source, dict) or source.get("pruned") is not True:
         return False
-    duplicates = [d for d in origin.get("duplicates") or [] if isinstance(d, dict)]
-    return all(d.get("pruned") for d in duplicates)
+    duplicates = origin.get("duplicates") or []
+    if not isinstance(duplicates, list):
+        return False
+    return all(isinstance(d, dict) and d.get("pruned") is True for d in duplicates)
 
 
 def _origin_cell(cfg: Any) -> str:

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -549,6 +549,28 @@ def _redacted_servers_json(servers: dict[str, Any]) -> dict[str, Any]:
     return redacted
 
 
+def _origin_fully_pruned(origin: Any) -> bool:
+    """True when provenance records *every* host source as pruned (#475 PR4).
+
+    The primary ``origin.source`` plus all recorded ``duplicates`` — the
+    condition under which the entry exists only behind STM, so removing it
+    from STM would leave the server registered nowhere. One predicate
+    shared by the ``mms list`` pruned marker and the ``mms remove`` eject
+    hint: the two surfaces must not contradict each other on what "pruned"
+    means (a primary-only check would star an entry that an un-pruned
+    duplicate still registers). Advisory by construction — flags are as
+    recorded at prune time; ``mms eject``'s live no-clobber check stays the
+    authoritative guard.
+    """
+    if not isinstance(origin, dict):
+        return False
+    source = origin.get("source")
+    if not isinstance(source, dict) or not source.get("pruned"):
+        return False
+    duplicates = [d for d in origin.get("duplicates") or [] if isinstance(d, dict)]
+    return all(d.get("pruned") for d in duplicates)
+
+
 def _origin_cell(cfg: Any) -> str:
     """ORIGIN table cell for one ``mms list`` row (#475 PR4).
 
@@ -556,16 +578,17 @@ def _origin_cell(cfg: Any) -> str:
     imports); otherwise the recorded ``origin.source.kind`` — the
     machine-readable identifier, not the human label, so the cell stays
     within one column and matches what ``--json`` exposes. A trailing ``*``
-    marks a primary source whose host original was pruned (the entry now
-    exists only behind STM); the legend under the table points at
-    ``mms eject``. Unknown kinds print as recorded — the cell is a display
-    of stored provenance, not a validation of it.
+    marks an entry whose every recorded host source was pruned (the entry
+    now exists only behind STM — see :func:`_origin_fully_pruned`); the
+    legend under the table points at ``mms eject``. Unknown kinds print as
+    recorded — the cell is a display of stored provenance, not a
+    validation of it.
     """
     origin = cfg.get("origin") if isinstance(cfg, dict) else None
     source = origin.get("source") if isinstance(origin, dict) else None
     if not isinstance(source, dict) or not isinstance(source.get("kind"), str):
         return "-"
-    return source["kind"] + ("*" if source.get("pruned") else "")
+    return source["kind"] + ("*" if _origin_fully_pruned(origin) else "")
 
 
 @cli.command()
@@ -2456,10 +2479,11 @@ def _remove_eject_hint(name: str, entry: Any) -> str | None:
     """Eject hint printed before removing an imported entry (#475 PR4).
 
     Fires only when the recorded provenance says removal would leave the
-    server registered **nowhere**: the primary source was pruned and no
-    un-pruned duplicate source remains. Entries without an ``origin`` block
-    (manual ``mms add``, pre-#475 imports) and entries whose host original
-    still exists get no hint — removing those just stops proxying.
+    server registered **nowhere** — :func:`_origin_fully_pruned`, the same
+    predicate behind the ``mms list`` pruned marker. Entries without an
+    ``origin`` block (manual ``mms add``, pre-#475 imports) and entries
+    some host still registers get no hint — removing those just stops
+    proxying.
 
     Advisory only: the flags are as recorded at prune time (a manually
     re-added host entry isn't detected), and ``mms eject``'s live
@@ -2470,14 +2494,9 @@ def _remove_eject_hint(name: str, entry: Any) -> str | None:
     if not isinstance(entry, dict):
         return None
     origin = entry.get("origin")
-    if not isinstance(origin, dict):
+    if not _origin_fully_pruned(origin):
         return None
     source = origin.get("source")
-    if not isinstance(source, dict) or not source.get("pruned"):
-        return None
-    duplicates = [d for d in origin.get("duplicates") or [] if isinstance(d, dict)]
-    if any(not d.get("pruned") for d in duplicates):
-        return None
     kind = source.get("kind")
     spec = _SOURCE_BY_KIND.get(kind) if isinstance(kind, str) else None
     label = spec.label if spec else (kind if isinstance(kind, str) else "its host client")

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -539,6 +539,84 @@ class TestListServers:
         # The COMPRESSION column starts at the same offset on header
         # and row — drift used to put them several chars apart.
         assert header.index("COMPRESSION") == row.index("auto")
+        # Same pin for the ORIGIN column added in #475 PR4 ("-" is the
+        # no-provenance cell; this entry was added manually).
+        assert row[header.index("ORIGIN")] == "-"
+
+    def test_list_origin_column_summarizes_provenance(self, runner, config):
+        """The ORIGIN column shows the recorded source kind for imported
+        entries, ``*`` when the host original was pruned, and ``-`` for
+        entries without provenance (#475 PR4). The pruned legend points
+        at ``mms eject``."""
+
+        def _entry(kind: str, pruned: bool) -> dict:
+            return {
+                "prefix": "xx",
+                "transport": "stdio",
+                "command": "npx",
+                "origin": {
+                    "schema_version": 1,
+                    "source": {"kind": kind, "pruned": pruned},
+                    "duplicates": [],
+                    "imported_at": "2026-06-11T00:00:00Z",
+                    "original": {"command": "npx"},
+                },
+            }
+
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {
+                        "manual": {"prefix": "mn", "command": "npx"},
+                        "stm-only": _entry("claude-user", pruned=True),
+                        "dual": _entry("claude-desktop", pruned=False),
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["list", *_cfg_args(config)])
+        assert result.exit_code == 0
+        lines = result.output.splitlines()
+        header = next(line for line in lines if "NAME" in line and "ORIGIN" in line)
+        names = ("manual", "stm-only", "dual")
+        rows = {n: next(line for line in lines if line.startswith(n)) for n in names}
+        assert "claude-user*" in rows["stm-only"]
+        assert "claude-desktop" in rows["dual"]
+        assert "claude-desktop*" not in rows["dual"]
+        assert rows["manual"][header.index("ORIGIN")] == "-"
+        assert "mms eject" in result.output
+
+    def test_list_origin_legend_absent_without_pruned_entries(self, runner, config):
+        """The ``mms eject`` legend only appears when some row actually
+        carries the pruned marker — an all-dual / all-manual table stays
+        free of restore advice that doesn't apply."""
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {
+                        "manual": {"prefix": "mn", "command": "npx"},
+                        "dual": {
+                            "prefix": "du",
+                            "command": "npx",
+                            "origin": {
+                                "schema_version": 1,
+                                "source": {"kind": "claude-user", "pruned": False},
+                                "duplicates": [],
+                                "imported_at": "2026-06-11T00:00:00Z",
+                                "original": {"command": "npx"},
+                            },
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["list", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "mms eject" not in result.output
 
     def test_json_output(self, runner, config):
         """``list --json`` mirrors ``status --json`` shape for scripting."""
@@ -5464,6 +5542,88 @@ class TestRemove:
         assert result.exit_code != 0
         data = json.loads(config.read_text(encoding="utf-8"))
         assert "fs" in data["upstream_servers"]
+
+
+class TestRemoveEjectHint:
+    """``mms remove`` warns before deleting the only registration of an
+    imported entry whose host original was pruned — the exact scenario
+    #475 exists for ("registered nowhere"). The hint is advisory: it
+    precedes the confirm prompt and never blocks the removal."""
+
+    def _imported_entry(self, *, pruned: bool = True, duplicates: list | None = None) -> dict:
+        return {
+            "prefix": "gh",
+            "transport": "stdio",
+            "command": "npx",
+            "origin": {
+                "schema_version": 1,
+                "source": {"kind": "claude-user", "pruned": pruned},
+                "duplicates": duplicates or [],
+                "imported_at": "2026-06-11T00:00:00Z",
+                "original": {"command": "npx"},
+            },
+        }
+
+    def _seed(self, config, entry: dict) -> None:
+        config.write_text(
+            json.dumps({"enabled": True, "upstream_servers": {"gh": entry}}),
+            encoding="utf-8",
+        )
+
+    def test_hint_shown_and_removal_proceeds_under_yes(self, runner, config):
+        self._seed(config, self._imported_entry())
+        result = runner.invoke(cli, ["remove", "gh", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "registered nowhere" in result.output
+        assert "mms eject gh" in result.output
+        # The recorded kind resolves to its human label, not the raw kind.
+        assert "Claude Code (user)" in result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "gh" not in data["upstream_servers"]
+
+    def test_hint_precedes_confirm_so_decline_keeps_entry(self, runner, config):
+        """The point of hinting before the prompt: a TTY user who meant
+        'stop proxying, keep the server' can abort and run eject instead."""
+        self._seed(config, self._imported_entry())
+        result = runner.invoke(cli, ["remove", "gh", *_cfg_args(config)], input="n\n")
+        assert result.exit_code != 0
+        assert "mms eject gh" in result.output
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert "gh" in data["upstream_servers"]
+
+    def test_no_hint_without_origin(self, runner, config):
+        self._seed(config, {"prefix": "gh", "transport": "stdio", "command": "npx"})
+        result = runner.invoke(cli, ["remove", "gh", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "mms eject" not in result.output
+
+    def test_no_hint_when_host_original_remains(self, runner, config):
+        """Un-pruned origin → the host still has the direct registration;
+        removing the STM entry just stops proxying."""
+        self._seed(config, self._imported_entry(pruned=False))
+        result = runner.invoke(cli, ["remove", "gh", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "mms eject" not in result.output
+
+    def test_no_hint_when_unpruned_duplicate_remains(self, runner, config):
+        """A duplicate source that was never pruned still registers the
+        server somewhere — removal does not orphan it."""
+        self._seed(
+            config,
+            self._imported_entry(duplicates=[{"kind": "claude-desktop", "pruned": False}]),
+        )
+        result = runner.invoke(cli, ["remove", "gh", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "mms eject" not in result.output
+
+    def test_hint_when_every_source_was_pruned(self, runner, config):
+        self._seed(
+            config,
+            self._imported_entry(duplicates=[{"kind": "claude-desktop", "pruned": True}]),
+        )
+        result = runner.invoke(cli, ["remove", "gh", "--yes", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "mms eject gh" in result.output
 
 
 # ── End-to-end ───────────────────────────────────────────────────────────

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -5578,6 +5578,67 @@ class TestRemove:
         assert "fs" in data["upstream_servers"]
 
 
+class TestOriginFullyPruned:
+    """The shared every-source predicate behind the ``mms list`` pruned
+    marker and the ``mms remove`` orphaning hint. Strict types by design:
+    provenance is written by our own pydantic-backed writers, so malformed
+    shapes mean a hand-edited config — the predicate answers False rather
+    than letting truthiness back an unproven "registered nowhere" claim
+    (codex R2)."""
+
+    def _origin(self, *, pruned=True, duplicates=None) -> dict:
+        return {
+            "schema_version": 1,
+            "source": {"kind": "claude-user", "pruned": pruned},
+            "duplicates": [] if duplicates is None else duplicates,
+            "imported_at": "2026-06-11T00:00:00Z",
+            "original": {"command": "npx"},
+        }
+
+    def test_fully_pruned_with_and_without_duplicates(self):
+        from memtomem_stm.cli.proxy import _origin_fully_pruned
+
+        assert _origin_fully_pruned(self._origin()) is True
+        assert (
+            _origin_fully_pruned(
+                self._origin(duplicates=[{"kind": "claude-desktop", "pruned": True}])
+            )
+            is True
+        )
+
+    def test_unpruned_source_or_duplicate(self):
+        from memtomem_stm.cli.proxy import _origin_fully_pruned
+
+        assert _origin_fully_pruned(self._origin(pruned=False)) is False
+        assert (
+            _origin_fully_pruned(
+                self._origin(duplicates=[{"kind": "claude-desktop", "pruned": False}])
+            )
+            is False
+        )
+
+    def test_malformed_provenance_is_never_fully_pruned(self):
+        """Truthy-but-not-True values and wrong container shapes must not
+        classify as pruned: `"false"` is a truthy string, a dict
+        ``duplicates`` would iterate its keys, and a non-dict duplicate
+        row can't prove anything about its source."""
+        from memtomem_stm.cli.proxy import _origin_fully_pruned
+
+        assert _origin_fully_pruned(None) is False
+        assert _origin_fully_pruned("pruned") is False
+        assert _origin_fully_pruned({"source": "claude-user"}) is False
+        assert _origin_fully_pruned(self._origin(pruned="false")) is False
+        assert _origin_fully_pruned(self._origin(pruned=1)) is False
+        assert (
+            _origin_fully_pruned(self._origin(duplicates={"kind": "x", "pruned": False})) is False
+        )
+        assert _origin_fully_pruned(self._origin(duplicates=["claude-desktop"])) is False
+        assert (
+            _origin_fully_pruned(self._origin(duplicates=[{"kind": "x", "pruned": "false"}]))
+            is False
+        )
+
+
 class TestRemoveEjectHint:
     """``mms remove`` warns before deleting the only registration of an
     imported entry whose host original was pruned — the exact scenario

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -588,6 +588,40 @@ class TestListServers:
         assert rows["manual"][header.index("ORIGIN")] == "-"
         assert "mms eject" in result.output
 
+    def test_list_no_pruned_marker_when_unpruned_duplicate_remains(self, runner, config):
+        """Partial prune (primary source pruned, duplicate source not) must
+        NOT star the row: an un-pruned duplicate still registers the server,
+        so 'exists only behind STM' would be false — and the marker would
+        contradict ``mms remove``'s orphaning hint, which shares the same
+        every-source predicate (codex R1)."""
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {
+                        "partial": {
+                            "prefix": "pa",
+                            "command": "npx",
+                            "origin": {
+                                "schema_version": 1,
+                                "source": {"kind": "claude-user", "pruned": True},
+                                "duplicates": [{"kind": "claude-desktop", "pruned": False}],
+                                "imported_at": "2026-06-11T00:00:00Z",
+                                "original": {"command": "npx"},
+                            },
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["list", *_cfg_args(config)])
+        assert result.exit_code == 0
+        row = next(line for line in result.output.splitlines() if line.startswith("partial"))
+        assert "claude-user" in row
+        assert "claude-user*" not in row
+        assert "mms eject" not in result.output
+
     def test_list_origin_legend_absent_without_pruned_entries(self, runner, config):
         """The ``mms eject`` legend only appears when some row actually
         carries the pruned marker — an all-dual / all-manual table stays

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -523,3 +523,80 @@ def test_compression_md_llm_section_documents_timeout_fallback() -> None:
             "`llm_summary→timeout_fallback` metric label has no "
             "documented origin."
         )
+
+
+def test_cli_md_commands_index_matches_click_group() -> None:
+    """The Commands index in docs/cli.md must list exactly the commands
+    registered on the ``mms`` click group (#475 PR4).
+
+    The index is the verbatim ``mms --help`` listing; a command added
+    without a docs entry (or documented after removal) is invisible drift —
+    the reference reads as complete, so nobody goes looking for what's
+    missing. Set equality pins both directions against the click group
+    itself rather than a hand-maintained list.
+    """
+    from memtomem_stm.cli.proxy import cli as mms_cli
+
+    cli_md = _read("docs/cli.md")
+    blocks = re.findall(r"```\n(Usage: mms \[OPTIONS\] COMMAND.*?)```", cli_md, re.DOTALL)
+    if len(blocks) != 1:
+        pytest.fail(
+            "Expected exactly one fenced `Usage: mms [OPTIONS] COMMAND` block "
+            f"in docs/cli.md (the top-level help), found {len(blocks)} — the "
+            "reference was restructured; update this test alongside it."
+        )
+    commands_match = re.search(r"Commands:\n(.*)\Z", blocks[0], re.DOTALL)
+    assert commands_match, "The top-level help block lost its `Commands:` listing"
+    documented = {line.split()[0] for line in commands_match.group(1).splitlines() if line.strip()}
+    registered = set(mms_cli.commands)
+    assert documented == registered, (
+        "docs/cli.md Commands index is out of sync with the `mms` click "
+        f"group.\n  missing from docs: {sorted(registered - documented)}\n"
+        f"  documented but not registered: {sorted(documented - registered)}\n"
+        "Regenerate the block from `mms --help`."
+    )
+
+
+def test_cli_md_eject_section_documents_every_flag() -> None:
+    """docs/cli.md's ``### `eject` `` section must mention every long flag
+    the command actually exposes, plus the prune backup log it points at.
+
+    ``mms eject`` is the data-loss-sensitive end of the #475 round-trip:
+    its guards (``--accept-schema-loss``, ``--allow-argv-secrets``,
+    ``--force``) exist to make destructive variants explicit. A flag added
+    to the command but absent from the section leaves users discovering
+    safety semantics from error messages instead of the reference.
+    """
+    from memtomem_stm.cli.proxy import cli as mms_cli
+
+    eject_cmd = mms_cli.commands.get("eject")
+    assert eject_cmd is not None, "`mms eject` is gone — update docs/cli.md and this test"
+
+    cli_md = _read("docs/cli.md")
+    section_match = re.search(r"### `eject`\n(.*?)(?=\n### |\n## |\Z)", cli_md, re.DOTALL)
+    assert section_match, "docs/cli.md must have a ### `eject` section"
+    section = section_match.group(1)
+
+    long_flags = [
+        opt
+        for param in eject_cmd.params
+        for opt in getattr(param, "opts", [])
+        if opt.startswith("--") and opt != "--config"
+    ]
+    assert long_flags, "eject lost all its options? update this test"
+    missing = [flag for flag in long_flags if flag not in section]
+    assert not missing, (
+        f"docs/cli.md eject section does not mention: {missing!r}. "
+        "Document the flag (usage block + semantics if it guards something)."
+    )
+
+    # The no-origin fallback story leans on the prune backup log; keep the
+    # filename in the section so the suggestion in eject's error output has
+    # a documented home. The literal is pinned against the source so a
+    # rename fails here instead of silently splitting the two.
+    backup_name = "pruned_upstreams.json"
+    assert backup_name in _read("src/memtomem_stm/cli/proxy.py")
+    assert backup_name in section, (
+        "docs/cli.md eject section must mention the prune backup log "
+        f"({backup_name}) — eject suggests it for entries without an origin."
+    )

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -526,14 +526,18 @@ def test_compression_md_llm_section_documents_timeout_fallback() -> None:
 
 
 def test_cli_md_commands_index_matches_click_group() -> None:
-    """The Commands index in docs/cli.md must list exactly the commands
-    registered on the ``mms`` click group (#475 PR4).
+    """The Commands index in docs/cli.md must match the ``mms`` click group:
+    the exact command-name set (both directions) and, per command, a
+    description that is a verbatim prefix of the command's actual short
+    help (#475 PR4).
 
-    The index is the verbatim ``mms --help`` listing; a command added
-    without a docs entry (or documented after removal) is invisible drift —
-    the reference reads as complete, so nobody goes looking for what's
-    missing. Set equality pins both directions against the click group
-    itself rather than a hand-maintained list.
+    A command added without a docs entry (or documented after removal) is
+    invisible drift — the reference reads as complete, so nobody goes
+    looking for what's missing — and a stale description misleads even
+    when the name survives. Prefix comparison rather than byte equality
+    because click's help wrapping (and the ``...`` truncation point)
+    shifts with the rendering width, which is not deterministic across
+    environments; the words themselves are.
     """
     from memtomem_stm.cli.proxy import cli as mms_cli
 
@@ -547,25 +551,35 @@ def test_cli_md_commands_index_matches_click_group() -> None:
         )
     commands_match = re.search(r"Commands:\n(.*)\Z", blocks[0], re.DOTALL)
     assert commands_match, "The top-level help block lost its `Commands:` listing"
-    documented = {line.split()[0] for line in commands_match.group(1).splitlines() if line.strip()}
-    registered = set(mms_cli.commands)
-    assert documented == registered, (
+    documented = dict(re.findall(r"^ {2}(\S+) +(.+?)\s*$", commands_match.group(1), re.MULTILINE))
+    registered = mms_cli.commands
+    assert set(documented) == set(registered), (
         "docs/cli.md Commands index is out of sync with the `mms` click "
-        f"group.\n  missing from docs: {sorted(registered - documented)}\n"
-        f"  documented but not registered: {sorted(documented - registered)}\n"
+        f"group.\n  missing from docs: {sorted(set(registered) - set(documented))}\n"
+        f"  documented but not registered: {sorted(set(documented) - set(registered))}\n"
         "Regenerate the block from `mms --help`."
     )
+    for name, desc in documented.items():
+        prefix = desc[:-3].rstrip() if desc.endswith("...") else desc
+        actual = registered[name].get_short_help_str(limit=500)
+        assert actual.startswith(prefix), (
+            f"docs/cli.md Commands index line for `{name}` no longer matches "
+            f"its short help.\n  documented: {desc!r}\n  actual:     {actual!r}\n"
+            "Regenerate the block from `mms --help`."
+        )
 
 
-def test_cli_md_eject_section_documents_every_flag() -> None:
-    """docs/cli.md's ``### `eject` `` section must mention every long flag
-    the command actually exposes, plus the prune backup log it points at.
+def test_cli_md_eject_usage_block_flags_match_command() -> None:
+    """docs/cli.md's ``### `eject` `` usage block must list exactly the
+    options ``mms eject`` exposes — both directions — plus the prune
+    backup log the section points at (#475 PR4).
 
     ``mms eject`` is the data-loss-sensitive end of the #475 round-trip:
     its guards (``--accept-schema-loss``, ``--allow-argv-secrets``,
     ``--force``) exist to make destructive variants explicit. A flag added
-    to the command but absent from the section leaves users discovering
-    safety semantics from error messages instead of the reference.
+    to the command but absent from the docs leaves users discovering
+    safety semantics from error messages; a documented flag the command
+    dropped is worse — copy-pasted commands fail.
     """
     from memtomem_stm.cli.proxy import cli as mms_cli
 
@@ -576,18 +590,26 @@ def test_cli_md_eject_section_documents_every_flag() -> None:
     section_match = re.search(r"### `eject`\n(.*?)(?=\n### |\n## |\Z)", cli_md, re.DOTALL)
     assert section_match, "docs/cli.md must have a ### `eject` section"
     section = section_match.group(1)
+    block_match = re.search(r"```\n(Usage: mms eject .*?)```", section, re.DOTALL)
+    assert block_match, "the eject section lost its fenced usage block"
 
-    long_flags = [
+    # Option lines sit at exactly two spaces of indent (`  --to TARGET`,
+    # `  -y, --yes`); wrapped continuation lines are indented deeper, so
+    # flag mentions inside option help text don't count as documented.
+    documented = set(re.findall(r"^ {2}(?:-\w, )?(--[\w-]+)", block_match.group(1), re.MULTILINE))
+    registered = {
         opt
         for param in eject_cmd.params
         for opt in getattr(param, "opts", [])
-        if opt.startswith("--") and opt != "--config"
-    ]
-    assert long_flags, "eject lost all its options? update this test"
-    missing = [flag for flag in long_flags if flag not in section]
-    assert not missing, (
-        f"docs/cli.md eject section does not mention: {missing!r}. "
-        "Document the flag (usage block + semantics if it guards something)."
+        if opt.startswith("--")
+    }
+    assert registered, "eject lost all its options? update this test"
+    assert documented == registered, (
+        "docs/cli.md eject usage block is out of sync with `mms eject`.\n"
+        f"  missing from docs: {sorted(registered - documented)}\n"
+        f"  documented but not on the command: {sorted(documented - registered)}\n"
+        "Regenerate the block from `mms eject --help` (drop the `-h, --help` "
+        "line, matching the other sections)."
     )
 
     # The no-origin fallback story leans on the prune backup log; keep the


### PR DESCRIPTION
## Summary

PR4 of 4 for #475 — the last PR of the round-trip chain (#476 origin capture → #477 backup log + locks → #478 `mms eject`). Closes out the issue's PR table: `mms remove` eject hint, `mms list` origin summary, and reference docs for the whole feature.

### `mms remove` — orphaning hint

The scenario #475 opened with: import with `--prune`, later `mms remove` → the server is registered **nowhere**. `remove` now prints a note before the confirm prompt when the recorded provenance says that would happen — the primary source was pruned and no un-pruned duplicate remains:

```
Note: 'github' was imported from Claude Code (user) and the host original was pruned —
  removing it from STM leaves it registered nowhere.
  To restore it to the host instead, run: mms eject github
```

Advisory by design: the removal is never blocked, the hint precedes the prompt so a TTY user can abort, and the pruned flags are trusted as recorded — `mms eject`'s live no-clobber check (#478) stays the authoritative guard. No origin / un-pruned origin / surviving duplicate → no hint (removing those just stops proxying).

### `mms list` — ORIGIN column

```
NAME       PREFIX  TRANSPORT  COMPRESSION  ORIGIN           COMMAND / URL
--------------------------------------------------------------------------
manual     mn      stdio      auto         -                npx -y @demo
imported   im      stdio      auto         claude-user*     npx -y @gh
dual       du      sse        auto         claude-desktop   https://x.example/mcp

3 server(s) configured.
* host original pruned — `mms eject NAME` restores it (see `mms eject -h`).
```

The cell shows `origin.source.kind` (machine identifier, matching what `--json` exposes), `*` marks a pruned host original, and the legend only renders when a starred row exists. `--json` output is unchanged — the redacted origin block shipped in #476.

### Docs

- **docs/cli.md**: new `eject` section (restore semantics, host-write-first invariant, no-clobber, verified release / `--accept-schema-loss`, argv secret gate, per-entry failure contract, backup-log suggestion); `list` ORIGIN column + `--json` redaction; `remove` hint; backup-before-delete log in `prune`; reversibility paragraph in the `add --import` docs; `eject` added to the Commands index and Examples.
- **README**: one sentence noting the import transition is reversible via `mms eject`.

### Structural docs fix (consequent, isolated in its own commit)

The `prune` section's "Dual-registered" / "STM's own config" paragraphs and its examples block were stranded under `### surfacing` (that section was inserted mid-prune by #422). Inserting `### eject` between prune and surfacing required resolving the split, so the second commit moves them back verbatim — no prose changes to the moved paragraphs.

## Why the hint logic doesn't live-probe host configs

A live `_host_existing_entry` check per remove would catch a manually re-added host entry, but the hint is advisory and the recorded flags are correct for the flow the feature targets (our own prune writers set them per source in #477). Over-firing in the manually-re-added case is harmless — `mms eject` then detects the identical host entry, skips the write, and removes the STM entry, which is exactly what the user wants.

## Tests

- `TestRemoveEjectHint` (7 cases): hint fires only when source pruned **and** all duplicates pruned; precedes the confirm prompt (decline keeps the entry); never fires for manual adds, un-pruned origins, or surviving duplicates; removal proceeds under `--yes`.
- `TestListServers`: ORIGIN column content (`kind`, `*`, `-`), legend presence/absence, and the existing header-alignment pin extended to the new column.
- `tests/test_docs_sync.py` (2 new pins): the cli.md Commands index must equal the click group's registered command set (both directions), and the eject section must mention every long flag the command actually exposes plus the backup-log filename pinned against the source literal — the "verbatim from --help" claims in this PR are test-enforced, not aspirational.

`pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge"`: **3359 passed, 3 skipped**. `ruff check` / `ruff format --check src` clean; mypy errors unchanged from main (8 pre-existing, none in `cli/proxy.py`).

## Behavior change

`mms list` human-readable output gains a column and (when applicable) a trailing legend line; anything parsing the human table by column offset will see the COMMAND/URL column shifted right. `--json` is unchanged and remains the supported scripting surface. `mms remove` may print up to three extra stdout lines before the prompt/removal.

Closes #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)