### PR TITLE
docs: auto-index Stage 4 is library-mode only, by design

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ flowchart TB
     STM <-.->|surfacing<br/>via MCP| LTM
 ```
 
-> The **INDEX** stage requires a `FileIndexer` engine. The standalone
-> `mms` server does not wire one today, so `auto_index` and `extraction`
-> config is inert in the default deployment — enabling them logs an
-> `inert` warning at startup but does not write back to LTM. See
-> [#288](https://github.com/memtomem/memtomem-stm/issues/288) for the
-> tracking issue on a future MCP-protocol-only adapter.
+> The **INDEX** stage requires a `FileIndexer` engine, and the bundled
+> `mms` server wires none **by design** — `auto_index` and `extraction`
+> config is inert in the default deployment; enabling them logs an
+> `inert` warning at startup but does not write back to LTM. The hooks
+> are library-mode only: pass `index_engine=` when constructing
+> `ProxyManager` yourself (see
+> [docs/configuration.md](https://github.com/memtomem/memtomem-stm/blob/main/docs/configuration.md)).
+> [#288](https://github.com/memtomem/memtomem-stm/issues/288) has the
+> history.
 
 ## Installation
 
@@ -156,7 +159,7 @@ through `updatedToolOutput`. This is separate from the MCP proxy: `Write`,
 `Edit`, and other mutation tools stay out of the surfacing path, and the hook
 always fails open to the original tool output.
 
-**STM does NOT write back to LTM at runtime today.** The standalone `mms` server constructs the proxy without a `FileIndexer` engine, so the INDEX stage (`auto_index`, `extraction`) is inert even when enabled in `stm_proxy.json` — a warning is logged at startup. Surfacing *reads* from LTM via MCP; runtime *writes* are tracked in [#288](https://github.com/memtomem/memtomem-stm/issues/288) and require an MCP-protocol-only adapter that doesn't exist yet.
+**STM does NOT write back to LTM at runtime.** The bundled `mms` server constructs the proxy without a `FileIndexer` engine by design, so the INDEX stage (`auto_index`, `extraction`) is inert even when enabled in `stm_proxy.json` — a warning is logged at startup. Surfacing *reads* from LTM via MCP; runtime *writes* are library-mode only — callers embedding STM as a library can pass `index_engine=` to `ProxyManager` themselves ([#288](https://github.com/memtomem/memtomem-stm/issues/288) has the history).
 
 To bring file or shell operations under STM, register an MCP server that exposes them (the [filesystem example](#1-add-an-upstream-mcp-server) above is the most common case) and steer the agent toward the proxied alias instead of the built-in. This is the same boundary every MCP proxy lives within — it's not specific to STM.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,16 +75,19 @@ export MEMTOMEM_STM_PROXY__PROGRESSIVE_READS__ENABLED=true
 export MEMTOMEM_STM_PROXY__PROGRESSIVE_READS__DB_PATH=~/.memtomem/stm_feedback.db
 
 # Auto-indexing (Stage 4 — save large responses to LTM)
-# NOTE: In the standalone `mms` server today, `auto_index` and
-# `extraction` are inert — `ProxyManager` is constructed without an
-# `index_engine`, so Stage 4 is silently skipped. This covers every
+# NOTE: library-mode only, by design. The bundled `mms` server does not
+# wire an LTM write adapter: `ProxyManager` is constructed without an
+# `index_engine`, so in the standalone server `auto_index` and
+# `extraction` are inert and Stage 4 is skipped. This covers every
 # enable-path: the global ENABLED flag below, the per-upstream
 # `auto_index: true` knob on `UpstreamServerConfig`, and the per-tool
 # `auto_index: true` override on `ToolOverrideConfig`. All three are
-# valid config but currently have no runtime effect; the proxy logs a
-# "config is enabled but inert" warning at startup naming each site.
-# Tracking issue for the MCP-protocol-only adapter that will unblock
-# this: #288.
+# valid config but have no runtime effect in the bundled server; the
+# proxy logs a "config is enabled but inert" warning at startup naming
+# each site (history: #288). These settings take effect only for
+# library callers that construct `ProxyManager(..., index_engine=...)`
+# themselves — the hook the `FileIndexer` Protocol
+# (`proxy/protocols.py`) exists for.
 export MEMTOMEM_STM_PROXY__AUTO_INDEX__ENABLED=false
 export MEMTOMEM_STM_PROXY__AUTO_INDEX__MIN_CHARS=2000
 export MEMTOMEM_STM_PROXY__AUTO_INDEX__MEMORY_DIR=~/.memtomem/proxy_index

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -288,7 +288,15 @@ def test_configuration_md_stage4_inert_note_pinned() -> None:
         )
     note = block_match.group(1).lower()
 
-    required = ("library", "inert", "index_engine", "#288")
+    required = (
+        "library",
+        "inert",
+        "index_engine",
+        "fileindexer",
+        "bundled",
+        "no runtime effect",
+        "#288",
+    )
     missing = [kw for kw in required if kw.lower() not in note]
     if missing:
         pytest.fail(

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -187,16 +187,17 @@ def test_bundled_server_proxy_manager_omits_index_engine() -> None:
     """The bundled ``mms`` server's ``ProxyManager(...)`` construction in
     ``app_lifespan`` must not pass ``index_engine=``.
 
-    ``docs/configuration.md`` (Stage 4 NOTE block, ~lines 73-87) tells
-    operators that ``AUTO_INDEX__*`` / ``EXTRACTION__*`` are inert in the
-    bundled server because no index engine is wired. That claim is grounded
-    in ``src/memtomem_stm/server.py``'s single ``ProxyManager(...)`` call,
-    which today passes only ``config.proxy`` and ``tracker`` positionally
-    plus a fixed set of unrelated kwargs (#288/#299, PR #339). If a future
-    PR wires an ``index_engine=`` here without also dropping the inert
-    NOTE, the docs silently revalidate against stale prose — operators
-    keep seeing the no-op warning in the docs while the server now writes
-    to LTM.
+    This is a decision, not a gap (2026-06-11): LTM write hooks are
+    **library-mode only** — the bundled server intentionally wires no
+    index engine, and ``docs/configuration.md`` (Stage 4 NOTE block)
+    says so. The pin is grounded in ``src/memtomem_stm/server.py``'s
+    single ``ProxyManager(...)`` call, which passes only ``config.proxy``
+    and ``tracker`` positionally plus a fixed set of unrelated kwargs
+    (#288/#299, PR #339). Wiring an ``index_engine=`` here means the
+    library-only decision was deliberately reversed — do it WITH a docs
+    update (drop the library-only NOTE), not around it; otherwise the
+    docs keep telling operators the env vars are no-ops while the server
+    writes to LTM.
 
     Paired with ``test_configuration_md_stage4_inert_note_pinned`` (the
     inverse direction).
@@ -250,15 +251,18 @@ def test_bundled_server_proxy_manager_omits_index_engine() -> None:
 
 
 def test_configuration_md_stage4_inert_note_pinned() -> None:
-    """``docs/configuration.md``'s Stage 4 NOTE block must keep the inert-
-    state warning that pairs with ``server.py``'s engine-less ``ProxyManager``
-    construction.
+    """``docs/configuration.md``'s Stage 4 NOTE block must keep the
+    library-mode-only framing that pairs with ``server.py``'s engine-less
+    ``ProxyManager`` construction.
 
     PR #339 (resolving the operator-visible half of #288) added a comment
     block immediately above the ``AUTO_INDEX__*`` exports explaining that
-    those env vars currently have no runtime effect because the bundled
-    server constructs ``ProxyManager`` without an ``index_engine``. If
-    that NOTE goes away while the server still has no engine wired
+    those env vars have no runtime effect in the bundled server; the
+    2026-06-11 write-integration decision upgraded that wording from
+    "currently inert, adapter tracked" to "library-mode only, by design"
+    (the env vars apply to callers constructing
+    ``ProxyManager(..., index_engine=...)`` directly). If the NOTE goes
+    away while the server still has no engine wired
     (``test_bundled_server_proxy_manager_omits_index_engine``), operators
     flipping ``AUTO_INDEX__ENABLED=true`` get zero behaviour and zero
     explanation again — the failure mode #288 originally reported.
@@ -284,16 +288,17 @@ def test_configuration_md_stage4_inert_note_pinned() -> None:
         )
     note = block_match.group(1).lower()
 
-    required = ("inert", "index_engine", "#288")
+    required = ("library", "inert", "index_engine", "#288")
     missing = [kw for kw in required if kw.lower() not in note]
     if missing:
         pytest.fail(
             f"docs/configuration.md Stage 4 NOTE is missing keyword(s): "
-            f"{missing!r}. If `mms` now wires `index_engine`, also delete "
-            "`test_bundled_server_proxy_manager_omits_index_engine` and "
-            "close #299. Otherwise restore the inert NOTE — operators "
-            "flipping `AUTO_INDEX__ENABLED=true` need to know the env var "
-            "is currently a no-op in the bundled server (PR #339, #288)."
+            f"{missing!r}. If `mms` now wires `index_engine` (reversing the "
+            "library-only decision), also delete "
+            "`test_bundled_server_proxy_manager_omits_index_engine`. "
+            "Otherwise restore the library-mode NOTE — operators flipping "
+            "`AUTO_INDEX__ENABLED=true` need to know the env var is a no-op "
+            "in the bundled server (PR #339, #288)."
         )
 
 


### PR DESCRIPTION
## Summary

Closes out the STM→LTM write-integration design question (#288 lineage) at its decision point: the bundled `mms` server **intentionally** wires no LTM write adapter, and the docs now say so as a design statement instead of a temporary gap.

## Why now

The question was opened 2026-05-02 with a ~6-week decision window and an explicit default (document the status quo honestly). The window closes 2026-06-15. Signal check across the whole window, all four reopen conditions:

1. **Operator reports of inert `AUTO_INDEX__*` config**: zero. The only issue ever filed (#288) was self-identified during an internal review, and its operator-visible half was already resolved by the startup `inert` warning (#339, shipped May).
2. **A use case wanting STM to warm LTM** (agent pipeline leaving indexable artifacts): none filed — issues or Discussions.
3. **Write-side payload redaction shipping**: not shipped (still deferred).
4. **`mem_add`/`mem_index` schema contract stabilizing in core**: no signal; core upstream remains alpha-pinned.

Zero incidents → per the pre-committed decision rule (and plain YAGNI), adopt the zero-code option rather than build an adapter nobody has asked for.

## What changes

- **docs/configuration.md** Stage 4 NOTE: reframed from "currently inert — tracking issue for the adapter that will unblock this: #288" (forward-looking promise; #288 is closed) to "**library-mode only, by design**" — the `AUTO_INDEX__*`/extraction settings take effect only for library callers constructing `ProxyManager(..., index_engine=...)` directly (the hook the `FileIndexer` Protocol exists for). Inert-in-bundled-server semantics and the #339 startup warning reference are unchanged.
- **tests/test_docs_sync.py**: the two existing paired pins (server `ProxyManager` source pin ↔ configuration.md NOTE pin, both from #339) keep enforcing both directions; their docstrings/messages now state the decision framing, and the NOTE pin additionally requires the "library" keyword. Stale "close #299" instructions in failure messages updated (#299 closed in May).

No code or behavior change. `FileIndexer` and the `index_engine=` kwarg stay as-is (zero churn, cheap to reverse).

**Reversal trigger** (any one): an operator actually reports inert `AUTO_INDEX` config expecting server-side writes; a concrete warm-LTM use case lands; or core's `mem_add` MCP contract stabilizes enough to negotiate (mirroring the existing `search_formats` capability negotiation).

## Tests

`tests/test_docs_sync.py` 11 passed; ruff clean. Doc-only — full suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)