### PR TITLE
ci(bench_qa): promote suite to a required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,16 @@ jobs:
             --nbmake-timeout=180 --tb=short -q
 
   bench_qa:
-    # Advisory for the first 1–2 weeks while per-scenario thresholds
-    # settle. Do not promote to a required check until qa_gate_min /
-    # compressed_chars floors have been ratcheted up from observed data.
+    # Required gate. Per-scenario floors (qa_gate_min, ratio_violation) are
+    # hard-asserted at the pytest level and were ratcheted up from observed
+    # data over a multi-week advisory period (2026-04..06). The floors live
+    # in tests/bench/fixtures/<scenario>.json; the suite is deterministic
+    # (fake upstream, no network/LLM — the LLM judge runs under a separate
+    # opt-in marker). A failure here now blocks merge: it signals a real
+    # compression/surfacing regression, so adjust the code or, if the new
+    # behaviour is intended, re-baseline the affected fixture's floor.
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## Background

The `bench_qa` CI job has run `continue-on-error: true` since it landed in #171 (2026-04-17). The plan was to keep it **advisory for ~1–2 weeks** while per-scenario thresholds settled, then ratchet the floors from observed data and promote it to a required check. That trigger has been sitting unresolved for ~2 months (the "advisory for the first 1–2 weeks" comment hasn't been touched since #171).

## Why now

The observation window has long since passed and the promotion criteria are met:

- **Green for ~2 months** — the suite has stayed passing continuously.
- **Floors already ratcheted from observed data** — per-scenario `qa_gate_min` / `ratio_violation` floors live in `tests/bench/fixtures/*.json` and were tightened to "no worse than today" during the advisory period (e.g. s02–s04 `qa_gate_min=0.66` vs observed `0.667`, s07 `0.75` vs `0.833`).
- **Deterministic** — fake upstream, no network and no LLM in this marker (the LLM judge is a separate opt-in `bench_qa_llm_judge` marker, already excluded). Two back-to-back local runs produced byte-identical report tables, so there is no run-to-run flakiness risk in making it blocking.

## Change

- Flip the `bench_qa` job to `continue-on-error: false` so a regression fails CI instead of being silently swallowed.
- Replace the stale "advisory for the first 1–2 weeks" comment with the current contract: the floors are hard-asserted at the pytest level, a failure signals a real compression/surfacing regression, and an *intended* behaviour change means re-baselining the affected fixture's floor.

No test or fixture changes — the gate logic already lived in the suite; this only stops CI from swallowing its failures.

## Follow-up (optional, admin)

This makes the check report pass/fail on every PR. Adding `bench_qa` to the branch-protection **required-checks** list is a separate admin action to make it strictly merge-blocking.

## Test

- `uv run pytest -m "bench_qa and not bench_qa_sweep" -q` → `13 passed` (run twice, identical report tables).
- YAML parses; `jobs.bench_qa.continue-on-error == False`; test step unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)