### PR TITLE
ci(bench_qa): post summary.md as a sticky PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,51 @@ jobs:
           path: bench-qa-report/
           if-no-files-found: warn
           retention-days: 14
+
+  bench_qa_pr_comment:
+    # Surface the bench_qa summary.md table as a sticky PR comment (item 5 of
+    # the post-gate roadmap). Deliberately a *separate* job from the required
+    # bench_qa gate so that (a) pull-requests:write is scoped to this job only,
+    # keeping the gate least-privilege, and (b) a comment failure can never
+    # turn the required check red. Runs even when the gate fails (always() +
+    # needs) so reviewers still see the table on a regression. Skipped on push
+    # and on fork PRs, whose GITHUB_TOKEN is read-only and cannot comment.
+    needs: bench_qa
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download bench_qa report
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: bench-qa-report
+          path: bench-qa-report
+      - name: Upsert sticky summary comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MARKER='<!-- bench-qa-summary -->'
+          FILE=bench-qa-report/summary.md
+          if [ ! -f "$FILE" ]; then
+            echo "no summary.md in artifact; nothing to post"
+            exit 0
+          fi
+          { printf '%s\n\n' "$MARKER"; cat "$FILE"; } > body.md
+          CID="$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+                  --jq 'map(select((.body // "") | startswith("'"$MARKER"'"))) | .[0].id // empty')"
+          if [ -n "$CID" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$CID" -F body=@body.md >/dev/null
+            echo "updated sticky bench_qa comment ($CID)"
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@body.md >/dev/null
+            echo "created sticky bench_qa comment"
+          fi


### PR DESCRIPTION
## What

Post-gate roadmap **item 5**. Now that the bench_qa suite is a required gate (#482), surface its per-scenario `tier / ratio / qa` table directly on each PR as a **sticky comment**, instead of leaving it buried in the uploaded artifact. Reviewers see the compression/surfacing outcome without downloading anything.

This very PR exercises the new job — see the auto-posted `bench_qa summary` comment below.

## Design — why a separate job, not a step in the gate

Added as a new `bench_qa_pr_comment` job rather than a step inside the required `bench_qa` job, deliberately:

- **Least-privilege gate** — `pull-requests: write` is scoped to this job only; the required gate keeps the default read-only token.
- **Failure isolation** — a comment failure (transient API error, fork PR, etc.) lands in a *non-required* job and can never turn the required `bench_qa` check red.
- **Posts on failure too** — `needs: bench_qa` + `if: always()` means the table is still posted when the gate fails, which is exactly when a reviewer most wants it. It downloads the report uploaded with `if: always()`.

## Behaviour

- **Sticky** — a hidden `<!-- bench-qa-summary -->` marker keys an upsert; re-runs edit the existing comment in place instead of piling on new ones.
- **Skipped** on `push` events and on **fork PRs** (read-only `GITHUB_TOKEN` cannot comment) via an `if` guard on `head.repo.full_name == github.repository`.

## Known limitation (separate follow-up)

A scenario that fails its assertion is recorded into the report only if it reached the collector call, so on a gate failure the posted table may omit the failing scenario. The red gate check still flags the regression; enriching the harness to record failed scenarios is out of scope here.

## Test

- YAML parses; `jobs.bench_qa_pr_comment` shape verified (needs/permissions/if/steps); gate job unchanged (`continue-on-error: false`).
- Comment bash dry-run locally: marker lands on line 1 of the body; the jq upsert filter returns the existing comment id when present, empty when absent, and tolerates `null` bodies.
- End-to-end self-test: this PR's CI run posts the sticky comment (create on first run; a later push edits in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)