### PR TITLE
feat(proxy): stm_selection_stats — surface tool-selection telemetry (#467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`stm_selection_stats` observability tool — read-side surface for selection telemetry** (#484, issue #467) — surfaces the JSONL selection/execution log (added in #471) through a new opt-in observability MCP tool: live write-path counters plus a persisted aggregate (event counts, selections by ranker version, by server and tool, execution ok/error rate and latency p50/p95/p99, and the hard-filter reject-reason tally from #465). Makes accumulated telemetry inspectable ahead of offline replay/eval (#468). Advertised only when `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true`; reads the active log file (rotated backups are noted but not parsed).
+
 ## [0.1.28] — 2026-06-11
 
 A security-hardening, correctness, and tool-selection release. A targeted audit across four issue classes — SQLite file permissions, sensitive-value caching, secret-content persistence, and extraction-call privacy — produced six security fixes. Thirteen correctness fixes address critical paths found in the implementation review (PROGRESSIVE metrics assignment, network LTM reconnects, shutdown ExceptionGroup handling) and the remaining medium and low backlog items across daemon, surfacing, compression, config, and CLI layers. Two new opt-in features instrument the tool-selection path (JSONL telemetry sink and BM25 relevance scoring), and a third hardens what the proxy advertises to MCP clients via an STM-native eligibility filter at exposure time.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ A second tier of management lets you decide *which MCP servers a given project s
 | [Selection telemetry](https://github.com/memtomem/memtomem-stm/blob/main/docs/selection-telemetry.md) | Opt-in JSONL log of tool selection + execution outcomes |
 | [CLI](https://github.com/memtomem/memtomem-stm/blob/main/docs/cli.md) | CLI commands, host sync, hooks, daemon, and MCP tools |
 
-STM advertises four model-facing MCP tools by default. Eight observability and
+STM advertises four model-facing MCP tools by default. Nine observability and
 admin tools (`stm_proxy_stats`, `stm_surfacing_stats`, `stm_index_stats`, etc.)
 are hidden unless `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true` is set,
 which keeps eager-loading clients from paying schema tokens for rarely used

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -608,7 +608,7 @@ observation rather than a CI failure signal. `sync` is the ongoing
 reconciliation path: `--plan` previews, `--apply` writes, `--force` adopts
 entries marked changed, and `--yes` bypasses confirmation prompts for scripts.
 
-## MCP Tools (4 default + 8 opt-in + proxied)
+## MCP Tools (4 default + 9 opt-in + proxied)
 
 These are exposed by the `memtomem-stm` MCP server and become available to your agent once it's connected.
 
@@ -621,7 +621,7 @@ The four model-facing tools are advertised by default:
 | `stm_surfacing_feedback` | `surfacing_id`, `rating?`, `memory_id?`, `ratings?` | Rate surfaced memories (`helpful` / `partially_helpful` / `not_relevant` / `already_known`); `ratings=[{memory_id, rating}]` for batched per-memory feedback |
 | `stm_compression_feedback` | `server`, `tool`, `missing`, `kind?`, `trace_id?` | Report missing info from a compressed response (learning signal) |
 
-Eight observability/admin tools are hidden unless
+Nine observability/admin tools are hidden unless
 `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true` is set before server start:
 
 | Tool | Arguments | Description |
@@ -631,6 +631,7 @@ Eight observability/admin tools are hidden unless
 | `stm_proxy_health` | — | Upstream server connectivity and circuit breaker status |
 | `stm_surfacing_stats` | `tool?` | Surfacing event counts, feedback breakdown, helpfulness %, plus per-tool skip reasons / outcomes / cache hit ratio (since process start) |
 | `stm_index_stats` | `tool?` | INDEX attempt/outcome counts for extraction and auto-index paths |
+| `stm_selection_stats` | — | Tool-selection telemetry: live write-path counters plus persisted selections by ranker version, server/tool, execution outcomes, and hard-filter reject reasons |
 | `stm_compression_stats` | `tool?` | Compression feedback counts by kind and tool |
 | `stm_progressive_stats` | `tool?` | Progressive-delivery follow-up rate, coverage, and per-tool breakdown |
 | `stm_tuning_recommendations` | `since_hours?`, `tool?` | Per-tool compression tuning recommendations from the auto-tuner |
@@ -672,9 +673,9 @@ See [Configuration → General](configuration.md#general) for details.
 ## Trimming the advertised MCP tool surface
 
 STM advertises four model-facing MCP tools by default (progressive-delivery
-unlocks and feedback channels). Eight additional tools are operator-facing
+unlocks and feedback channels). Nine additional tools are operator-facing
 (observability / admin). On clients that eager-load MCP tool schemas into
-the model context at session start, the eight observability tools would
+the model context at session start, the nine observability tools would
 pay schema tokens for calls the model rarely makes.
 
 Set the following and restart STM to advertise them over MCP:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,10 +34,11 @@ apply changes.
 export MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true   # opt in
 ```
 
-When unset or `false`, hides STM's eight observability / admin tools
+When unset or `false`, hides STM's nine observability / admin tools
 (`stm_proxy_stats`, `stm_proxy_health`, `stm_proxy_cache_clear`,
-`stm_surfacing_stats`, `stm_index_stats`, `stm_compression_stats`,
-`stm_progressive_stats`, `stm_tuning_recommendations`) from the MCP
+`stm_surfacing_stats`, `stm_index_stats`, `stm_selection_stats`,
+`stm_compression_stats`, `stm_progressive_stats`,
+`stm_tuning_recommendations`) from the MCP
 `tools/list` surface so eager-loading clients (e.g. OpenAI Codex CLI)
 don't pay schema tokens for tools the model rarely calls. Hidden admin
 tools are not registered with the MCP server while the flag is unset or

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -180,3 +180,25 @@ never data. Backstop drops are per-record, so an `execution` whose paired
 
 Telemetry failures never propagate to proxied calls: write errors are
 counted (`write_errors`) and logged, and the call proceeds untouched.
+
+## Reading the telemetry
+
+The `stm_selection_stats` MCP tool reads the active log back into a quick
+operator summary, so a health check needs no hand-parsing of JSONL. It is one
+of the opt-in observability tools — advertise it with
+`MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true` (see [cli.md](cli.md)) — and
+it reports two views:
+
+- **Live counters** — this process's write-path counters (`events_written` /
+  `events_sampled_out` / `redaction_drops` / `write_errors`), reset at
+  restart. These come straight off the running `SelectionTelemetryLog`, so
+  they reflect activity even when sampling or the redaction backstop kept
+  records off disk.
+- **Persisted aggregate** — read off the active log file: event counts,
+  selections **by ranker version** (the #468 cohort split — confirm each
+  cohort has enough samples before replay), by server and tool, execution
+  ok/error rate and latency p50/p95/p99, and the #465 reject-reason tally.
+
+Rotated backups (`log.1` …) are noted but not parsed — the summary covers the
+active log only. For the full history, or any join against `proxy_metrics.db`,
+stream the JSONL directly (see [Replay joins](#replay-joins)).

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -498,6 +498,16 @@ class ProxyManager:
             self._relevance_scorer_cfg = current_cfg
         return self._relevance_scorer_instance
 
+    @property
+    def selection_log(self) -> SelectionTelemetryLog | None:
+        """The selection-telemetry sink, or ``None`` when disabled.
+
+        Public read accessor for ``stm_selection_stats`` — parity with
+        ``index_observability``; ``None`` is the disabled signal the stats
+        tool renders distinctly from "enabled but empty".
+        """
+        return self._selection_log
+
     # Delegates to proxy.tool_metadata module (backward-compatible)
     _truncate_description = staticmethod(truncate_description)
     _distill_schema = staticmethod(distill_schema)

--- a/src/memtomem_stm/proxy/selection_log.py
+++ b/src/memtomem_stm/proxy/selection_log.py
@@ -72,9 +72,11 @@ import random
 import threading
 import time
 import uuid
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from memtomem_stm.proxy.metrics import _percentile
 from memtomem_stm.proxy.privacy import contains_sensitive_content
 
 logger = logging.getLogger(__name__)
@@ -166,6 +168,23 @@ class SelectionTelemetryLog:
         """No-op — the file is opened per append so rotation never holds a
         stale descriptor. Exists so lifespan teardown can treat every store
         uniformly."""
+
+    def snapshot(self) -> dict[str, int]:
+        """Return this process's live write-path counters.
+
+        These reflect the running instance only (reset at restart), unlike
+        ``aggregate_selection_log`` which reads the persisted history off
+        disk — the same in-memory-vs-store split as ``stm_index_stats`` /
+        ``stm_surfacing_stats``. Read under ``self._lock`` so a concurrent
+        ``_append`` can't tear a counter.
+        """
+        with self._lock:
+            return {
+                "events_written": self.events_written,
+                "events_sampled_out": self.events_sampled_out,
+                "redaction_drops": self.redaction_drops,
+                "write_errors": self.write_errors,
+            }
 
     # ── event emitters ───────────────────────────────────────────────────
 
@@ -357,3 +376,133 @@ class SelectionTelemetryLog:
             if src.exists():
                 src.replace(self._path.with_name(f"{self._path.name}.{i + 1}"))
         self._path.replace(self._path.with_name(f"{self._path.name}.1"))
+
+
+def _top(counter: Counter[str], n: int) -> list[list[Any]]:
+    """Return the ``n`` highest-count entries as ``[[key, count], …]``.
+
+    Sorted by count descending then key ascending so the order is stable
+    across runs with the same data (ties never reshuffle a rendered table).
+    """
+    ordered = sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [[k, v] for k, v in ordered[:n]]
+
+
+def aggregate_selection_log(path: Path | str, *, top_n: int = 10) -> dict[str, Any]:
+    """Stream-aggregate a selection-telemetry JSONL log for read-side stats.
+
+    Pure and side-effect-free: opens the *active* log file (rotated backups
+    ``.1``/``.2``/… are counted via ``rotated_backups`` but not parsed — a
+    50 MB default means rotation is rare, and reading the tail of history is
+    a wait-for-signal extension), parses one JSON object per line, and never
+    raises on a malformed line (counted in ``malformed`` and skipped) so a
+    half-written tail or a hand-edited file can't break the stats tool.
+
+    The high-cardinality maps (server / tool / error-type / reject-reason)
+    are returned as ``top_n`` ``[key, count]`` lists plus a ``*_distinct``
+    cardinality so truncation never reads as "that's all there was";
+    ``by_ranker_version`` is returned in full (low cardinality, and the
+    cohort split is the #468 replay signal).
+    """
+    path = Path(path).expanduser()
+    rotated = sum(1 for _ in path.parent.glob(f"{path.name}.*")) if path.parent.exists() else 0
+    result: dict[str, Any] = {
+        "path": str(path),
+        "exists": path.exists(),
+        "rotated_backups": rotated,
+        "total_lines": 0,
+        "malformed": 0,
+        "events": {"selection": 0, "execution": 0, "feedback": 0},
+        "by_ranker_version": [],
+        "by_server": [],
+        "by_server_distinct": 0,
+        "by_selected_tool": [],
+        "by_selected_tool_distinct": 0,
+        "outcomes": {"ok": 0, "error": 0, "error_rate": 0.0},
+        "by_error_type": [],
+        "by_error_type_distinct": 0,
+        "reject_reasons": [],
+        "reject_reasons_distinct": 0,
+        "latency_ms": {"count": 0, "p50": 0.0, "p95": 0.0, "p99": 0.0},
+    }
+    if not result["exists"]:
+        return result
+
+    rankers: Counter[str] = Counter()
+    servers: Counter[str] = Counter()
+    tools: Counter[str] = Counter()
+    error_types: Counter[str] = Counter()
+    reject_reasons: Counter[str] = Counter()
+    ok = err = 0
+    latencies: list[float] = []
+
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                result["total_lines"] += 1
+                try:
+                    rec = json.loads(line)
+                except (ValueError, TypeError):
+                    result["malformed"] += 1
+                    continue
+                if not isinstance(rec, dict):
+                    result["malformed"] += 1
+                    continue
+                event = rec.get("event")
+                if event == "selection":
+                    result["events"]["selection"] += 1
+                    rankers[str(rec.get("ranker_version"))] += 1
+                    if rec.get("server") is not None:
+                        servers[str(rec["server"])] += 1
+                    if rec.get("selected_tool") is not None:
+                        tools[str(rec["selected_tool"])] += 1
+                    rr = rec.get("reject_reasons")
+                    if isinstance(rr, dict):
+                        for reason in rr.values():
+                            reject_reasons[str(reason)] += 1
+                elif event == "execution":
+                    result["events"]["execution"] += 1
+                    if rec.get("ok"):
+                        ok += 1
+                    else:
+                        err += 1
+                    etype = rec.get("error_type")
+                    if etype is not None:
+                        error_types[str(etype)] += 1
+                    lat = rec.get("latency_ms")
+                    if isinstance(lat, (int, float)) and not isinstance(lat, bool):
+                        latencies.append(float(lat))
+                elif event == "feedback":
+                    result["events"]["feedback"] += 1
+                else:
+                    result["malformed"] += 1
+    except OSError:
+        # Treat an unreadable file like an absent one rather than raising
+        # out of an observability path — the tool reports what it could read.
+        return result
+
+    result["by_ranker_version"] = _top(rankers, len(rankers))
+    result["by_server"] = _top(servers, top_n)
+    result["by_server_distinct"] = len(servers)
+    result["by_selected_tool"] = _top(tools, top_n)
+    result["by_selected_tool_distinct"] = len(tools)
+    result["by_error_type"] = _top(error_types, top_n)
+    result["by_error_type_distinct"] = len(error_types)
+    result["reject_reasons"] = _top(reject_reasons, top_n)
+    result["reject_reasons_distinct"] = len(reject_reasons)
+    result["outcomes"] = {
+        "ok": ok,
+        "error": err,
+        "error_rate": round(err / (ok + err), 4) if (ok + err) else 0.0,
+    }
+    if latencies:
+        latencies.sort()
+        result["latency_ms"] = {
+            "count": len(latencies),
+            "p50": round(_percentile(latencies, 50), 2),
+            "p95": round(_percentile(latencies, 95), 2),
+            "p99": round(_percentile(latencies, 99), 2),
+        }
+    return result

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -20,6 +20,7 @@ from memtomem_stm.proxy.config import ProxyConfig, collect_proxy_env_overrides
 from memtomem_stm.proxy.manager import ProxyManager
 from memtomem_stm.proxy.metrics import TokenTracker
 from memtomem_stm.proxy.progressive_reads import ProgressiveReadsTracker
+from memtomem_stm.proxy.selection_log import aggregate_selection_log
 from memtomem_stm.surfacing.engine import SurfacingEngine
 from memtomem_stm.surfacing.observability import (
     FAULT_SKIP_REASONS,
@@ -420,6 +421,7 @@ _STM_UTILITY_TOOL_NAMES: tuple[str, ...] = (
     "stm_surfacing_feedback",
     "stm_surfacing_stats",
     "stm_index_stats",
+    "stm_selection_stats",
     "stm_compression_feedback",
     "stm_compression_stats",
     "stm_progressive_stats",
@@ -1278,6 +1280,129 @@ def _format_index_observability_sections(snapshot: dict, *, tool_filter: str | N
             lines.append(f"  {tool_name}:")
             for outcome, count in sorted(tool_outcomes.items(), key=lambda kv: (-kv[1], kv[0])):
                 lines.append(f"    {outcome}: {count}")
+
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Tool: stm_selection_stats
+# ---------------------------------------------------------------------------
+
+
+@_obs_tool
+async def stm_selection_stats(
+    ctx: CtxType = None,  # type: ignore[assignment]
+) -> str:
+    """Show tool-selection telemetry recorded by the proxy (#467).
+
+    Surfaces the selection/execution log the proxy writes when
+    ``proxy.selection_telemetry.enabled`` is set — the substrate for
+    offline replay/eval (#468). Two views, the same in-memory-vs-store
+    split as ``stm_index_stats``:
+
+    - **Live counters** — this process's write-path counters (events
+      written / sampled out / redaction drops / write errors), reset at
+      restart.
+    - **Persisted aggregate** — read back off the active JSONL log: event
+      counts, selections by ranker version (the #468 cohort split), by
+      server and tool, execution ok/error + latency percentiles, and the
+      #465 hard-filter reject-reason tally.
+
+    Takes no arguments. Rotated backups are noted but not parsed (the
+    active log only).
+    """
+    app = _get_ctx(ctx)
+    pm = app.proxy_manager
+    if pm is None:
+        return "Proxy is not enabled."
+    sink = pm.selection_log
+    if sink is None:
+        return (
+            "Selection telemetry is disabled "
+            "(set proxy.selection_telemetry.enabled = true to record it)."
+        )
+
+    with traced("stm_selection_stats"):
+        agg = aggregate_selection_log(sink.path)
+        live = sink.snapshot()
+        # An empty disk log with no live activity is genuinely "no data".
+        # But if events were written and then rotated/sampled away, the live
+        # counters still explain where they went — render rather than hide.
+        if (not agg["exists"] or agg["total_lines"] == 0) and not any(live.values()):
+            return f"No selection telemetry recorded yet at {agg['path']}."
+        lines = ["Selection Stats", "==============="]
+        lines.extend(_format_selection_stats_sections(agg, live))
+        return "\n".join(lines)
+
+
+def _append_top_section(lines: list[str], title: str, top: list[list[Any]], distinct: int) -> None:
+    """Append a ``title`` section listing ``[key, count]`` rows, if any.
+
+    Notes truncation as ``(top N of M)`` when the aggregate held more
+    distinct keys than the rendered slice, so a capped list never reads as
+    the full set.
+    """
+    if not top:
+        return
+    suffix = f" (top {len(top)} of {distinct})" if distinct > len(top) else ""
+    lines.append(f"\n{title}{suffix}:")
+    for key, count in top:
+        lines.append(f"  {key}: {count}")
+
+
+def _format_selection_stats_sections(agg: dict, live: dict[str, int]) -> list[str]:
+    """Render the sections for ``stm_selection_stats``.
+
+    Returns lines (no leading blank; caller appends to the header). ``agg``
+    is an ``aggregate_selection_log`` result (persisted, off disk); ``live``
+    is ``SelectionTelemetryLog.snapshot`` (this process only).
+    """
+    lines: list[str] = [f"\nLog: {agg['path']}"]
+    if agg["rotated_backups"]:
+        lines.append(f"  ({agg['rotated_backups']} rotated backup(s) present — not included below)")
+
+    lines.append("\nLive counters (this process):")
+    for label in ("events_written", "events_sampled_out", "redaction_drops", "write_errors"):
+        lines.append(f"  {label}: {live[label]}")
+
+    ev = agg["events"]
+    lines.append("\nEvents (persisted):")
+    for label in ("selection", "execution", "feedback"):
+        lines.append(f"  {label}: {ev[label]}")
+    if agg["malformed"]:
+        lines.append(f"  malformed (skipped): {agg['malformed']}")
+
+    if agg["by_ranker_version"]:
+        lines.append("\nSelections by ranker version:")
+        for rv, count in agg["by_ranker_version"]:
+            lines.append(f"  {rv}: {count}")
+
+    _append_top_section(lines, "Selections by server", agg["by_server"], agg["by_server_distinct"])
+    _append_top_section(
+        lines, "Selections by tool", agg["by_selected_tool"], agg["by_selected_tool_distinct"]
+    )
+
+    if ev["execution"]:
+        out = agg["outcomes"]
+        lines.append("\nExecution outcomes:")
+        lines.append(f"  ok: {out['ok']}")
+        lines.append(f"  error: {out['error']}")
+        lines.append(f"  error_rate: {out['error_rate']:.4f}")
+        lat = agg["latency_ms"]
+        if lat["count"]:
+            lines.append(
+                f"  latency_ms p50/p95/p99: {lat['p50']} / {lat['p95']} / {lat['p99']} "
+                f"(n={lat['count']})"
+            )
+    _append_top_section(
+        lines, "Execution error types", agg["by_error_type"], agg["by_error_type_distinct"]
+    )
+    _append_top_section(
+        lines,
+        "Reject reasons (#465 hard filter)",
+        agg["reject_reasons"],
+        agg["reject_reasons_distinct"],
+    )
 
     return lines
 

--- a/tests/test_qa_round3.py
+++ b/tests/test_qa_round3.py
@@ -165,7 +165,7 @@ class TestDocsToolCount:
     def test_cli_md_has_current_tool_counts(self):
         cli_md = Path(__file__).parent.parent / "docs" / "cli.md"
         content = cli_md.read_text(encoding="utf-8")
-        assert "4 default + 8 opt-in + proxied" in content
+        assert "4 default + 9 opt-in + proxied" in content
         assert "stm_proxy_health" in content
         assert "stm_compression_feedback" in content
         assert "stm_progressive_stats" in content
@@ -175,7 +175,7 @@ class TestDocsToolCount:
         readme = Path(__file__).parent.parent / "README.md"
         content = readme.read_text(encoding="utf-8")
         assert "four model-facing MCP tools by default" in content
-        assert "Eight observability and" in content
+        assert "Nine observability and" in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_selection_log.py
+++ b/tests/test_selection_log.py
@@ -31,6 +31,7 @@ from memtomem_stm.proxy.selection_log import (
     SCHEMA_VERSION,
     SelectionTelemetryLog,
     _canonical_args,
+    aggregate_selection_log,
 )
 
 _skip_on_windows = pytest.mark.skipif(
@@ -524,3 +525,195 @@ class TestManagerWireIn:
             name="srv", config=server_cfg, session=session, tools=[]
         )
         assert await mgr.call_tool("srv", "tool", {}) == "ok!"
+
+
+# ── snapshot (live write-path counters) ──────────────────────────────────
+
+
+class TestSnapshot:
+    def test_snapshot_keys_and_initial_zeros(self, tmp_path):
+        log = _make_log(tmp_path)
+        snap = log.snapshot()
+        assert snap == {
+            "events_written": 0,
+            "events_sampled_out": 0,
+            "redaction_drops": 0,
+            "write_errors": 0,
+        }
+
+    def test_snapshot_reflects_writes(self, tmp_path):
+        log = _make_log(tmp_path)
+        _log_pair(log)  # one selection + one execution
+        assert log.snapshot()["events_written"] == 2
+
+    def test_snapshot_reflects_sampling(self, tmp_path):
+        log = _make_log(tmp_path, sample_rate=0.0)
+        assert _log_pair(log) is None  # sampled out, no execution
+        snap = log.snapshot()
+        assert snap["events_sampled_out"] == 1
+        assert snap["events_written"] == 0
+
+    def test_snapshot_reflects_redaction_drop(self, tmp_path):
+        log = _make_log(tmp_path)
+        # A credential-looking selected_tool trips the storage backstop.
+        sid = log.log_selection(
+            server="srv",
+            selected_tool="sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcd",
+            candidate_tools=["x"],
+            arguments={},
+            trace_id=None,
+        )
+        # Drop still returns an id (documented left-outer), but nothing
+        # reached disk and the counter recorded the drop.
+        assert sid is not None
+        assert log.snapshot()["redaction_drops"] == 1
+        assert log.snapshot()["events_written"] == 0
+
+
+# ── aggregate_selection_log (read-side stats) ────────────────────────────
+
+
+def _write_lines(path: Path, lines: list) -> None:
+    """Write raw JSONL; dict entries are dumped, str entries written verbatim
+    (so malformed/non-object lines can be exercised)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for item in lines:
+            fh.write((item if isinstance(item, str) else json.dumps(item)) + "\n")
+
+
+def _sel(**kw) -> dict:
+    base = {
+        "event": "selection",
+        "ranker_version": RANKER_VERSION,
+        "server": "srv",
+        "selected_tool": "srv__a",
+        "reject_reasons": {},
+    }
+    base.update(kw)
+    return base
+
+
+def _exec(**kw) -> dict:
+    base = {"event": "execution", "ok": True, "latency_ms": 10.0, "error_type": None}
+    base.update(kw)
+    return base
+
+
+class TestAggregateSelectionLog:
+    def test_absent_file_returns_zeroed_shape(self, tmp_path):
+        agg = aggregate_selection_log(tmp_path / "nope.jsonl")
+        assert agg["exists"] is False
+        assert agg["total_lines"] == 0
+        assert agg["events"] == {"selection": 0, "execution": 0, "feedback": 0}
+        assert agg["by_ranker_version"] == []
+        assert agg["outcomes"] == {"ok": 0, "error": 0, "error_rate": 0.0}
+
+    def test_empty_file_exists_but_no_lines(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        p.write_text("", encoding="utf-8")
+        agg = aggregate_selection_log(p)
+        assert agg["exists"] is True
+        assert agg["total_lines"] == 0
+
+    def test_malformed_and_unknown_lines_skipped_and_counted(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        _write_lines(
+            p,
+            [
+                _sel(),
+                "{ this is not json",  # bad JSON
+                "[1, 2, 3]",  # valid JSON, not an object
+                {"event": "mystery"},  # unknown event type
+                "",  # blank line ignored, not counted as malformed
+            ],
+        )
+        agg = aggregate_selection_log(p)
+        # blank line skipped before counting; 4 real lines counted
+        assert agg["total_lines"] == 4
+        assert agg["malformed"] == 3
+        assert agg["events"]["selection"] == 1
+
+    def test_event_counts_and_ranker_cohorts(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        _write_lines(
+            p,
+            [
+                _sel(ranker_version="v0-passthrough"),
+                _sel(ranker_version="v1-bm25-tool-relevance"),
+                _sel(ranker_version="v1-bm25-tool-relevance"),
+                _exec(),
+                {"event": "feedback", "selection_id": "z"},
+            ],
+        )
+        agg = aggregate_selection_log(p)
+        assert agg["events"] == {"selection": 3, "execution": 1, "feedback": 1}
+        # full, sorted by count desc then key asc
+        assert agg["by_ranker_version"] == [
+            ["v1-bm25-tool-relevance", 2],
+            ["v0-passthrough", 1],
+        ]
+
+    def test_by_server_and_tool_with_topn_truncation(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        rows = [_sel(selected_tool=f"srv__t{i}") for i in range(5)]
+        # make t0 the most frequent
+        rows += [_sel(selected_tool="srv__t0") for _ in range(3)]
+        _write_lines(p, rows)
+        agg = aggregate_selection_log(p, top_n=2)
+        assert agg["by_selected_tool_distinct"] == 5
+        assert len(agg["by_selected_tool"]) == 2
+        assert agg["by_selected_tool"][0] == ["srv__t0", 4]
+        # server is the same for all → single distinct
+        assert agg["by_server_distinct"] == 1
+        assert agg["by_server"] == [["srv", 8]]
+
+    def test_outcomes_error_rate_and_error_types(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        _write_lines(
+            p,
+            [
+                _exec(ok=True),
+                _exec(ok=False, error_type="TimeoutError"),
+                _exec(ok=False, error_type="TimeoutError"),
+                _exec(ok=False, error_type="ValueError"),
+            ],
+        )
+        agg = aggregate_selection_log(p)
+        assert agg["outcomes"] == {"ok": 1, "error": 3, "error_rate": 0.75}
+        assert agg["by_error_type"] == [["TimeoutError", 2], ["ValueError", 1]]
+        assert agg["by_error_type_distinct"] == 2
+
+    def test_reject_reasons_tallied_across_selections(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        _write_lines(
+            p,
+            [
+                _sel(reject_reasons={"srv__b": "config_hidden", "srv__c": "unhealthy"}),
+                _sel(reject_reasons={"srv__d": "config_hidden"}),
+                _sel(reject_reasons={}),
+            ],
+        )
+        agg = aggregate_selection_log(p)
+        assert agg["reject_reasons"] == [["config_hidden", 2], ["unhealthy", 1]]
+        assert agg["reject_reasons_distinct"] == 2
+
+    def test_latency_percentiles_and_bool_excluded(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        rows = [_exec(latency_ms=float(v)) for v in (10, 20, 30, 40, 50)]
+        # a malformed/bool latency must not poison the percentile pool
+        rows.append(_exec(latency_ms=True))
+        _write_lines(p, rows)
+        agg = aggregate_selection_log(p)
+        assert agg["latency_ms"]["count"] == 5
+        assert agg["latency_ms"]["p50"] == 30.0
+
+    def test_rotated_backups_counted_not_parsed(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        _write_lines(p, [_sel()])
+        (tmp_path / "log.jsonl.1").write_text("ignored\n", encoding="utf-8")
+        (tmp_path / "log.jsonl.2").write_text("ignored\n", encoding="utf-8")
+        agg = aggregate_selection_log(p)
+        assert agg["rotated_backups"] == 2
+        # only the active file's one selection is in the aggregate
+        assert agg["events"]["selection"] == 1

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -19,6 +19,7 @@ from memtomem_stm.server import (
     stm_proxy_read_more,
     stm_proxy_select_chunks,
     stm_proxy_stats,
+    stm_selection_stats,
     stm_surfacing_feedback,
     stm_surfacing_stats,
     stm_tuning_recommendations,
@@ -1082,6 +1083,99 @@ class TestProgressiveStats:
         mock_tracker.get_stats.assert_called_once_with("docfix:get_doc")
 
 
+# ── stm_selection_stats ───────────────────────────────────────────────────
+
+
+def _selection_log(tmp_path):
+    from memtomem_stm.proxy.selection_log import SelectionTelemetryLog
+
+    log = SelectionTelemetryLog(tmp_path / "sel.jsonl")
+    log.initialize()
+    return log
+
+
+def _ctx_with_selection(tmp_path, *, log):
+    cfg = ProxyConfig(config_path=tmp_path / "p.json", upstream_servers={})
+    pm = ProxyManager(cfg, TokenTracker(), selection_log=log)
+    return _make_ctx(proxy_manager=pm)
+
+
+class TestSelectionStats:
+    async def test_proxy_not_enabled(self):
+        app = STMContext(
+            config=STMConfig(),
+            proxy_manager=None,  # type: ignore[arg-type]
+            tracker=TokenTracker(),
+            surfacing_engine=None,
+            feedback_tracker=None,
+            compression_feedback_tracker=None,
+            progressive_reads_tracker=None,
+        )
+        ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
+        assert await stm_selection_stats(ctx=ctx) == "Proxy is not enabled."
+
+    async def test_telemetry_disabled(self, tmp_path):
+        ctx = _ctx_with_selection(tmp_path, log=None)
+        result = await stm_selection_stats(ctx=ctx)
+        assert "Selection telemetry is disabled" in result
+
+    async def test_enabled_but_empty(self, tmp_path):
+        ctx = _ctx_with_selection(tmp_path, log=_selection_log(tmp_path))
+        result = await stm_selection_stats(ctx=ctx)
+        assert "No selection telemetry recorded yet" in result
+
+    async def test_populated_renders_all_sections(self, tmp_path):
+        log = _selection_log(tmp_path)
+        sid = log.log_selection(
+            server="gh",
+            selected_tool="gh__a",
+            candidate_tools=["gh__a", "gh__b"],
+            arguments={"q": "x"},
+            trace_id=None,
+            reject_reasons={"gh__b": "config_hidden"},
+        )
+        log.log_execution(
+            selection_id=sid,
+            trace_id=None,
+            server="gh",
+            selected_tool="gh__a",
+            ok=True,
+            latency_ms=12.0,
+        )
+        ctx = _ctx_with_selection(tmp_path, log=log)
+        result = await stm_selection_stats(ctx=ctx)
+
+        assert "Selection Stats" in result
+        assert "Live counters (this process):" in result
+        assert "events_written: 2" in result
+        assert "Selections by ranker version:" in result
+        assert "v0-passthrough: 1" in result
+        assert "Selections by server:" in result
+        assert "Execution outcomes:" in result
+        assert "ok: 1" in result
+        assert "Reject reasons (#465 hard filter):" in result
+        assert "config_hidden: 1" in result
+
+    async def test_sampled_out_still_renders_live_counters(self, tmp_path):
+        from memtomem_stm.proxy.selection_log import SelectionTelemetryLog
+
+        # sample_rate 0 → nothing persisted, but the live drop counter is real
+        # signal the operator should still see (not "no data").
+        log = SelectionTelemetryLog(tmp_path / "sel.jsonl", sample_rate=0.0)
+        log.initialize()
+        log.log_selection(
+            server="gh",
+            selected_tool="gh__a",
+            candidate_tools=["gh__a"],
+            arguments={},
+            trace_id=None,
+        )
+        ctx = _ctx_with_selection(tmp_path, log=log)
+        result = await stm_selection_stats(ctx=ctx)
+        assert "Selection Stats" in result
+        assert "events_sampled_out: 1" in result
+
+
 # ── stm_tuning_recommendations ────────────────────────────────────────────
 
 
@@ -1447,6 +1541,7 @@ _OBSERVABILITY_TOOLS = {
     "stm_proxy_cache_clear",
     "stm_surfacing_stats",
     "stm_index_stats",
+    "stm_selection_stats",
     "stm_compression_stats",
     "stm_progressive_stats",
     "stm_tuning_recommendations",
@@ -1509,10 +1604,10 @@ class TestAdvertiseObservabilityFlagEndToEnd:
         assert names == _MODEL_FACING_TOOLS
         assert _OBSERVABILITY_TOOLS.isdisjoint(names)
 
-    def test_flag_true_advertises_all_twelve(self):
+    def test_flag_true_advertises_all_thirteen(self):
         names = set(self._list_registered(env_override="true"))
         assert names == _MODEL_FACING_TOOLS | _OBSERVABILITY_TOOLS
-        assert len(names) == 12
+        assert len(names) == 13
 
     def test_flag_false_keeps_only_model_facing(self):
         names = set(self._list_registered(env_override="false"))
@@ -1583,7 +1678,7 @@ class TestAdvertiseOrder:
 
     def test_reorder_skips_missing_stm_tools(self):
         """When ``MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=false`` hides
-        the 8 observability tools, ``_tool_manager._tools`` only holds the
+        the 9 observability tools, ``_tool_manager._tools`` only holds the
         4 model-facing STM tools. The reorder helper must not KeyError on
         the absent names — ``.pop(name, None)`` is the contract."""
         from memtomem_stm.server import _move_stm_tools_to_end


### PR DESCRIPTION
## Why

The #467 selection-telemetry sink (shipped in v0.1.28, #471) is **write-only**: the proxy records selection/execution events to `~/.memtomem/stm_selection_log.jsonl`, but nothing reads them back. An operator can't see how much telemetry has accumulated, how it splits by `ranker_version`, the #465 hard-filter reject-reason distribution, or call outcomes. That inspectability is the gate on **offline replay/eval (#468)** — you can't begin tuning until you can confirm each ranker cohort has enough samples. This adds the read/observability surface so the telemetry the proxy already captures becomes visible.

This is the "stats surfacing" follow-up recorded in #471. The other recorded follow-ups already shipped: `reject_reasons` (#473) and `ranker_version` stamping (#472).

## What

A new opt-in observability MCP tool, **`stm_selection_stats`** (the 9th observability tool), mirroring the `stm_*_stats` family. It combines two sources:

- **Live counters** — off the running `SelectionTelemetryLog` (`events_written` / `events_sampled_out` / `redaction_drops` / `write_errors`), reset at restart. Surfaces activity even when sampling or the redaction backstop kept records off disk.
- **Persisted aggregate** — read off the active JSONL log via a new pure `aggregate_selection_log(path, *, top_n)`: event counts, selections **by ranker version** (the #468 cohort split), by server and tool (top-N + distinct), execution ok/error rate and latency p50/p95/p99 (reusing `proxy.metrics._percentile`), and the #465 reject-reason tally.

The aggregator never raises on a malformed line (counted + skipped), so a half-written tail or hand-edited file can't break the stats tool. Rotated backups are counted but not parsed (active log only).

Rendered output (smoke):

```
Selection Stats
===============

Log: ~/.memtomem/stm_selection_log.jsonl

Live counters (this process):
  events_written: 6
  ...
Selections by ranker version:
  v1-bm25-tool-relevance: 2
  v0-passthrough: 1
Execution outcomes:
  ok: 2
  error: 1
  error_rate: 0.3333
  latency_ms p50/p95/p99: 25.0 / 38.5 / 39.7 (n=3)
Reject reasons (#465 hard filter):
  config_hidden: 1
```

## Out of scope (separate follow-up)

- **`cache_hit` population** — the cache-hit path (`manager._on_cache_hit`) skips selection telemetry entirely today, so making that field meaningful is a behavior change, not field wiring. Deserves its own PR + design review.
- Reading rotated backups into the aggregate (wait-for-signal; v0 notes them).

## Notes

- Adding a 9th observability tool bumps the "8 opt-in / Eight observability" count literals across `docs/cli.md`, `docs/configuration.md`, `README.md`, and the `test_qa_round3.py` / `test_server_tools.py` pins (all updated together).
- `stm_selection_stats` is gated behind `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true` like its siblings.

## Test

- `tests/test_selection_log.py` — aggregator units (absent/empty/malformed/cohorts/top-N/outcomes/reject-reasons/percentiles/rotated-backups) + `snapshot()`.
- `tests/test_server_tools.py::TestSelectionStats` — disabled / empty / populated / sampled-out rendering; advertise-set membership + count bumped to 13.
- Full suite `-m "not ollama"`: 3392 passed, 3 skipped. `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)