### PR TITLE
feat(proxy): populate selection-telemetry execution.cache_hit (#467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - **`stm_selection_stats` observability tool — read-side surface for selection telemetry** (#484, issue #467) — surfaces the JSONL selection/execution log (added in #471) through a new opt-in observability MCP tool: live write-path counters plus a persisted aggregate (event counts, selections by ranker version, by server and tool, execution ok/error rate and latency p50/p95/p99, and the hard-filter reject-reason tally from #465). Makes accumulated telemetry inspectable ahead of offline replay/eval (#468). Advertised only when `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true`; reads the active log file (rotated backups are noted but not parsed).
 
+### Changed
+
+- **Selection-telemetry `execution.cache_hit` is now populated** (#485, issue #467) — the reserved field is set `true`/`false` per call (served from the proxy response cache vs a live upstream call; `null` when a raise escaped before it was attributable), and `stm_selection_stats` reports the cache hit/miss rate. **Behavior change**: when `selection_telemetry.enabled`, execution records now carry a real `cache_hit` value instead of `null` — additive, the schema key set is unchanged.
+
 ## [0.1.28] — 2026-06-11
 
 A security-hardening, correctness, and tool-selection release. A targeted audit across four issue classes — SQLite file permissions, sensitive-value caching, secret-content persistence, and extraction-call privacy — produced six security fixes. Thirteen correctness fixes address critical paths found in the implementation review (PROGRESSIVE metrics assignment, network LTM reconnects, shutdown ExceptionGroup handling) and the remaining medium and low backlog items across daemon, surfacing, compression, config, and CLI layers. Two new opt-in features instrument the tool-selection path (JSONL telemetry sink and BM25 relevance scoring), and a third hardens what the proxy advertises to MCP clients via an STM-native eligibility filter at exposure time.

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -68,7 +68,8 @@ stamp).
 | `ok` | `true`/`false` |
 | `latency_ms` | proxy-side wall time for the full pipeline (what the agent experienced) |
 | `error_type` | exception class name only; the typed category stays in `proxy_metrics.db` |
-| `retry_count`, `cost`, `cache_hit` | reserved `null` in v0 |
+| `cache_hit` | `true` when the result was served from the proxy response cache, `false` on a live upstream call, `null` when a raise escaped before the hit/miss was attributable |
+| `retry_count`, `cost` | reserved `null` |
 
 ### `feedback` — schema pinned, no emitter yet
 
@@ -197,7 +198,8 @@ it reports two views:
 - **Persisted aggregate** — read off the active log file: event counts,
   selections **by ranker version** (the #468 cohort split — confirm each
   cohort has enough samples before replay), by server and tool, execution
-  ok/error rate and latency p50/p95/p99, and the #465 reject-reason tally.
+  ok/error rate, latency p50/p95/p99, cache hit/miss rate, and the #465
+  reject-reason tally.
 
 Rotated backups (`log.1` …) are noted but not parsed — the summary covers the
 active log only. For the full history, or any join against `proxy_metrics.db`,

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1328,7 +1328,9 @@ class ProxyManager:
             metadata={"server": server, "tool": tool, "trace_id": trace_id},
         ):
             try:
-                result = await self._call_tool_guarded(server, tool, arguments, trace_id=trace_id)
+                result, cache_hit = await self._call_tool_guarded(
+                    server, tool, arguments, trace_id=trace_id
+                )
             except Exception as exc:
                 # Upstream/transport/timeout/protocol errors are already
                 # recorded inside _call_tool_inner via record_error(); a raise
@@ -1388,6 +1390,7 @@ class ProxyManager:
                 started,
                 ok=True,
                 ranker_version=ranker_version,
+                cache_hit=cache_hit,
             )
             return result
 
@@ -1478,6 +1481,7 @@ class ProxyManager:
         ok: bool,
         error_type: str | None = None,
         ranker_version: str | None = None,
+        cache_hit: bool | None = None,
     ) -> None:
         """Emit the execution-outcome event paired to ``selection_id``.
 
@@ -1485,7 +1489,10 @@ class ProxyManager:
         category and message live in ``proxy_metrics.db``, joinable via
         ``trace_id`` — telemetry never duplicates (or leaks) error text.
         ``ranker_version`` mirrors the paired selection so replay groups
-        both halves under the same cohort.
+        both halves under the same cohort. ``cache_hit`` is ``True``/``False``
+        on a completed call (served from the response cache vs a live
+        upstream call) and left ``None`` when a raise escaped before the
+        hit/miss was attributable.
         """
         if self._selection_log is None or selection_id is None:
             return
@@ -1499,6 +1506,7 @@ class ProxyManager:
                 latency_ms=(_time.perf_counter() - started) * 1000.0,
                 error_type=error_type,
                 ranker_version=ranker_version,
+                cache_hit=cache_hit,
             )
         except Exception:
             logger.debug("Execution telemetry write failed", exc_info=True)
@@ -1510,7 +1518,7 @@ class ProxyManager:
         arguments: dict[str, Any],
         *,
         trace_id: str,
-    ) -> str | list:
+    ) -> tuple[str | list, bool]:
         """Cache stampede guard: serialize identical concurrent ``call_tool``
         invocations on a per-key lock so a cold cache + duplicate requests
         trigger one upstream call rather than N.
@@ -1522,7 +1530,12 @@ class ProxyManager:
         ``finally`` while the lock is still held so any waiter already
         queued on the same lock sees the cached result on its own
         double-check, and a new arrival after pop likewise finds the set
-        value (stampede window closed)."""
+        value (stampede window closed).
+
+        Returns ``(result, cache_hit)`` so ``call_tool`` can stamp the
+        selection-telemetry execution event (#467): ``True`` on either
+        cache-hit return path, ``False`` on a live ``_call_tool_inner``
+        call (including the no-cache configuration)."""
         upstream_args = (
             {k: v for k, v in arguments.items() if k != "_context_query"} if arguments else {}
         )
@@ -1531,11 +1544,11 @@ class ProxyManager:
         if self._cache is not None:
             cached = self._cache.get(server, tool, upstream_args)
             if cached is not None:
-                return await self._on_cache_hit(cached, server, tool, arguments, trace_id)
+                return await self._on_cache_hit(cached, server, tool, arguments, trace_id), True
 
         # No cache configured — stampede protection N/A, go straight through.
         if self._cache is None:
-            return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id)
+            return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id), False
 
         cache_key = _cache_key(server, tool, upstream_args)
         lock = self._key_locks.setdefault(cache_key, asyncio.Lock())
@@ -1545,8 +1558,10 @@ class ProxyManager:
                 # lock ahead of us may have populated the cache already.
                 cached = self._cache.get(server, tool, upstream_args)
                 if cached is not None:
-                    return await self._on_cache_hit(cached, server, tool, arguments, trace_id)
-                return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id)
+                    return await self._on_cache_hit(cached, server, tool, arguments, trace_id), True
+                return await self._call_tool_inner(
+                    server, tool, arguments, trace_id=trace_id
+                ), False
             finally:
                 self._key_locks.pop(cache_key, None)
 

--- a/src/memtomem_stm/proxy/selection_log.py
+++ b/src/memtomem_stm/proxy/selection_log.py
@@ -32,8 +32,10 @@ sorted, so a replay harness can stream-parse and diff runs:
     wall time for the full pipeline, what the agent experienced),
     ``error_type`` (exception class name; the *typed* error category
     stays in ``proxy_metrics.db``, joinable via ``trace_id`` — not
-    duplicated here), ``retry_count`` / ``cost`` / ``cache_hit``
-    (reserved ``null`` in v0), ``ts``.
+    duplicated here), ``cache_hit`` (``true`` when the result was served
+    from the proxy response cache, ``false`` on a live upstream call,
+    ``null`` when telemetry can't attribute it — e.g. an in-pipeline
+    raise), ``retry_count`` / ``cost`` (reserved ``null``), ``ts``.
 
 ``feedback``
     ``selection_id`` (+ optional ``trace_id``), ``user_corrected``,
@@ -254,6 +256,7 @@ class SelectionTelemetryLog:
         latency_ms: float,
         error_type: str | None = None,
         ranker_version: str | None = None,
+        cache_hit: bool | None = None,
     ) -> None:
         self._append(
             {
@@ -270,7 +273,7 @@ class SelectionTelemetryLog:
                 "error_type": error_type,
                 "retry_count": None,
                 "cost": None,
-                "cache_hit": None,
+                "cache_hit": cache_hit,
             }
         )
 
@@ -424,6 +427,7 @@ def aggregate_selection_log(path: Path | str, *, top_n: int = 10) -> dict[str, A
         "reject_reasons": [],
         "reject_reasons_distinct": 0,
         "latency_ms": {"count": 0, "p50": 0.0, "p95": 0.0, "p99": 0.0},
+        "cache": {"hit": 0, "miss": 0, "unknown": 0, "hit_rate": 0.0},
     }
     if not result["exists"]:
         return result
@@ -434,6 +438,7 @@ def aggregate_selection_log(path: Path | str, *, top_n: int = 10) -> dict[str, A
     error_types: Counter[str] = Counter()
     reject_reasons: Counter[str] = Counter()
     ok = err = 0
+    cache_hit = cache_miss = cache_unknown = 0
     latencies: list[float] = []
 
     try:
@@ -471,6 +476,13 @@ def aggregate_selection_log(path: Path | str, *, top_n: int = 10) -> dict[str, A
                     etype = rec.get("error_type")
                     if etype is not None:
                         error_types[str(etype)] += 1
+                    ch = rec.get("cache_hit")
+                    if ch is True:
+                        cache_hit += 1
+                    elif ch is False:
+                        cache_miss += 1
+                    else:
+                        cache_unknown += 1
                     lat = rec.get("latency_ms")
                     if isinstance(lat, (int, float)) and not isinstance(lat, bool):
                         latencies.append(float(lat))
@@ -505,4 +517,14 @@ def aggregate_selection_log(path: Path | str, *, top_n: int = 10) -> dict[str, A
             "p95": round(_percentile(latencies, 95), 2),
             "p99": round(_percentile(latencies, 99), 2),
         }
+    # hit_rate is over attributable executions only (hit + miss); unknowns
+    # (in-pipeline raises before the field is set) are excluded from the
+    # denominator so a burst of errors can't deflate the cache hit rate.
+    attributable = cache_hit + cache_miss
+    result["cache"] = {
+        "hit": cache_hit,
+        "miss": cache_miss,
+        "unknown": cache_unknown,
+        "hit_rate": round(cache_hit / attributable, 4) if attributable else 0.0,
+    }
     return result

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -1394,6 +1394,13 @@ def _format_selection_stats_sections(agg: dict, live: dict[str, int]) -> list[st
                 f"  latency_ms p50/p95/p99: {lat['p50']} / {lat['p95']} / {lat['p99']} "
                 f"(n={lat['count']})"
             )
+        cache = agg["cache"]
+        if cache["hit"] or cache["miss"] or cache["unknown"]:
+            unknown = f", unknown {cache['unknown']}" if cache["unknown"] else ""
+            lines.append(
+                f"  cache hit/miss: {cache['hit']} / {cache['miss']} "
+                f"(hit_rate {cache['hit_rate']:.4f}{unknown})"
+            )
     _append_top_section(
         lines, "Execution error types", agg["by_error_type"], agg["by_error_type_distinct"]
     )

--- a/tests/test_selection_log.py
+++ b/tests/test_selection_log.py
@@ -156,7 +156,7 @@ class TestSchemaStability:
 
     def test_v0_reserved_fields(self, tmp_path):
         """Reserved-until-later fields are present and null/empty in v0 so
-        the schema doesn't change shape when #465/toolgraph populate them."""
+        the schema doesn't change shape when later work populates them."""
         log = _make_log(tmp_path)
         _log_pair(log)
 
@@ -166,7 +166,25 @@ class TestSchemaStability:
         assert selection["graph_generation"] is None
         assert execution["retry_count"] is None
         assert execution["cost"] is None
-        assert execution["cache_hit"] is None
+
+    def test_cache_hit_is_per_call_populatable(self, tmp_path):
+        """The cache_hit seam is populated, not added — passing it sets the
+        field without changing the top-level key set, and omitting it keeps
+        the unattributable ``None`` default."""
+        log = _make_log(tmp_path)
+        for value in (True, False, None):
+            log.log_execution(
+                selection_id="s",
+                trace_id=None,
+                server="srv",
+                selected_tool="test__tool",
+                ok=True,
+                latency_ms=1.0,
+                cache_hit=value,
+            )
+        records = _read_events(log)
+        assert all(set(r) == EXECUTION_KEYS for r in records)
+        assert [r["cache_hit"] for r in records] == [True, False, None]
 
     def test_reject_reasons_are_per_call_populatable(self, tmp_path):
         """#465 wires the hard filter's verdict into the reserved seam: the
@@ -409,7 +427,9 @@ def _make_result(text: str):
     return SimpleNamespace(content=[_text_content(text)], isError=False)
 
 
-def _make_manager(tmp_path: Path, **log_kwargs) -> tuple[ProxyManager, SelectionTelemetryLog]:
+def _make_manager(
+    tmp_path: Path, *, cache=None, **log_kwargs
+) -> tuple[ProxyManager, SelectionTelemetryLog]:
     server_cfg = UpstreamServerConfig(
         prefix="test",
         compression=CompressionStrategy.NONE,
@@ -422,7 +442,7 @@ def _make_manager(tmp_path: Path, **log_kwargs) -> tuple[ProxyManager, Selection
         min_result_retention=0.0,
     )
     log = _make_log(tmp_path, **log_kwargs)
-    mgr = ProxyManager(proxy_cfg, TokenTracker(), selection_log=log)
+    mgr = ProxyManager(proxy_cfg, TokenTracker(), cache=cache, selection_log=log)
 
     session = AsyncMock()
     tool = SimpleNamespace(name="tool", description="a tool", inputSchema={"type": "object"})
@@ -525,6 +545,47 @@ class TestManagerWireIn:
             name="srv", config=server_cfg, session=session, tools=[]
         )
         assert await mgr.call_tool("srv", "tool", {}) == "ok!"
+
+    async def test_cache_hit_field_true_on_hit_false_on_live(self, tmp_path):
+        """The execution event records whether the result came from the
+        response cache: ``True`` on a fast-path hit, ``False`` on a live
+        upstream call. Wires through ``_call_tool_guarded``'s
+        ``(result, cache_hit)`` return (the #467 cache_hit field)."""
+        from memtomem_stm.proxy.cache import ProxyCache
+
+        cache = ProxyCache(tmp_path / "cache.db")
+        cache.initialize()
+        cache.set("srv", "tool", {"q": "hit"}, "cached!", ttl_seconds=300.0)
+        mgr, log = _make_manager(tmp_path, cache=cache)
+        mgr.get_proxy_tools()
+        mgr._connections["srv"].session.call_tool.return_value = _make_result("live!")
+
+        # Pre-cached args → fast-path hit (no upstream call).
+        assert await mgr.call_tool("srv", "tool", {"q": "hit"}) == "cached!"
+        # Un-cached args → live upstream call.
+        assert await mgr.call_tool("srv", "tool", {"q": "miss"}) == "live!"
+
+        executions = [e for e in _read_events(log) if e["event"] == "execution"]
+        assert len(executions) == 2
+        # Events append in call order: first call (hit) then second (live).
+        assert executions[0]["cache_hit"] is True
+        assert executions[1]["cache_hit"] is False
+
+    async def test_pipeline_error_leaves_cache_hit_null(self, tmp_path):
+        """A raise escaping the guarded call means the hit/miss was never
+        attributed — the execution event stays ``cache_hit=None`` rather
+        than guessing."""
+        mgr, log = _make_manager(tmp_path)
+        mgr.get_proxy_tools()
+        mgr._connections["srv"].session.call_tool.side_effect = RuntimeError("boom")
+
+        with pytest.raises(Exception):
+            await mgr.call_tool("srv", "tool", {})
+
+        executions = [e for e in _read_events(log) if e["event"] == "execution"]
+        assert len(executions) == 1
+        assert executions[0]["ok"] is False
+        assert executions[0]["cache_hit"] is None
 
 
 # ── snapshot (live write-path counters) ──────────────────────────────────
@@ -717,3 +778,26 @@ class TestAggregateSelectionLog:
         assert agg["rotated_backups"] == 2
         # only the active file's one selection is in the aggregate
         assert agg["events"]["selection"] == 1
+
+    def test_cache_hit_miss_unknown_tally_and_hit_rate(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        _write_lines(
+            p,
+            [
+                _exec(cache_hit=True),
+                _exec(cache_hit=True),
+                _exec(cache_hit=True),
+                _exec(cache_hit=False),
+                _exec(cache_hit=None),  # in-pipeline raise: unattributable
+                _exec(),  # missing field → unknown
+            ],
+        )
+        agg = aggregate_selection_log(p)
+        # hit_rate denominator excludes the 2 unknowns: 3 / (3 + 1) = 0.75
+        assert agg["cache"] == {"hit": 3, "miss": 1, "unknown": 2, "hit_rate": 0.75}
+
+    def test_cache_zeroed_when_no_executions(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        _write_lines(p, [_sel()])
+        agg = aggregate_selection_log(p)
+        assert agg["cache"] == {"hit": 0, "miss": 0, "unknown": 0, "hit_rate": 0.0}

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1141,6 +1141,7 @@ class TestSelectionStats:
             selected_tool="gh__a",
             ok=True,
             latency_ms=12.0,
+            cache_hit=True,
         )
         ctx = _ctx_with_selection(tmp_path, log=log)
         result = await stm_selection_stats(ctx=ctx)
@@ -1153,6 +1154,7 @@ class TestSelectionStats:
         assert "Selections by server:" in result
         assert "Execution outcomes:" in result
         assert "ok: 1" in result
+        assert "cache hit/miss: 1 / 0" in result
         assert "Reject reasons (#465 hard filter):" in result
         assert "config_hidden: 1" in result
 


### PR DESCRIPTION
## Why

The #467 execution event reserved a `cache_hit` field but always wrote `null`. This corrects an earlier assumption (stated in #484's description): cache hits are **not** invisible to selection telemetry. `call_tool` logs the selection event **before** and the execution event **after** `_call_tool_guarded`, and cache hits return *through* that guarded call (`_on_cache_hit`), so they already emit a selection+execution pair. The only gap was that the hit/miss boolean lived inside `_call_tool_guarded` and was never threaded up to the execution event.

So this is **plumbing, not a design fork and not a volume change** — the follow-up flagged as "deferred" in #484 turns out to be small.

## What

- `_call_tool_guarded` now returns `(result, cache_hit)` — `True` on either cache-hit return path, `False` on a live `_call_tool_inner` call (no-cache config included). Idiomatic here: internal helpers already return tuples (e.g. the compression fallback path, `manager.py:800/848`).
- `call_tool` unpacks it and stamps the execution event; on a raise (hit/miss unattributable) the field stays `None`.
- `log_execution` / `ProxyManager._log_execution` gain a `cache_hit` kwarg.
- `aggregate_selection_log` tallies hit/miss/unknown + a `hit_rate` over **attributable** executions only (unknowns excluded from the denominator so an error burst can't deflate it). `stm_selection_stats` renders a `cache hit/miss` line.

Rendered (smoke):
```
Execution outcomes:
  ok: 4
  error: 1
  error_rate: 0.2000
  latency_ms p50/p95/p99: 12.0 / 13.8 / 13.96 (n=5)
  cache hit/miss: 3 / 1 (hit_rate 0.7500, unknown 1)
```

## Behavior change

When `selection_telemetry.enabled`, execution records now carry a real `cache_hit` value instead of `null`. **Additive** — the schema key set is unchanged (`cache_hit` was always present), so replay tooling that treated it as nullable is unaffected. Replay can now weight or exclude cache hits (they skip ranking and have cache-shaped latency), which matters for #468 offline eval.

## Test

- `tests/test_selection_log.py`: unit (`log_execution(cache_hit=...)` populates the field, key set unchanged), aggregator (hit/miss/unknown tally + hit_rate excludes unknowns + zeroed when no executions), and **wire-in** through `call_tool` — pre-cached args → `cache_hit=True`, un-cached → `False`, pipeline raise → `None` (per the wire-in-asserts-counters convention).
- `tests/test_server_tools.py`: the populated render test now asserts the `cache hit/miss` line.
- Full suite `-m "not ollama"`: 3397 passed, 3 skipped. `ruff` clean.

Follows #484 (the `stm_selection_stats` surface); this leaves no remaining items from the #471 follow-up list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)