### PR TITLE
test(bench_qa): full-suite 2-run deep-equal determinism gate

### DIFF
--- a/tests/bench/bench_qa/__init__.py
+++ b/tests/bench/bench_qa/__init__.py
@@ -7,6 +7,7 @@ See ``/Users/pdstudio/.claude/plans/mcp-snug-river.md`` for the design
 
 from .judge import qa_answerable_ratio, surfacing_recall_at_k
 from .loader import fixtures_dir, load_fixture
+from .replay import run_scenario_once
 from .report import BenchReportCollector, canonicalize_report
 from .runner import (
     deterministic_trace_id,
@@ -35,5 +36,6 @@ __all__ = [
     "load_fixture",
     "make_proxy_manager",
     "qa_answerable_ratio",
+    "run_scenario_once",
     "surfacing_recall_at_k",
 ]

--- a/tests/bench/bench_qa/replay.py
+++ b/tests/bench/bench_qa/replay.py
@@ -1,0 +1,214 @@
+"""Single-scenario replay driver for bench_qa determinism checks.
+
+Drives any fixture scenario through the same ``ProxyManager`` pipeline the
+gate tests use — minus the gate assertions — and returns a single-scenario
+``BenchReport`` dict ready for :func:`canonicalize_report`. Centralizing
+the per-scenario driving here keeps the full-suite determinism gate thin
+*and* faithful: the driver records the exact fields the live suite records
+(``metrics`` byte counts, ``qa`` ratio, ``progressive`` round-trip,
+``surfacing`` recall), so a non-deterministic compressor / fallback ladder
+/ surfacing path surfaces as a report diff in the gate rather than silently
+drifting in CI's ``report.json``.
+
+Dispatch mirrors the gate tests' split (``test_bench_qa_scenarios.py`` +
+``test_bench_qa_fallback.py``):
+
+* ``surfacing_seeds`` present → live surfacing pipeline (s10)
+* ``force_tier`` set         → forced fallback ladder (s01/s06/s08)
+* otherwise                  → happy path (s02/s03/s04/s05/s07/s09)
+
+The driver intentionally does **not** assert the gates — it only needs the
+recorded report row. The gate assertions stay in the scenario test files;
+this module is the determinism gate's faithful, assertion-free replay.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from .judge import qa_answerable_ratio, surfacing_recall_at_k
+from .loader import load_fixture
+from .progressive import reassemble
+from .report import BenchReportCollector
+from .runner import (
+    deterministic_trace_id,
+    latest_metrics_row,
+    make_proxy_manager,
+    make_surfacing_proxy_manager,
+    make_tool_result,
+)
+from .schema import BenchFixture, SurfacingResult
+
+# Mirror of ``test_bench_qa_scenarios.py::_SURFACING_ID_RE`` — matches the
+# formatter's ``_surfacing_id: <id>_`` line and the rating-spec callable
+# rendered just below it.
+_SURFACING_ID_RE = re.compile(r"surfacing_id[:=]\s*\"?([a-f0-9]{16})")
+
+
+def _stub_raise(*_args, **_kwargs):
+    raise RuntimeError("forced fallback-ladder failure (bench_qa replay)")
+
+
+async def _record_plain(
+    fixture: BenchFixture, tmp_path: Path, collector: BenchReportCollector
+) -> None:
+    """Happy path: AUTO / SELECTIVE / SKELETON resolve a concrete strategy
+    and the content fits the (possibly lowered) retention floor."""
+    scenario_id = fixture["scenario_id"]
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+        min_retention=fixture.get("min_retention", 0.65),
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+    trace_id = deterministic_trace_id(scenario_id)
+    try:
+        result = await mgr.call_tool("fake", f"tool_{scenario_id}", {}, trace_id=trace_id)
+        row = latest_metrics_row(store)
+        answerable, total = qa_answerable_ratio(fixture.get("qa_probes", []), result)
+        collector.record_scenario(
+            scenario_id=scenario_id,
+            trace_id=row["trace_id"],
+            row=row,
+            qa_answerable=answerable,
+            qa_total=total,
+            original_chars=len(fixture["payload"]),
+            verdict="pass",
+        )
+    finally:
+        store.close()
+
+
+async def _record_fallback(
+    fixture: BenchFixture, tmp_path: Path, collector: BenchReportCollector
+) -> None:
+    """Forced fallback ladder: stub ``_apply_compression`` to overshoot the
+    retention floor, then stub the higher tiers off per ``force_tier`` so a
+    specific ladder rung runs. Tier-1 records the progressive round-trip."""
+    scenario_id = fixture["scenario_id"]
+    force_tier = fixture["force_tier"] or 0
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+    mgr._apply_compression = AsyncMock(return_value=("x" * 50, None))
+    if force_tier >= 2:
+        mgr._apply_progressive = _stub_raise  # type: ignore[method-assign]
+    if force_tier >= 3:
+        mgr._apply_hybrid = _stub_raise  # type: ignore[method-assign]
+    trace_id = deterministic_trace_id(scenario_id)
+    try:
+        first_chunk = await mgr.call_tool("fake", f"tool_{scenario_id}", {}, trace_id=trace_id)
+        row = latest_metrics_row(store)
+        progressive = None
+        if force_tier == 1:
+            # Round-trip equality is the gate test's assertion; here we only
+            # need the (deterministic) chunk count + total chars it records.
+            reassembled = reassemble(mgr, first_chunk)
+            progressive = {
+                "round_trip_equal": True,
+                "chunks": reassembled.chunks,
+                "total_chars": len(reassembled.content),
+            }
+        collector.record_scenario(
+            scenario_id=scenario_id,
+            trace_id=row["trace_id"],
+            row=row,
+            qa_answerable=0,
+            qa_total=0,
+            original_chars=len(fixture["payload"]),
+            verdict="pass",
+            progressive=progressive,
+        )
+    finally:
+        store.close()
+
+
+async def _record_surfacing(
+    fixture: BenchFixture, tmp_path: Path, collector: BenchReportCollector
+) -> None:
+    """Live surfacing pipeline: spawn the fake LTM (``--seeds``) so chunk IDs
+    are deterministic, then record recall@k off the formatter-injected
+    surfacing_id (not ``ORDER BY created_at``) so the row is self-contained."""
+    scenario_id = fixture["scenario_id"]
+    seeds = fixture["surfacing_seeds"]
+    seeds_path = tmp_path / f"{scenario_id}_seeds.json"
+    seeds_path.write_text(json.dumps(seeds), encoding="utf-8")
+
+    source_to_chunk_id = {
+        seed["source"]: hashlib.sha256(seed["content"].encode()).hexdigest()[:16] for seed in seeds
+    }
+    expected_chunk_ids = [
+        source_to_chunk_id[src] for src in fixture["surfacing_eval"]["expected_ids"]
+    ]
+    k = fixture["surfacing_eval"]["k"]
+
+    mgr, store, session, adapter, _engine, tracker = make_surfacing_proxy_manager(
+        tmp_path,
+        seeds_path=seeds_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+    trace_id = deterministic_trace_id(scenario_id)
+
+    await adapter.start()
+    try:
+        result = await mgr.call_tool(
+            "fake",
+            f"tool_{scenario_id}",
+            {"_context_query": fixture["surfacing_eval"]["query"]},
+            trace_id=trace_id,
+        )
+        row = latest_metrics_row(store)
+        id_match = _SURFACING_ID_RE.search(result)
+        returned_ids = (
+            tracker.store.get_memory_ids_for_surfacing(id_match.group(1)) if id_match else []
+        )
+        recall = surfacing_recall_at_k(returned_ids, expected_chunk_ids, k)
+        answerable, total = qa_answerable_ratio(fixture.get("qa_probes", []), result)
+        collector.record_scenario(
+            scenario_id=scenario_id,
+            trace_id=row["trace_id"],
+            row=row,
+            qa_answerable=answerable,
+            qa_total=total,
+            original_chars=len(fixture["payload"]),
+            verdict="pass",
+            surfacing=SurfacingResult(
+                recall_at_k=recall,
+                returned_ids=returned_ids[:k],
+                expected_ids=expected_chunk_ids,
+            ),
+        )
+    finally:
+        await adapter.stop()
+        tracker.close()
+        store.close()
+
+
+async def run_scenario_once(scenario_id: str, tmp_path: Path, *, run_seed: int = 0) -> dict:
+    """Drive *scenario_id* through the full bench pipeline once and return a
+    single-scenario ``BenchReport`` dict.
+
+    Dispatches on fixture shape so a new scenario is covered by the
+    determinism gate automatically once it declares the standard fields
+    (``force_tier`` / ``surfacing_seeds``). Two calls with the same
+    ``scenario_id`` (fresh ``tmp_path`` each) must canonicalize-equal.
+    """
+    fixture = load_fixture(scenario_id)
+    collector = BenchReportCollector()
+    if fixture.get("surfacing_seeds"):
+        await _record_surfacing(fixture, tmp_path, collector)
+    elif fixture.get("force_tier"):
+        await _record_fallback(fixture, tmp_path, collector)
+    else:
+        await _record_plain(fixture, tmp_path, collector)
+    return dict(collector.build_report(run_seed=run_seed))

--- a/tests/bench/test_bench_qa_determinism.py
+++ b/tests/bench/test_bench_qa_determinism.py
@@ -6,12 +6,23 @@ timings. This is the load-bearing assumption that makes ``report.json``
 diffs meaningful as a regression signal: without it, every PR's bench
 artifact differs for reasons unrelated to the code under test.
 
-Scope: one scenario (s09, the smallest budget-fit fixture) exercised
-twice in fresh ``tmp_path`` dirs — enough to prove the property per
-scenario without pulling every bench_qa case into a single test. If a
-future change desynchronises a specific compressor, the scenario-local
-determinism check for that scenario can be added alongside the regular
-gate assertions.
+Scope: the full recorded suite. Every fixture that the live bench_qa run
+records as a ``ScenarioReport`` row is replayed twice in fresh
+``tmp_path`` dirs via :func:`bench.bench_qa.run_scenario_once`, which
+drives the same pipeline the gate tests use (happy path / fallback ladder
+/ surfacing) and records the same fields — so a desynchronised compressor,
+fallback ladder, or surfacing path shows up here as a report diff. The
+``s09``-only predecessor only proved the property for one AUTO scenario;
+this gate covers the compaction strategies (AUTO/SELECTIVE/SKELETON), the
+three fallback tiers, and the surfacing recall path.
+
+Cross-process note: the recorded fields are all hash-seed-independent
+(byte counts, categorical strategy, ``sha256`` chunk IDs, recall floats,
+``sha256``-derived trace_id), verified by replaying every scenario under
+several ``PYTHONHASHSEED`` values. The two runs below therefore share a
+process safely — drift would only appear cross-process if a recorded
+field became hash-ordering-dependent, which the roster tripwire and a
+varied-seed manual run would catch.
 """
 
 from __future__ import annotations
@@ -19,55 +30,47 @@ from __future__ import annotations
 import pytest
 
 from bench.bench_qa import (
-    BenchReportCollector,
     canonicalize_report,
     deterministic_trace_id,
-    latest_metrics_row,
-    load_fixture,
-    make_proxy_manager,
+    fixtures_dir,
+    run_scenario_once,
 )
-from bench.bench_qa.runner import make_tool_result
 
+# Every fixture that records a ``ScenarioReport`` row into ``report.json``.
+# Explicit (not globbed) so adding a fixture forces a conscious include /
+# exclude decision via ``test_determinism_roster_covers_every_fixture``.
+DETERMINISM_SCENARIOS = [
+    "s01",  # Tier-2 hybrid_fallback
+    "s02",  # AUTO → extract_fields
+    "s03",  # AUTO → truncate
+    "s04",  # AUTO → truncate
+    "s05",  # SKELETON (chat transcript)
+    "s06",  # Tier-1 progressive_fallback (round-trip)
+    "s07",  # SELECTIVE TOC
+    "s08",  # Tier-3 truncate_fallback
+    "s09",  # AUTO → none (fits budget)
+    "s10",  # surfacing recall@k
+]
 
-async def _run_s09_once(tmp_path) -> dict:
-    """Drive s09 through the full bench pipeline once, return the
-    single-scenario ``BenchReport`` dict."""
-    fixture = load_fixture("s09")
-    mgr, store, session = make_proxy_manager(
-        tmp_path,
-        compression=fixture["expected_compressor"],
-        max_result_chars=fixture["max_result_chars"],
-    )
-    session.call_tool.return_value = make_tool_result(fixture["payload"])
-    trace_id = deterministic_trace_id("s09")
-
-    try:
-        await mgr.call_tool("fake", "tool_s09", {}, trace_id=trace_id)
-        row = latest_metrics_row(store)
-    finally:
-        store.close()
-
-    collector = BenchReportCollector()
-    collector.record_scenario(
-        scenario_id="s09",
-        trace_id=row["trace_id"],
-        row=row,
-        qa_answerable=0,
-        qa_total=0,
-        original_chars=len(fixture["payload"]),
-        verdict="pass",
-    )
-    return dict(collector.build_report(run_seed=0))
+# Fixtures intentionally outside the determinism gate, each with its reason.
+_EXCLUDED_FIXTURES = {
+    "s11": (
+        "F2 min_score sweep — a bench_qa_sweep measurement run emitting a "
+        "curve sidecar, not a ScenarioReport row "
+        "(test_bench_qa_scenarios.test_s11_min_score_sweep)."
+    ),
+}
 
 
 @pytest.mark.bench_qa
 @pytest.mark.asyncio
-async def test_two_runs_same_seed_produce_canonically_equal_reports(tmp_path_factory):
-    tmp_a = tmp_path_factory.mktemp("bench_det_a")
-    tmp_b = tmp_path_factory.mktemp("bench_det_b")
+@pytest.mark.parametrize("scenario_id", DETERMINISM_SCENARIOS)
+async def test_two_runs_same_seed_produce_canonically_equal_reports(scenario_id, tmp_path_factory):
+    tmp_a = tmp_path_factory.mktemp(f"bench_det_{scenario_id}_a")
+    tmp_b = tmp_path_factory.mktemp(f"bench_det_{scenario_id}_b")
 
-    report_a = await _run_s09_once(tmp_a)
-    report_b = await _run_s09_once(tmp_b)
+    report_a = await run_scenario_once(scenario_id, tmp_a)
+    report_b = await run_scenario_once(scenario_id, tmp_b)
 
     canon_a = canonicalize_report(report_a)
     canon_b = canonicalize_report(report_b)
@@ -75,13 +78,33 @@ async def test_two_runs_same_seed_produce_canonically_equal_reports(tmp_path_fac
     # trace_id must survive canonicalization — it's deterministic and
     # differences there indicate an injection bug, not wall-clock noise.
     scenario_a = canon_a["scenarios"][0]
-    assert scenario_a["trace_id"] == deterministic_trace_id("s09")
+    assert scenario_a["trace_id"] == deterministic_trace_id(scenario_id), (
+        f"{scenario_id}: trace_id is not the deterministic value — injection bug"
+    )
 
     assert canon_a == canon_b, (
-        "bench_qa determinism broken — two runs of s09 at run_seed=0 "
-        "diverged after canonicalization. Inspect: "
-        f"A={canon_a!r} B={canon_b!r}"
+        f"bench_qa determinism broken — two runs of {scenario_id} at run_seed=0 "
+        f"diverged after canonicalization. Inspect:\nA={canon_a!r}\nB={canon_b!r}"
     )
+
+
+@pytest.mark.bench_qa
+def test_determinism_roster_covers_every_fixture():
+    """Tripwire against silent under-coverage: every ``s*.json`` fixture must
+    be either in :data:`DETERMINISM_SCENARIOS` or :data:`_EXCLUDED_FIXTURES`
+    (with a documented reason). A new fixture trips this until it's classified.
+    """
+    on_disk = {p.stem for p in fixtures_dir().glob("s*.json")}
+    covered = set(DETERMINISM_SCENARIOS) | set(_EXCLUDED_FIXTURES)
+
+    unclassified = on_disk - covered
+    assert not unclassified, (
+        f"new fixture(s) {sorted(unclassified)} are neither in DETERMINISM_SCENARIOS "
+        f"nor _EXCLUDED_FIXTURES — add each to the determinism gate or document why "
+        f"it is excluded."
+    )
+    stale = set(DETERMINISM_SCENARIOS) - on_disk
+    assert not stale, f"DETERMINISM_SCENARIOS references missing fixture(s): {sorted(stale)}"
 
 
 @pytest.mark.bench_qa


### PR DESCRIPTION
## What

Extend the bench_qa determinism gate from **s09-only** to the **full recorded suite (s01–s10)**.

The gate proves `report.json` is byte-stable across two runs at the same `run_seed` (after stripping wall-clock timings) — the load-bearing assumption that makes the artifact diffable as a regression signal. Until now it only proved this for s09, a single AUTO scenario. A desynchronised SELECTIVE/SKELETON compressor, fallback ladder, or surfacing path could have drifted `report.json` silently while the gate stayed green.

## How

- **New `bench_qa.run_scenario_once`** (`tests/bench/bench_qa/replay.py`) — a fixture-driven replay driver that dispatches on fixture shape:
  - `surfacing_seeds` present → live surfacing pipeline (s10)
  - `force_tier` set → forced fallback ladder (s01/s06/s08)
  - otherwise → happy path (s02/s03/s04/s05/s07/s09)

  It mirrors the gate tests' driving **minus their assertions** and records the same `ScenarioReport` fields, so the determinism test stays thin and doesn't drift from `test_bench_qa_scenarios.py` / `test_bench_qa_fallback.py`.

- **Parametrized gate** over `s01–s10` — every fixture that records a `ScenarioReport` row.

- **Roster tripwire** (`test_determinism_roster_covers_every_fixture`) — every `s*.json` fixture must be in `DETERMINISM_SCENARIOS` or documented in `_EXCLUDED_FIXTURES`. A new fixture trips this until it's classified, so coverage can't silently shrink. `s11` (min_score sweep, a `bench_qa_sweep` measurement run, not a `ScenarioReport` row) is excluded with a reason.

## Verification

- Drove every scenario twice in fresh `tmp_path` dirs → all canonicalize-equal.
- Cross-process check under `PYTHONHASHSEED=0/1/12345`: every scenario row is byte-identical across hash seeds. The recorded fields (byte counts, categorical strategy, `sha256` chunk IDs, recall floats, `sha256`-derived `trace_id`) are hash-seed-independent — so the in-process two-run check is faithful to CI's cross-run `report.json` diff.
- `uv run pytest -m bench_qa` → **24 passed** (determinism file: 12 = 10 scenarios + tripwire + canonicalize guard).
- `uv run ruff check` / `ruff format --check` → clean. (`mypy` only checks `src`; no `tests/` impact.)

Kept as a focused standalone PR per the post-gate roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)