### PR TITLE
test(bench_qa): cross-version drift gate (advisory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           version: "latest"
       - run: uv sync --frozen
-      - run: uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep" --tb=short -q
+      - run: uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift" --tb=short -q
 
   notebooks:
     runs-on: ubuntu-latest
@@ -150,3 +150,34 @@ jobs:
             gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@body.md >/dev/null
             echo "created sticky bench_qa comment"
           fi
+
+  bench_qa_drift:
+    # ADVISORY cross-version drift gate (post-gate roadmap item 8). Pins the
+    # whole canonical report.json to tests/bench/fixtures/drift_baseline.json so
+    # a metric sliding the wrong way across PRs — even while still above its
+    # per-scenario floor — must pass through a reviewed baseline diff. The
+    # per-PR `bench_qa` gate only enforces absolute floors and cannot see a slow
+    # slide between them. Self-contained: the test rebuilds the report in-process
+    # from fixtures (no dependency on the bench-qa-report artifact). continue-on-
+    # error keeps it non-blocking; promote to required (flip to false + add to
+    # branch-protection) after an observation window, mirroring #482.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - run: uv sync --frozen
+      - name: Run bench_qa drift gate
+        env:
+          BENCH_QA_REPORT_DIR: ${{ github.workspace }}/bench-qa-drift-report
+        run: uv run pytest -m "bench_qa_drift" --tb=short -q
+      - name: Upload drift report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-qa-drift-report
+          path: bench-qa-drift-report/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,32 @@ short version follows. When adding a new scenario:
    must stay green. If you changed anything the LLM judge touches,
    also run `OPENAI_API_KEY=… uv run pytest -m bench_qa_llm_judge`
    and sanity-check the correlation log.
+6. Add the scenario id to `SUITE_SCENARIOS` in
+   `tests/bench/bench_qa/replay.py` (the shared roster behind both the
+   determinism and drift gates), then regenerate the drift baseline (see
+   below) — adding a scenario changes the merged `report.json`.
+
+## The cross-version drift gate
+
+`bench_qa_drift` (advisory) pins the whole canonical `report.json` to the
+committed `tests/bench/fixtures/drift_baseline.json`. The per-PR `bench_qa`
+gate only enforces *absolute* per-scenario floors; the drift gate catches a
+metric sliding the wrong way across PRs while still above its floor, by
+forcing every report change through a reviewed baseline diff.
+
+When `uv run pytest -m bench_qa_drift` (or the advisory CI job) reds and the
+change is **intended** — a compressor/surfacing change, a new scenario, a
+re-baselined floor — regenerate and commit the baseline in the same PR:
+
+```bash
+uv run python tests/bench/bench_qa/regen_drift_baseline.py
+```
+
+The script prints a directional REGRESSION / IMPROVEMENT / NEUTRAL summary of
+what moved; read it, confirm the direction is intended, then commit
+`drift_baseline.json` with a `## Baseline change` callout in the PR body
+explaining each moved field. Never hand-edit the baseline — byte-stability is
+the gate's contract and the regen script is its only writer.
 
 ## Contributor License Agreement (CLA)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ cd memtomem-stm
 uv sync
 
 # Run tests (same filter CI uses)
-uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep"
+uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift"
 
 # Lint and format
 uv run ruff check src
@@ -43,7 +43,7 @@ The LTM core lives in a separate repository: [memtomem/memtomem](https://github.
 2. Keep changes focused — one feature or fix per PR
 3. Add tests for new functionality
 4. Ensure `uv run ruff check src` and `uv run ruff format --check src` pass
-5. Ensure `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep"` passes
+5. Ensure `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift"` passes
 6. `uv run mypy src` is advisory but aim to not introduce new errors
 7. Write a clear commit message describing the "why"
 8. Sign the CLA on your first pull request (see below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ markers = [
     "bench_qa_meta: self-test probes for bench_qa — intentional failures, NOT CI-safe",
     "bench_qa_llm_judge: LLM-as-judge advisory scoring — requires OPENAI_API_KEY or ANTHROPIC_API_KEY, off in default CI",
     "bench_qa_sweep: measurement runs that emit curve artifacts; off in default and advisory CI, invoked manually",
+    "bench_qa_drift: cross-version snapshot drift gate vs committed drift_baseline.json; advisory until promoted (regen with tests/bench/bench_qa/regen_drift_baseline.py)",
 ]
 
 [tool.mypy]

--- a/tests/bench/bench_qa/__init__.py
+++ b/tests/bench/bench_qa/__init__.py
@@ -5,9 +5,10 @@ See ``/Users/pdstudio/.claude/plans/mcp-snug-river.md`` for the design
 (Context → Goals → Harness → Metrics → Integration).
 """
 
+from .drift import classify_drift, format_drift_md
 from .judge import qa_answerable_ratio, surfacing_recall_at_k
 from .loader import fixtures_dir, load_fixture
-from .replay import run_scenario_once
+from .replay import SUITE_SCENARIOS, run_full_suite, run_scenario_once
 from .report import BenchReportCollector, canonicalize_report
 from .runner import (
     deterministic_trace_id,
@@ -23,6 +24,7 @@ from .schema import (
 )
 
 __all__ = [
+    "SUITE_SCENARIOS",
     "BenchFixture",
     "BenchReport",
     "BenchReportCollector",
@@ -30,12 +32,15 @@ __all__ = [
     "ScenarioReport",
     "SurfacingEval",
     "canonicalize_report",
+    "classify_drift",
     "deterministic_trace_id",
     "fixtures_dir",
+    "format_drift_md",
     "latest_metrics_row",
     "load_fixture",
     "make_proxy_manager",
     "qa_answerable_ratio",
+    "run_full_suite",
     "run_scenario_once",
     "surfacing_recall_at_k",
 ]

--- a/tests/bench/bench_qa/drift.py
+++ b/tests/bench/bench_qa/drift.py
@@ -84,11 +84,17 @@ SCENARIO_EXCLUDED: dict[str, str] = {
 
 # Top-level BenchReport totals direction.
 TOTALS_DIRECTION: dict[str, str] = {
-    "totals.scenarios": NEUTRAL,  # roster size; a drop is caught by the roster lockstep test
+    "totals.scenarios": NEUTRAL,  # roster size; a one-sided drop trips the roster lockstep test
     "totals.passing": DOWN_BAD,
     "totals.failing": UP_BAD,
     "totals.tokens_saved_approx": DOWN_BAD,  # coarse //4 suite-sum; advisory trend
 }
+
+# Nested metric dicts inside a ScenarioReport (vs scalar scenario-level fields).
+_SCENARIO_SECTIONS = ("metrics", "rule_judge", "qa", "progressive", "surfacing")
+# Top-level BenchReport keys diffed structurally elsewhere in classify_drift;
+# every other top-level key (schema_version, run_seed, …) is walked as a scalar.
+_REPORT_AGGREGATES = ("scenarios", "totals", "tier_histogram")
 
 
 @dataclass(frozen=True)
@@ -168,22 +174,30 @@ def _diff_section(
 
 
 def _diff_scenario(sid: str, old: dict[str, Any], new: dict[str, Any]) -> list[FieldDrift]:
+    """Diff one scenario, walking EVERY key so a new field can never be silently
+    dropped from the summary — unknown scalars surface as NEUTRAL "unclassified
+    field", mirroring :func:`_diff_section`. The coverage test still forces a
+    deliberate direction for known fields; this generic walk is the runtime net
+    that keeps the classifier complete vs the gate's whole-dict deep-equal."""
     drifts: list[FieldDrift] = []
-    nested = ("metrics", "rule_judge", "qa", "progressive", "surfacing")
-    scalars = ("trace_id", "tier", "verdict")
-    for section in nested:
-        ov, nv = old.get(section, {}) or {}, new.get(section, {}) or {}
-        for d in _diff_section(section, ov, nv, SCENARIO_DIRECTION):
-            if d.scope in SCENARIO_EXCLUDED:
-                continue
-            drifts.append(FieldDrift(f"{sid}.{d.scope}", d.old, d.new, d.label, d.note))
-    for field in scalars:
-        ov, nv = old.get(field), new.get(field)
+    for key in sorted(set(old) | set(new)):
+        if key == "scenario_id":  # the row key, not a metric
+            continue
+        ov, nv = old.get(key), new.get(key)
         if ov == nv:
             continue
-        policy = SCENARIO_DIRECTION.get(field, NEUTRAL)
-        label, note = _direction_label(policy, ov, nv)
-        drifts.append(FieldDrift(f"{sid}.{field}", ov, nv, label, note))
+        if key in _SCENARIO_SECTIONS:
+            for d in _diff_section(key, ov or {}, nv or {}, SCENARIO_DIRECTION):
+                if d.scope in SCENARIO_EXCLUDED:
+                    continue
+                drifts.append(FieldDrift(f"{sid}.{d.scope}", d.old, d.new, d.label, d.note))
+        else:
+            policy = SCENARIO_DIRECTION.get(key)
+            if policy is None:
+                drifts.append(FieldDrift(f"{sid}.{key}", ov, nv, "NEUTRAL", "unclassified field"))
+            else:
+                label, note = _direction_label(policy, ov, nv)
+                drifts.append(FieldDrift(f"{sid}.{key}", ov, nv, label, note))
     return drifts
 
 
@@ -220,6 +234,17 @@ def classify_drift(old_report: dict[str, Any], new_report: dict[str, Any]) -> li
                 "strategy routing distribution changed",
             )
         )
+
+    # Top-level report scalars (schema_version, run_seed, any future key). The
+    # gate compares the whole dict, so the classifier must walk every top-level
+    # key too — otherwise a scalar-only diff fails the gate while the summary
+    # reads "No drift". Aggregates above are already covered.
+    for key in sorted(set(old_report) | set(new_report)):
+        if key in _REPORT_AGGREGATES:
+            continue
+        ov, nv = old_report.get(key), new_report.get(key)
+        if ov != nv:
+            drifts.append(FieldDrift(key, ov, nv, "NEUTRAL", "top-level report field changed"))
     return drifts
 
 

--- a/tests/bench/bench_qa/drift.py
+++ b/tests/bench/bench_qa/drift.py
@@ -1,0 +1,242 @@
+"""Directional classifier for the bench_qa cross-version drift gate.
+
+The drift gate's pass/fail is a whole-report deep-equal against a committed
+baseline (``test_bench_qa_drift.py``) — this module never decides pass/fail.
+Its only job is to make a failing diff *readable*: given the old (baseline)
+and new (live) canonical reports, it walks every changed field and tags it
+``REGRESSION`` / ``IMPROVEMENT`` / ``NEUTRAL`` from a hard-coded direction
+table, so the failure message and PR surface say "s03 compression_ratio up
+[REGRESSION]" in English instead of a bare ``dict != dict``.
+
+Pure functions, no I/O. The direction table is the single place that encodes
+"which way is bad" for each report field; the coverage test in
+``test_bench_qa_drift.py`` asserts every schema field is either classified
+here or explicitly excluded — a new ScenarioReport field can't silently
+become an unclassified drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+Label = Literal["REGRESSION", "IMPROVEMENT", "NEUTRAL"]
+
+# Direction policies (see per-field table below):
+#   UP_BAD          increase = REGRESSION, decrease = IMPROVEMENT
+#   DOWN_BAD        decrease = REGRESSION, increase = IMPROVEMENT
+#   BOOL_TRUE_GOOD  True->False = REGRESSION, False->True = IMPROVEMENT
+#   VERDICT         pass<->fail ordered; anything involving "advisory" = NEUTRAL
+#   ERROR_PRESENCE  None->str = REGRESSION, str->None = IMPROVEMENT, str->str' = NEUTRAL
+#   IDENTITY        any change = REGRESSION (deterministic id; a change is a bug)
+#   NEUTRAL         any change = NEUTRAL (routing / structural / read-via-another-field)
+UP_BAD = "UP_BAD"
+DOWN_BAD = "DOWN_BAD"
+BOOL_TRUE_GOOD = "BOOL_TRUE_GOOD"
+VERDICT = "VERDICT"
+ERROR_PRESENCE = "ERROR_PRESENCE"
+IDENTITY = "IDENTITY"
+NEUTRAL = "NEUTRAL"
+
+# Keyed by ScenarioReport-relative path: "<section>.<field>" for the nested
+# metric dicts, bare names for scenario-level scalars. Rationale per field is
+# grounded in report.py / schema.py (compression_ratio = compressed/cleaned;
+# lower = more savings; qa/recall higher = better; ratio_violation 0 good).
+SCENARIO_DIRECTION: dict[str, str] = {
+    # identity
+    "trace_id": IDENTITY,  # bench-<sha256(...)>; deterministic, a change = injection bug
+    # metrics
+    "metrics.original_chars": NEUTRAL,  # input size; fixed payload — change = fixture/cleaning, read via ratio
+    "metrics.cleaned_chars": NEUTRAL,  # post-clean size; read via ratio
+    "metrics.compressed_chars": UP_BAD,  # more bytes kept = less savings
+    "metrics.compression_ratio": UP_BAD,  # compressed/cleaned; up = weaker compression
+    "metrics.compression_strategy": NEUTRAL,  # routing label; change = different strategy chosen
+    "metrics.ratio_violation": UP_BAD,  # 0 good, 1 = fell to fallback ladder
+    "metrics.surfacing_on_progressive_ok": DOWN_BAD,  # 1 = surfacing survived progressive path
+    "metrics.surface_error": ERROR_PRESENCE,  # None good; appearance = a new surfacing failure
+    # rule_judge.score is EXCLUDED below (always-0.0 sentinel under replay drivers)
+    "rule_judge.missing_keywords": NEUTRAL,  # list; informational
+    # qa
+    "qa.answerable": DOWN_BAD,  # probes still answerable post-compression
+    "qa.total": NEUTRAL,  # fixture-fixed probe count; a change is structural
+    "qa.ratio": DOWN_BAD,  # answerable/total; primary info-loss guard
+    # progressive
+    "progressive.round_trip_equal": BOOL_TRUE_GOOD,  # reassembled == cleaned (driver pins True)
+    "progressive.chunks": NEUTRAL,  # chunk count; structural
+    "progressive.total_chars": NEUTRAL,  # reassembled length; structural
+    # surfacing
+    "surfacing.recall_at_k": DOWN_BAD,  # right memories surfaced in top-k
+    "surfacing.returned_ids": NEUTRAL,  # ordered ids; read via recall
+    "surfacing.expected_ids": NEUTRAL,  # ground-truth ids; read via recall
+    # scenario-level scalars
+    "tier": NEUTRAL,  # == compression_strategy or "unknown"; routing
+    "verdict": VERDICT,  # pass<->fail ordered
+}
+
+# Fields present in the report but deliberately not direction-classified.
+SCENARIO_EXCLUDED: dict[str, str] = {
+    "rule_judge.score": (
+        "always 0.0 under the replay drivers (not-scored sentinel) — a drop-to-0.0 "
+        "would be a guaranteed false REGRESSION; revisit if the drivers ever score it"
+    ),
+    "scenario_id": "the row key, not a metric",
+}
+
+# Top-level BenchReport totals direction.
+TOTALS_DIRECTION: dict[str, str] = {
+    "totals.scenarios": NEUTRAL,  # roster size; a drop is caught by the roster lockstep test
+    "totals.passing": DOWN_BAD,
+    "totals.failing": UP_BAD,
+    "totals.tokens_saved_approx": DOWN_BAD,  # coarse //4 suite-sum; advisory trend
+}
+
+
+@dataclass(frozen=True)
+class FieldDrift:
+    """One changed field between baseline and live, with a direction label."""
+
+    scope: str
+    old: Any
+    new: Any
+    label: Label
+    note: str = ""
+
+    def render(self) -> str:
+        arrow = f"{self.old!r} → {self.new!r}"
+        suffix = f" — {self.note}" if self.note else ""
+        return f"`{self.scope}`: {arrow}{suffix}"
+
+
+def _direction_label(policy: str, old: Any, new: Any) -> tuple[Label, str]:
+    """Map a (policy, old, new) change to a (label, note)."""
+    if policy == NEUTRAL:
+        return "NEUTRAL", ""
+    if policy == IDENTITY:
+        return "REGRESSION", "deterministic id changed — likely an injection bug"
+    if policy == BOOL_TRUE_GOOD:
+        if old and not new:
+            return "REGRESSION", "True→False"
+        if new and not old:
+            return "IMPROVEMENT", "False→True"
+        return "NEUTRAL", ""
+    if policy == VERDICT:
+        if old == "pass" and new == "fail":
+            return "REGRESSION", "pass→fail"
+        if old == "fail" and new == "pass":
+            return "IMPROVEMENT", "fail→pass"
+        return "NEUTRAL", "involves advisory"
+    if policy == ERROR_PRESENCE:
+        if old is None and new is not None:
+            return "REGRESSION", "new surface_error appeared"
+        if old is not None and new is None:
+            return "IMPROVEMENT", "surface_error cleared"
+        return "NEUTRAL", "error text changed (presence unchanged)"
+    # numeric directions
+    if policy in (UP_BAD, DOWN_BAD):
+        try:
+            delta = float(new) - float(old)
+        except (TypeError, ValueError):
+            return "NEUTRAL", "non-numeric change"
+        if delta == 0:
+            return "NEUTRAL", ""
+        worse_on_increase = policy == UP_BAD
+        increased = delta > 0
+        if increased == worse_on_increase:
+            return "REGRESSION", f"{'up' if increased else 'down'}"
+        return "IMPROVEMENT", f"{'up' if increased else 'down'}"
+    return "NEUTRAL", "unclassified field"
+
+
+def _diff_section(
+    prefix: str, old: dict[str, Any], new: dict[str, Any], table: dict[str, str]
+) -> list[FieldDrift]:
+    drifts: list[FieldDrift] = []
+    for key in sorted(set(old) | set(new)):
+        ov, nv = old.get(key), new.get(key)
+        if ov == nv:
+            continue
+        path = f"{prefix}.{key}" if prefix else key
+        policy = table.get(path)
+        if policy is None:
+            # Unknown changed field — surfaced as NEUTRAL so it is never lost,
+            # but the coverage test prevents this from happening in practice.
+            drifts.append(FieldDrift(path, ov, nv, "NEUTRAL", "unclassified field"))
+            continue
+        label, note = _direction_label(policy, ov, nv)
+        drifts.append(FieldDrift(path, ov, nv, label, note))
+    return drifts
+
+
+def _diff_scenario(sid: str, old: dict[str, Any], new: dict[str, Any]) -> list[FieldDrift]:
+    drifts: list[FieldDrift] = []
+    nested = ("metrics", "rule_judge", "qa", "progressive", "surfacing")
+    scalars = ("trace_id", "tier", "verdict")
+    for section in nested:
+        ov, nv = old.get(section, {}) or {}, new.get(section, {}) or {}
+        for d in _diff_section(section, ov, nv, SCENARIO_DIRECTION):
+            if d.scope in SCENARIO_EXCLUDED:
+                continue
+            drifts.append(FieldDrift(f"{sid}.{d.scope}", d.old, d.new, d.label, d.note))
+    for field in scalars:
+        ov, nv = old.get(field), new.get(field)
+        if ov == nv:
+            continue
+        policy = SCENARIO_DIRECTION.get(field, NEUTRAL)
+        label, note = _direction_label(policy, ov, nv)
+        drifts.append(FieldDrift(f"{sid}.{field}", ov, nv, label, note))
+    return drifts
+
+
+def classify_drift(old_report: dict[str, Any], new_report: dict[str, Any]) -> list[FieldDrift]:
+    """Walk two canonical reports and return every changed field, direction-tagged.
+
+    *old_report* is the committed baseline, *new_report* the freshly replayed
+    live report. Both must already be ``canonicalize_report``-ed (timings and
+    the llm_judge block stripped). Returns an empty list when they are equal.
+    """
+    drifts: list[FieldDrift] = []
+    old_s = {s["scenario_id"]: s for s in old_report.get("scenarios", [])}
+    new_s = {s["scenario_id"]: s for s in new_report.get("scenarios", [])}
+
+    for sid in sorted(set(old_s) - set(new_s)):
+        drifts.append(FieldDrift(sid, "present", "removed", "REGRESSION", "scenario dropped"))
+    for sid in sorted(set(new_s) - set(old_s)):
+        drifts.append(FieldDrift(sid, "absent", "added", "NEUTRAL", "new scenario"))
+    for sid in sorted(set(old_s) & set(new_s)):
+        drifts.extend(_diff_scenario(sid, old_s[sid], new_s[sid]))
+
+    drifts.extend(
+        _diff_section(
+            "totals", old_report.get("totals", {}), new_report.get("totals", {}), TOTALS_DIRECTION
+        )
+    )
+    if old_report.get("tier_histogram") != new_report.get("tier_histogram"):
+        drifts.append(
+            FieldDrift(
+                "tier_histogram",
+                old_report.get("tier_histogram"),
+                new_report.get("tier_histogram"),
+                "NEUTRAL",
+                "strategy routing distribution changed",
+            )
+        )
+    return drifts
+
+
+def format_drift_md(drifts: list[FieldDrift]) -> str:
+    """Render a direction-grouped markdown summary of a drift list."""
+    if not drifts:
+        return "No drift — live report matches the committed baseline."
+    order: list[Label] = ["REGRESSION", "NEUTRAL", "IMPROVEMENT"]
+    by_label: dict[Label, list[FieldDrift]] = {lbl: [] for lbl in order}
+    for d in drifts:
+        by_label[d.label].append(d)
+    lines = ["### bench_qa drift vs committed baseline", ""]
+    for lbl in order:
+        items = by_label[lbl]
+        if not items:
+            continue
+        lines.append(f"**{lbl} ({len(items)})**")
+        lines.extend(f"- {d.render()}" for d in items)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/bench/bench_qa/regen_drift_baseline.py
+++ b/tests/bench/bench_qa/regen_drift_baseline.py
@@ -1,0 +1,77 @@
+"""Regenerate the committed bench_qa cross-version drift baseline.
+
+Run from the repo root:
+
+    uv run python tests/bench/bench_qa/regen_drift_baseline.py
+
+Replays the full scenario roster in-process (the exact code path the drift
+gate uses), canonicalizes the merged report, prints a directional drift
+summary against the existing baseline — so you SEE which fields moved which
+way before committing — and writes ``tests/bench/fixtures/drift_baseline.json``.
+
+When a PR legitimately changes ``report.json`` the ``bench_qa_drift`` advisory
+gate goes red; run this, read the printed REGRESSION / IMPROVEMENT / NEUTRAL
+table, confirm the change is intended, and commit the regenerated baseline IN
+THE SAME PR with a "## Baseline change" callout. Never hand-edit the baseline —
+byte-stability is the gate's contract and this script is its only writer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+# Self-bootstrap: this module lives at tests/bench/bench_qa/regen_drift_baseline.py.
+# Put tests/ on sys.path so ``import bench...`` resolves when the file is run as a
+# script by path, mirroring how pytest makes the bench package importable (a raw
+# ``python`` invocation does not add tests/ the way pytest's rootdir insertion does).
+_TESTS_DIR = Path(__file__).resolve().parents[2]
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
+from bench.bench_qa import (  # noqa: E402  (import follows the sys.path bootstrap above)
+    canonicalize_report,
+    classify_drift,
+    fixtures_dir,
+    format_drift_md,
+    run_full_suite,
+)
+
+BASELINE_PATH = fixtures_dir() / "drift_baseline.json"
+
+
+def serialize_baseline(report: dict) -> str:
+    """Exact on-disk form of the baseline.
+
+    Mirrors ``report.py``'s ``json.dumps(report, indent=2, sort_keys=True)``
+    (ensure_ascii default, no trailing newline) so the written file is
+    byte-identical to what a re-run produces — that is what makes
+    ``test_regen_baseline_is_idempotent`` meaningful.
+    """
+    return json.dumps(report, indent=2, sort_keys=True)
+
+
+async def build_canonical_report() -> dict:
+    """Replay the full roster under a throwaway temp dir, return canonical form."""
+    with tempfile.TemporaryDirectory(prefix="bench_qa_drift_regen_") as td:
+        report = await run_full_suite(Path(td))
+    return canonicalize_report(report)
+
+
+def main() -> int:
+    new_report = asyncio.run(build_canonical_report())
+    if BASELINE_PATH.exists():
+        old_report = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+        print(format_drift_md(classify_drift(old_report, new_report)))
+    else:
+        print("No existing baseline — writing a fresh one.")
+    BASELINE_PATH.write_text(serialize_baseline(new_report), encoding="utf-8")
+    print(f"\nWrote {BASELINE_PATH} ({len(new_report['scenarios'])} scenarios).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bench/bench_qa/replay.py
+++ b/tests/bench/bench_qa/replay.py
@@ -43,6 +43,26 @@ from .runner import (
 )
 from .schema import BenchFixture, SurfacingResult
 
+# Canonical roster: every fixture that records a ``ScenarioReport`` row into
+# ``report.json``. This is the single source of truth shared by the determinism
+# gate (``test_bench_qa_determinism.py``) and the cross-version drift gate
+# (``test_bench_qa_drift.py`` + ``run_full_suite`` below) — both operate on
+# exactly this set, so duplicating the list in two test files would risk drift.
+# Sweep fixtures (s11) emit only a sidecar, not a ScenarioReport row, and are
+# excluded (see ``test_bench_qa_determinism._EXCLUDED_FIXTURES``).
+SUITE_SCENARIOS = [
+    "s01",  # Tier-2 hybrid_fallback
+    "s02",  # AUTO → extract_fields
+    "s03",  # AUTO → truncate
+    "s04",  # AUTO → truncate
+    "s05",  # SKELETON (chat transcript)
+    "s06",  # Tier-1 progressive_fallback (round-trip)
+    "s07",  # SELECTIVE TOC
+    "s08",  # Tier-3 truncate_fallback
+    "s09",  # AUTO → none (fits budget)
+    "s10",  # surfacing recall@k
+]
+
 # Mirror of ``test_bench_qa_scenarios.py::_SURFACING_ID_RE`` — matches the
 # formatter's ``_surfacing_id: <id>_`` line and the rating-spec callable
 # rendered just below it.
@@ -194,21 +214,56 @@ async def _record_surfacing(
         store.close()
 
 
-async def run_scenario_once(scenario_id: str, tmp_path: Path, *, run_seed: int = 0) -> dict:
-    """Drive *scenario_id* through the full bench pipeline once and return a
-    single-scenario ``BenchReport`` dict.
+async def _dispatch(fixture: BenchFixture, tmp_path: Path, collector: BenchReportCollector) -> None:
+    """Record one scenario into *collector*, dispatching on fixture shape.
 
-    Dispatches on fixture shape so a new scenario is covered by the
-    determinism gate automatically once it declares the standard fields
-    (``force_tier`` / ``surfacing_seeds``). Two calls with the same
-    ``scenario_id`` (fresh ``tmp_path`` each) must canonicalize-equal.
+    A new scenario is covered automatically once it declares the standard
+    fields (``force_tier`` / ``surfacing_seeds``). Shared by
+    :func:`run_scenario_once` (one scenario) and :func:`run_full_suite`
+    (the whole roster into a single collector).
     """
-    fixture = load_fixture(scenario_id)
-    collector = BenchReportCollector()
     if fixture.get("surfacing_seeds"):
         await _record_surfacing(fixture, tmp_path, collector)
     elif fixture.get("force_tier"):
         await _record_fallback(fixture, tmp_path, collector)
     else:
         await _record_plain(fixture, tmp_path, collector)
+
+
+async def run_scenario_once(scenario_id: str, tmp_path: Path, *, run_seed: int = 0) -> dict:
+    """Drive *scenario_id* through the full bench pipeline once and return a
+    single-scenario ``BenchReport`` dict.
+
+    Two calls with the same ``scenario_id`` (fresh ``tmp_path`` each) must
+    canonicalize-equal — that is what the determinism gate asserts.
+    """
+    fixture = load_fixture(scenario_id)
+    collector = BenchReportCollector()
+    await _dispatch(fixture, tmp_path, collector)
+    return dict(collector.build_report(run_seed=run_seed))
+
+
+async def run_full_suite(
+    base_dir: Path, *, scenario_ids: list[str] | None = None, run_seed: int = 0
+) -> dict:
+    """Replay the whole roster into one report — the canonical full ``report.json``.
+
+    Each scenario runs in its own ``base_dir/<scenario_id>`` subdir so the
+    per-run stores never cross-talk (``latest_metrics_row`` reads the most
+    recent ``proxy_metrics`` row, so a shared DB would mis-attribute rows).
+    Returns the merged multi-scenario ``BenchReport`` dict — feed it through
+    :func:`canonicalize_report` before diffing against the committed drift
+    baseline. The result is byte-deterministic across runs and hash seeds,
+    which is what makes a committed snapshot baseline sound.
+
+    ``scenario_ids`` defaults to :data:`SUITE_SCENARIOS`; pass an explicit
+    subset only in tests that need a narrower roster.
+    """
+    roster = SUITE_SCENARIOS if scenario_ids is None else scenario_ids
+    collector = BenchReportCollector()
+    for scenario_id in roster:
+        fixture = load_fixture(scenario_id)
+        scenario_dir = base_dir / scenario_id
+        scenario_dir.mkdir(parents=True, exist_ok=True)
+        await _dispatch(fixture, scenario_dir, collector)
     return dict(collector.build_report(run_seed=run_seed))

--- a/tests/bench/fixtures/drift_baseline.json
+++ b/tests/bench/fixtures/drift_baseline.json
@@ -1,0 +1,288 @@
+{
+  "run_seed": 0,
+  "scenarios": [
+    {
+      "metrics": {
+        "cleaned_chars": 1132,
+        "compressed_chars": 849,
+        "compression_ratio": 0.75,
+        "compression_strategy": "truncate\u2192hybrid_fallback",
+        "original_chars": 4536,
+        "ratio_violation": 1,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 0,
+        "ratio": 1.0,
+        "total": 0
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s01",
+      "tier": "truncate\u2192hybrid_fallback",
+      "trace_id": "bench-006fdf0f7456627d",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 2520,
+        "compressed_chars": 1993,
+        "compression_ratio": 0.7909,
+        "compression_strategy": "extract_fields",
+        "original_chars": 2521,
+        "ratio_violation": 0,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 2,
+        "ratio": 0.6667,
+        "total": 3
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s02",
+      "tier": "extract_fields",
+      "trace_id": "bench-d837cdb9d88dbd9c",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 1671,
+        "compressed_chars": 1379,
+        "compression_ratio": 0.8253,
+        "compression_strategy": "truncate",
+        "original_chars": 1672,
+        "ratio_violation": 0,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 2,
+        "ratio": 0.6667,
+        "total": 3
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s03",
+      "tier": "truncate",
+      "trace_id": "bench-bde1a603f1f9a674",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 3244,
+        "compressed_chars": 2513,
+        "compression_ratio": 0.7747,
+        "compression_strategy": "truncate",
+        "original_chars": 3245,
+        "ratio_violation": 0,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 2,
+        "ratio": 0.6667,
+        "total": 3
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s04",
+      "tier": "truncate",
+      "trace_id": "bench-bffc5f0f1765615b",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 11827,
+        "compressed_chars": 3231,
+        "compression_ratio": 0.2732,
+        "compression_strategy": "skeleton",
+        "original_chars": 11828,
+        "ratio_violation": 0,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 3,
+        "ratio": 1.0,
+        "total": 3
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s05",
+      "tier": "skeleton",
+      "trace_id": "bench-da0b6833c009f2a0",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 10859,
+        "compressed_chars": 4143,
+        "compression_ratio": 0.3815,
+        "compression_strategy": "truncate\u2192progressive_fallback",
+        "original_chars": 10860,
+        "ratio_violation": 1,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "progressive": {
+        "chunks": 3,
+        "round_trip_equal": true,
+        "total_chars": 10859
+      },
+      "qa": {
+        "answerable": 0,
+        "ratio": 1.0,
+        "total": 0
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s06",
+      "tier": "truncate\u2192progressive_fallback",
+      "trace_id": "bench-89b457e498ab3f2e",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 12513,
+        "compressed_chars": 8118,
+        "compression_ratio": 0.6488,
+        "compression_strategy": "selective",
+        "original_chars": 12513,
+        "ratio_violation": 1,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 5,
+        "ratio": 0.8333,
+        "total": 6
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s07",
+      "tier": "selective",
+      "trace_id": "bench-63270e3f4c379fdb",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 1434,
+        "compressed_chars": 992,
+        "compression_ratio": 0.6918,
+        "compression_strategy": "truncate\u2192truncate_fallback",
+        "original_chars": 7180,
+        "ratio_violation": 1,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 0,
+        "ratio": 1.0,
+        "total": 0
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s08",
+      "tier": "truncate\u2192truncate_fallback",
+      "trace_id": "bench-de8eaa257436c85e",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 2513,
+        "compressed_chars": 2513,
+        "compression_ratio": 1.0,
+        "compression_strategy": "none",
+        "original_chars": 2514,
+        "ratio_violation": 0,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 3,
+        "ratio": 1.0,
+        "total": 3
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s09",
+      "tier": "none",
+      "trace_id": "bench-32813a76d14037fd",
+      "verdict": "pass"
+    },
+    {
+      "metrics": {
+        "cleaned_chars": 5114,
+        "compressed_chars": 5114,
+        "compression_ratio": 1.0,
+        "compression_strategy": "none",
+        "original_chars": 5115,
+        "ratio_violation": 0,
+        "surface_error": null,
+        "surfacing_on_progressive_ok": null
+      },
+      "qa": {
+        "answerable": 2,
+        "ratio": 1.0,
+        "total": 2
+      },
+      "rule_judge": {
+        "missing_keywords": [],
+        "score": 0.0
+      },
+      "scenario_id": "s10",
+      "surfacing": {
+        "expected_ids": [
+          "6b358287b37ef447",
+          "4eee90bb62974036"
+        ],
+        "recall_at_k": 1.0,
+        "returned_ids": [
+          "6b358287b37ef447",
+          "4eee90bb62974036"
+        ]
+      },
+      "tier": "none",
+      "trace_id": "bench-2f21951e09186984",
+      "verdict": "pass"
+    }
+  ],
+  "schema_version": 1,
+  "tier_histogram": {
+    "extract_fields": 1,
+    "none": 2,
+    "selective": 1,
+    "skeleton": 1,
+    "truncate": 2,
+    "truncate\u2192hybrid_fallback": 1,
+    "truncate\u2192progressive_fallback": 1,
+    "truncate\u2192truncate_fallback": 1
+  },
+  "totals": {
+    "failing": 0.0,
+    "passing": 10.0,
+    "scenarios": 10.0,
+    "tokens_saved_approx": 5495.0
+  }
+}

--- a/tests/bench/test_bench_qa_determinism.py
+++ b/tests/bench/test_bench_qa_determinism.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import pytest
 
 from bench.bench_qa import (
+    SUITE_SCENARIOS,
     canonicalize_report,
     deterministic_trace_id,
     fixtures_dir,
@@ -37,20 +38,11 @@ from bench.bench_qa import (
 )
 
 # Every fixture that records a ``ScenarioReport`` row into ``report.json``.
-# Explicit (not globbed) so adding a fixture forces a conscious include /
-# exclude decision via ``test_determinism_roster_covers_every_fixture``.
-DETERMINISM_SCENARIOS = [
-    "s01",  # Tier-2 hybrid_fallback
-    "s02",  # AUTO → extract_fields
-    "s03",  # AUTO → truncate
-    "s04",  # AUTO → truncate
-    "s05",  # SKELETON (chat transcript)
-    "s06",  # Tier-1 progressive_fallback (round-trip)
-    "s07",  # SELECTIVE TOC
-    "s08",  # Tier-3 truncate_fallback
-    "s09",  # AUTO → none (fits budget)
-    "s10",  # surfacing recall@k
-]
+# Sourced from the canonical roster in ``bench_qa.replay`` (shared with the
+# cross-version drift gate) so the two gates can never drift apart; the
+# tripwire below still forces a conscious include/exclude decision when a
+# fixture is added. Not globbed — the roster is explicit on purpose.
+DETERMINISM_SCENARIOS = SUITE_SCENARIOS
 
 # Fixtures intentionally outside the determinism gate, each with its reason.
 _EXCLUDED_FIXTURES = {

--- a/tests/bench/test_bench_qa_drift.py
+++ b/tests/bench/test_bench_qa_drift.py
@@ -1,0 +1,330 @@
+"""bench_qa — cross-version drift gate (post-gate roadmap item 8).
+
+The per-PR ``bench_qa`` gate enforces *absolute* per-scenario floors
+(``qa_gate_min``, ``ratio_violation``). A metric can sit just above its floor
+forever while eroding across many PRs — each one passing its own floor, the
+slow slide invisible. This gate closes that gap: it pins the WHOLE canonical
+``report.json`` to a committed baseline (``fixtures/drift_baseline.json``) so
+any move — even one still above the floor — must pass through a reviewed
+baseline diff.
+
+Why an exact snapshot rather than per-metric tolerances: the suite is
+byte-deterministic (the determinism gate, #486, proves report.json is
+identical run-to-run and across PYTHONHASHSEED). With zero run-to-run
+variance, a tolerance can only *mask* a real regression smaller than itself —
+exactly the slow slide this gate exists to catch. So equality is the gate; a
+non-gating directional classifier (``bench_qa.drift``) only frames the diff
+as REGRESSION / IMPROVEMENT / NEUTRAL for the human reading the failure.
+
+Marker split:
+* ``@pytest.mark.bench_qa_drift`` — the baseline-comparison gate + the heavy
+  full-suite rebuilds. ADVISORY: runs only in the dedicated CI job, excluded
+  from the required ``bench_qa`` gate and the default ``test`` job, so a
+  forgotten re-baseline never blocks merge during the observation window.
+* unmarked — the machinery guards (classifier coverage, roster lockstep,
+  marker pin, strip sanity). These run in the required ``test`` job: a broken
+  invariant *should* block merge even while the gate itself is advisory.
+
+When this gate reds on a legitimate change, run
+``uv run python tests/bench/bench_qa/regen_drift_baseline.py`` and commit the
+regenerated baseline in the same PR.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from bench.bench_qa import (
+    SUITE_SCENARIOS,
+    canonicalize_report,
+    classify_drift,
+    fixtures_dir,
+    format_drift_md,
+    run_full_suite,
+)
+from bench.bench_qa.drift import (
+    SCENARIO_DIRECTION,
+    SCENARIO_EXCLUDED,
+    TOTALS_DIRECTION,
+)
+from bench.bench_qa.regen_drift_baseline import serialize_baseline
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BASELINE_PATH = fixtures_dir() / "drift_baseline.json"
+_REGEN_CMD = "uv run python tests/bench/bench_qa/regen_drift_baseline.py"
+
+
+def _load_baseline() -> dict:
+    return json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------
+# The gate (advisory marker)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.bench_qa_drift
+@pytest.mark.asyncio
+async def test_live_report_matches_committed_baseline(tmp_path):
+    """The full canonical report must deep-equal the committed baseline."""
+    baseline = _load_baseline()
+    live = canonicalize_report(await run_full_suite(tmp_path))
+
+    if live.get("schema_version") != baseline.get("schema_version"):
+        pytest.fail(
+            f"report schema_version bumped "
+            f"({baseline.get('schema_version')} → {live.get('schema_version')}). "
+            f"Regenerate the drift baseline: {_REGEN_CMD}"
+        )
+
+    if live != baseline:
+        drifts = classify_drift(baseline, live)
+        summary = format_drift_md(drifts)
+        # Persist the directional summary as a CI artifact when a report dir
+        # is configured (the advisory job sets BENCH_QA_REPORT_DIR).
+        report_dir = os.environ.get("BENCH_QA_REPORT_DIR")
+        if report_dir:
+            out = Path(report_dir)
+            out.mkdir(parents=True, exist_ok=True)
+            (out / "drift.md").write_text(summary, encoding="utf-8")
+        pytest.fail(
+            "bench_qa report drifted from the committed baseline.\n\n"
+            f"{summary}\n"
+            f"If this change is intended, regenerate the baseline:\n  {_REGEN_CMD}\n"
+            "then commit tests/bench/fixtures/drift_baseline.json in this PR with a "
+            "'## Baseline change' callout.\n"
+            "(A large all-float diff usually means a rounding-precision change in report.py.)"
+        )
+
+
+@pytest.mark.bench_qa_drift
+@pytest.mark.asyncio
+async def test_regen_serialization_is_byte_identical_to_committed(tmp_path):
+    """Re-serializing a fresh full-suite report must byte-match the committed
+    file — catches a hand-edited baseline (wrong precision / key order /
+    trailing newline) that a parsed-dict compare would silently tolerate."""
+    live = canonicalize_report(await run_full_suite(tmp_path))
+    regenerated = serialize_baseline(live)
+    committed = _BASELINE_PATH.read_text(encoding="utf-8")
+    assert regenerated == committed, (
+        "serialized full-suite report is not byte-identical to the committed "
+        f"baseline — regenerate it with: {_REGEN_CMD}"
+    )
+
+
+@pytest.mark.bench_qa_drift
+@pytest.mark.asyncio
+async def test_full_suite_is_rerun_stable(tmp_path_factory):
+    """Two independent full-suite runs canonicalize-equal — a false-positive
+    guard so the gate can never red on an unchanged tree."""
+    a = canonicalize_report(await run_full_suite(tmp_path_factory.mktemp("drift_a")))
+    b = canonicalize_report(await run_full_suite(tmp_path_factory.mktemp("drift_b")))
+    assert a == b, "run_full_suite is not deterministic across two runs"
+
+
+# --------------------------------------------------------------------------
+# Machinery guards (unmarked → required test job)
+# --------------------------------------------------------------------------
+
+
+def test_drift_baseline_matches_suite_roster():
+    """The committed baseline must cover exactly the canonical roster — guards
+    against a silently shrunk report (a dropped scenario blessed by a regen)."""
+    baseline = _load_baseline()
+    ids = [s["scenario_id"] for s in baseline["scenarios"]]
+    assert ids == sorted(SUITE_SCENARIOS), (
+        f"baseline scenarios {ids} != SUITE_SCENARIOS {sorted(SUITE_SCENARIOS)} — "
+        f"a fixture was added/removed without regenerating; run {_REGEN_CMD}"
+    )
+    assert baseline["schema_version"] == 1
+
+
+def test_drift_baseline_has_no_nonreproducible_fields():
+    """The committed baseline must already be canonicalized — no wall-clock
+    stage timings and no llm_judge block (those would never reproduce)."""
+    from bench.bench_qa.report import _STAGE_TIMING_FIELDS
+
+    baseline = _load_baseline()
+    for scenario in baseline["scenarios"]:
+        assert "llm_judge" not in scenario, (
+            f"{scenario['scenario_id']}: llm_judge leaked into baseline"
+        )
+        for field in _STAGE_TIMING_FIELDS:
+            assert field not in scenario["metrics"], (
+                f"{scenario['scenario_id']}: timing field {field} leaked into baseline"
+            )
+
+
+def test_direction_table_covers_every_schema_field():
+    """Every field that can appear in a canonical ScenarioReport must be either
+    direction-classified or explicitly excluded — no silent UNKNOWN drift.
+    Parallel to the determinism roster tripwire."""
+    from bench.bench_qa.report import _STAGE_TIMING_FIELDS
+    from bench.bench_qa.schema import (
+        MetricSummary,
+        ProgressiveResult,
+        QAResult,
+        RuleJudgeResult,
+        SurfacingResult,
+    )
+
+    expected: set[str] = set()
+    for section, td in [
+        ("metrics", MetricSummary),
+        ("qa", QAResult),
+        ("surfacing", SurfacingResult),
+        ("progressive", ProgressiveResult),
+        ("rule_judge", RuleJudgeResult),
+    ]:
+        for field in td.__annotations__:
+            expected.add(f"{section}.{field}")
+    # Stage timings are stripped by canonicalize_report — never seen by the classifier.
+    expected -= {f"metrics.{f}" for f in _STAGE_TIMING_FIELDS}
+    # Scenario-level scalars the classifier handles directly.
+    expected |= {"trace_id", "tier", "verdict"}
+
+    classified = set(SCENARIO_DIRECTION) | set(SCENARIO_EXCLUDED)
+    missing = expected - classified
+    assert not missing, (
+        f"unclassified ScenarioReport fields {sorted(missing)} — add each to "
+        f"SCENARIO_DIRECTION or SCENARIO_EXCLUDED in bench_qa/drift.py"
+    )
+    assert {
+        "totals.scenarios",
+        "totals.passing",
+        "totals.failing",
+        "totals.tokens_saved_approx",
+    } <= set(TOTALS_DIRECTION)
+
+
+def test_drift_marker_registered():
+    """docs-sync-style pin: the bench_qa_drift marker must be registered in
+    pyproject AND referenced in ci.yml, and excluded from the default test job
+    filter — loud-fail 'update test + workflow together'."""
+    pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    ci = (_REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "bench_qa_drift:" in pyproject, (
+        "bench_qa_drift marker missing from pyproject [tool.pytest] markers"
+    )
+    assert "bench_qa_drift" in ci, "bench_qa_drift not referenced in ci.yml (advisory job missing?)"
+    assert "and not bench_qa_drift" in ci, (
+        "default test job filter must exclude bench_qa_drift so the advisory gate "
+        "does not run in (and block) the required test job"
+    )
+
+
+# --------------------------------------------------------------------------
+# Classifier unit tests — planted drifts must be caught + labelled (unmarked)
+# --------------------------------------------------------------------------
+
+
+def _scenario_row(sid: str = "s03") -> dict:
+    return {
+        "scenario_id": sid,
+        "trace_id": "bench-deadbeefdeadbeef",
+        "metrics": {
+            "original_chars": 1672,
+            "cleaned_chars": 1671,
+            "compressed_chars": 1379,
+            "compression_ratio": 0.8253,
+            "compression_strategy": "truncate",
+            "ratio_violation": 0,
+            "surfacing_on_progressive_ok": None,
+            "surface_error": None,
+        },
+        "rule_judge": {"score": 0.0, "missing_keywords": []},
+        "qa": {"answerable": 2, "total": 3, "ratio": 0.6667},
+        "tier": "truncate",
+        "verdict": "pass",
+    }
+
+
+def _report(scenario: dict, *, passing: float = 1.0, failing: float = 0.0) -> dict:
+    return {
+        "schema_version": 1,
+        "run_seed": 0,
+        "scenarios": [scenario],
+        "tier_histogram": {scenario["tier"]: 1},
+        "totals": {
+            "scenarios": 1.0,
+            "passing": passing,
+            "failing": failing,
+            "tokens_saved_approx": 73.0,
+        },
+    }
+
+
+def _find(drifts, scope):
+    return next((d for d in drifts if d.scope == scope), None)
+
+
+def test_classify_catches_compression_ratio_regression():
+    old = _report(_scenario_row())
+    new_row = copy.deepcopy(_scenario_row())
+    new_row["metrics"]["compression_ratio"] = 0.91
+    new_row["metrics"]["compressed_chars"] = 1520
+    drifts = classify_drift(old, _report(new_row))
+    ratio = _find(drifts, "s03.metrics.compression_ratio")
+    assert ratio is not None and ratio.label == "REGRESSION" and "up" in ratio.note
+    bytes_drift = _find(drifts, "s03.metrics.compressed_chars")
+    assert bytes_drift is not None and bytes_drift.label == "REGRESSION"
+
+
+def test_classify_catches_qa_and_verdict_regression():
+    old = _report(_scenario_row(), passing=1.0, failing=0.0)
+    new_row = copy.deepcopy(_scenario_row())
+    new_row["qa"] = {"answerable": 1, "total": 3, "ratio": 0.3333}
+    new_row["verdict"] = "fail"
+    drifts = classify_drift(old, _report(new_row, passing=0.0, failing=1.0))
+    qa = _find(drifts, "s03.qa.ratio")
+    assert qa is not None and qa.label == "REGRESSION"
+    verdict = _find(drifts, "s03.verdict")
+    assert verdict is not None and verdict.label == "REGRESSION" and verdict.note == "pass→fail"
+    assert _find(drifts, "totals.passing").label == "REGRESSION"
+    assert _find(drifts, "totals.failing").label == "REGRESSION"
+
+
+def test_classify_compression_improvement_is_not_a_regression():
+    old = _report(_scenario_row())
+    new_row = copy.deepcopy(_scenario_row())
+    new_row["metrics"]["compression_ratio"] = 0.70  # more aggressive = better
+    drifts = classify_drift(old, _report(new_row))
+    ratio = _find(drifts, "s03.metrics.compression_ratio")
+    assert ratio is not None and ratio.label == "IMPROVEMENT"
+
+
+def test_classify_strategy_change_is_neutral():
+    old = _report(_scenario_row())
+    new_row = copy.deepcopy(_scenario_row())
+    new_row["metrics"]["compression_strategy"] = "extract_fields"
+    new_row["tier"] = "extract_fields"
+    drifts = classify_drift(old, _report(new_row))
+    strat = _find(drifts, "s03.metrics.compression_strategy")
+    assert strat is not None and strat.label == "NEUTRAL"
+
+
+def test_classify_dropped_scenario_is_regression():
+    old = _report(_scenario_row("s03"))
+    new = {**_report(_scenario_row("s03")), "scenarios": []}
+    drifts = classify_drift(old, new)
+    dropped = _find(drifts, "s03")
+    assert dropped is not None and dropped.label == "REGRESSION" and "dropped" in dropped.note
+
+
+def test_classify_equal_reports_no_drift():
+    old = _report(_scenario_row())
+    assert classify_drift(old, copy.deepcopy(old)) == []
+
+
+def test_format_drift_md_groups_by_label():
+    old = _report(_scenario_row())
+    new_row = copy.deepcopy(_scenario_row())
+    new_row["metrics"]["compression_ratio"] = 0.91
+    md = format_drift_md(classify_drift(old, _report(new_row)))
+    assert "REGRESSION" in md and "compression_ratio" in md
+    assert format_drift_md([]).startswith("No drift")

--- a/tests/bench/test_bench_qa_drift.py
+++ b/tests/bench/test_bench_qa_drift.py
@@ -84,7 +84,15 @@ async def test_live_report_matches_committed_baseline(tmp_path):
 
     if live != baseline:
         drifts = classify_drift(baseline, live)
-        summary = format_drift_md(drifts)
+        # classify_drift walks the whole report, so this fallback should be
+        # unreachable — it guards against ever printing "No drift" inside a red
+        # failure if a future field escapes the walk.
+        summary = (
+            format_drift_md(drifts)
+            if drifts
+            else "Reports differ but no field-level drift was classified — "
+            "inspect the report.json deep-equal directly."
+        )
         # Persist the directional summary as a CI artifact when a report dir
         # is configured (the advisory job sets BENCH_QA_REPORT_DIR).
         report_dir = os.environ.get("BENCH_QA_REPORT_DIR")
@@ -142,6 +150,15 @@ def test_drift_baseline_matches_suite_roster():
         f"a fixture was added/removed without regenerating; run {_REGEN_CMD}"
     )
     assert baseline["schema_version"] == 1
+    # Coverage floor: a snapshot scheme can't fully prevent a self-blessing
+    # same-PR roster shrink (delete fixture + drop from SUITE_SCENARIOS +
+    # regen), but pinning a minimum forces that reduction to be a deliberate,
+    # reviewable edit to this number rather than a silent one.
+    assert len(SUITE_SCENARIOS) >= 10, (
+        f"SUITE_SCENARIOS shrank to {len(SUITE_SCENARIOS)} below the canonical 10 "
+        "(s01–s10) — lowering coverage must be intentional; drop this floor "
+        "explicitly with reviewer sign-off."
+    )
 
 
 def test_drift_baseline_has_no_nonreproducible_fields():
@@ -170,23 +187,29 @@ def test_direction_table_covers_every_schema_field():
         ProgressiveResult,
         QAResult,
         RuleJudgeResult,
+        ScenarioReport,
         SurfacingResult,
     )
 
+    sections = {
+        "metrics": MetricSummary,
+        "qa": QAResult,
+        "surfacing": SurfacingResult,
+        "progressive": ProgressiveResult,
+        "rule_judge": RuleJudgeResult,
+    }
     expected: set[str] = set()
-    for section, td in [
-        ("metrics", MetricSummary),
-        ("qa", QAResult),
-        ("surfacing", SurfacingResult),
-        ("progressive", ProgressiveResult),
-        ("rule_judge", RuleJudgeResult),
-    ]:
+    for section, td in sections.items():
         for field in td.__annotations__:
             expected.add(f"{section}.{field}")
     # Stage timings are stripped by canonicalize_report — never seen by the classifier.
     expected -= {f"metrics.{f}" for f in _STAGE_TIMING_FIELDS}
-    # Scenario-level scalars the classifier handles directly.
-    expected |= {"trace_id", "tier", "verdict"}
+    # Scenario-level scalars — derived from the schema (not hard-coded) so a NEW
+    # top-level ScenarioReport field (e.g. a cache_hit mirroring #485) trips this
+    # until it is given a deliberate direction. llm_judge is stripped by
+    # canonicalize_report; scenario_id is the row key.
+    top_scalars = set(ScenarioReport.__annotations__) - set(sections) - {"scenario_id", "llm_judge"}
+    expected |= top_scalars
 
     classified = set(SCENARIO_DIRECTION) | set(SCENARIO_EXCLUDED)
     missing = expected - classified
@@ -319,6 +342,31 @@ def test_classify_dropped_scenario_is_regression():
 def test_classify_equal_reports_no_drift():
     old = _report(_scenario_row())
     assert classify_drift(old, copy.deepcopy(old)) == []
+
+
+def test_classify_surfaces_top_level_scalar_drift():
+    """A run_seed-only diff (or any top-level scalar) must surface — otherwise
+    the gate would red while the summary said 'No drift'."""
+    old = _report(_scenario_row())
+    new = copy.deepcopy(old)
+    new["run_seed"] = 1
+    drifts = classify_drift(old, new)
+    seed = _find(drifts, "run_seed")
+    assert seed is not None and seed.label == "NEUTRAL"
+    assert not format_drift_md(drifts).startswith("No drift")
+
+
+def test_classify_surfaces_unknown_scenario_field():
+    """A NEW top-level ScenarioReport field (not in the direction table) must
+    be surfaced as NEUTRAL 'unclassified', never silently dropped — guards the
+    classifier's invariant that it stays complete vs the gate's deep-equal."""
+    old = _report(_scenario_row())
+    new = copy.deepcopy(old)
+    new["scenarios"][0]["cache_hit"] = True  # hypothetical future field
+    drifts = classify_drift(old, new)
+    unknown = _find(drifts, "s03.cache_hit")
+    assert unknown is not None and unknown.label == "NEUTRAL"
+    assert "unclassified" in unknown.note
 
 
 def test_format_drift_md_groups_by_label():


### PR DESCRIPTION
## What

Post-gate roadmap **item 8**: a cross-version drift gate that pins the whole canonical `report.json` to a committed baseline (`tests/bench/fixtures/drift_baseline.json`).

The per-PR `bench_qa` gate enforces *absolute* per-scenario floors (`qa_gate_min`, `ratio_violation`). A metric can sit just above its floor forever while eroding across many PRs — each one passing its own floor, the slow slide invisible. This gate closes that gap: **any** report change — even one still above the floor — must pass through a reviewed baseline diff.

## Why an exact snapshot, not per-metric tolerances

The suite is byte-deterministic — the determinism gate (#486) proves `report.json` is identical run-to-run and across `PYTHONHASHSEED`. With **zero** run-to-run variance, a tolerance can only *mask* a real regression smaller than itself — exactly the slide this gate exists to catch. So **equality is the gate**; a non-gating directional classifier only *frames* a failure as REGRESSION / IMPROVEMENT / NEUTRAL for the human reading it.

(A design panel weighed snapshot vs. directional-tolerance vs. hybrid; the directional-tolerance approach was rejected precisely because the suite has no variance to fit a tolerance to.)

## How

- **`replay.run_full_suite(base_dir)`** replays the whole roster into one report (each scenario in its own subdir so per-run stores never cross-talk), reusing the existing `run_scenario_once` drivers. `SUITE_SCENARIOS` becomes the single-source roster shared with the determinism gate (no two-file drift).
- **`drift.classify_drift` / `format_drift_md`** — a pure directional classifier (`compression_ratio` up = bad, `qa.ratio`/`recall` down = bad, `ratio_violation` up = bad, `verdict` pass→fail = bad, …). `rule_judge.score` is excluded (always-0.0 sentinel under the replay drivers). Never decides pass/fail.
- **`regen_drift_baseline.py`** — `uv run python tests/bench/bench_qa/regen_drift_baseline.py` rebuilds the suite, prints a directional drift summary vs the old baseline, and writes the file byte-stably. The only writer; never hand-edit.
- **`test_bench_qa_drift.py`** — the gate (deep-equal + classifier failure message + schema_version pre-check + `drift.md` artifact) under the advisory `bench_qa_drift` marker; plus required machinery guards (roster lockstep + coverage floor, classifier-coverage tripwire, marker pin, strip sanity, planted-regression + false-positive unit tests).
- **CI** — advisory `bench_qa_drift` job (`continue-on-error: true`, self-contained, distinct `bench-qa-drift-report` artifact). Marker registered in `pyproject.toml` and excluded from the default `test` job filter, so the advisory gate runs **only** in its own job and never blocks a required check.
- **CONTRIBUTING.md** — the regen workflow + a `## Baseline change` PR-callout convention.

## Verification

- 16 drift tests + the required `bench_qa` gate (23) pass; full CI-faithful suite green (`test_docs_sync` pin kept in sync).
- **End-to-end planted drift**: mutating the baseline reds the gate with the correct directional labels (`s03.qa.ratio` REGRESSION, `s03.compression_ratio` IMPROVEMENT); restore → green.
- Marker isolation verified: the required `bench_qa` job and the default `test` job both collect **0** drift gate tests.

## Adversarial review (multi-agent)

An independent review pass returned **SHIP_WITH_NITS** — no blocker/high, no live-regression escape. Its findings (the classifier walked only a hard-coded subset of fields, so a future top-level field — e.g. a `cache_hit` like #485 — could fail the gate while the summary said "No drift") were **fixed in this PR** rather than deferred: `classify_drift` now walks every report key (unknown → NEUTRAL "unclassified"), the coverage tripwire derives its field set from `ScenarioReport.__annotations__`, and a roster coverage floor + two regression tests pin the cases.

## Decisions (recommended defaults; flag if you'd prefer otherwise)

- **Advisory-first.** Promote to required (flip `continue-on-error` + add to branch protection) after an observation window, mirroring #482. The property is deterministic and two-run-proven, so a short window suffices — the only false-positive source is a forgotten re-baseline.
- **Snapshot reds on any move**, including improvements — keeps the enforced baseline honest (no stale-low floor).
- Baseline lives at `tests/bench/fixtures/drift_baseline.json` (next to the source-of-truth fixtures).
- The optional sticky-PR-comment job and pinning the runner Python patch for byte-stability are **deferred** to before promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)