### PR TITLE
test(bench_qa): LLM-judge multi-model agreement (advisory)

### DIFF
--- a/tests/bench/bench_qa/llm_judge_adapter.py
+++ b/tests/bench/bench_qa/llm_judge_adapter.py
@@ -25,7 +25,12 @@ from pathlib import Path
 
 from ..harness import BenchTask, QAPair
 from ..llm_judge import JudgeDimension, LLMJudge, LLMJudgeResult
-from .schema import LLMJudgeProbeResult, LLMJudgeResultReport, QAProbe
+from .schema import (
+    LLMJudgeAgreementReport,
+    LLMJudgeProbeResult,
+    LLMJudgeResultReport,
+    QAProbe,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -197,3 +202,57 @@ def to_report_dict(result: LLMJudgeResult) -> LLMJudgeResultReport:
     if result.error:
         report["error"] = str(result.error)
     return report
+
+
+def compute_agreement(
+    report_a: LLMJudgeResultReport,
+    report_b: LLMJudgeResultReport,
+) -> LLMJudgeAgreementReport:
+    """Two-judge cross-provider agreement for one scenario (item 9).
+
+    ``report_a`` / ``report_b`` are :func:`to_report_dict` outputs — already
+    normalised to 0.0–1.0 — from two different judges. Returns an
+    :class:`LLMJudgeAgreementReport` with per-dimension absolute differences
+    and a scalar ``agreement_score = 1 - mean(|a - b|)`` over ``overall`` and
+    the three dimensions (``overall`` weighted equally with each component, so
+    the headline judgment counts the same as one dimension).
+    ``agreement_score == 1.0`` is perfect inter-judge agreement; ``0.0`` is
+    maximal disagreement — same polarity and scale as the underlying scores,
+    so it slots into logs and any future ratchet without rescaling.
+
+    If *either* report carries an ``error`` (transport / parse failure), the
+    numeric fields are omitted and only ``model_a`` / ``model_b`` / ``error``
+    are returned: a failed judge's ``overall=0.0`` would otherwise fabricate a
+    large diff that poisons the cross-scenario correlation. The headline test
+    excludes any scenario whose agreement block carries an ``error``.
+    """
+    agreement: LLMJudgeAgreementReport = {
+        "model_a": str(report_a.get("model", "")),
+        "model_b": str(report_b.get("model", "")),
+    }
+    err_a = report_a.get("error")
+    err_b = report_b.get("error")
+    if err_a or err_b:
+        agreement["error"] = f"a={err_a or None} b={err_b or None}"
+        return agreement
+
+    overall_a = report_a.get("overall", 0.0)
+    overall_b = report_b.get("overall", 0.0)
+    diff_overall = abs(overall_a - overall_b)
+    diff_fc = abs(
+        report_a.get("factual_completeness", 0.0) - report_b.get("factual_completeness", 0.0)
+    )
+    diff_sc = abs(
+        report_a.get("structural_coherence", 0.0) - report_b.get("structural_coherence", 0.0)
+    )
+    diff_as = abs(report_a.get("answer_sufficiency", 0.0) - report_b.get("answer_sufficiency", 0.0))
+    mean_abs_diff = (diff_overall + diff_fc + diff_sc + diff_as) / 4.0
+
+    agreement["overall_a"] = overall_a
+    agreement["overall_b"] = overall_b
+    agreement["diff_overall"] = round(diff_overall, 4)
+    agreement["diff_factual_completeness"] = round(diff_fc, 4)
+    agreement["diff_structural_coherence"] = round(diff_sc, 4)
+    agreement["diff_answer_sufficiency"] = round(diff_as, 4)
+    agreement["agreement_score"] = round(max(0.0, min(1.0, 1.0 - mean_abs_diff)), 4)
+    return agreement

--- a/tests/bench/bench_qa/report.py
+++ b/tests/bench/bench_qa/report.py
@@ -23,6 +23,7 @@ from typing import Any
 from .schema import (
     REPORT_SCHEMA_VERSION,
     BenchReport,
+    LLMJudgeAgreementReport,
     LLMJudgeResultReport,
     MetricSummary,
     ProgressiveResult,
@@ -52,12 +53,14 @@ def canonicalize_report(report: BenchReport) -> dict[str, Any]:
 
     * ``scenarios[*].metrics.clean_ms`` / ``compress_ms`` / ``surface_ms``
       — stage latencies differ run-to-run by definition.
-    * ``scenarios[*].llm_judge`` — the whole block. Even at ``temperature=0``
-      the LLM judge is non-reproducible across provider-side model updates,
-      plus ``cached`` / token counts flip between runs. Stripping the block
-      wholesale keeps the determinism diff silent when the marker is off
-      (key absent on both sides) and when it is on (key absent on both
-      sides after stripping).
+    * ``scenarios[*].llm_judge`` / ``llm_judge_b`` / ``llm_judge_agreement``
+      — the whole LLM-judge surface (model A, model B, and the two-model
+      agreement). Even at ``temperature=0`` LLM scores are non-reproducible
+      across provider-side model updates, plus ``cached`` / token counts flip
+      between runs; the agreement diffs are derived from those same scores, so
+      they drift too. Stripping all three wholesale keeps the determinism diff
+      silent when the marker is off (keys absent on both sides) and when it is
+      on (keys absent on both sides after stripping).
 
     Preserved:
 
@@ -74,6 +77,8 @@ def canonicalize_report(report: BenchReport) -> dict[str, Any]:
         for field in _STAGE_TIMING_FIELDS:
             metrics.pop(field, None)
         scenario.pop("llm_judge", None)
+        scenario.pop("llm_judge_b", None)
+        scenario.pop("llm_judge_agreement", None)
     return canon
 
 
@@ -191,6 +196,36 @@ class BenchReportCollector:
         logger.warning(
             "record_llm_judge: no scenario row for %r — run with "
             "-m 'bench_qa or bench_qa_llm_judge' to capture the score in report.json",
+            scenario_id,
+        )
+
+    def record_llm_judge_agreement(
+        self,
+        *,
+        scenario_id: str,
+        llm_judge_b: LLMJudgeResultReport,
+        agreement: LLMJudgeAgreementReport,
+    ) -> None:
+        """Attach the second judge's block + the two-model agreement (item 9).
+
+        Mirrors :meth:`record_llm_judge` — enriches an existing row when the
+        multi-model agreement test runs in the same session as the main
+        ``bench_qa`` suite. Model A's block continues to come through
+        :meth:`record_llm_judge` (``llm_judge``); this records ``llm_judge_b``
+        and ``llm_judge_agreement``. Same no-row warning: without a prior
+        ``record_scenario`` the agreement is still visible via the test's
+        ``logger.info`` but does not reach ``report.json``, since the row would
+        be missing ``metrics`` / ``qa`` / ``verdict`` that the report builder
+        and summary formatter read unconditionally.
+        """
+        for entry in self._rows:
+            if entry.get("scenario_id") == scenario_id:
+                entry["llm_judge_b"] = llm_judge_b
+                entry["llm_judge_agreement"] = agreement
+                return
+        logger.warning(
+            "record_llm_judge_agreement: no scenario row for %r — run with "
+            "-m 'bench_qa or bench_qa_llm_judge' to capture the agreement in report.json",
             scenario_id,
         )
 

--- a/tests/bench/bench_qa/schema.py
+++ b/tests/bench/bench_qa/schema.py
@@ -146,6 +146,35 @@ class LLMJudgeResultReport(TypedDict, total=False):
     error: str
 
 
+class LLMJudgeAgreementReport(TypedDict, total=False):
+    """Two-judge cross-provider agreement for a single scenario (item 9).
+
+    Advisory only — never gates pass/fail. Derived from two LLM judges'
+    normalised scores, so ``canonicalize_report`` strips it wholesale for the
+    same drift reason it strips ``llm_judge``: provider-side model updates
+    shift the scores (and the diffs computed from them) even at
+    ``temperature=0``. All floats are 0.0–1.0 (the per-model reports are
+    already ``/10``-normalised, rounded to 4 dp), so ``agreement_score`` lines
+    up with ``qa.ratio`` / ``rule_judge.score`` without rescaling.
+
+    On a transport/parse failure in *either* judge, only ``model_a`` /
+    ``model_b`` / ``error`` are populated and the numeric fields are omitted —
+    a failed judge's ``overall=0.0`` must not fabricate a large diff that
+    poisons the cross-scenario correlation.
+    """
+
+    model_a: str
+    model_b: str
+    overall_a: float
+    overall_b: float
+    diff_overall: float
+    diff_factual_completeness: float
+    diff_structural_coherence: float
+    diff_answer_sufficiency: float
+    agreement_score: float  # round(max(0, min(1, 1 - mean(4 diffs))), 4)
+    error: str
+
+
 class ScenarioReport(TypedDict, total=False):
     scenario_id: str
     trace_id: str
@@ -155,6 +184,11 @@ class ScenarioReport(TypedDict, total=False):
     progressive: ProgressiveResult
     surfacing: SurfacingResult
     llm_judge: LLMJudgeResultReport
+    # Second judge's full block (model_a stays in ``llm_judge``) + the
+    # two-model agreement summary (item 9). Both stripped by
+    # ``canonicalize_report`` like ``llm_judge``.
+    llm_judge_b: LLMJudgeResultReport
+    llm_judge_agreement: LLMJudgeAgreementReport
     tier: str
     verdict: Literal["pass", "fail", "advisory"]
 

--- a/tests/bench/test_bench_qa_determinism.py
+++ b/tests/bench/test_bench_qa_determinism.py
@@ -144,3 +144,102 @@ def test_canonicalize_strips_only_stage_timings():
     assert result["scenarios"][0]["trace_id"] == "bench-abc"
     # Original must not be mutated.
     assert "clean_ms" in sample["scenarios"][0]["metrics"]
+
+
+@pytest.mark.bench_qa
+def test_canonicalize_strips_llm_judge_agreement():
+    """The item-9 keys ``llm_judge_b`` + ``llm_judge_agreement`` are derived
+    from drift-prone LLM scores, so canonicalization must strip them alongside
+    ``llm_judge`` — otherwise the multi-model agreement marker would break the
+    two-run determinism diff (and the #487 drift snapshot)."""
+    sample = {
+        "schema_version": 1,
+        "run_seed": 0,
+        "scenarios": [
+            {
+                "scenario_id": "s09",
+                "trace_id": "bench-abc",
+                "metrics": {
+                    "original_chars": 100,
+                    "cleaned_chars": 95,
+                    "compressed_chars": 80,
+                    "compression_ratio": 0.84,
+                    "compression_strategy": "none",
+                    "ratio_violation": 0,
+                    "surfacing_on_progressive_ok": None,
+                    "surface_error": None,
+                    "clean_ms": 1.23,
+                    "compress_ms": 4.56,
+                    "surface_ms": 0.0,
+                },
+                "tier": "none",
+                "verdict": "pass",
+                "llm_judge": {"model": "gpt-4.1-nano", "overall": 0.9},
+                "llm_judge_b": {"model": "claude-haiku-4-5-20251001", "overall": 0.7},
+                "llm_judge_agreement": {
+                    "model_a": "gpt-4.1-nano",
+                    "model_b": "claude-haiku-4-5-20251001",
+                    "agreement_score": 0.8,
+                },
+            }
+        ],
+        "tier_histogram": {"none": 1},
+        "totals": {"scenarios": 1.0},
+    }
+    scenario = canonicalize_report(sample)["scenarios"][0]  # type: ignore[arg-type]
+    assert "llm_judge" not in scenario
+    assert "llm_judge_b" not in scenario
+    assert "llm_judge_agreement" not in scenario
+    # Determinism-safe fields still survive the strip.
+    assert scenario["metrics"]["compressed_chars"] == 80
+    assert scenario["trace_id"] == "bench-abc"
+    # Original must not be mutated.
+    assert "llm_judge_agreement" in sample["scenarios"][0]
+
+
+@pytest.mark.bench_qa
+def test_compute_agreement_metric_math():
+    """Pin the item-9 agreement metric: per-dimension absolute diffs, the
+    ``1 - mean(diffs)`` score (rounded 4 dp, clamped to [0, 1]), and the
+    either-error degrade path that omits numerics so a failed judge can't
+    poison the cross-scenario correlation. No API key — runs in default CI."""
+    from bench.bench_qa.llm_judge_adapter import compute_agreement
+
+    report_a = {
+        "model": "gpt-4.1-nano",
+        "overall": 0.80,
+        "factual_completeness": 0.90,
+        "structural_coherence": 0.70,
+        "answer_sufficiency": 1.00,
+    }
+    report_b = {
+        "model": "claude-haiku-4-5-20251001",
+        "overall": 0.60,
+        "factual_completeness": 0.90,
+        "structural_coherence": 0.50,
+        "answer_sufficiency": 0.80,
+    }
+    agreement = compute_agreement(report_a, report_b)  # type: ignore[arg-type]
+    assert agreement["model_a"] == "gpt-4.1-nano"
+    assert agreement["model_b"] == "claude-haiku-4-5-20251001"
+    assert agreement["overall_a"] == 0.80
+    assert agreement["overall_b"] == 0.60
+    assert agreement["diff_overall"] == 0.2
+    assert agreement["diff_factual_completeness"] == 0.0
+    assert agreement["diff_structural_coherence"] == 0.2
+    assert agreement["diff_answer_sufficiency"] == 0.2
+    # 1 - mean(0.2, 0.0, 0.2, 0.2) = 1 - 0.15 = 0.85
+    assert agreement["agreement_score"] == 0.85
+    assert "error" not in agreement
+
+    # Either-error degrade: numeric fields omitted, error carries both sides.
+    degraded = compute_agreement(
+        {"model": "gpt-4.1-nano", "overall": 0.0, "error": "boom"},  # type: ignore[arg-type]
+        report_b,  # type: ignore[arg-type]
+    )
+    assert degraded["model_a"] == "gpt-4.1-nano"
+    assert degraded["model_b"] == "claude-haiku-4-5-20251001"
+    assert "error" in degraded
+    assert "boom" in degraded["error"]
+    assert "agreement_score" not in degraded
+    assert "diff_overall" not in degraded

--- a/tests/bench/test_bench_qa_drift.py
+++ b/tests/bench/test_bench_qa_drift.py
@@ -163,14 +163,14 @@ def test_drift_baseline_matches_suite_roster():
 
 def test_drift_baseline_has_no_nonreproducible_fields():
     """The committed baseline must already be canonicalized — no wall-clock
-    stage timings and no llm_judge block (those would never reproduce)."""
+    stage timings and no llm_judge* blocks (model A / model B / agreement,
+    none of which would reproduce)."""
     from bench.bench_qa.report import _STAGE_TIMING_FIELDS
 
     baseline = _load_baseline()
     for scenario in baseline["scenarios"]:
-        assert "llm_judge" not in scenario, (
-            f"{scenario['scenario_id']}: llm_judge leaked into baseline"
-        )
+        for key in ("llm_judge", "llm_judge_b", "llm_judge_agreement"):
+            assert key not in scenario, f"{scenario['scenario_id']}: {key} leaked into baseline"
         for field in _STAGE_TIMING_FIELDS:
             assert field not in scenario["metrics"], (
                 f"{scenario['scenario_id']}: timing field {field} leaked into baseline"
@@ -206,9 +206,15 @@ def test_direction_table_covers_every_schema_field():
     expected -= {f"metrics.{f}" for f in _STAGE_TIMING_FIELDS}
     # Scenario-level scalars — derived from the schema (not hard-coded) so a NEW
     # top-level ScenarioReport field (e.g. a cache_hit mirroring #485) trips this
-    # until it is given a deliberate direction. llm_judge is stripped by
-    # canonicalize_report; scenario_id is the row key.
-    top_scalars = set(ScenarioReport.__annotations__) - set(sections) - {"scenario_id", "llm_judge"}
+    # until it is given a deliberate direction. The llm_judge* blocks (model A,
+    # model B, and the two-model agreement) are all stripped by
+    # canonicalize_report so the classifier never sees them; scenario_id is the
+    # row key.
+    top_scalars = (
+        set(ScenarioReport.__annotations__)
+        - set(sections)
+        - {"scenario_id", "llm_judge", "llm_judge_b", "llm_judge_agreement"}
+    )
     expected |= top_scalars
 
     classified = set(SCENARIO_DIRECTION) | set(SCENARIO_EXCLUDED)

--- a/tests/bench/test_bench_qa_llm_judge.py
+++ b/tests/bench/test_bench_qa_llm_judge.py
@@ -46,7 +46,7 @@ from bench.bench_qa import (
     make_proxy_manager,
     qa_answerable_ratio,
 )
-from bench.bench_qa.llm_judge_adapter import score_scenario, to_report_dict
+from bench.bench_qa.llm_judge_adapter import compute_agreement, score_scenario, to_report_dict
 from bench.bench_qa.runner import make_tool_result
 from bench.llm_judge import compute_correlation
 
@@ -54,16 +54,44 @@ logger = logging.getLogger(__name__)
 
 LLM_JUDGE_SCENARIOS = ["s02", "s03", "s04", "s05", "s07", "s09"]
 
+# Cross-provider judge pair for the two-model agreement (item 9). Two *different
+# providers* (not two OpenAI / two Anthropic models) is the strongest
+# judge-bias signal: same-provider models share training bias. Both are the
+# cheapest current model for their provider.
+_AGREEMENT_MODEL_A = ("openai", "gpt-4.1-nano")
+_AGREEMENT_MODEL_B = ("anthropic", "claude-haiku-4-5-20251001")
+
 _keyword_vs_llm_pairs: list[tuple[float, float]] = []
+# (overall_a, overall_b) and agreement_score per non-error scenario, for the
+# cross-scenario agreement headline.
+_agreement_pairs: list[tuple[float, float]] = []
+_agreement_scores: list[float] = []
 
 
 def _have_api_key() -> bool:
     return bool(os.environ.get("OPENAI_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"))
 
 
+def _have_both_api_keys() -> bool:
+    return bool(os.environ.get("OPENAI_API_KEY") and os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def _judge_override_env_set() -> bool:
+    """``BENCH_LLM_JUDGE_PROVIDER`` / ``_MODEL`` override the explicit
+    ``provider=`` / ``model=`` kwargs in ``_resolve_config`` — in multi-model
+    mode that collapses both judges onto one model and fabricates
+    ``agreement_score=1.0``. The agreement tests skip when either is set rather
+    than removing the single-judge debugging affordance."""
+    return bool(
+        os.environ.get("BENCH_LLM_JUDGE_PROVIDER") or os.environ.get("BENCH_LLM_JUDGE_MODEL")
+    )
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _reset_correlation_buffer():
     _keyword_vs_llm_pairs.clear()
+    _agreement_pairs.clear()
+    _agreement_scores.clear()
     yield
 
 
@@ -147,4 +175,122 @@ def test_zz_keyword_vs_llm_judge_correlation() -> None:
         corr.pearson_r,
         corr.spearman_rho,
         corr.mean_abs_diff,
+    )
+
+
+@pytest.mark.bench_qa_llm_judge
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario_id", LLM_JUDGE_SCENARIOS)
+async def test_llm_judge_multimodel_agreement(scenario_id: str, tmp_path, bench_qa_report) -> None:
+    """Score one scenario with two cross-provider judges and record their
+    agreement (item 9). Advisory — the only hard assert is transport sanity
+    (both judges returned a result). The agreement block, both per-model
+    blocks, and the cross-scenario correlation are logged / recorded but never
+    gate the run; ``canonicalize_report`` strips them before the determinism
+    diff.
+    """
+    if not _have_both_api_keys():
+        pytest.skip("multi-model agreement needs BOTH OPENAI_API_KEY and ANTHROPIC_API_KEY")
+    if _judge_override_env_set():
+        pytest.skip(
+            "BENCH_LLM_JUDGE_PROVIDER / BENCH_LLM_JUDGE_MODEL override set — would collapse "
+            "both judges onto one model and fake agreement=1.0"
+        )
+
+    fixture = load_fixture(scenario_id)
+    assert fixture.get("force_tier") is None, (
+        f"{scenario_id}: force_tier set — LLM judge covers happy-path only in this PR"
+    )
+
+    mgr, store, session = make_proxy_manager(
+        tmp_path,
+        compression=fixture["expected_compressor"],
+        max_result_chars=fixture["max_result_chars"],
+    )
+    session.call_tool.return_value = make_tool_result(fixture["payload"])
+
+    trace_id = deterministic_trace_id(fixture["scenario_id"])
+    compressed = await mgr.call_tool("fake", f"tool_{scenario_id}", {}, trace_id=trace_id)
+    try:
+        row = latest_metrics_row(store)
+        assert row, f"{scenario_id}: proxy_metrics row was not written"
+
+        probes = fixture.get("qa_probes", [])
+        common = dict(
+            scenario_id=scenario_id,
+            description=fixture.get("description", ""),
+            original=fixture["payload"],
+            compressed=compressed,
+            probes=probes,
+            content_type=fixture.get("content_type", "text"),
+        )
+        provider_a, model_a = _AGREEMENT_MODEL_A
+        provider_b, model_b = _AGREEMENT_MODEL_B
+        result_a = await score_scenario(**common, provider=provider_a, model=model_a)
+        result_b = await score_scenario(**common, provider=provider_b, model=model_b)
+        assert result_a is not None and result_b is not None, (
+            f"{scenario_id}: score_scenario returned None despite both API keys present"
+        )
+
+        report_a = to_report_dict(result_a)
+        report_b = to_report_dict(result_b)
+        agreement = compute_agreement(report_a, report_b)
+
+        # Model A goes into the existing ``llm_judge`` slot; B + agreement are
+        # the item-9 additions. Recording all three makes the agreement row
+        # self-contained regardless of whether the single-judge test ran.
+        bench_qa_report.record_llm_judge(scenario_id=scenario_id, llm_judge=report_a)
+        bench_qa_report.record_llm_judge_agreement(
+            scenario_id=scenario_id, llm_judge_b=report_b, agreement=agreement
+        )
+
+        logger.info(
+            "llm_judge agreement scenario=%s %s=%s %s=%s agreement=%s "
+            "(d_overall=%s fc=%s sc=%s as=%s)%s",
+            scenario_id,
+            agreement["model_a"],
+            agreement.get("overall_a"),
+            agreement["model_b"],
+            agreement.get("overall_b"),
+            agreement.get("agreement_score"),
+            agreement.get("diff_overall"),
+            agreement.get("diff_factual_completeness"),
+            agreement.get("diff_structural_coherence"),
+            agreement.get("diff_answer_sufficiency"),
+            f" error={agreement['error']!r}" if agreement.get("error") else "",
+        )
+        if "error" not in agreement:
+            _agreement_pairs.append((agreement["overall_a"], agreement["overall_b"]))
+            _agreement_scores.append(agreement["agreement_score"])
+    finally:
+        store.close()
+
+
+@pytest.mark.bench_qa_llm_judge
+def test_zz_multimodel_agreement_correlation() -> None:
+    """Log cross-scenario Pearson/Spearman between the two judges' overall
+    scores plus mean per-scenario agreement. Advisory.
+
+    Spearman is the genuine judge-bias backstop: a high mean agreement with
+    low or negative Spearman means the judges agree only because both scores
+    sit in a narrow band, not because they rank scenarios concordantly.
+    """
+    if not _have_both_api_keys():
+        pytest.skip("multi-model agreement needs BOTH OPENAI_API_KEY and ANTHROPIC_API_KEY")
+    if _judge_override_env_set():
+        pytest.skip("BENCH_LLM_JUDGE_PROVIDER / BENCH_LLM_JUDGE_MODEL override set")
+    if len(_agreement_pairs) < 3:
+        pytest.skip(f"need >=3 scenario results for correlation; have {len(_agreement_pairs)}")
+    overall_a = [p[0] for p in _agreement_pairs]
+    overall_b = [p[1] for p in _agreement_pairs]
+    corr = compute_correlation(overall_a, overall_b)
+    mean_agreement = sum(_agreement_scores) / len(_agreement_scores)
+    logger.info(
+        "llm_judge multimodel agreement: n=%d pearson=%.3f spearman=%.3f mad=%.3f "
+        "mean_agreement=%.3f",
+        corr.n,
+        corr.pearson_r,
+        corr.spearman_rho,
+        corr.mean_abs_diff,
+        mean_agreement,
     )


### PR DESCRIPTION
## What

Item 9 of the bench_qa roadmap — **LLM-judge multi-model agreement** (advisory). Runs two cross-provider judges on each happy-path scenario and records an agreement score to detect single-judge bias. The keyword gate stays the sole source of pass/fail — nothing here asserts a threshold.

Cross-provider pair (OpenAI `gpt-4.1-nano` + Anthropic `claude-haiku-4-5-20251001`, both the current cheapest for their provider) is the strongest bias signal: two same-provider models share training bias.

## Changes (5 files, all under `tests/bench/`, no `src/`)

- **`bench_qa/schema.py`** — `LLMJudgeAgreementReport` TypedDict + `llm_judge_b` / `llm_judge_agreement` optional keys on `ScenarioReport` (no schema-version bump — `total=False`, stripped before any determinism diff).
- **`bench_qa/llm_judge_adapter.py`** — `compute_agreement(report_a, report_b)`: per-dimension absolute diffs + `agreement_score = 1 - mean(|a - b|)` over `overall` + the 3 dimensions, rounded and clamped to `[0, 1]`. **Either-error degrade**: if either judge errors, the numeric fields are omitted so a failed judge's `overall=0.0` cannot fabricate a large diff that poisons the cross-scenario correlation.
- **`bench_qa/report.py`** — `record_llm_judge_agreement` collector; `canonicalize_report` strips both new blocks (LLM-score-derived, so drift-prone like `llm_judge`).
- **`test_bench_qa_llm_judge.py`** — parametrized agreement test + cross-scenario Pearson/Spearman headline (Spearman is the bias backstop: high agreement with low rank correlation = narrow-band artifact, not concordance). Both skip unless **both** keys are set **and** neither `BENCH_LLM_JUDGE_PROVIDER`/`_MODEL` override is set.
- **`test_bench_qa_determinism.py`** — two `@bench_qa` unit tests (no API key, run in default CI) pinning the determinism strip and the agreement metric math incl. the either-error path.

## Why it's safe

- **Advisory only** — no threshold/gate; the only hard assert is transport sanity (both judges returned non-`None`).
- **Determinism** — both new blocks are stripped by `canonicalize_report`, so the #486 two-run determinism gate and #487 drift snapshot stay green.
- **No-override skip** — `BENCH_LLM_JUDGE_PROVIDER`/`_MODEL` override the explicit `provider=`/`model=` kwargs in `_resolve_config`; left unguarded they would collapse both judges onto one model and fake `agreement=1.0`.
- **Marker reuse** — network tests carry `bench_qa_llm_judge` (off in the default and required CI jobs); zero `ci.yml` / `CONTRIBUTING` / `pyproject` change.

## Validation

- `ruff check` + `ruff format --check` clean; `mypy` clean on the changed files (the 18 remaining errors are pre-existing in `runner.py`/`replay.py`).
- `-m "bench_qa and not bench_qa_sweep"` → 25 passed; `-m bench_qa_drift` → 3 passed; `test_contributing_pytest_command_matches_ci` green.
- **Real-API run** (`-m bench_qa_llm_judge`, both keys present): 14 passed. Agreement headline `n=4 pearson=0.673 spearman=0.447 mean_agreement=0.894`. 2 of 6 scenarios (s02/s04) exercised the either-error degrade — Anthropic Haiku appended prose after its JSON object — and were correctly excluded from the correlation.

## Follow-up (separate PR, not here)

`tests/bench/llm_judge.py::_parse_score_response` does a bare `json.loads` and fails when a provider without a JSON-object response mode (Anthropic Haiku) appends prose after the JSON. This is a pre-existing robustness gap — the single-judge default is OpenAI's `json_object` mode, which never hits it — so it is left as a driveby. Fixing it would lift agreement coverage from n=4 to n=6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)