### PR TITLE
fix(bench_qa): tolerate fenced/trailing-prose JSON in LLM judge parser

### DIFF
--- a/tests/bench/llm_judge.py
+++ b/tests/bench/llm_judge.py
@@ -143,6 +143,36 @@ Can this question be answered from the document above?"""
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Response parsing
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _loads_lenient(raw: str) -> dict:
+    """Parse one JSON object from an LLM response.
+
+    Tolerates two shapes a bare ``json.loads`` rejects but judge models emit
+    routinely: a markdown code fence around the object, and trailing prose
+    *after* the object (``json.JSONDecodeError: Extra data``). The OpenAI judge
+    sets ``response_format={"type": "json_object"}`` and never hits either, but
+    the Anthropic Messages API has no equivalent mode, so Haiku appends a
+    sentence often enough to fail real runs. Strip a leading fence, then decode
+    just the first JSON value from the first ``{`` — anything after the object
+    is discarded.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else text[3:]
+        if text.endswith("```"):
+            text = text[:-3]
+        text = text.strip()
+    start = text.find("{")
+    if start == -1:
+        raise json.JSONDecodeError("no JSON object in response", text or raw, 0)
+    obj, _end = json.JSONDecoder().raw_decode(text, start)
+    return obj
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # LLM providers
 # ═══════════════════════════════════════════════════════════════════════════
 
@@ -282,15 +312,7 @@ class LLMJudge:
 
     def _parse_score_response(self, raw: str) -> tuple[float, list[JudgeDimension]]:
         """Parse JSON score response from LLM."""
-        # Strip markdown code fences if present
-        text = raw.strip()
-        if text.startswith("```"):
-            text = text.split("\n", 1)[1] if "\n" in text else text[3:]
-            if text.endswith("```"):
-                text = text[:-3]
-            text = text.strip()
-
-        data = json.loads(text)
+        data = _loads_lenient(raw)
         dims = []
         for key in ("factual_completeness", "structural_coherence", "answer_sufficiency"):
             d = data.get(key, {})
@@ -330,12 +352,7 @@ class LLMJudge:
                     qa_raw, qp, qc = await self._call_llm(_QA_SYSTEM_PROMPT, qa_prompt)
                     total_qa_tokens = (total_qa_tokens[0] + qp, total_qa_tokens[1] + qc)
                     try:
-                        qa_text = qa_raw.strip()
-                        if qa_text.startswith("```"):
-                            qa_text = qa_text.split("\n", 1)[1] if "\n" in qa_text else qa_text[3:]
-                            if qa_text.endswith("```"):
-                                qa_text = qa_text[:-3]
-                        qa_data = json.loads(qa_text.strip())
+                        qa_data = _loads_lenient(qa_raw)
                         qa_results.append(
                             {
                                 "question": qa.question,

--- a/tests/bench/test_llm_judge_parse.py
+++ b/tests/bench/test_llm_judge_parse.py
@@ -1,0 +1,50 @@
+"""Unit tests for the LLM-judge lenient JSON parser.
+
+No API key required — these pin ``_loads_lenient`` against the response shapes
+that a bare ``json.loads`` rejected, the trailing-prose case being the one that
+errored 2 of 6 scenarios on real Anthropic Haiku runs (the Messages API has no
+JSON-object response mode, so the model appends a sentence after the object).
+Runs in the default ``test`` CI job (unmarked).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bench.llm_judge import _loads_lenient
+
+
+def test_plain_object():
+    assert _loads_lenient('{"overall": 8, "ok": true}') == {"overall": 8, "ok": True}
+
+
+def test_strips_code_fence():
+    assert _loads_lenient('```json\n{"overall": 7}\n```') == {"overall": 7}
+
+
+def test_ignores_trailing_prose():
+    # The Haiku failure mode: a valid object followed by a trailing sentence.
+    raw = '{"overall": 6, "note": "x"}\n\nThis compression preserved the key facts.'
+    assert _loads_lenient(raw) == {"overall": 6, "note": "x"}
+
+
+def test_skips_leading_prose():
+    assert _loads_lenient('Here is my assessment:\n{"overall": 9}') == {"overall": 9}
+
+
+def test_fence_then_trailing_prose():
+    # Close fence not stripped (text no longer ends with ```), but raw_decode
+    # stops at the end of the object regardless.
+    assert _loads_lenient('```\n{"overall": 5}\n```\nDone.') == {"overall": 5}
+
+
+def test_nested_object_survives_trailing_prose():
+    raw = '{"factual_completeness": {"score": 7}, "overall": 7} trailing'
+    assert _loads_lenient(raw) == {"factual_completeness": {"score": 7}, "overall": 7}
+
+
+def test_no_object_raises():
+    with pytest.raises(json.JSONDecodeError):
+        _loads_lenient("no json here at all")


### PR DESCRIPTION
## What

Follow-up to #489. The LLM judge's `_parse_score_response` and per-QA parse did a bare `json.loads` after stripping a leading code fence. The OpenAI judge sets `response_format={"type": "json_object"}` and never trips it, but the **Anthropic Messages API has no equivalent mode** — Haiku appends a sentence after its JSON object often enough that **2 of 6 scenarios (s02, s04) errored on real runs** with `Extra data: line N column 1`, so the either-error degrade excluded them from the multi-model agreement correlation (n stuck at 4/6).

## Change (2 files, `tests/bench/` only)

- **`llm_judge.py`** — extract a shared `_loads_lenient(raw)` helper: strip a leading fence, then decode only the **first** JSON value from the first `{` via `JSONDecoder().raw_decode`, discarding any trailing prose. Replaces the duplicated fence-strip + `json.loads` at both the score-response and per-QA parse sites. OpenAI's clean JSON is unaffected (first `{` at index 0, whole object parsed).
- **`test_llm_judge_parse.py`** — new unit tests (no API key, run in the default `test` CI job) pinning plain / fenced / trailing-prose / leading-prose / fence-then-prose / nested-object / no-object cases.

## Validation

- `ruff` + `ruff format` clean; `mypy` clean on `llm_judge.py`.
- Full default `test` filter locally: **3419 passed, 3 skipped** (+7 new parser tests, no regression).
- **Real-API run** (both keys): the agreement headline goes **n=4 → n=6** — s02/s04 now parse. s04 surfaces a genuine inter-judge disagreement (`nano 0.80` vs `Haiku 0.23`, agreement 0.43) that the parse error had been masking — exactly the judge-bias signal #489 exists to expose. New headline: `n=6 pearson=0.306 spearman=0.403 mean_agreement=0.784`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)