### PR TITLE
feat(proxy): add tool-graph eligibility provider config + adapter (#465)

### DIFF
--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -689,6 +689,82 @@ class ExposureConfig(BaseModel):
     ``review``."""
 
 
+class ToolgraphConfig(BaseModel):
+    """Optional external tool-graph eligibility provider (#465).
+
+    Consults a separate, non-proxied tool-graph MCP server for cross-server
+    authorization / data-flow eligibility facts and feeds them into the
+    STM-native exposure filter as an additional rule source (alongside the
+    config / structural / native-signal rules already in
+    ``tool_eligibility.filter_tools``). The graph is *consulted*, never
+    proxied: the client never sees its tools, and STM holds **no
+    Python-level dependency** on the external package — all traffic goes
+    over the MCP protocol via :class:`~memtomem_stm.proxy.toolgraph_provider.ToolgraphConsultAdapter`
+    (stdio transport), mirroring the surfacing LTM-consult pattern.
+
+    Default-off: when ``enabled`` is ``True`` the consult runs once at
+    proxy startup so the advertised tool set stays session-stable, exactly
+    like the health-flag precompute. This first step parses the block and
+    ships the adapter, but the eligibility wiring (consult at ``start()`` +
+    ``filter_tools`` branch + ``toolgraph_*`` reject codes + telemetry) is a
+    follow-up, so an enabled block logs a "config is enabled but inert"
+    startup WARNING (#288 pattern) until then. Neo4j (behind the graph
+    server) is an operational prerequisite of enabling this block.
+    """
+
+    enabled: bool = False
+    command: str = "toolgraph"
+    """Launch command for the stdio tool-graph MCP server. Defaults to the
+    graph server's registered console script (mirroring the surfacing
+    ``memtomem-server`` default); ``serve`` with no flag runs stdio
+    (``serve --http`` is out of scope for v1 — stdio transport only)."""
+    args: list[str] = ["serve"]
+    env: dict[str, str] | None = None
+    """Extra environment for the launched server (e.g. ``NEO4J_URI`` /
+    ``NEO4J_USER`` / ``NEO4J_PASSWORD``). ``None`` inherits only mcp's safe
+    default-environment allowlist (PATH / HOME / SHELL / TERM / USER /
+    LOGNAME); set ``NEO4J_*`` etc. explicitly here — they are merged *over*
+    that default and are not picked up from the proxy's own environment."""
+    agent_id: str = "stm-proxy"
+    """Identity the graph authorizes eligibility against; must be registered
+    in the graph. A typo returns ``agent_found=false`` — see
+    ``on_agent_not_found``."""
+    server_name_map: dict[str, str] = {}
+    """Maps an STM upstream connection key (the operator-chosen key in
+    ``upstream_servers``) to the tool-graph server's *crawled* name. The two
+    are independent strings, so they coincide only by luck; an empty map
+    assumes identity and relies on a heuristic mismatch warning (a follow-up)."""
+    query_profile: str = "strict"
+    """Profile passed to the upstream ``eligible_tools`` consult. Kept a free
+    string (not coupled to STM's own ``ExposureProfile``) because the graph's
+    profile ladder is the external package's concern; STM applies its own
+    profile semantics on top (RFC Decision 1)."""
+    on_unreachable: Literal["open", "closed"] = "open"
+    """Transport down / timeout. ``open`` (default) skips the external rule
+    family and advertises per STM-native rules (the graph is an enhancement,
+    not a hard dependency); ``closed`` withholds every tool the graph did not
+    bless (high-assurance)."""
+    on_agent_not_found: Literal["fail_start", "open", "closed"] = "fail_start"
+    """Graph reachable but ``agent_id`` unknown — almost always a config
+    typo. ``fail_start`` (default) fails startup loudly so a typo cannot
+    silently disable enforcement; ``open`` / ``closed`` are explicit opt-ins."""
+    on_protocol_error: Literal["fail_start", "open", "closed"] = "fail_start"
+    """Graph reachable but incompatible (missing ``eligible_tools``, malformed
+    ``structuredContent``, non-int ``graph_generation``, unknown-profile
+    error). ``fail_start`` (default) treats a contract break as a loud
+    startup failure rather than a silent passthrough."""
+    on_tool_not_found: Literal["open", "closed"] = "open"
+    """A specific candidate was never crawled (the graph's blind spot).
+    ``open`` (default) does not hide a working tool; ``closed`` rejects
+    uncrawled candidates (high-assurance)."""
+    risk_penalty_scale: float = Field(default=1.0, ge=0.0)
+    """Multiplier mapping the upstream ``risk_score`` to a relevance
+    ``risk_penalty`` (consumed by a follow-up); ``0`` disables the risk
+    signal."""
+    timeout_seconds: float = Field(default=5.0, gt=0.0)
+    """Per-consult timeout for the startup batch query."""
+
+
 # Static context window sizes (tokens) for known model families.
 # Used by ProxyConfig.effective_max_result_chars() to scale compression budget.
 # Prefix-matched: "claude-sonnet-4-20250514" matches "claude-sonnet-4".
@@ -824,6 +900,7 @@ class ProxyConfig(BaseModel):
     selection_telemetry: SelectionTelemetryConfig = Field(default_factory=SelectionTelemetryConfig)
     tool_relevance: ToolRelevanceConfig = Field(default_factory=ToolRelevanceConfig)
     exposure: ExposureConfig = Field(default_factory=ExposureConfig)
+    toolgraph: ToolgraphConfig = Field(default_factory=ToolgraphConfig)
 
     @model_validator(mode="after")
     def _check_nonempty_upstream_prefixes(self) -> Self:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -337,6 +337,19 @@ class ProxyManager:
                 exposure_cfg.profile.value,
             )
 
+        # #465: the optional external tool-graph eligibility provider is
+        # configured but not yet consulted here — the startup consult that
+        # feeds ``filter_tools`` (beside the health-flag precompute above) is a
+        # follow-up. Until it lands, an enabled block does nothing, so warn
+        # (the #288 "config is enabled but inert" pattern) rather than let an
+        # operator believe external eligibility facts are being enforced.
+        if self._config.toolgraph.enabled:
+            logger.warning(
+                "toolgraph.enabled is set but the eligibility provider is not "
+                "wired yet — config is enabled but inert; no external "
+                "eligibility facts will be consulted."
+            )
+
     def _open_transport(self, cfg: UpstreamServerConfig):  # noqa: ANN201
         match cfg.transport:
             case TransportType.SSE:

--- a/src/memtomem_stm/proxy/toolgraph_provider.py
+++ b/src/memtomem_stm/proxy/toolgraph_provider.py
@@ -1,0 +1,243 @@
+"""MCP client adapter for the optional tool-graph eligibility provider (#465).
+
+STM consults a separate, non-proxied tool-graph MCP server for cross-server
+authorization / data-flow eligibility facts and feeds them into the
+exposure filter as an additional rule source. This module mirrors
+``surfacing/mcp_client.py::McpClientSearchAdapter`` (the proven "consult a
+separate, non-proxied MCP server" pattern): one ``ClientSession`` over a
+launched stdio child, and **zero** Python-level dependency on the external
+package — all traffic goes over the MCP protocol.
+
+This first step ships the config block + a connectable adapter only: the
+adapter can connect and run the ``eligible_tools`` consult, but nothing wires
+it into the eligibility filter yet. The startup consult (beside
+``compute_health_flags``), the ``filter_tools`` branch, the ``toolgraph_*``
+reject codes, and the ``graph_generation`` telemetry pin are follow-ups.
+Unlike the surfacing adapter the consult runs once per session at proxy
+startup (so the advertised set stays stable), which is why this adapter has
+no per-request lazy-start / reconnect machinery: the caller starts it once
+and maps any failure onto the configured ``on_*`` knobs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from contextlib import AsyncExitStack
+from typing import Any, cast
+
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.types import TextContent
+
+from memtomem_stm.proxy.config import ToolgraphConfig
+
+logger = logging.getLogger(__name__)
+
+# The upstream MCP tool this adapter consults (toolgraph/server/app.py).
+_ELIGIBLE_TOOLS = "eligible_tools"
+
+
+class ToolgraphConsultError(Exception):
+    """Base error for a failed tool-graph consult."""
+
+
+class ToolgraphUnreachableError(ToolgraphConsultError):
+    """The tool-graph server could not be reached, or the consult timed out.
+
+    An *availability* failure at the **transport** layer: the stdio child
+    never came up, the pipe broke, or the consult exceeded ``timeout_seconds``.
+    The caller maps this onto ``on_unreachable``. Note this is narrower than
+    "the graph is unavailable": a backend (e.g. Neo4j) outage where the graph
+    *server* stays up surfaces as an ``isError`` tool result, not a transport
+    error, and is therefore classified ``ToolgraphProtocolError`` (below) —
+    consistent with the RFC treating any server-side error envelope as a
+    contract class.
+    """
+
+
+class ToolgraphProtocolError(ToolgraphConsultError):
+    """The tool-graph server is reachable but returned an incompatible response.
+
+    A *contract* failure: the ``eligible_tools`` tool is missing, the call
+    came back ``isError`` (including a backend/DB outage the graph server
+    reports as a tool error), or the structured payload is absent / malformed.
+    The caller maps this onto ``on_protocol_error``. Distinct from
+    ``ToolgraphUnreachableError`` so a version/contract drift is never
+    silently treated as "the graph is down".
+    """
+
+
+class ToolgraphConsultAdapter:
+    """Connects to a tool-graph MCP server (stdio) and consults ``eligible_tools``.
+
+    Lifecycle mirrors :class:`~memtomem_stm.surfacing.mcp_client.McpClientSearchAdapter`:
+    ``start()`` launches the stdio child and opens one initialized
+    ``ClientSession``; ``stop()`` tears it down. ``eligible_tools()`` runs the
+    batch consult and returns the raw structured response for the caller to
+    interpret.
+    """
+
+    # Transport failure modes that mean "graph unreachable" rather than a
+    # contract mismatch. stdio pipe failures surface as
+    # OSError / EOFError / BrokenPipeError; a blocked/slow server surfaces as
+    # ``asyncio.TimeoutError`` via the per-consult ``timeout_seconds``.
+    _TRANSPORT_ERRORS = (
+        OSError,
+        ConnectionError,
+        EOFError,
+        BrokenPipeError,
+        asyncio.TimeoutError,
+    )
+
+    def __init__(self, config: ToolgraphConfig) -> None:
+        self._config = config
+        self._stack: AsyncExitStack | None = None
+        self._session: ClientSession | None = None
+
+    @property
+    def is_started(self) -> bool:
+        """True once :meth:`start` has opened a live session."""
+        return self._session is not None
+
+    async def start(self) -> None:
+        """Launch the stdio tool-graph server and open one ``ClientSession``."""
+        stack = AsyncExitStack()
+        self._stack = stack
+        try:
+            # ``env=None`` lets mcp use ``get_default_environment()`` (PATH etc.);
+            # a configured ``env`` is merged *over* that default by stdio_client,
+            # so setting e.g. NEO4J_* does not strip the inherited PATH.
+            params = StdioServerParameters(
+                command=self._config.command,
+                args=list(self._config.args),
+                env=self._config.env,
+            )
+            streams = await stack.enter_async_context(stdio_client(params))
+            self._session = await stack.enter_async_context(ClientSession(streams[0], streams[1]))
+            await self._session.initialize()
+            logger.info("Tool-graph consult adapter connected via stdio: %s", self._config.command)
+        except BaseException:
+            # Roll back the stdio subprocess + session streams so a failed
+            # start does not leak file descriptors / child processes across
+            # retries (mirrors McpClientSearchAdapter.start()).
+            try:
+                await stack.aclose()
+            except Exception:
+                logger.debug("Error during tool-graph adapter start() cleanup", exc_info=True)
+            self._stack = None
+            self._session = None
+            raise
+
+    async def stop(self) -> None:
+        """Disconnect from the tool-graph server and reap the child."""
+        if self._stack is not None:
+            await self._stack.aclose()
+            self._stack = None
+            self._session = None
+
+    async def eligible_tools(
+        self,
+        candidates: list[str],
+        *,
+        agent: str | None = None,
+        profile: str | None = None,
+    ) -> dict[str, Any]:
+        """Consult the graph's ``eligible_tools`` for *candidates*.
+
+        ``candidates`` are server-qualified ``"<server>::<tool>"`` refs (bare
+        names risk ``AMBIGUOUS_TOOL``). ``agent`` / ``profile`` fall back to
+        the configured ``agent_id`` / ``query_profile``.
+
+        Returns the raw structured response dict
+        ``{agent, agent_found, profile, eligible, rejected, graph_generation}``
+        (input order preserved on ``eligible``). The caller interprets it:
+        ``agent_found=false`` is a structured *abort* signal (not an empty
+        result), and each ``rejected`` row carries a ``reason`` plus optional
+        ``paths`` / ``candidates``.
+
+        Raises:
+            ToolgraphUnreachableError: transport down / timeout / not started.
+            ToolgraphProtocolError: ``isError`` result, missing tool, or a
+                missing / non-dict structured payload.
+        """
+        if self._session is None:
+            raise ToolgraphUnreachableError("tool-graph adapter not started")
+
+        args: dict[str, Any] = {
+            "agent": self._config.agent_id if agent is None else agent,
+            "candidates": candidates,
+            "profile": self._config.query_profile if profile is None else profile,
+        }
+
+        try:
+            result = await asyncio.wait_for(
+                self._session.call_tool(_ELIGIBLE_TOOLS, args),
+                timeout=self._config.timeout_seconds,
+            )
+        except self._TRANSPORT_ERRORS as exc:
+            raise ToolgraphUnreachableError(str(exc)) from exc
+        except ToolgraphConsultError:
+            raise
+        except Exception as exc:
+            # Any other call_tool failure (e.g. an MCP error for an unknown
+            # tool) is a contract problem, not an availability one.
+            raise ToolgraphProtocolError(str(exc)) from exc
+
+        if result.isError:
+            raise ToolgraphProtocolError(
+                f"eligible_tools returned an error result: {_result_error_text(result)}"
+            )
+
+        # Prefer ``structuredContent`` if the upstream emits it, but mcp 1.27.x
+        # does NOT auto-wrap a bare ``-> dict`` tool return — the JSON-serialized
+        # verdict arrives as a TextContent instead (toolgraph returns ``dict``),
+        # so text-JSON is the actual production path today. ``structuredContent``
+        # stays the preferred path in case the upstream switches to a typed
+        # (BaseModel / TypedDict) return.
+        verdict = result.structuredContent
+        if not isinstance(verdict, dict):
+            verdict = _parse_text_verdict(result)
+        if not isinstance(verdict, dict):
+            raise ToolgraphProtocolError(
+                "eligible_tools response carried no parseable verdict "
+                "(neither structuredContent nor a JSON text payload)"
+            )
+        return verdict
+
+
+def _parse_text_verdict(result: Any) -> dict[str, Any] | None:
+    """Parse the verdict dict from a CallToolResult's text content.
+
+    mcp 1.27.x serializes a bare ``-> dict`` tool return into a single
+    ``TextContent`` JSON string rather than ``structuredContent``. Joins the
+    text parts and JSON-decodes them; returns ``None`` on a missing / malformed
+    / non-dict payload (the caller raises ``ToolgraphProtocolError``).
+    """
+    parts = [
+        cast(TextContent, c).text or ""
+        for c in (result.content or [])
+        if getattr(c, "type", None) == "text"
+    ]
+    if not parts:
+        return None
+    try:
+        parsed = json.loads("\n".join(parts))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _result_error_text(result: Any) -> str:
+    """Best-effort one-line error text from an ``isError`` CallToolResult.
+
+    Tolerates spec-noncompliant ``content=None`` / ``text=None`` the same way
+    the surfacing adapter does (mirrors PR #114 / manager.py).
+    """
+    parts = [
+        cast(TextContent, c).text or ""
+        for c in (result.content or [])
+        if getattr(c, "type", None) == "text"
+    ]
+    return " ".join(p for p in parts if p) or "(no error text)"

--- a/tests/_fake_toolgraph_server.py
+++ b/tests/_fake_toolgraph_server.py
@@ -1,0 +1,80 @@
+"""Tiny stdio MCP server used by the ToolgraphConsultAdapter tests.
+
+Stands in for the real tool-graph MCP server (``toolgraph serve``) so that
+STM's :class:`~memtomem_stm.proxy.toolgraph_provider.ToolgraphConsultAdapter`
+can be exercised end-to-end over a real stdio child without depending on the
+external package or a running Neo4j. It exposes the one tool the adapter
+calls — ``eligible_tools`` — returning the real structured shape
+(``{agent, agent_found, profile, eligible, rejected, graph_generation}``).
+
+Returning a bare ``-> dict`` means mcp serializes the verdict into a
+``TextContent`` JSON payload (mcp 1.27.x does not emit ``structuredContent``
+for an untyped dict return), which is exactly the production wire shape the
+adapter parses.
+
+Input-driven behaviors (so one fixture covers every adapter path):
+
+* ``profile == "boom"`` raises (unknown-profile mirror) → ``isError`` →
+  the adapter raises ``ToolgraphProtocolError``.
+* ``profile == "sleep"`` blocks far longer than any test timeout → the
+  adapter's per-consult ``asyncio.wait_for`` fires → ``ToolgraphUnreachableError``.
+* ``agent == "ghost"`` returns ``agent_found=False`` as a *structured*
+  result (NOT an error) — the abort signal the adapter must surface as data.
+* any candidate ending in ``"::blocked"`` comes back as a ``NOT_GRANTED``
+  rejected row; all others are eligible, in input order.
+
+Run with: ``python <path-to-this-file>``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("fake-toolgraph")
+
+# Arbitrary fixed monotonic graph generation so tests can assert the field is
+# threaded through verbatim.
+_GRAPH_GENERATION = 11
+
+
+@mcp.tool()
+async def eligible_tools(agent: str, candidates: list[str], profile: str = "strict") -> dict:
+    """Canned ``eligible_tools`` consult mirroring the real structured shape."""
+    if profile == "boom":
+        raise ValueError(f"unknown profile {profile!r}")
+    if profile == "sleep":
+        await asyncio.sleep(30)
+    if agent == "ghost":
+        return {
+            "agent": agent,
+            "agent_found": False,
+            "profile": profile,
+            "eligible": [],
+            "rejected": [],
+            "graph_generation": _GRAPH_GENERATION,
+        }
+
+    eligible: list[str] = []
+    rejected: list[dict] = []
+    for candidate in candidates:  # input order is part of the upstream contract
+        if candidate.endswith("::blocked"):
+            rejected.append(
+                {"candidate": candidate, "tool_key": candidate, "reason": "NOT_GRANTED"}
+            )
+        else:
+            eligible.append(candidate)
+
+    return {
+        "agent": agent,
+        "agent_found": True,
+        "profile": profile,
+        "eligible": eligible,
+        "rejected": rejected,
+        "graph_generation": _GRAPH_GENERATION,
+    }
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/test_env_overrides.py
+++ b/tests/test_env_overrides.py
@@ -42,6 +42,10 @@ class TestCollectProxyEnvOverrides:
             }
         }
 
+    def test_toolgraph_nested_field(self) -> None:
+        env = {"MEMTOMEM_STM_PROXY__TOOLGRAPH__ENABLED": "true"}
+        assert collect_proxy_env_overrides(env) == {"toolgraph": {"enabled": "true"}}
+
     def test_unrelated_env_vars_ignored(self) -> None:
         env = {
             "PATH": "/usr/bin",
@@ -87,6 +91,17 @@ class TestLoadFromFileWithEnvOverrides:
 
         assert cfg is not None
         assert cfg.default_max_result_chars == 16000
+
+    def test_toolgraph_env_wins_over_file(self, tmp_path: Path) -> None:
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"toolgraph": {"on_unreachable": "open"}}))
+
+        cfg = ProxyConfig.load_from_file(
+            cfg_file, env_overrides={"toolgraph": {"on_unreachable": "closed"}}
+        )
+
+        assert cfg is not None
+        assert cfg.toolgraph.on_unreachable == "closed"
 
     def test_env_overrides_when_file_missing(self, tmp_path: Path) -> None:
         cfg = ProxyConfig.load_from_file(

--- a/tests/test_toolgraph_provider.py
+++ b/tests/test_toolgraph_provider.py
@@ -1,0 +1,259 @@
+"""Tests for the optional tool-graph eligibility provider (#465, PR1).
+
+Covers the ``toolgraph`` config block (defaults / failure-knob defaults /
+file parse) and the connectable ``ToolgraphConsultAdapter`` (stdio lifecycle
++ ``eligible_tools`` consult against a real fake stdio child). PR1 wires
+nothing into the eligibility filter; the only runtime touch is the
+"enabled but inert" startup warning, asserted here too.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from memtomem_stm.proxy.config import ProxyConfig, ToolgraphConfig
+from memtomem_stm.proxy.manager import ProxyManager
+from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.toolgraph_provider import (
+    ToolgraphConsultAdapter,
+    ToolgraphProtocolError,
+    ToolgraphUnreachableError,
+    _parse_text_verdict,
+)
+
+# Real stdio MCP child (mirrors tests/_fake_memtomem_server.py usage).
+_FAKE_TOOLGRAPH = Path(__file__).resolve().parent / "_fake_toolgraph_server.py"
+
+
+def _adapter(**overrides) -> ToolgraphConsultAdapter:
+    """Adapter pointed at the fake stdio toolgraph server."""
+    cfg = ToolgraphConfig(
+        enabled=True,
+        command=sys.executable,
+        args=[str(_FAKE_TOOLGRAPH)],
+        **overrides,
+    )
+    return ToolgraphConsultAdapter(cfg)
+
+
+# ── config block ──────────────────────────────────────────────────────────
+
+
+class TestToolgraphConfig:
+    def test_toolgraph_config_parse_defaults_off(self):
+        tg = ProxyConfig().toolgraph
+        assert tg.enabled is False  # default-off
+        assert tg.command == "toolgraph"
+        assert tg.args == ["serve"]
+        assert tg.env is None
+        assert tg.agent_id == "stm-proxy"
+        assert tg.server_name_map == {}
+        assert tg.query_profile == "strict"
+        assert tg.risk_penalty_scale == 1.0
+        assert tg.timeout_seconds == 5.0
+
+    def test_failure_knob_defaults(self):
+        tg = ProxyConfig().toolgraph
+        # whole-call classes that silently disabling enforcement would be a
+        # security footgun fail startup loudly by default; availability /
+        # blind-spot classes stay open.
+        assert tg.on_agent_not_found == "fail_start"
+        assert tg.on_protocol_error == "fail_start"
+        assert tg.on_unreachable == "open"
+        assert tg.on_tool_not_found == "open"
+
+    def test_block_parses_from_config_file(self, tmp_path):
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "toolgraph": {
+                        "enabled": True,
+                        "agent_id": "fleet-1",
+                        "server_name_map": {"gh": "github"},
+                        "on_unreachable": "closed",
+                        "risk_penalty_scale": 0.5,
+                    },
+                }
+            )
+        )
+        config = ProxyConfig.load_from_file(cfg_file)
+        assert config is not None
+        tg = config.toolgraph
+        assert tg.enabled is True
+        assert tg.agent_id == "fleet-1"
+        assert tg.server_name_map == {"gh": "github"}
+        assert tg.on_unreachable == "closed"
+        assert tg.risk_penalty_scale == 0.5
+        # unset knobs keep their defaults
+        assert tg.on_agent_not_found == "fail_start"
+
+    @pytest.mark.parametrize(
+        "field",
+        ["on_unreachable", "on_agent_not_found", "on_protocol_error", "on_tool_not_found"],
+    )
+    def test_invalid_failure_knob_rejected(self, field):
+        with pytest.raises(ValidationError):
+            ProxyConfig.model_validate({"toolgraph": {field: "bogus"}})
+
+
+# ── adapter lifecycle + consult (real stdio child) ──────────────────────────
+
+
+class TestToolgraphConsultAdapter:
+    async def test_start_stop_lifecycle(self):
+        adapter = _adapter()
+        assert adapter.is_started is False
+        await adapter.start()
+        try:
+            assert adapter.is_started is True
+        finally:
+            await adapter.stop()
+        assert adapter.is_started is False
+
+    async def test_eligible_tools_returns_structured_verdict(self):
+        adapter = _adapter()
+        await adapter.start()
+        try:
+            verdict = await adapter.eligible_tools(
+                ["s::a", "s::blocked", "s::b"], agent="planner", profile="strict"
+            )
+        finally:
+            await adapter.stop()
+        assert verdict["agent"] == "planner"
+        assert verdict["agent_found"] is True
+        assert verdict["profile"] == "strict"
+        # input order preserved; blocked candidate routed to rejected
+        assert verdict["eligible"] == ["s::a", "s::b"]
+        assert verdict["rejected"] == [
+            {"candidate": "s::blocked", "tool_key": "s::blocked", "reason": "NOT_GRANTED"}
+        ]
+        assert verdict["graph_generation"] == 11
+
+    async def test_eligible_tools_uses_config_agent_and_profile_defaults(self):
+        adapter = _adapter(agent_id="default-agent", query_profile="review")
+        await adapter.start()
+        try:
+            verdict = await adapter.eligible_tools(["s::a"])
+        finally:
+            await adapter.stop()
+        assert verdict["agent"] == "default-agent"
+        assert verdict["profile"] == "review"
+
+    async def test_agent_not_found_is_structured_not_error(self):
+        adapter = _adapter()
+        await adapter.start()
+        try:
+            verdict = await adapter.eligible_tools(["s::a"], agent="ghost")
+        finally:
+            await adapter.stop()
+        # agent_found=false is an abort SIGNAL carried as data, never an error
+        assert verdict["agent_found"] is False
+        assert verdict["eligible"] == []
+        assert verdict["graph_generation"] == 11
+
+    async def test_protocol_error_on_tool_error_result(self):
+        adapter = _adapter()
+        await adapter.start()
+        try:
+            with pytest.raises(ToolgraphProtocolError):
+                await adapter.eligible_tools(["s::a"], profile="boom")
+        finally:
+            await adapter.stop()
+
+    async def test_eligible_tools_before_start_raises_unreachable(self):
+        adapter = _adapter()
+        with pytest.raises(ToolgraphUnreachableError):
+            await adapter.eligible_tools(["s::a"])
+
+    async def test_timeout_raises_unreachable(self):
+        adapter = _adapter(timeout_seconds=0.3)
+        await adapter.start()
+        try:
+            with pytest.raises(ToolgraphUnreachableError):
+                await adapter.eligible_tools(["s::a"], profile="sleep")
+        finally:
+            await adapter.stop()
+
+    async def test_start_failure_rolls_back_and_not_started(self):
+        adapter = ToolgraphConsultAdapter(
+            ToolgraphConfig(enabled=True, command="this-binary-does-not-exist-xyz", args=[])
+        )
+        with pytest.raises(OSError):  # spawn failure: FileNotFoundError
+            await adapter.start()
+        assert adapter.is_started is False
+
+
+# ── manager "enabled but inert" startup warning (PR1) ───────────────────────
+
+
+class TestToolgraphInertWarning:
+    async def test_enabled_warns_inert_at_startup(self, tmp_path, caplog):
+        cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={},
+            toolgraph=ToolgraphConfig(enabled=True),
+        )
+        mgr = ProxyManager(cfg, TokenTracker())
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr.start()
+        try:
+            assert any(
+                "toolgraph.enabled is set" in r.message and "inert" in r.message
+                for r in caplog.records
+            )
+        finally:
+            await mgr.stop()
+
+    async def test_disabled_does_not_warn(self, tmp_path, caplog):
+        cfg = ProxyConfig(config_path=tmp_path / "proxy.json", upstream_servers={})
+        mgr = ProxyManager(cfg, TokenTracker())
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr.start()
+        try:
+            assert not any("toolgraph.enabled" in r.message for r in caplog.records)
+        finally:
+            await mgr.stop()
+
+
+# ── text-JSON verdict parsing (the production wire path on mcp 1.27.x) ───────
+
+
+def _text_result(*texts: str | None):
+    """A minimal CallToolResult stand-in carrying text content parts."""
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=t) for t in texts])
+
+
+class TestParseTextVerdict:
+    def test_parses_json_dict(self):
+        verdict = _parse_text_verdict(_text_result('{"agent": "a", "eligible": []}'))
+        assert verdict == {"agent": "a", "eligible": []}
+
+    def test_joins_multi_part_text(self):
+        verdict = _parse_text_verdict(_text_result('{"agent":', ' "a"}'))
+        assert verdict == {"agent": "a"}
+
+    def test_malformed_json_returns_none(self):
+        assert _parse_text_verdict(_text_result("not json")) is None
+
+    def test_non_dict_json_returns_none(self):
+        assert _parse_text_verdict(_text_result("[1, 2, 3]")) is None
+
+    def test_empty_content_returns_none(self):
+        assert _parse_text_verdict(SimpleNamespace(content=[])) is None
+
+    def test_none_content_returns_none(self):
+        # spec-noncompliant upstream returning content=None
+        assert _parse_text_verdict(SimpleNamespace(content=None)) is None
+
+    def test_none_text_part_returns_none(self):
+        # TextContent.text=None degrades to "" → unparseable → None
+        assert _parse_text_verdict(_text_result(None)) is None


### PR DESCRIPTION
## Summary

First step toward the optional external tool-graph eligibility provider (#465): an external authorization/data-flow graph that STM can consult, over MCP, for cross-server eligibility facts feeding the tool-exposure filter. This PR ships **only** the config surface and a connectable adapter — **nothing is wired into the exposure filter yet**. A follow-up adds the startup consult, the `filter_tools` branch, the reject codes, and the selection telemetry.

The graph is *consulted, never proxied*: the client never sees its tools, and STM holds **no Python-level dependency** on the external package — all traffic goes over the MCP protocol, mirroring the existing surfacing LTM-consult pattern (`surfacing/mcp_client.py`).

## What's in this PR

- **config** — new default-off `ToolgraphConfig` on `ProxyConfig.toolgraph` carrying the stdio launch `command`/`args`/`env`, `agent_id`, `server_name_map`, `query_profile`, the four `on_*` failure knobs, `risk_penalty_scale`, and `timeout_seconds`.
  - `on_unreachable` / `on_tool_not_found` default **`open`** — the graph is an enhancement, not a hard dependency.
  - `on_agent_not_found` / `on_protocol_error` default **`fail_start`** — a config typo or a contract drift must not silently disable enforcement.
  - Default command is **`toolgraph serve`** (the graph server's registered stdio console-script entry), mirroring the surfacing `memtomem-server` default.
- **adapter** — `proxy/toolgraph_provider.py::ToolgraphConsultAdapter`: one `ClientSession` over a launched stdio child, zero import of the external package. `eligible_tools()` returns the structured verdict, preferring `structuredContent` but falling back to the **text-JSON payload that mcp 1.27 actually emits for a bare `-> dict` tool return** (the real production wire shape). Transport/timeout failures raise `ToolgraphUnreachableError`; an `isError` result or a malformed payload raises `ToolgraphProtocolError`.
- **manager** — an "enabled but inert" startup `WARNING` (the same pattern as `auto_index`/`extraction`) when the block is enabled but the provider is not consulted yet.

## Behavior change

None beyond the inert startup warning. The block is default-off and nothing consults the adapter, so an unconfigured deployment is unaffected; an operator who explicitly sets `toolgraph.enabled=true` gets a one-line warning that the provider is not wired yet.

## Follow-up flagged for the next PR

A backend (Neo4j) outage where the graph *server* stays up surfaces as a server-side `isError` tool result — which classifies as `ToolgraphProtocolError` → `on_protocol_error: fail_start` (startup failure), not the graceful `on_unreachable: open` degrade one might expect for "the graph is down". Only stdio pipe/process death and consult timeout map to `ToolgraphUnreachableError`. The adapter docstrings here document the actual behavior; whether to inspect the `isError` envelope and remap a backend outage onto the unreachable class is a wiring-time decision for the next PR.

## Test plan

- config: defaults-off, the four failure-knob defaults, file parse, env > file precedence, invalid-literal rejection.
- adapter (against a real fake stdio child, `tests/_fake_toolgraph_server.py`): start/stop lifecycle, structured verdict with input order preserved, config agent/profile defaults, `agent_found=false` returned as data (not an error), protocol-error on an `isError` result, timeout → unreachable, before-start → unreachable, start-failure rollback.
- `_parse_text_verdict` parse-failure branches (malformed/empty/non-dict/`None` content).
- the manager "enabled but inert" warning (positive + negative).

`ruff check`/`ruff format` clean; full suite green (`3467 passed`); mypy clean for the new module.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)