### PR TITLE
feat(proxy): wire tool-graph eligibility provider into exposure filter + telemetry (#465)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -359,6 +359,67 @@ reasons land in each selection event's `reject_reasons` when
 `selection_telemetry` is enabled; see
 [selection-telemetry.md](selection-telemetry.md) for the reason vocabulary.
 
+`toolgraph` (off by default) plugs an **optional external tool-graph
+eligibility provider** into that same hard filter as an additional rule
+source. When `enabled`, STM consults a separate, non-proxied tool-graph MCP
+server once at startup (stdio; default command `toolgraph serve`) for
+cross-server authorization / data-flow eligibility facts, and feeds its
+per-candidate verdicts into `filter_tools` alongside the native rules. The
+graph is *consulted, never proxied* — its tools never reach the client and STM
+holds no Python-level dependency on it. Per-candidate rejects follow the
+exposure profile ladder (strict rejects / review demotes / explore ignores)
+under `toolgraph_*` reason codes; ranking can never resurrect them.
+
+```json
+"toolgraph": {
+  "enabled": true,
+  "command": "toolgraph",
+  "args": ["serve"],
+  "agent_id": "stm-proxy",
+  "server_name_map": { "<stm-upstream-key>": "<graph-crawled-name>" },
+  "query_profile": "strict",
+  "on_unreachable": "open",
+  "on_agent_not_found": "fail_start",
+  "on_protocol_error": "fail_start",
+  "on_tool_not_found": "open",
+  "timeout_seconds": 5.0
+}
+```
+
+Enabling the block makes the graph's backend (e.g. Neo4j) a startup
+prerequisite. The four `on_*` knobs choose the posture when the consult
+cannot produce a usable verdict:
+
+- **`on_unreachable`** (`open` default) — the graph server is down / the
+  consult times out. `open` degrades to STM-native rules; `closed` withholds
+  every tool (high-assurance).
+- **`on_agent_not_found`** (`fail_start` default) — `agent_id` is unknown to
+  the graph, almost always a typo. `fail_start` refuses startup loudly so a
+  typo cannot silently disable enforcement; `open` / `closed` are explicit
+  opt-ins.
+- **`on_protocol_error`** (`fail_start` default) — the graph is reachable but
+  returns an incompatible / error response. **A backend (Neo4j) outage while
+  the graph *server* stays up surfaces here** (a server-side error envelope),
+  not as `on_unreachable` — so the default `fail_start` means a backend outage
+  refuses proxy startup. Set it to `open` to degrade instead (availability
+  over assurance; note this also degrades on genuine contract drift).
+- **`on_tool_not_found`** (`open` default) — a specific candidate was never
+  crawled (the graph's blind spot). `open` keeps the working tool advertised;
+  `closed` rejects uncrawled candidates.
+
+A failure that resolves to `open` SKIPS the external rule family for the
+session — so it is surfaced loudly: a startup WARNING and a `DEGRADED` line in
+`stm_proxy_health`, so a one-time `open` cannot silently become a permanent
+enforcement blind spot. `stm_proxy_health` also reports a `WITHHOLDING ALL`
+posture (a `closed` knob fired) and, on success, the active graph generation +
+the count of graph-rejected tools.
+
+`server_name_map` translates an STM upstream connection key to the
+tool-graph's *crawled* server name (the two are independent strings); an empty
+map assumes identity and relies on a heuristic warning when an entire
+upstream's tools come back unknown to the graph. The provider runs only when
+`enabled` — a disabled block is fully inert.
+
 ### Token-equivalent budgets (CJK / non-Latin workloads)
 
 By default, every result-size budget in STM is expressed in **characters** (`max_result_chars`, `default_max_result_chars`, `head_chars`). For Latin-script content this approximates token spend reasonably — English averages ~4 characters per token in modern BPE tokenizers (GPT-3.5/4 cl100k_base, similar for Claude). For Korean, Chinese, and Japanese content it does not: Korean averages ~1.85 chars/token, so the same character budget caps roughly **half** the token spend the operator probably intended, and char-based compression gates trip on Korean responses that are token-dense but character-light.

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -56,7 +56,7 @@ stamp).
 | `candidate_tools`, `candidate_count` | what the proxy last advertised (`get_proxy_tools()` snapshot) |
 | `reject_reasons` | prefixed tool → reason code for every tool the #465 filter withheld from that advertisement (see [Hard-filter reject reasons](#hard-filter-reject-reasons-465)); `{}` when nothing was rejected |
 | `candidate_features` | ranking output object when #466 ranking ran (shape below); `null` otherwise |
-| `graph_generation` | reserved `null` until toolgraph#13 integration |
+| `graph_generation` | the external tool-graph generation the advertisement was filtered under (#465), pinning replay to a graph state; `null` when the `toolgraph` provider is disabled, unconsulted, or the consult failed without a usable verdict (unreachable / protocol error). On an agent-not-found degrade the graph still responded, so the generation is recorded |
 | `args_sha256`, `args_chars` | canonical-JSON hash + length of the call arguments |
 | `ts` | unix seconds |
 
@@ -138,6 +138,8 @@ reason code`:
 | `name_overflow` | composed client-side name exceeds the 64-char MCP limit | all |
 | `sensitive_metadata` | credential-pattern match in the tool's description/schema | rejects under `strict`; demotes under `review` |
 | `unhealthy` | upstream-attributable error rate over the recent metrics window crossed the threshold | rejects under `strict`; demotes under `review` |
+| `toolgraph_not_granted`, `toolgraph_deny_violation`, `toolgraph_deny_governed`, `toolgraph_drifted`, `toolgraph_ambiguous`, `toolgraph_unmapped`, `toolgraph_tool_not_found`, `toolgraph_rejected` | per-candidate verdict from the optional external tool-graph provider (the `toolgraph` block — one code per upstream reason, `toolgraph_rejected` is the forward-compatible fallback for an unrecognized reason) | rejects under `strict`; demotes under `review` |
+| `toolgraph_unreachable`, `toolgraph_agent_not_found`, `toolgraph_protocol_error` | whole-call fail-closed: the consult failed under a `closed` knob, so **every** tool is withheld under one code | all (profile-independent) |
 
 Reason codes are the only #465 payload in the log — no tool metadata, no
 error text — so the redaction policy below is untouched. `reject_reasons`

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -704,12 +704,15 @@ class ToolgraphConfig(BaseModel):
 
     Default-off: when ``enabled`` is ``True`` the consult runs once at
     proxy startup so the advertised tool set stays session-stable, exactly
-    like the health-flag precompute. This first step parses the block and
-    ships the adapter, but the eligibility wiring (consult at ``start()`` +
-    ``filter_tools`` branch + ``toolgraph_*`` reject codes + telemetry) is a
-    follow-up, so an enabled block logs a "config is enabled but inert"
-    startup WARNING (#288 pattern) until then. Neo4j (behind the graph
-    server) is an operational prerequisite of enabling this block.
+    like the health-flag precompute. The verdict feeds
+    ``tool_eligibility.filter_tools`` via per-candidate ``toolgraph_*`` reject
+    codes (profile-gated, like the native signal rules) or a whole-call
+    fail-closed withhold, and pins ``graph_generation`` into selection
+    telemetry. Failures map onto the four ``on_*`` knobs below. Neo4j (behind
+    the graph server) is an operational prerequisite of enabling this block:
+    a backend outage while the graph *server* stays up surfaces as a
+    server-side error and is classified as a contract failure
+    (``on_protocol_error``).
     """
 
     enabled: bool = False
@@ -733,12 +736,12 @@ class ToolgraphConfig(BaseModel):
     """Maps an STM upstream connection key (the operator-chosen key in
     ``upstream_servers``) to the tool-graph server's *crawled* name. The two
     are independent strings, so they coincide only by luck; an empty map
-    assumes identity and relies on a heuristic mismatch warning (a follow-up)."""
+    assumes identity and relies on a heuristic mismatch warning."""
     query_profile: str = "strict"
     """Profile passed to the upstream ``eligible_tools`` consult. Kept a free
     string (not coupled to STM's own ``ExposureProfile``) because the graph's
     profile ladder is the external package's concern; STM applies its own
-    profile semantics on top (RFC Decision 1)."""
+    profile semantics on top."""
     on_unreachable: Literal["open", "closed"] = "open"
     """Transport down / timeout. ``open`` (default) skips the external rule
     family and advertises per STM-native rules (the graph is an enhancement,

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import time as _time
 import uuid
+from collections import Counter
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -68,9 +69,19 @@ from memtomem_stm.proxy.token_estimate import tokens_to_chars
 from memtomem_stm.proxy.tool_eligibility import (
     REASON_CONFIG_HIDDEN,
     REASON_PROFILE_EXCLUDED,
+    REASON_TOOLGRAPH_AGENT_NOT_FOUND,
+    REASON_TOOLGRAPH_PROTOCOL_ERROR,
+    REASON_TOOLGRAPH_UNREACHABLE,
     ExposureCandidate,
     compute_health_flags,
     filter_tools,
+    interpret_verdict,
+)
+from memtomem_stm.proxy.toolgraph_provider import (
+    TRANSPORT_ERRORS as TOOLGRAPH_TRANSPORT_ERRORS,
+    ToolgraphConsultAdapter,
+    ToolgraphProtocolError,
+    ToolgraphUnreachableError,
 )
 from memtomem_stm.proxy.tool_relevance import (
     RANKER_VERSION_BM25,
@@ -106,6 +117,29 @@ from memtomem_stm.observability.tracing import traced
 _NO_RETRY_CODES = {-32600, -32601, -32602, -32603}  # INVALID_REQUEST/METHOD/PARAMS/INTERNAL
 
 logger = logging.getLogger(__name__)
+
+# Errors the tool-graph consult treats as "graph unreachable" → on_unreachable.
+# ``eligible_tools()`` already wraps transport failures into
+# ``ToolgraphUnreachableError``; ``start()`` re-raises them RAW, so the manager
+# catches both. Built here (not inline in the ``except``) so mypy sees a typed
+# exception tuple rather than a star-unpack.
+_TOOLGRAPH_UNREACHABLE_ERRORS: tuple[type[BaseException], ...] = (
+    ToolgraphUnreachableError,
+    *TOOLGRAPH_TRANSPORT_ERRORS,
+)
+
+
+class ToolgraphStartupError(RuntimeError):
+    """A ``fail_start`` tool-graph failure aborts proxy startup (#465).
+
+    Raised from ``ProxyManager.start()`` when an enabled provider's consult
+    fails (unreachable / agent-not-found / protocol error) and the matching
+    ``on_*`` knob is ``fail_start`` (the default for the contract-class
+    failures). Propagates out of ``start()`` so the lifespan refuses to bring
+    the proxy up — loud and recoverable, never a silent fail-open. The operator
+    sets the knob to ``open`` (degrade) or ``closed`` (withhold all) to choose
+    a different posture.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,6 +226,22 @@ class ProxyManager:
         # registered) and later get_proxy_tools() calls (teardown, tests),
         # or telemetry would lie about the candidate set the client saw.
         self._unhealthy_tools: frozenset[tuple[str, str]] = frozenset()
+        # #465 optional external tool-graph eligibility provider. Consulted
+        # ONCE per start() (beside the health-flag precompute) so the
+        # advertised set stays session-stable; the snapshots below feed every
+        # get_proxy_tools() pass. ``_toolgraph_external_rejects`` are
+        # per-candidate verdicts (profile-gated in filter_tools);
+        # ``_toolgraph_withhold_all`` is the whole-call fail-closed code (a
+        # ``closed`` knob fired); ``_graph_generation`` pins selection
+        # telemetry to the graph state (#468); ``_toolgraph_degraded`` records
+        # that a failure resolved to ``open`` so the external rule family was
+        # SKIPPED — surfaced loudly so a one-time ``open`` cannot silently
+        # become a permanent enforcement blind spot.
+        self._toolgraph_external_rejects: dict[tuple[str, str], str] = {}
+        self._toolgraph_withhold_all: str | None = None
+        self._graph_generation: int | None = None
+        self._toolgraph_degraded: bool = False
+        self._toolgraph_degraded_reason: str | None = None
         self._connections: dict[str, UpstreamConnection] = {}
         self._stack: AsyncExitStack | None = None
         self._selective_compressor: SelectiveCompressor | None = None
@@ -337,18 +387,189 @@ class ProxyManager:
                 exposure_cfg.profile.value,
             )
 
-        # #465: the optional external tool-graph eligibility provider is
-        # configured but not yet consulted here — the startup consult that
-        # feeds ``filter_tools`` (beside the health-flag precompute above) is a
-        # follow-up. Until it lands, an enabled block does nothing, so warn
-        # (the #288 "config is enabled but inert" pattern) rather than let an
-        # operator believe external eligibility facts are being enforced.
+        # #465: consult the optional external tool-graph eligibility provider
+        # once, beside the health-flag precompute, so its verdict joins the
+        # exposure filter for the rest of the session. A ``fail_start`` knob
+        # raises here — before any tool is advertised — which is the intended
+        # loud failure (a broken/typo'd provider must not silently disable
+        # enforcement).
         if self._config.toolgraph.enabled:
-            logger.warning(
-                "toolgraph.enabled is set but the eligibility provider is not "
-                "wired yet — config is enabled but inert; no external "
-                "eligibility facts will be consulted."
+            await self._consult_toolgraph()
+
+    def _build_toolgraph_candidates(self) -> tuple[dict[str, list[tuple[str, str]]], list[str]]:
+        """Map every discovered upstream tool to its graph candidate ref.
+
+        A ref is ``"<graph-server>::<tool>"`` where ``<graph-server>`` is the
+        tool-graph's CRAWLED server name — an independent string from STM's own
+        connection key, hence the ``server_name_map`` translation (identity
+        when unmapped). Bare names risk ``AMBIGUOUS_TOOL``, so refs are always
+        server-qualified. Refs are deduplicated for the batch consult; the
+        returned map fans one ref's verdict back to EVERY STM
+        ``(server, original_name)`` key that shares it (two upstreams mapped to
+        one graph server with a same-named tool both inherit that verdict).
+        """
+        name_map = self._config.toolgraph.server_name_map
+        ref_to_keys: dict[str, list[tuple[str, str]]] = {}
+        for conn in self._connections.values():
+            graph_server = name_map.get(conn.name, conn.name)
+            for t in conn.tools:
+                ref = f"{graph_server}::{t.name}"
+                ref_to_keys.setdefault(ref, []).append((conn.name, t.name))
+        return ref_to_keys, list(ref_to_keys.keys())
+
+    async def _consult_toolgraph(self) -> None:
+        """Run the one-shot startup consult and cache its verdict (#465).
+
+        Mirrors :func:`compute_health_flags`: consult once, hold the snapshot
+        for the session so the advertised set stays stable. The adapter is
+        started, consulted, and stopped here — there is no per-request lazy
+        start, so nothing holds the stdio child past startup. Failures are
+        classified onto the configured ``on_*`` knobs; ``fail_start`` raises
+        :class:`ToolgraphStartupError` (out of ``start()``) before any tool is
+        advertised.
+        """
+        cfg = self._config.toolgraph
+        # Reset the cached snapshot first: start() is a supported re-entry path
+        # (the double-start guard re-runs discovery + compute_health_flags), so
+        # a recovered graph on a second start must not inherit the previous
+        # session's withhold-all / degraded / reject state.
+        self._toolgraph_external_rejects = {}
+        self._toolgraph_withhold_all = None
+        self._graph_generation = None
+        self._toolgraph_degraded = False
+        self._toolgraph_degraded_reason = None
+
+        ref_to_keys, refs = self._build_toolgraph_candidates()
+        if not refs:
+            logger.info(
+                "Tool-graph provider enabled but no upstream tools were discovered "
+                "— consult skipped"
             )
+            return
+
+        adapter = ToolgraphConsultAdapter(cfg)
+        try:
+            try:
+                # ``start()`` re-raises raw transport errors (caught below as
+                # unreachable); the consult itself is bounded by the adapter's
+                # ``timeout_seconds`` (the realistic hang is a slow Neo4j query,
+                # which happens during the consult, not during initialize()).
+                await adapter.start()
+                verdict = await adapter.eligible_tools(refs)
+                interp = interpret_verdict(verdict)
+            finally:
+                try:
+                    await adapter.stop()
+                except Exception:
+                    logger.debug("Tool-graph adapter stop() failed", exc_info=True)
+        except _TOOLGRAPH_UNREACHABLE_ERRORS as exc:
+            self._tg_whole_call(cfg.on_unreachable, REASON_TOOLGRAPH_UNREACHABLE, str(exc))
+            return
+        except ToolgraphProtocolError as exc:
+            self._tg_whole_call(cfg.on_protocol_error, REASON_TOOLGRAPH_PROTOCOL_ERROR, str(exc))
+            return
+
+        # Reachable + well-formed. Pin the generation even on an abort — the
+        # graph responded, so it is a meaningful telemetry key.
+        self._graph_generation = interp.graph_generation
+
+        if not interp.agent_found:
+            self._tg_whole_call(
+                cfg.on_agent_not_found,
+                REASON_TOOLGRAPH_AGENT_NOT_FOUND,
+                f"agent_id {cfg.agent_id!r} is not registered in the tool-graph",
+            )
+            return
+
+        # Per-candidate verdicts. TOOL_NOT_FOUND (the graph's blind spot) obeys
+        # ``on_tool_not_found``: ``open`` keeps the working tool advertised,
+        # ``closed`` rejects the uncrawled candidate.
+        rejects = dict(interp.rejects)
+        if cfg.on_tool_not_found == "open":
+            for ref in interp.tool_not_found_refs:
+                rejects.pop(ref, None)
+        self._toolgraph_external_rejects = {
+            key: code for ref, code in rejects.items() for key in ref_to_keys.get(ref, ())
+        }
+        if self._toolgraph_external_rejects:
+            logger.info(
+                "Tool-graph consult: %d candidate(s) rejected by the graph (generation %s)",
+                len(self._toolgraph_external_rejects),
+                self._graph_generation,
+            )
+        self._warn_server_name_mismatch(interp.tool_not_found_refs, ref_to_keys)
+
+    def _tg_whole_call(self, knob: str, code: str, detail: str) -> None:
+        """Apply a whole-call tool-graph failure per its ``on_*`` knob.
+
+        ``fail_start`` raises (aborts startup); ``closed`` withholds every tool
+        under ``code`` (profile-independent); ``open`` degrades to STM-native
+        rules and records the skip loudly so the lost enforcement is never
+        silent (a one-time ``open`` must not quietly become a permanent blind
+        spot — see ``stm_proxy_health``).
+        """
+        if knob == "fail_start":
+            raise ToolgraphStartupError(
+                f"tool-graph consult failed ({code}: {detail}); the matching on_* knob "
+                f"is 'fail_start'. Fix the provider, or set the knob to 'open' (degrade "
+                f"to STM-native rules) or 'closed' (withhold all tools)."
+            )
+        if knob == "closed":
+            self._toolgraph_withhold_all = code
+            logger.warning(
+                "Tool-graph consult failed (%s: %s) — knob is 'closed': withholding "
+                "ALL tools this session.",
+                code,
+                detail,
+            )
+            return
+        # "open" — degrade.
+        self._toolgraph_degraded = True
+        self._toolgraph_degraded_reason = code
+        logger.warning(
+            "Tool-graph consult failed (%s: %s) — knob is 'open': DEGRADED. The "
+            "external eligibility rule family is SKIPPED this session; tools are "
+            "advertised per STM-native rules only. Tool-graph enforcement is NOT active.",
+            code,
+            detail,
+        )
+
+    def _warn_server_name_mismatch(
+        self,
+        tool_not_found_refs: frozenset[str],
+        ref_to_keys: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        """Heuristic: warn when an entire upstream's tools are unknown to the graph.
+
+        STM cannot precisely verify its connection key against the graph's
+        crawled server name (they are independent strings and no ``list_servers``
+        MCP tool exists to reconcile them), so it infers a likely
+        ``server_name_map`` gap: if EVERY candidate from one
+        upstream came back ``TOOL_NOT_FOUND`` and that upstream has no map
+        entry, the names probably don't line up. Conservative by design (fires
+        only at a 100% miss for an unmapped server) so a partially-crawled
+        server never trips a false positive.
+        """
+        name_map = self._config.toolgraph.server_name_map
+        sent: Counter[str] = Counter()
+        missed: Counter[str] = Counter()
+        for ref, keys in ref_to_keys.items():
+            for server, _tool in keys:
+                sent[server] += 1
+                if ref in tool_not_found_refs:
+                    missed[server] += 1
+        for server, n in sent.items():
+            if n > 0 and missed[server] == n and server not in name_map:
+                logger.warning(
+                    "All %d tool(s) from upstream '%s' are unknown to the tool-graph. "
+                    "If '%s' is crawled under a different name, add a "
+                    "toolgraph.server_name_map['%s'] entry; otherwise these tools are "
+                    "simply not in the graph.",
+                    n,
+                    server,
+                    server,
+                    server,
+                )
 
     def _open_transport(self, cfg: UpstreamServerConfig):  # noqa: ANN201
         match cfg.transport:
@@ -594,7 +815,13 @@ class ProxyManager:
                     )
                 )
 
-        verdict = filter_tools(candidates, self._config.exposure, self._unhealthy_tools)
+        verdict = filter_tools(
+            candidates,
+            self._config.exposure,
+            self._unhealthy_tools,
+            external_rejects=self._toolgraph_external_rejects or None,
+            withhold_all=self._toolgraph_withhold_all,
+        )
         if verdict.reject_reasons != self._advertised_reject_reasons:
             self._log_exposure_rejects(verdict.reject_reasons)
         self._advertised_infos = verdict.eligible
@@ -1274,6 +1501,31 @@ class ProxyManager:
             }
         return health
 
+    def get_toolgraph_status(self) -> dict[str, Any] | None:
+        """External tool-graph eligibility provider status (#465), or ``None``
+        when the block is disabled.
+
+        Surfaces the once-per-startup consult outcome so an operator can
+        confirm whether external enforcement is actually ACTIVE this session.
+        This is load-bearing, not cosmetic: a failure that resolved to ``open``
+        silently skips the rule family, and a one-time ``on_*: open`` must
+        never become an unnoticed permanent enforcement blind spot. ``degraded``
+        means the family was skipped (advertising per STM-native rules only);
+        ``withholding_all`` means a ``closed`` knob withheld every tool;
+        otherwise the consult succeeded and ``external_reject_count`` reflects
+        the per-candidate verdicts in force.
+        """
+        if not self._config.toolgraph.enabled:
+            return None
+        return {
+            "enabled": True,
+            "degraded": self._toolgraph_degraded,
+            "degraded_reason": self._toolgraph_degraded_reason,
+            "withholding_all": self._toolgraph_withhold_all,
+            "graph_generation": self._graph_generation,
+            "external_reject_count": len(self._toolgraph_external_rejects),
+        }
+
     async def _on_cache_hit(
         self,
         cached: str,
@@ -1478,6 +1730,7 @@ class ProxyManager:
                 candidate_features=candidate_features,
                 ranker_version=ranker_version,
                 reject_reasons=self._advertised_reject_reasons,
+                graph_generation=self._graph_generation,
             )
         except Exception:
             logger.debug("Selection telemetry write failed", exc_info=True)

--- a/src/memtomem_stm/proxy/selection_log.py
+++ b/src/memtomem_stm/proxy/selection_log.py
@@ -201,6 +201,7 @@ class SelectionTelemetryLog:
         candidate_features: dict[str, Any] | None = None,
         ranker_version: str | None = None,
         reject_reasons: dict[str, str] | None = None,
+        graph_generation: int | None = None,
     ) -> str | None:
         """Record a selection event; returns its ``selection_id``.
 
@@ -211,7 +212,10 @@ class SelectionTelemetryLog:
         which ranker produced it (``None`` = the unranked default).
         ``reject_reasons`` is the #465 hard filter's verdict for the
         advertisement this call selected from — reason codes only, no tool
-        metadata (``None`` records the empty map).
+        metadata (``None`` records the empty map). ``graph_generation`` pins
+        the external tool-graph generation the advertisement was filtered
+        under (#465/#468 replay) — ``None`` when the provider is disabled,
+        degraded, or unconsulted.
         """
         if not self._sampled_in():
             with self._lock:
@@ -233,7 +237,7 @@ class SelectionTelemetryLog:
                 "candidate_count": len(candidate_tools),
                 "reject_reasons": dict(reject_reasons) if reject_reasons else {},
                 "candidate_features": candidate_features,
-                "graph_generation": None,
+                "graph_generation": graph_generation,
                 "args_sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
                 "args_chars": len(canonical),
             }

--- a/src/memtomem_stm/proxy/tool_eligibility.py
+++ b/src/memtomem_stm/proxy/tool_eligibility.py
@@ -51,6 +51,22 @@ then the remaining rules apply per tool in this order, first match wins:
     count against the tool) over the recent metrics window crossed the
     configured threshold with enough samples. Signal rule, like
     ``sensitive_metadata``.
+``toolgraph_*``
+    The optional external tool-graph eligibility provider (#465) rejected
+    this candidate — one ``toolgraph_<reason>`` code per upstream verdict
+    (NOT_GRANTED / DENY_VIOLATION / DENY_GOVERNED / DRIFTED / AMBIGUOUS /
+    UNMAPPED / TOOL_NOT_FOUND, plus a generic ``toolgraph_rejected``
+    fallback for any upstream reason STM does not recognize). Passed
+    in pre-resolved via ``external_rejects`` (the manager runs the consult
+    once at startup and maps upstream reasons to codes). Signal rule, ranked
+    above ``unhealthy`` but below ``sensitive_metadata``.
+
+A whole-call ``toolgraph_*`` outcome (``toolgraph_unreachable`` /
+``toolgraph_agent_not_found`` / ``toolgraph_protocol_error``) is a SEPARATE
+mechanism: when the consult itself fails under a ``closed`` knob, the manager
+passes ``withhold_all`` and EVERY candidate is withheld under that one code,
+profile-INDEPENDENTLY (explore included) — the operator's explicit "no graph,
+no tools" posture, distinct from the per-candidate signal rules above.
 
 Profile semantics (``ExposureProfile``): ``strict`` enforces signal rules as
 hard rejects; ``review`` keeps flagged tools advertised but assigns them a
@@ -88,6 +104,7 @@ from __future__ import annotations
 import json
 import logging
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -99,6 +116,7 @@ from memtomem_stm.proxy.config import (
 )
 from memtomem_stm.proxy.metrics import ErrorCategory
 from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS, contains_sensitive_content
+from memtomem_stm.proxy.toolgraph_provider import ToolgraphProtocolError
 
 if TYPE_CHECKING:
     from memtomem_stm.proxy.manager import ProxyToolInfo
@@ -116,6 +134,51 @@ REASON_NAME_OVERFLOW = "name_overflow"
 REASON_DUPLICATE_NAME = "duplicate_name"
 REASON_SENSITIVE_METADATA = "sensitive_metadata"
 REASON_UNHEALTHY = "unhealthy"
+
+# External tool-graph eligibility provider codes (#465). Two families:
+#
+# PER-CANDIDATE — a successful consult's ``rejected`` rows, one STM code per
+# upstream reason. These ride the profile-gated signal block (like
+# ``unhealthy``): strict rejects, review demotes, explore ignores. They are
+# the value side of ``filter_tools(external_rejects=...)`` — the manager has
+# already mapped the upstream reason to one of these before the filter runs.
+REASON_TOOLGRAPH_NOT_GRANTED = "toolgraph_not_granted"
+REASON_TOOLGRAPH_DENY_VIOLATION = "toolgraph_deny_violation"
+REASON_TOOLGRAPH_DENY_GOVERNED = "toolgraph_deny_governed"
+REASON_TOOLGRAPH_DRIFTED = "toolgraph_drifted"
+REASON_TOOLGRAPH_AMBIGUOUS = "toolgraph_ambiguous"
+REASON_TOOLGRAPH_UNMAPPED = "toolgraph_unmapped"
+REASON_TOOLGRAPH_TOOL_NOT_FOUND = "toolgraph_tool_not_found"
+# Forward-compatible fallback: an upstream ``rejected`` reason STM does not
+# recognize still results in a withhold (never a silent advertise of a tool
+# the graph wanted blocked), just under a generic code.
+REASON_TOOLGRAPH_REJECTED = "toolgraph_rejected"
+
+# WHOLE-CALL — the consult itself failed (or aborted) and the operator's
+# ``on_*`` knob resolved to ``closed``. These are profile-INDEPENDENT and
+# withhold EVERY candidate at once (``filter_tools(withhold_all=...)``); they
+# are STM-owned, never derived from an upstream row.
+REASON_TOOLGRAPH_UNREACHABLE = "toolgraph_unreachable"
+REASON_TOOLGRAPH_AGENT_NOT_FOUND = "toolgraph_agent_not_found"
+REASON_TOOLGRAPH_PROTOCOL_ERROR = "toolgraph_protocol_error"
+
+# Upstream ``eligible_tools`` reject reason → STM per-candidate code. The graph
+# owns its own reason vocabulary (selector.py); this is the 1:1 translation at
+# the boundary. ``TOOL_NOT_FOUND`` is intentionally absent here — it is gated
+# by the ``on_tool_not_found`` knob, applied by the caller, not unconditionally
+# mapped. An upstream reason missing from this map maps to the generic
+# ``REASON_TOOLGRAPH_REJECTED`` (forward-compatible withhold).
+_TOOLGRAPH_REASON_MAP: dict[str, str] = {
+    "NOT_GRANTED": REASON_TOOLGRAPH_NOT_GRANTED,
+    "DENY_VIOLATION": REASON_TOOLGRAPH_DENY_VIOLATION,
+    "DENY_GOVERNED": REASON_TOOLGRAPH_DENY_GOVERNED,
+    "DRIFTED": REASON_TOOLGRAPH_DRIFTED,
+    "AMBIGUOUS_TOOL": REASON_TOOLGRAPH_AMBIGUOUS,
+    "UNMAPPED": REASON_TOOLGRAPH_UNMAPPED,
+}
+# The upstream reason string for an uncrawled candidate (the graph's blind
+# spot), gated separately by ``on_tool_not_found``.
+_TOOLGRAPH_TOOL_NOT_FOUND = "TOOL_NOT_FOUND"
 
 # Error categories that count against a TOOL's health. Proxy-side failures
 # (programming, internal_error, lock_timeout) are our bugs, not the
@@ -232,17 +295,133 @@ def _metadata_scan_text(candidate: ExposureCandidate) -> str:
     return "\n".join((candidate.raw_description, candidate.info.description, schema_text))
 
 
+@dataclass(frozen=True, slots=True)
+class InterpretedVerdict:
+    """Structured, policy-free read of one ``eligible_tools`` consult response.
+
+    Pure parse of the upstream wire shape into what the manager needs, with no
+    knowledge of the ``on_*`` knobs (the caller applies those):
+
+    - ``agent_found`` — ``False`` is the upstream's structured *abort* signal
+      (the configured ``agent_id`` is unknown to the graph), distinct from an
+      empty result; the caller maps it onto ``on_agent_not_found``.
+    - ``rejects`` — graph candidate ref → STM per-candidate reason code, for
+      *every* ``rejected`` row INCLUDING ``TOOL_NOT_FOUND`` (mapped to
+      :data:`REASON_TOOLGRAPH_TOOL_NOT_FOUND`). The caller drops the
+      tool-not-found entries when ``on_tool_not_found`` is ``open``.
+    - ``tool_not_found_refs`` — the subset of refs the graph never crawled,
+      surfaced separately so the manager can run the server-name-mismatch
+      heuristic regardless of the ``on_tool_not_found`` posture.
+    - ``graph_generation`` — the replay/cache key (#468); always a real ``int``
+      because the upstream stamps every response (the ``agent_found=False``
+      abort included), so a missing one is contract drift.
+    """
+
+    agent_found: bool
+    rejects: dict[str, str]
+    tool_not_found_refs: frozenset[str]
+    graph_generation: int
+
+
+def interpret_verdict(verdict: Mapping[str, Any]) -> InterpretedVerdict:
+    """Validate the ``eligible_tools`` verdict shape and parse it (no policy).
+
+    Raises :class:`ToolgraphProtocolError` on a malformed payload — a reachable
+    graph returning a shape STM cannot trust is a *contract* failure (the
+    caller maps it onto ``on_protocol_error``), never silently treated as an
+    empty/clean result. ``graph_generation`` must be a real ``int`` on EVERY
+    path (the abort included — the server stamps it unconditionally); ``bool``
+    is rejected as it is an ``int`` subclass but never a valid generation.
+    """
+    agent_found = verdict.get("agent_found")
+    if not isinstance(agent_found, bool):
+        raise ToolgraphProtocolError(
+            f"eligible_tools verdict has a non-boolean 'agent_found': {agent_found!r}"
+        )
+
+    gen = verdict.get("graph_generation")
+    if isinstance(gen, bool) or not isinstance(gen, int):
+        raise ToolgraphProtocolError(
+            f"eligible_tools verdict has a non-integer 'graph_generation': {gen!r}"
+        )
+    graph_generation = gen
+
+    if not agent_found:
+        return InterpretedVerdict(
+            agent_found=False,
+            rejects={},
+            tool_not_found_refs=frozenset(),
+            graph_generation=graph_generation,
+        )
+
+    rows = verdict.get("rejected")
+    if not isinstance(rows, list):
+        raise ToolgraphProtocolError(
+            f"eligible_tools verdict 'rejected' is not a list: {type(rows).__name__}"
+        )
+
+    rejects: dict[str, str] = {}
+    tool_not_found: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ToolgraphProtocolError(f"eligible_tools 'rejected' row is not an object: {row!r}")
+        ref = row.get("candidate")
+        reason = row.get("reason")
+        if not isinstance(ref, str) or not isinstance(reason, str):
+            raise ToolgraphProtocolError(
+                f"eligible_tools 'rejected' row missing string candidate/reason: {row!r}"
+            )
+        if reason == _TOOLGRAPH_TOOL_NOT_FOUND:
+            tool_not_found.add(ref)
+            rejects[ref] = REASON_TOOLGRAPH_TOOL_NOT_FOUND
+        else:
+            # Unknown upstream reasons still withhold (fail-safe) under a
+            # generic code rather than silently advertising a blocked tool.
+            rejects[ref] = _TOOLGRAPH_REASON_MAP.get(reason, REASON_TOOLGRAPH_REJECTED)
+
+    return InterpretedVerdict(
+        agent_found=True,
+        rejects=rejects,
+        tool_not_found_refs=frozenset(tool_not_found),
+        graph_generation=graph_generation,
+    )
+
+
 def filter_tools(
     candidates: list[ExposureCandidate],
     cfg: ExposureConfig,
     unhealthy: frozenset[tuple[str, str]] = frozenset(),
+    *,
+    external_rejects: Mapping[tuple[str, str], str] | None = None,
+    withhold_all: str | None = None,
 ) -> EligibilityResult:
     """Apply the hard-filter rules to one advertisement candidate set.
 
-    Pure and deterministic: same candidates + config + health flags →
-    identical result, independent of call count or wall clock. *unhealthy*
-    is the cached startup snapshot from :func:`compute_health_flags`.
+    Pure and deterministic: same candidates + config + health flags +
+    external verdict → identical result, independent of call count or wall
+    clock. *unhealthy* is the cached startup snapshot from
+    :func:`compute_health_flags`.
+
+    *external_rejects* maps ``(server, original_name)`` → an already-resolved
+    ``toolgraph_*`` code (the optional tool-graph provider's per-candidate
+    verdict, #465). It is a SIGNAL rule: it rides the profile ladder exactly
+    like ``unhealthy`` (strict rejects, review demotes, explore ignores), and
+    ranks above ``unhealthy`` but below ``sensitive_metadata`` — an explicit
+    graph policy verdict outweighs a heuristic error-rate flag, but a
+    credential in tool metadata (upstream compromise) outweighs both.
+
+    *withhold_all*, when set, is the whole-call fail-closed code: the consult
+    failed under a ``closed`` knob, so EVERY candidate is withheld under that
+    one STM-owned code, profile-INDEPENDENTLY (explore included). This is the
+    operator's explicit "no graph, no tools" posture and short-circuits every
+    per-candidate rule below.
     """
+    if withhold_all is not None:
+        return EligibilityResult(
+            eligible=[],
+            reject_reasons={candidate.info.prefixed_name: withhold_all for candidate in candidates},
+            risk_penalties={},
+        )
     # ── ambiguity pre-pass (every profile) ───────────────────────────────
     # A composed name carried by MORE than one candidate is structurally
     # ambiguous and the whole group is withheld: upstream calls route by
@@ -292,8 +471,17 @@ def filter_tools(
         # ── signal rules (profile-dependent) ─────────────────────────────
         if cfg.profile is not ExposureProfile.EXPLORE:
             flagged_reason: str | None = None
+            external_reason = (
+                external_rejects.get((info.server, info.original_name))
+                if external_rejects
+                else None
+            )
+            # Precedence: upstream-compromise (credential in metadata) >
+            # explicit graph policy verdict > heuristic error-rate health.
             if contains_sensitive_content(_metadata_scan_text(candidate), CREDENTIAL_PATTERNS):
                 flagged_reason = REASON_SENSITIVE_METADATA
+            elif external_reason is not None:
+                flagged_reason = external_reason
             elif (info.server, info.original_name) in unhealthy:
                 flagged_reason = REASON_UNHEALTHY
             if flagged_reason is not None:

--- a/src/memtomem_stm/proxy/toolgraph_provider.py
+++ b/src/memtomem_stm/proxy/toolgraph_provider.py
@@ -8,15 +8,16 @@ separate, non-proxied MCP server" pattern): one ``ClientSession`` over a
 launched stdio child, and **zero** Python-level dependency on the external
 package — all traffic goes over the MCP protocol.
 
-This first step ships the config block + a connectable adapter only: the
-adapter can connect and run the ``eligible_tools`` consult, but nothing wires
-it into the eligibility filter yet. The startup consult (beside
-``compute_health_flags``), the ``filter_tools`` branch, the ``toolgraph_*``
-reject codes, and the ``graph_generation`` telemetry pin are follow-ups.
-Unlike the surfacing adapter the consult runs once per session at proxy
-startup (so the advertised set stays stable), which is why this adapter has
-no per-request lazy-start / reconnect machinery: the caller starts it once
-and maps any failure onto the configured ``on_*`` knobs.
+This module is the transport adapter only: it connects and runs the
+``eligible_tools`` consult, returning the raw structured verdict. The
+``ProxyManager`` drives it once at startup (beside ``compute_health_flags``),
+interprets the verdict (see ``tool_eligibility.interpret_verdict``), feeds it
+into ``filter_tools`` as per-candidate ``toolgraph_*`` rejects or a whole-call
+withhold, and pins ``graph_generation`` into selection telemetry. Unlike the
+surfacing adapter the consult runs once per session at proxy startup (so the
+advertised set stays stable), which is why this adapter has no per-request
+lazy-start / reconnect machinery: the caller starts it once and maps any
+failure onto the configured ``on_*`` knobs.
 """
 
 from __future__ import annotations
@@ -38,6 +39,22 @@ logger = logging.getLogger(__name__)
 # The upstream MCP tool this adapter consults (toolgraph/server/app.py).
 _ELIGIBLE_TOOLS = "eligible_tools"
 
+# Transport failure modes that mean "graph unreachable" rather than a contract
+# mismatch. ``eligible_tools()`` wraps these into ``ToolgraphUnreachableError``;
+# ``start()`` re-raises them RAW (its rollback only cleans up), so the manager
+# catches this tuple directly to classify a failed launch as unreachable.
+# Module-level so the manager need not duplicate it. stdio pipe failures
+# surface as OSError / EOFError / BrokenPipeError; a blocked/slow server
+# surfaces as ``asyncio.TimeoutError`` (per-consult or via the caller's
+# ``wait_for`` around ``start()``).
+TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    OSError,
+    ConnectionError,
+    EOFError,
+    BrokenPipeError,
+    asyncio.TimeoutError,
+)
+
 
 class ToolgraphConsultError(Exception):
     """Base error for a failed tool-graph consult."""
@@ -52,8 +69,7 @@ class ToolgraphUnreachableError(ToolgraphConsultError):
     "the graph is unavailable": a backend (e.g. Neo4j) outage where the graph
     *server* stays up surfaces as an ``isError`` tool result, not a transport
     error, and is therefore classified ``ToolgraphProtocolError`` (below) —
-    consistent with the RFC treating any server-side error envelope as a
-    contract class.
+    any server-side error envelope is treated as a contract class.
     """
 
 
@@ -79,17 +95,9 @@ class ToolgraphConsultAdapter:
     interpret.
     """
 
-    # Transport failure modes that mean "graph unreachable" rather than a
-    # contract mismatch. stdio pipe failures surface as
-    # OSError / EOFError / BrokenPipeError; a blocked/slow server surfaces as
-    # ``asyncio.TimeoutError`` via the per-consult ``timeout_seconds``.
-    _TRANSPORT_ERRORS = (
-        OSError,
-        ConnectionError,
-        EOFError,
-        BrokenPipeError,
-        asyncio.TimeoutError,
-    )
+    # Module-level :data:`TRANSPORT_ERRORS` aliased here for the
+    # ``eligible_tools()`` ``except`` clause (kept for call-site readability).
+    _TRANSPORT_ERRORS = TRANSPORT_ERRORS
 
     def __init__(self, config: ToolgraphConfig) -> None:
         self._config = config

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -665,8 +665,42 @@ async def stm_proxy_health(
         cb_state = "open (failing)" if cb.is_open else "closed (healthy)"
         lines.append(f"\nSurfacing circuit breaker: {cb_state}")
 
+    lines.extend(_toolgraph_health_lines(pm.get_toolgraph_status()))
+
     lines.extend(bootstrap_lines)
     return "\n".join(lines)
+
+
+def _toolgraph_health_lines(status: dict | None) -> list[str]:
+    """Render the external tool-graph eligibility provider status (#465).
+
+    Empty when the provider is disabled. When enabled, the line makes a
+    DEGRADED or withhold-all posture loud so an operator never mistakes a
+    skipped external rule family for active enforcement.
+    """
+    if status is None:
+        return []
+    lines = ["", "Tool-graph eligibility provider", "=============================="]
+    if status["withholding_all"]:
+        lines.append(
+            f"  WITHHOLDING ALL tools — consult failed ({status['withholding_all']}), "
+            "knob is 'closed'"
+        )
+    elif status["degraded"]:
+        lines.append(
+            f"  DEGRADED — external enforcement NOT active ({status['degraded_reason']}); "
+            "advertising per STM-native rules only"
+        )
+    elif status["graph_generation"] is None:
+        # Enabled, no failure, but no usable generation → the consult was
+        # skipped (no upstream tools discovered). Not "active" enforcement.
+        lines.append("  enabled, not consulted (no upstream tools discovered)")
+    else:
+        lines.append(
+            f"  active (graph generation {status['graph_generation']}, "
+            f"{status['external_reject_count']} tool(s) rejected by the graph)"
+        )
+    return lines
 
 
 def _surfacing_bootstrap_lines(app: STMContext) -> list[str]:

--- a/tests/_fake_toolgraph_server.py
+++ b/tests/_fake_toolgraph_server.py
@@ -21,7 +21,9 @@ Input-driven behaviors (so one fixture covers every adapter path):
 * ``agent == "ghost"`` returns ``agent_found=False`` as a *structured*
   result (NOT an error) — the abort signal the adapter must surface as data.
 * any candidate ending in ``"::blocked"`` comes back as a ``NOT_GRANTED``
-  rejected row; all others are eligible, in input order.
+  rejected row; a candidate whose tool part starts with ``"missing"`` comes
+  back as a ``TOOL_NOT_FOUND`` rejected row (the graph's blind spot); all
+  others are eligible, in input order.
 
 Run with: ``python <path-to-this-file>``.
 """
@@ -59,10 +61,13 @@ async def eligible_tools(agent: str, candidates: list[str], profile: str = "stri
     eligible: list[str] = []
     rejected: list[dict] = []
     for candidate in candidates:  # input order is part of the upstream contract
+        tool_part = candidate.split("::", 1)[-1]
         if candidate.endswith("::blocked"):
             rejected.append(
                 {"candidate": candidate, "tool_key": candidate, "reason": "NOT_GRANTED"}
             )
+        elif tool_part.startswith("missing"):
+            rejected.append({"candidate": candidate, "tool_key": None, "reason": "TOOL_NOT_FOUND"})
         else:
             eligible.append(candidate)
 

--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -20,6 +20,8 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
+
 from memtomem_stm.proxy.config import (
     CompressionStrategy,
     ExposureConfig,
@@ -38,13 +40,20 @@ from memtomem_stm.proxy.tool_eligibility import (
     REASON_NAME_OVERFLOW,
     REASON_PROFILE_EXCLUDED,
     REASON_SENSITIVE_METADATA,
+    REASON_TOOLGRAPH_NOT_GRANTED,
+    REASON_TOOLGRAPH_REJECTED,
+    REASON_TOOLGRAPH_TOOL_NOT_FOUND,
+    REASON_TOOLGRAPH_UNMAPPED,
+    REASON_TOOLGRAPH_UNREACHABLE,
     REASON_UNHEALTHY,
     UPSTREAM_ERROR_CATEGORIES,
     ExposureCandidate,
     compute_health_flags,
     filter_tools,
+    interpret_verdict,
 )
 from memtomem_stm.proxy.tool_relevance import RANKER_VERSION_BM25_RISK
+from memtomem_stm.proxy.toolgraph_provider import ToolgraphProtocolError
 
 
 def _server_cfg(prefix: str = "test", **kwargs: Any) -> UpstreamServerConfig:
@@ -615,3 +624,170 @@ class TestManagerWireIn:
         finally:
             await mgr.stop()
             store.close()
+
+
+# ── interpret_verdict (pure parse of the external consult, #465) ────────────
+
+
+def _verdict(*, agent_found=True, rejected=None, graph_generation=11):
+    v: dict[str, Any] = {
+        "agent": "stm-proxy",
+        "agent_found": agent_found,
+        "profile": "strict",
+        "eligible": [],
+        "rejected": rejected or [],
+    }
+    if graph_generation is not _MISSING:
+        v["graph_generation"] = graph_generation
+    return v
+
+
+_MISSING = object()
+
+
+class TestInterpretVerdict:
+    def test_success_maps_reject_reasons(self):
+        v = _verdict(
+            rejected=[
+                {"candidate": "s::blocked", "reason": "NOT_GRANTED"},
+                {"candidate": "s::dangerous", "reason": "DENY_VIOLATION"},
+            ]
+        )
+        interp = interpret_verdict(v)
+        assert interp.agent_found is True
+        assert interp.graph_generation == 11
+        assert interp.rejects == {
+            "s::blocked": "toolgraph_not_granted",
+            "s::dangerous": "toolgraph_deny_violation",
+        }
+        assert interp.tool_not_found_refs == frozenset()
+
+    def test_unknown_reason_falls_back_to_generic_reject(self):
+        # An upstream reason STM does not recognize still withholds (fail-safe),
+        # never silently advertises a tool the graph rejected.
+        interp = interpret_verdict(
+            _verdict(rejected=[{"candidate": "s::x", "reason": "SOME_NEW_REASON"}])
+        )
+        assert interp.rejects == {"s::x": REASON_TOOLGRAPH_REJECTED}
+
+    def test_unmapped_reason_has_dedicated_code(self):
+        # UNMAPPED is a first-class reject in the graph's strict profile (the
+        # default query_profile), so it gets a 1:1 code, not the generic fallback.
+        interp = interpret_verdict(_verdict(rejected=[{"candidate": "s::u", "reason": "UNMAPPED"}]))
+        assert interp.rejects == {"s::u": REASON_TOOLGRAPH_UNMAPPED}
+
+    def test_tool_not_found_is_mapped_and_tracked(self):
+        interp = interpret_verdict(
+            _verdict(rejected=[{"candidate": "s::missing", "reason": "TOOL_NOT_FOUND"}])
+        )
+        assert interp.rejects == {"s::missing": REASON_TOOLGRAPH_TOOL_NOT_FOUND}
+        assert interp.tool_not_found_refs == frozenset({"s::missing"})
+
+    def test_agent_not_found_aborts_with_generation(self):
+        interp = interpret_verdict(_verdict(agent_found=False))
+        assert interp.agent_found is False
+        assert interp.rejects == {}
+        assert interp.tool_not_found_refs == frozenset()
+        assert interp.graph_generation == 11
+
+    def test_missing_generation_on_abort_is_protocol_error(self):
+        # The server stamps graph_generation on EVERY path via _with_generation
+        # (the abort included), so a missing one is contract drift even when
+        # agent_found is False.
+        with pytest.raises(ToolgraphProtocolError):
+            interpret_verdict(_verdict(agent_found=False, graph_generation=_MISSING))
+
+    def test_non_bool_agent_found_is_protocol_error(self):
+        with pytest.raises(ToolgraphProtocolError):
+            interpret_verdict({"agent_found": "yes", "graph_generation": 1, "rejected": []})
+
+    def test_missing_generation_when_found_is_protocol_error(self):
+        with pytest.raises(ToolgraphProtocolError):
+            interpret_verdict(_verdict(graph_generation=_MISSING))
+
+    def test_bool_generation_is_protocol_error(self):
+        # bool is an int subclass but never a valid generation.
+        with pytest.raises(ToolgraphProtocolError):
+            interpret_verdict(_verdict(graph_generation=True))
+
+    def test_rejected_not_a_list_is_protocol_error(self):
+        with pytest.raises(ToolgraphProtocolError):
+            interpret_verdict({"agent_found": True, "graph_generation": 1, "rejected": {}})
+
+    def test_reject_row_missing_fields_is_protocol_error(self):
+        with pytest.raises(ToolgraphProtocolError):
+            interpret_verdict(_verdict(rejected=[{"candidate": "s::x"}]))
+
+
+# ── filter_tools external_rejects + withhold_all (#465) ─────────────────────
+
+
+class TestExternalRejects:
+    def _ext(self, profile, code="toolgraph_not_granted"):
+        cfg = _server_cfg()
+        return filter_tools(
+            [_cand("a", cfg), _cand("b", cfg)],
+            profile,
+            external_rejects={("srv", "a"): code},
+        )
+
+    def test_strict_rejects_with_the_code(self):
+        result = self._ext(STRICT)
+        assert _names(result) == ["test__b"]
+        assert result.reject_reasons == {"test__a": REASON_TOOLGRAPH_NOT_GRANTED}
+
+    def test_review_demotes_not_rejects(self):
+        result = self._ext(REVIEW)
+        assert _names(result) == ["test__a", "test__b"]
+        assert result.reject_reasons == {}
+        assert result.risk_penalties["test__a"] == REVIEW.review_risk_penalty
+
+    def test_explore_ignores(self):
+        result = self._ext(EXPLORE)
+        assert _names(result) == ["test__a", "test__b"]
+        assert result.reject_reasons == {}
+        assert result.risk_penalties == {}
+
+    def test_external_outranks_unhealthy(self):
+        # A tool flagged by BOTH the graph and the health heuristic records the
+        # explicit graph code, not the heuristic one.
+        cfg = _server_cfg()
+        result = filter_tools(
+            [_cand("a", cfg)],
+            STRICT,
+            unhealthy=frozenset({("srv", "a")}),
+            external_rejects={("srv", "a"): REASON_TOOLGRAPH_NOT_GRANTED},
+        )
+        assert result.reject_reasons == {"test__a": REASON_TOOLGRAPH_NOT_GRANTED}
+
+    def test_sensitive_outranks_external(self):
+        # Credential-in-metadata (upstream compromise) outranks a graph verdict.
+        cfg = _server_cfg()
+        cand = _cand("a", cfg, raw_desc="token: ghp_" + "x" * 36)
+        result = filter_tools(
+            [cand], STRICT, external_rejects={("srv", "a"): REASON_TOOLGRAPH_NOT_GRANTED}
+        )
+        assert result.reject_reasons == {"test__a": REASON_SENSITIVE_METADATA}
+
+
+class TestWithholdAll:
+    def test_withholds_every_tool_with_one_code(self):
+        cfg = _server_cfg()
+        result = filter_tools(
+            [_cand("a", cfg), _cand("b", cfg)],
+            STRICT,
+            withhold_all=REASON_TOOLGRAPH_UNREACHABLE,
+        )
+        assert result.eligible == []
+        assert result.reject_reasons == {
+            "test__a": REASON_TOOLGRAPH_UNREACHABLE,
+            "test__b": REASON_TOOLGRAPH_UNREACHABLE,
+        }
+        assert result.risk_penalties == {}
+
+    def test_withhold_all_is_profile_independent(self):
+        # Even explore (which skips signal rules) honors a closed-knob withhold.
+        cfg = _server_cfg()
+        result = filter_tools([_cand("a", cfg)], EXPLORE, withhold_all=REASON_TOOLGRAPH_UNREACHABLE)
+        assert result.eligible == []
+        assert result.reject_reasons == {"test__a": REASON_TOOLGRAPH_UNREACHABLE}

--- a/tests/test_toolgraph_provider.py
+++ b/tests/test_toolgraph_provider.py
@@ -1,10 +1,14 @@
-"""Tests for the optional tool-graph eligibility provider (#465, PR1).
+"""Tests for the optional tool-graph eligibility provider (#465).
 
 Covers the ``toolgraph`` config block (defaults / failure-knob defaults /
 file parse) and the connectable ``ToolgraphConsultAdapter`` (stdio lifecycle
-+ ``eligible_tools`` consult against a real fake stdio child). PR1 wires
-nothing into the eligibility filter; the only runtime touch is the
-"enabled but inert" startup warning, asserted here too.
++ ``eligible_tools`` consult against a real fake stdio child). The
+``TestToolgraphConsultWiring`` section drives the startup consult END-TO-END
+through ``ProxyManager`` against that same fake stdio child: per-candidate
+rejects flow into the exposure filter and selection telemetry, the four
+``on_*`` failure knobs each map correctly (fail_start raises out of start() /
+open degrades / closed withholds all), ``graph_generation`` is pinned into the
+log, and the server-name-mismatch heuristic fires.
 """
 
 from __future__ import annotations
@@ -14,13 +18,34 @@ import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from pydantic import ValidationError
 
-from memtomem_stm.proxy.config import ProxyConfig, ToolgraphConfig
-from memtomem_stm.proxy.manager import ProxyManager
+from memtomem_stm.proxy.config import (
+    CompressionStrategy,
+    ExposureConfig,
+    ExposureProfile,
+    ProxyConfig,
+    ToolgraphConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import (
+    ProxyManager,
+    ToolgraphStartupError,
+    UpstreamConnection,
+)
 from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.selection_log import SelectionTelemetryLog
+from memtomem_stm.proxy.tool_eligibility import (
+    REASON_TOOLGRAPH_AGENT_NOT_FOUND,
+    REASON_TOOLGRAPH_NOT_GRANTED,
+    REASON_TOOLGRAPH_PROTOCOL_ERROR,
+    REASON_TOOLGRAPH_TOOL_NOT_FOUND,
+    REASON_TOOLGRAPH_UNREACHABLE,
+)
+from memtomem_stm.server import _toolgraph_health_lines
 from memtomem_stm.proxy.toolgraph_provider import (
     ToolgraphConsultAdapter,
     ToolgraphProtocolError,
@@ -192,34 +217,45 @@ class TestToolgraphConsultAdapter:
         assert adapter.is_started is False
 
 
-# ── manager "enabled but inert" startup warning (PR1) ───────────────────────
+# ── manager startup: the provider is consulted, no longer inert ──────────────
 
 
-class TestToolgraphInertWarning:
-    async def test_enabled_warns_inert_at_startup(self, tmp_path, caplog):
+class TestToolgraphStartupWiring:
+    async def test_enabled_no_upstreams_skips_consult_no_inert_warning(self, tmp_path, caplog):
+        # The startup consult replaced the earlier "enabled but inert" warning.
+        # With no upstream tools there is nothing to consult, so the consult is
+        # skipped (INFO) and the old inert WARNING must be gone.
         cfg = ProxyConfig(
             config_path=tmp_path / "proxy.json",
             upstream_servers={},
             toolgraph=ToolgraphConfig(enabled=True),
         )
         mgr = ProxyManager(cfg, TokenTracker())
-        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+        with caplog.at_level(logging.INFO, logger="memtomem_stm.proxy.manager"):
             await mgr.start()
         try:
-            assert any(
-                "toolgraph.enabled is set" in r.message and "inert" in r.message
-                for r in caplog.records
-            )
+            assert not any("inert" in r.message for r in caplog.records)
+            assert any("consult skipped" in r.message for r in caplog.records)
+            status = mgr.get_toolgraph_status()
+            assert status == {
+                "enabled": True,
+                "degraded": False,
+                "degraded_reason": None,
+                "withholding_all": None,
+                "graph_generation": None,
+                "external_reject_count": 0,
+            }
         finally:
             await mgr.stop()
 
-    async def test_disabled_does_not_warn(self, tmp_path, caplog):
+    async def test_disabled_status_is_none_and_no_warning(self, tmp_path, caplog):
         cfg = ProxyConfig(config_path=tmp_path / "proxy.json", upstream_servers={})
         mgr = ProxyManager(cfg, TokenTracker())
         with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
             await mgr.start()
         try:
-            assert not any("toolgraph.enabled" in r.message for r in caplog.records)
+            assert not any("toolgraph" in r.message.lower() for r in caplog.records)
+            assert mgr.get_toolgraph_status() is None
         finally:
             await mgr.stop()
 
@@ -257,3 +293,362 @@ class TestParseTextVerdict:
     def test_none_text_part_returns_none(self):
         # TextContent.text=None degrades to "" → unparseable → None
         assert _parse_text_verdict(_text_result(None)) is None
+
+
+# ── startup consult wired through ProxyManager (real fake stdio child) ───────
+
+
+def _tool_result(text: str = "ok"):
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=text)], isError=False)
+
+
+def _tg_manager(tmp_path, *, servers=None, exposure=None, **tg_overrides):
+    """ProxyManager with upstream(s) wired + toolgraph pointed at the fake child.
+
+    Connections are wired directly (no real upstream stdio) so the test
+    exercises the toolgraph consult path in isolation; the caller then runs
+    ``await mgr._consult_toolgraph()`` and ``mgr.get_proxy_tools()`` — or
+    ``await mgr.start()`` to drive the full startup path (the empty-command
+    upstream fails-and-logs in start()'s connect loop, leaving the pre-wired
+    mock connection in place for the consult).
+    """
+    servers = servers or {"srv": ["read_file", "blocked"]}
+    log = SelectionTelemetryLog(tmp_path / "log.jsonl")
+    log.initialize()
+    upstream_cfgs = {
+        name: UpstreamServerConfig(
+            prefix=name,
+            compression=CompressionStrategy.NONE,
+            max_retries=0,
+            reconnect_delay_seconds=0.0,
+        )
+        for name in servers
+    }
+    tg_kwargs: dict = {"command": sys.executable, "args": [str(_FAKE_TOOLGRAPH)]}
+    tg_kwargs.update(tg_overrides)  # callers may override command/args (unreachable tests)
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers=upstream_cfgs,
+        exposure=exposure or ExposureConfig(),
+        toolgraph=ToolgraphConfig(enabled=True, **tg_kwargs),
+    )
+    mgr = ProxyManager(proxy_cfg, TokenTracker(), selection_log=log)
+    for name, tool_names in servers.items():
+        tools = [
+            SimpleNamespace(name=n, description=f"{n} description", inputSchema={"type": "object"})
+            for n in tool_names
+        ]
+        session = AsyncMock()
+        session.call_tool.return_value = _tool_result()
+        mgr._connections[name] = UpstreamConnection(
+            name=name, config=upstream_cfgs[name], session=session, tools=tools
+        )
+    return mgr, log
+
+
+def _events(log: SelectionTelemetryLog) -> list[dict]:
+    return [json.loads(line) for line in log.path.read_text(encoding="utf-8").splitlines() if line]
+
+
+class TestToolgraphConsultWiring:
+    async def test_success_rejects_flow_into_exposure_and_telemetry(self, tmp_path):
+        mgr, log = _tg_manager(tmp_path)  # tools: read_file, blocked
+        await mgr._consult_toolgraph()
+        # "srv::blocked" → NOT_GRANTED → withheld under strict.
+        assert mgr._toolgraph_external_rejects == {("srv", "blocked"): REASON_TOOLGRAPH_NOT_GRANTED}
+        assert mgr._graph_generation == 11
+        advertised = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        assert advertised == ["srv__read_file"]
+        assert mgr._advertised_reject_reasons == {"srv__blocked": REASON_TOOLGRAPH_NOT_GRANTED}
+
+        await mgr.call_tool("srv", "read_file", {})
+        selection, _execution = _events(log)
+        assert selection["graph_generation"] == 11
+        assert selection["reject_reasons"] == {"srv__blocked": REASON_TOOLGRAPH_NOT_GRANTED}
+
+        status = mgr.get_toolgraph_status()
+        assert status["degraded"] is False
+        assert status["withholding_all"] is None
+        assert status["external_reject_count"] == 1
+
+    async def test_review_demotes_external_reject(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, exposure=ExposureConfig(profile=ExposureProfile.REVIEW))
+        await mgr._consult_toolgraph()
+        advertised = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        assert advertised == ["srv__read_file", "srv__blocked"]  # still advertised
+        assert mgr._advertised_reject_reasons == {}
+        assert mgr._advertised_risk_penalties["srv__blocked"] > 0
+
+    async def test_explore_ignores_external_reject(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, exposure=ExposureConfig(profile=ExposureProfile.EXPLORE))
+        await mgr._consult_toolgraph()
+        advertised = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        assert advertised == ["srv__read_file", "srv__blocked"]
+        assert mgr._advertised_reject_reasons == {}
+        assert mgr._advertised_risk_penalties == {}
+
+    async def test_multi_upstream_fan_out_to_one_graph_ref(self, tmp_path):
+        # Two upstreams both crawled under graph server "srv", each exposing a
+        # "blocked" tool → one graph ref "srv::blocked" fans its NOT_GRANTED
+        # verdict back to BOTH STM keys.
+        mgr, _ = _tg_manager(
+            tmp_path,
+            servers={"a": ["blocked"], "b": ["blocked"]},
+            server_name_map={"a": "srv", "b": "srv"},
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_external_rejects == {
+            ("a", "blocked"): REASON_TOOLGRAPH_NOT_GRANTED,
+            ("b", "blocked"): REASON_TOOLGRAPH_NOT_GRANTED,
+        }
+        assert mgr.get_proxy_tools() == []  # both withheld under strict
+
+    async def test_agent_not_found_fail_start_raises_through_consult(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, agent_id="ghost")  # on_agent_not_found defaults fail_start
+        with pytest.raises(ToolgraphStartupError):
+            await mgr._consult_toolgraph()
+
+    async def test_fail_start_aborts_public_start_before_advertising(self, tmp_path):
+        # The load-bearing invariant: a fail_start failure must propagate out of
+        # the PUBLIC start() (not just the private consult seam) so the lifespan
+        # never advertises a tool. Driven through mgr.start().
+        mgr, _ = _tg_manager(tmp_path, agent_id="ghost")
+        with pytest.raises(ToolgraphStartupError):
+            await mgr.start()
+        assert mgr._advertised_infos == []  # nothing was advertised
+        await mgr.stop()
+
+    async def test_protocol_error_fail_start_aborts_public_start(self, tmp_path):
+        mgr, _ = _tg_manager(
+            tmp_path, query_profile="boom"
+        )  # on_protocol_error defaults fail_start
+        with pytest.raises(ToolgraphStartupError):
+            await mgr.start()
+        assert mgr._advertised_infos == []
+        await mgr.stop()
+
+    async def test_agent_not_found_open_degrades(self, tmp_path, caplog):
+        mgr, _ = _tg_manager(tmp_path, agent_id="ghost", on_agent_not_found="open")
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr._consult_toolgraph()
+        assert mgr._toolgraph_degraded is True
+        assert mgr._toolgraph_degraded_reason == REASON_TOOLGRAPH_AGENT_NOT_FOUND
+        assert mgr._toolgraph_external_rejects == {}
+        # graph responded on the abort, so the generation is still pinned.
+        assert mgr._graph_generation == 11
+        advertised = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        assert advertised == ["srv__read_file", "srv__blocked"]
+        assert mgr.get_toolgraph_status()["degraded"] is True
+        # the loud-degrade WARNING is load-bearing — assert it was emitted.
+        assert any("DEGRADED" in r.message and "NOT active" in r.message for r in caplog.records)
+
+    async def test_agent_not_found_closed_withholds_all(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, agent_id="ghost", on_agent_not_found="closed")
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_withhold_all == REASON_TOOLGRAPH_AGENT_NOT_FOUND
+        assert mgr.get_proxy_tools() == []
+        assert mgr._advertised_reject_reasons == {
+            "srv__read_file": REASON_TOOLGRAPH_AGENT_NOT_FOUND,
+            "srv__blocked": REASON_TOOLGRAPH_AGENT_NOT_FOUND,
+        }
+        assert mgr.get_toolgraph_status()["withholding_all"] == REASON_TOOLGRAPH_AGENT_NOT_FOUND
+
+    async def test_withhold_all_verdict_reaches_telemetry(self, tmp_path):
+        # The whole-call (every candidate rejected, profile-independent) verdict
+        # must reach the selection log just like the per-candidate path does.
+        mgr, log = _tg_manager(tmp_path, agent_id="ghost", on_agent_not_found="closed")
+        await mgr._consult_toolgraph()
+        mgr.get_proxy_tools()
+        await mgr.call_tool("srv", "read_file", {})
+        selection, _execution = _events(log)
+        assert selection["reject_reasons"] == {
+            "srv__read_file": REASON_TOOLGRAPH_AGENT_NOT_FOUND,
+            "srv__blocked": REASON_TOOLGRAPH_AGENT_NOT_FOUND,
+        }
+
+    async def test_protocol_error_open_degrades(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, query_profile="boom", on_protocol_error="open")
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_degraded is True
+        assert mgr._toolgraph_degraded_reason == REASON_TOOLGRAPH_PROTOCOL_ERROR
+        assert mgr._graph_generation is None  # no usable verdict
+
+    async def test_protocol_error_closed_withholds_all(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, query_profile="boom", on_protocol_error="closed")
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_withhold_all == REASON_TOOLGRAPH_PROTOCOL_ERROR
+        assert mgr.get_proxy_tools() == []
+
+    async def test_timeout_maps_to_unreachable(self, tmp_path):
+        # query_profile="sleep" blocks past timeout_seconds → the consult
+        # wait_for fires → ToolgraphUnreachableError → on_unreachable default open.
+        mgr, _ = _tg_manager(tmp_path, query_profile="sleep", timeout_seconds=0.5)
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_degraded is True
+        assert mgr._toolgraph_degraded_reason == REASON_TOOLGRAPH_UNREACHABLE
+
+    async def test_unreachable_closed_withholds_all(self, tmp_path):
+        mgr, _ = _tg_manager(
+            tmp_path, command="this-binary-does-not-exist-xyz", args=[], on_unreachable="closed"
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_withhold_all == REASON_TOOLGRAPH_UNREACHABLE
+        assert mgr.get_proxy_tools() == []
+
+    async def test_unreachable_open_degrades(self, tmp_path):
+        mgr, _ = _tg_manager(
+            tmp_path, command="this-binary-does-not-exist-xyz", args=[]
+        )  # on_unreachable default open
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_degraded is True
+        assert mgr._toolgraph_degraded_reason == REASON_TOOLGRAPH_UNREACHABLE
+        assert [i.prefixed_name for i in mgr.get_proxy_tools()] == [
+            "srv__read_file",
+            "srv__blocked",
+        ]
+
+    async def test_tool_not_found_open_keeps_advertised(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, servers={"srv": ["read_file", "missing_x"]})
+        await mgr._consult_toolgraph()  # on_tool_not_found default open
+        assert mgr._toolgraph_external_rejects == {}
+        assert [i.prefixed_name for i in mgr.get_proxy_tools()] == [
+            "srv__read_file",
+            "srv__missing_x",
+        ]
+
+    async def test_tool_not_found_closed_rejects(self, tmp_path):
+        mgr, _ = _tg_manager(
+            tmp_path, servers={"srv": ["read_file", "missing_x"]}, on_tool_not_found="closed"
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_external_rejects == {
+            ("srv", "missing_x"): REASON_TOOLGRAPH_TOOL_NOT_FOUND
+        }
+        assert [i.prefixed_name for i in mgr.get_proxy_tools()] == ["srv__read_file"]
+
+    async def test_server_name_mismatch_warns_when_all_unknown(self, tmp_path, caplog):
+        # Every tool of "ext" comes back TOOL_NOT_FOUND and "ext" has no map
+        # entry → likely a server_name_map gap.
+        mgr, _ = _tg_manager(tmp_path, servers={"ext": ["missing_a", "missing_b"]})
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr._consult_toolgraph()
+        assert any(
+            "unknown to the tool-graph" in r.message and "'ext'" in r.message
+            for r in caplog.records
+        )
+
+    async def test_no_mismatch_warning_when_partially_crawled(self, tmp_path, caplog):
+        # read_file is eligible, so "srv" is not a 100% miss → no false positive.
+        mgr, _ = _tg_manager(tmp_path, servers={"srv": ["read_file", "missing_x"]})
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr._consult_toolgraph()
+        assert not any("unknown to the tool-graph" in r.message for r in caplog.records)
+
+    async def test_no_mismatch_warning_when_server_is_mapped(self, tmp_path, caplog):
+        # "ext" IS mapped, so even a 100% miss does not warn (operator declared
+        # the mapping; the misses are genuinely uncrawled tools).
+        mgr, _ = _tg_manager(
+            tmp_path, servers={"ext": ["missing_a"]}, server_name_map={"ext": "srv"}
+        )
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr._consult_toolgraph()
+        assert not any("unknown to the tool-graph" in r.message for r in caplog.records)
+
+    async def test_second_start_resets_recovered_graph(self, tmp_path):
+        # A closed-knob withhold on the first consult must not persist to a
+        # second consult where the graph has recovered.
+        mgr, _ = _tg_manager(
+            tmp_path, command="this-binary-does-not-exist-xyz", args=[], on_unreachable="closed"
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_withhold_all == REASON_TOOLGRAPH_UNREACHABLE
+        # "Recover" the graph by pointing the config at the working fake child,
+        # then re-consult: the withhold-all state must be cleared.
+        mgr._config.toolgraph.command = sys.executable
+        mgr._config.toolgraph.args = [str(_FAKE_TOOLGRAPH)]
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_withhold_all is None
+        assert mgr._toolgraph_degraded is False
+        assert mgr._graph_generation == 11
+
+    async def test_server_name_map_translates_ref(self, tmp_path):
+        # STM key "local" maps to graph-crawled "srv"; the "blocked" tool there
+        # still resolves to "srv::blocked" → NOT_GRANTED.
+        mgr, _ = _tg_manager(
+            tmp_path, servers={"local": ["read_file", "blocked"]}, server_name_map={"local": "srv"}
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_external_rejects == {
+            ("local", "blocked"): REASON_TOOLGRAPH_NOT_GRANTED
+        }
+
+
+# ── stm_proxy_health rendering of the toolgraph status (loud degrade) ─────────
+
+
+class TestToolgraphHealthRendering:
+    def test_disabled_renders_nothing(self):
+        assert _toolgraph_health_lines(None) == []
+
+    def test_active_shows_generation_and_reject_count(self):
+        lines = _toolgraph_health_lines(
+            {
+                "enabled": True,
+                "degraded": False,
+                "degraded_reason": None,
+                "withholding_all": None,
+                "graph_generation": 11,
+                "external_reject_count": 2,
+            }
+        )
+        body = "\n".join(lines)
+        assert "active" in body
+        assert "11" in body
+        assert "2 tool(s) rejected" in body
+
+    def test_degraded_is_loud(self):
+        lines = _toolgraph_health_lines(
+            {
+                "enabled": True,
+                "degraded": True,
+                "degraded_reason": REASON_TOOLGRAPH_UNREACHABLE,
+                "withholding_all": None,
+                "graph_generation": None,
+                "external_reject_count": 0,
+            }
+        )
+        body = "\n".join(lines)
+        assert "DEGRADED" in body
+        assert "NOT active" in body
+        assert REASON_TOOLGRAPH_UNREACHABLE in body
+
+    def test_withholding_all_is_loud(self):
+        lines = _toolgraph_health_lines(
+            {
+                "enabled": True,
+                "degraded": False,
+                "degraded_reason": None,
+                "withholding_all": REASON_TOOLGRAPH_PROTOCOL_ERROR,
+                "graph_generation": None,
+                "external_reject_count": 0,
+            }
+        )
+        body = "\n".join(lines)
+        assert "WITHHOLDING ALL" in body
+        assert REASON_TOOLGRAPH_PROTOCOL_ERROR in body
+
+    def test_not_consulted_when_no_generation(self):
+        # enabled, no failure, but no usable generation → consult was skipped.
+        lines = _toolgraph_health_lines(
+            {
+                "enabled": True,
+                "degraded": False,
+                "degraded_reason": None,
+                "withholding_all": None,
+                "graph_generation": None,
+                "external_reject_count": 0,
+            }
+        )
+        body = "\n".join(lines)
+        assert "not consulted" in body
+        assert "active" not in body


### PR DESCRIPTION
Consults the optional external tool-graph eligibility provider once at proxy startup and feeds its verdict into the exposure hard filter, replacing the "enabled but inert" warning. Builds on the config block + connectable adapter already merged.

## What it does

**Consult at start()** — `ProxyManager._consult_toolgraph()` runs beside `compute_health_flags`: start → batch `eligible_tools` consult → stop, all within startup, caching the snapshot so the advertised set stays session-stable (nothing holds the stdio child past startup). Candidates are server-qualified `"<graph-server>::<tool>"` refs built via `server_name_map` (identity when unmapped); one ref's verdict fans back to every STM `(server, tool)` key that shares it.

**Two separate mechanisms**
- *Per-candidate rejects* ride the profile-gated signal block in `filter_tools` via a new `external_rejects` param (strict rejects / review demotes / explore ignores), ranked above `unhealthy` but below `sensitive_metadata`, under `toolgraph_*` codes mapped 1:1 from upstream reasons (a generic `toolgraph_rejected` fallback keeps an unrecognized reason fail-safe — still withheld, never silently advertised).
- *Whole-call fail-closed* (a `closed` knob) withholds every tool via a new profile-independent `withhold_all` param under an STM-owned code.

**Failure model** maps onto the four `on_*` knobs. A backend (Neo4j) outage while the graph server stays up surfaces as a server-side `isError`, classified as a contract failure → `on_protocol_error` (default `fail_start`) — no error-text sniffing. `fail_start` raises out of `start()` **before any tool is advertised**, so a broken/misconfigured provider can never silently disable enforcement. Any failure that resolves to `open` SKIPS the external rule family for the session and is surfaced loudly (startup WARNING + a `DEGRADED` line in `stm_proxy_health`) so a one-time `open` cannot quietly become a permanent enforcement blind spot.

**Telemetry** — populates the previously-reserved `graph_generation` field in the selection log from the consult, pinning replay to the graph state.

**Server-name-mismatch heuristic** — warns conservatively (only at a 100% `TOOL_NOT_FOUND` miss for an unmapped upstream) to suggest a `server_name_map` entry; there is no `list_servers` tool to verify the crawled name precisely.

`toolgraph_provider.py` is unchanged behaviorally — only its transport-error tuple is promoted to a module constant so the manager classifies a raw `start()` launch failure as unreachable without duplicating it.

## Behavior change

No-op when `toolgraph.enabled` is false (the default). When enabled: the external verdict can withhold/demote advertised tools, and a contract-class failure (`on_protocol_error`/`on_agent_not_found` default `fail_start`) refuses proxy startup — enabling the block makes the graph backend a startup prerequisite. Operators choose availability over assurance per-knob (`open`/`closed`); the degraded posture is always loud.

## Tests / gates

- New: `interpret_verdict` parsing/validation, `filter_tools` `external_rejects`/`withhold_all` (profile ladder + precedence), and end-to-end manager consult wiring against a real fake stdio child (all four knobs incl. `fail_start` driven through the public `start()`, multi-upstream fan-out, telemetry pin, server-name-mismatch fire + no-false-positive, second-start reset, health rendering).
- Full suite 3512 passed / 3 skipped; ruff + format clean; mypy at baseline (no new errors).

Docs: `configuration.md` documents the `toolgraph` block + the four knobs (incl. the Neo4j-outage classification); `selection-telemetry.md` documents the new reason codes + `graph_generation` semantics.

Issue #465.

Co-Authored-By: Claude Code <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)