### PR TITLE
feat(proxy): consume tool-graph risk_score as relevance risk_penalty (#493)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -382,6 +382,7 @@ under `toolgraph_*` reason codes; ranking can never resurrect them.
   "on_agent_not_found": "fail_start",
   "on_protocol_error": "fail_start",
   "on_tool_not_found": "open",
+  "risk_penalty_scale": 1.0,
   "timeout_seconds": 5.0
 }
 ```
@@ -411,8 +412,22 @@ A failure that resolves to `open` SKIPS the external rule family for the
 session — so it is surfaced loudly: a startup WARNING and a `DEGRADED` line in
 `stm_proxy_health`, so a one-time `open` cannot silently become a permanent
 enforcement blind spot. `stm_proxy_health` also reports a `WITHHOLDING ALL`
-posture (a `closed` knob fired) and, on success, the active graph generation +
-the count of graph-rejected tools.
+posture (a `closed` knob fired) and, on success, the active graph generation,
+the count of graph-rejected tools, and the count carrying a graph risk penalty.
+
+- **`risk_penalty_scale`** (`1.0` default) — beyond the hard *reject* verdict,
+  the graph assigns each *eligible* candidate a rule-based `risk_score`
+  (`[0,1]`: e.g. an authorized tool whose evidence chain has unbacked edges).
+  STM maps it to a tool-relevance `risk_penalty = min(risk_score * scale, 1.0)`
+  that **demotes** the eligible-but-risky tool in ranking telemetry (#466) — in
+  every profile, since this is a ranking signal, not an exposure one (ranking
+  can neither resurrect nor hard-reject). When `> 0` the consult runs a second,
+  best-effort `rank_features` batch query in the same startup session; if that
+  query fails the proxy advertises normally and ranks without graph penalties
+  (logged, never a startup gate). The penalty composes with the native
+  `review_risk_penalty` (review profile) via a complement-product, and calls
+  it shaped stamp the `v3-bm25-graph-risk-penalty` ranker cohort (see
+  [Selection telemetry](selection-telemetry.md)). `0` disables the signal.
 
 `server_name_map` translates an STM upstream connection key to the
 tool-graph's *crawled* server name (the two are independent strings); an empty

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -425,9 +425,9 @@ the count of graph-rejected tools, and the count carrying a graph risk penalty.
   best-effort `rank_features` batch query in the same startup session; if that
   query fails the proxy advertises normally and ranks without graph penalties
   (logged, never a startup gate). The penalty composes with the native
-  `review_risk_penalty` (review profile) via a complement-product, and calls
-  it shaped stamp the `v3-bm25-graph-risk-penalty` ranker cohort (see
-  [Selection telemetry](selection-telemetry.md)). `0` disables the signal.
+  `review_risk_penalty` (review profile) via a complement-product, and a
+  graph-derived penalty stamps the `v3-bm25-graph-risk-penalty` ranker cohort
+  (see [Selection telemetry](selection-telemetry.md)). `0` disables the signal.
 
 `server_name_map` translates an STM upstream connection key to the
 tool-graph's *crawled* server name (the two are independent strings); an empty

--- a/docs/selection-telemetry.md
+++ b/docs/selection-telemetry.md
@@ -42,9 +42,14 @@ marker stamped on both halves of a pair: `"v0-passthrough"` when no ranking
 informed the call (the client model picked from the full advertised set
 unaided — the unranked baseline), `"v1-bm25-tool-relevance"` when the #466
 ranking ran (see [Tool-relevance ranking](#tool-relevance-ranking-466-v0)),
-and `"v2-bm25-risk-penalty"` when at least one nonzero #465 risk penalty
-shaped the scores (an all-zero penalty map is v1 math and keeps the v1
-stamp).
+`"v2-bm25-risk-penalty"` when at least one nonzero penalty came *only* from
+the #465 review-profile demotion, and `"v3-bm25-graph-risk-penalty"` when at
+least one penalty included a component derived from the external tool-graph's
+per-candidate `risk_score` (#493). The scoring math is identical across v1–v3;
+the cohorts split on penalty *provenance* (and reach — a graph risk penalty
+applies in every profile, the native review penalty only under `review`), so
+replay must not pool them. An all-zero penalty map is v1 math and keeps the v1
+stamp.
 
 ### `selection` — one per proxied call
 
@@ -91,7 +96,7 @@ query signal and recorded in `candidate_features`:
   "query_chars": 42,
   "ranked_candidates": [
     {"tool": "gh__create_issue", "rank": 1, "relevance_score": 2.41,
-     "risk_penalty": 0.0, "final_score": 2.41}
+     "risk_penalty": 0.0, "risk_penalty_source": "none", "final_score": 2.41}
   ]
 }
 ```
@@ -111,14 +116,20 @@ query signal and recorded in `candidate_features`:
   call's top-level string argument values (sorted by key, capped); no
   signal → no ranking, and the pair keeps the `v0-passthrough` baseline.
   The raw query never enters the log — `query_source`/sha256/length only.
-- `risk_penalty` is the #465 hard filter's demotion input: under the
-  `review` exposure profile a signal-flagged tool stays advertised but
-  carries the configured penalty, and `final_score = relevance_score *
-  (1 - risk_penalty)` (ordering follows `final_score`). Multiplicative
-  because BM25 scores are unbounded. Penalties are session-stable (health
-  flags are computed once at startup), so records stay deterministic
-  within a session and self-describing across sessions. When any nonzero
-  penalty applied, both pair halves stamp `"v2-bm25-risk-penalty"`.
+- `risk_penalty` demotes a tool without removing it: `final_score =
+  relevance_score * (1 - risk_penalty)` (ordering follows `final_score`),
+  multiplicative because BM25 scores are unbounded. Two sources feed it,
+  composed via a complement-product (`1 - (1 - native)(1 - graph)`): the #465
+  `review`-profile demotion (a signal-flagged-but-advertised tool), and the
+  #493 external tool-graph `risk_score` scaled by `risk_penalty_scale` (an
+  eligible-but-risky tool, demoted in *every* profile). `risk_penalty_source`
+  records which contributed — `none` / `review` / `graph` / `review+graph` —
+  so replay can attribute the demotion (the combined value alone can't). The
+  penalties are session-stable (health flags + the graph consult both run once
+  at startup), so records stay deterministic within a session and
+  self-describing across sessions. A graph-derived penalty stamps the pair
+  `"v3-bm25-graph-risk-penalty"`; a native-review-only penalty stamps
+  `"v2-bm25-risk-penalty"`.
 - `top_n` (default 20) bounds `ranked_candidates`; the full advertised set
   is already in `candidate_tools`.
 

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -761,9 +761,16 @@ class ToolgraphConfig(BaseModel):
     ``open`` (default) does not hide a working tool; ``closed`` rejects
     uncrawled candidates (high-assurance)."""
     risk_penalty_scale: float = Field(default=1.0, ge=0.0)
-    """Multiplier mapping the upstream ``risk_score`` to a relevance
-    ``risk_penalty`` (consumed by a follow-up); ``0`` disables the risk
-    signal."""
+    """Multiplier mapping the graph's per-candidate ``risk_score`` (the
+    rule-based data-flow/DENY risk, ``[0,1]``) to a relevance ``risk_penalty``
+    for eligible-but-risky tools (#493): ``penalty = min(risk_score * scale,
+    1.0)``, demoting them in tool-relevance ranking telemetry (#466) in EVERY
+    profile — never exposure (ranking can neither resurrect nor hard-reject).
+    When ``> 0`` the consult runs a second, best-effort ``rank_features`` batch
+    query in the same startup session; a failure there degrades to no penalties
+    (logged, never a startup gate). The penalty composes with the native
+    ``review_risk_penalty`` via a complement-product when both apply. ``0``
+    (or a disabled ``toolgraph`` block) skips the enrichment entirely."""
     timeout_seconds: float = Field(default=5.0, gt=0.0)
     """Per-consult timeout for the startup batch query."""
 

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -76,19 +76,26 @@ from memtomem_stm.proxy.tool_eligibility import (
     compute_health_flags,
     filter_tools,
     interpret_verdict,
+    parse_risk_scores,
 )
 from memtomem_stm.proxy.toolgraph_provider import (
     TRANSPORT_ERRORS as TOOLGRAPH_TRANSPORT_ERRORS,
     ToolgraphConsultAdapter,
+    ToolgraphConsultError,
     ToolgraphProtocolError,
     ToolgraphUnreachableError,
 )
 from memtomem_stm.proxy.tool_relevance import (
+    PENALTY_SOURCE_BOTH,
+    PENALTY_SOURCE_GRAPH,
     RANKER_VERSION_BM25,
+    RANKER_VERSION_BM25_GRAPH_RISK,
     RANKER_VERSION_BM25_RISK,
     ToolRelevanceRanker,
     build_candidate_features,
+    compose_risk_penalty,
     derive_query,
+    penalty_source,
 )
 from memtomem_stm.proxy.tool_metadata import (
     convention_suffix,
@@ -219,7 +226,13 @@ class ProxyManager:
         self._advertised_tools: list[str] = []
         self._advertised_infos: list[ProxyToolInfo] = []
         self._advertised_reject_reasons: dict[str, str] = {}
+        # Composed ranking demotions for the advertised set (#466), keyed by
+        # prefixed name: the #465 review demotion stacked with the #493 graph
+        # risk penalty (``compose_risk_penalty``). ``_sources`` records each
+        # one's provenance for #468 replay attribution. Both sparse (penalized
+        # tools only) and rebuilt every get_proxy_tools() pass.
         self._advertised_risk_penalties: dict[str, float] = {}
+        self._advertised_risk_penalty_sources: dict[str, str] = {}
         # Health flags for the #465 filter, computed ONCE per start() from
         # the persisted metrics store and held for the session — exposure
         # must not drift between the startup advertisement (what the client
@@ -238,6 +251,12 @@ class ProxyManager:
         # SKIPPED — surfaced loudly so a one-time ``open`` cannot silently
         # become a permanent enforcement blind spot.
         self._toolgraph_external_rejects: dict[tuple[str, str], str] = {}
+        # #493 per-candidate graph ``risk_score`` mapped to a relevance
+        # ``risk_penalty`` (scaled by ``risk_penalty_scale``), keyed by
+        # ``(server, original_name)``. A best-effort enrichment of the consult:
+        # ranking telemetry only, never exposure — so a rank_features failure
+        # leaves this empty rather than touching the on_* knobs.
+        self._toolgraph_risk_penalties: dict[tuple[str, str], float] = {}
         self._toolgraph_withhold_all: str | None = None
         self._graph_generation: int | None = None
         self._toolgraph_degraded: bool = False
@@ -434,6 +453,7 @@ class ProxyManager:
         # a recovered graph on a second start must not inherit the previous
         # session's withhold-all / degraded / reject state.
         self._toolgraph_external_rejects = {}
+        self._toolgraph_risk_penalties = {}
         self._toolgraph_withhold_all = None
         self._graph_generation = None
         self._toolgraph_degraded = False
@@ -448,6 +468,7 @@ class ProxyManager:
             return
 
         adapter = ToolgraphConsultAdapter(cfg)
+        risk_scores: dict[str, float] = {}
         try:
             try:
                 # ``start()`` re-raises raw transport errors (caught below as
@@ -457,6 +478,13 @@ class ProxyManager:
                 await adapter.start()
                 verdict = await adapter.eligible_tools(refs)
                 interp = interpret_verdict(verdict)
+                # #493 risk enrichment in the SAME session (one extra batch
+                # round-trip, still session-stable). Best-effort and gated on a
+                # resolved agent + an enabled scale; its own failures degrade to
+                # "no penalties" inside the helper, so they never reach the on_*
+                # knobs below — a flaky enrichment must not fail startup.
+                if interp.agent_found and cfg.risk_penalty_scale > 0.0:
+                    risk_scores = await self._fetch_risk_scores(adapter, refs)
             finally:
                 try:
                     await adapter.stop()
@@ -497,7 +525,47 @@ class ProxyManager:
                 len(self._toolgraph_external_rejects),
                 self._graph_generation,
             )
+
+        # #493 map each positive ``risk_score`` to a relevance ``risk_penalty``,
+        # scaled by ``risk_penalty_scale`` and clamped to the ranker's [0,1]
+        # range, fanned to every STM key sharing the ref. Ranking telemetry
+        # only — never an exposure input, so a rejected-but-risky ref simply
+        # never reaches the ranker (it is outside ``eligible``).
+        scale = cfg.risk_penalty_scale
+        self._toolgraph_risk_penalties = {
+            key: min(score * scale, 1.0)
+            for ref, score in risk_scores.items()
+            for key in ref_to_keys.get(ref, ())
+        }
+        if self._toolgraph_risk_penalties:
+            logger.info(
+                "Tool-graph consult: %d candidate(s) carry a graph risk penalty (generation %s)",
+                len(self._toolgraph_risk_penalties),
+                self._graph_generation,
+            )
         self._warn_server_name_mismatch(interp.tool_not_found_refs, ref_to_keys)
+
+    async def _fetch_risk_scores(
+        self, adapter: ToolgraphConsultAdapter, refs: list[str]
+    ) -> dict[str, float]:
+        """Best-effort ``rank_features`` enrichment (#493): ``{ref: risk_score}``.
+
+        The graph's per-candidate ``risk_score`` is a ranking-telemetry signal
+        only — never exposure, never a startup gate — so unlike the
+        ``eligible_tools`` verdict (whose failures ride the ``on_*`` knobs) any
+        fault here degrades silently to "no penalties", logged once at WARNING.
+        Returns an empty map on any consult error.
+        """
+        try:
+            verdict = await adapter.rank_features(refs)
+        except ToolgraphConsultError as exc:
+            logger.warning(
+                "Tool-graph risk enrichment (rank_features) failed (%s) — ranking "
+                "proceeds without graph risk penalties this session.",
+                exc,
+            )
+            return {}
+        return parse_risk_scores(verdict)
 
     def _tg_whole_call(self, knob: str, code: str, detail: str) -> None:
         """Apply a whole-call tool-graph failure per its ``on_*`` knob.
@@ -827,8 +895,36 @@ class ProxyManager:
         self._advertised_infos = verdict.eligible
         self._advertised_tools = [info.prefixed_name for info in verdict.eligible]
         self._advertised_reject_reasons = verdict.reject_reasons
-        self._advertised_risk_penalties = verdict.risk_penalties
+        self._advertised_risk_penalties, self._advertised_risk_penalty_sources = (
+            self._compose_advertised_penalties(verdict.eligible, verdict.risk_penalties)
+        )
         return verdict.eligible
+
+    def _compose_advertised_penalties(
+        self, eligible: list[ProxyToolInfo], native: dict[str, float]
+    ) -> tuple[dict[str, float], dict[str, str]]:
+        """Merge the two ranking-demotion sources over the advertised set (#493).
+
+        Composes the #465 ``review``-profile demotion (*native*, keyed by
+        prefixed name) with the #493 graph risk penalty
+        (``_toolgraph_risk_penalties``, keyed by ``(server, original_name)``)
+        via :func:`compose_risk_penalty`, returning parallel
+        ``{prefixed_name: penalty}`` / ``{prefixed_name: source}`` maps. Both
+        are sparse (penalized tools only); an absent tool ranks with no penalty
+        and source ``none``. The graph penalty is applied to every advertised
+        tool regardless of profile — it is ranking telemetry, not an exposure
+        signal — whereas *native* is review-profile-only by construction.
+        """
+        penalties: dict[str, float] = {}
+        sources: dict[str, str] = {}
+        for info in eligible:
+            n = native.get(info.prefixed_name, 0.0)
+            g = self._toolgraph_risk_penalties.get((info.server, info.original_name), 0.0)
+            if n <= 0.0 and g <= 0.0:
+                continue
+            penalties[info.prefixed_name] = compose_risk_penalty(n, g)
+            sources[info.prefixed_name] = penalty_source(n, g)
+        return penalties, sources
 
     @staticmethod
     def _log_exposure_rejects(reject_reasons: dict[str, str]) -> None:
@@ -1513,7 +1609,10 @@ class ProxyManager:
         means the family was skipped (advertising per STM-native rules only);
         ``withholding_all`` means a ``closed`` knob withheld every tool;
         otherwise the consult succeeded and ``external_reject_count`` reflects
-        the per-candidate verdicts in force.
+        the per-candidate verdicts in force. ``risk_penalty_count`` is the
+        number of candidates the graph assigned a positive ``risk_score`` that
+        STM mapped to a relevance demotion (#493) — ranking telemetry only,
+        ``0`` when ``risk_penalty_scale`` is ``0`` or the enrichment degraded.
         """
         if not self._config.toolgraph.enabled:
             return None
@@ -1524,6 +1623,7 @@ class ProxyManager:
             "withholding_all": self._toolgraph_withhold_all,
             "graph_generation": self._graph_generation,
             "external_reject_count": len(self._toolgraph_external_rejects),
+            "risk_penalty_count": len(self._toolgraph_risk_penalties),
         }
 
     async def _on_cache_hit(
@@ -1684,19 +1784,25 @@ class ProxyManager:
                 return None, None
             query, source = derived
             penalties = self._advertised_risk_penalties
+            penalty_sources = self._advertised_risk_penalty_sources
             ranked = ToolRelevanceRanker(top_n=trc.top_n).rank(
-                query, self._advertised_infos, penalties
+                query, self._advertised_infos, penalties, penalty_sources
             )
             if not ranked:
                 return None, None
             # The risk-penalty pathway changes the scoring function, so the
             # cohort stamp must change with it — but only when a penalty
-            # actually shaped the scores (an all-zero map is v1 math).
-            version = (
-                RANKER_VERSION_BM25_RISK
-                if any(p > 0.0 for p in penalties.values())
-                else RANKER_VERSION_BM25
-            )
+            # actually shaped the scores (an all-zero map is v1 math). A
+            # graph-derived component (#493) splits a finer cohort than a
+            # native-review-only penalty, since it reaches every profile.
+            if any(
+                s in (PENALTY_SOURCE_GRAPH, PENALTY_SOURCE_BOTH) for s in penalty_sources.values()
+            ):
+                version = RANKER_VERSION_BM25_GRAPH_RISK
+            elif any(p > 0.0 for p in penalties.values()):
+                version = RANKER_VERSION_BM25_RISK
+            else:
+                version = RANKER_VERSION_BM25
             return build_candidate_features(query, source, ranked), version
         except Exception:
             logger.debug("Tool-relevance ranking failed", exc_info=True)

--- a/src/memtomem_stm/proxy/tool_eligibility.py
+++ b/src/memtomem_stm/proxy/tool_eligibility.py
@@ -387,6 +387,41 @@ def interpret_verdict(verdict: Mapping[str, Any]) -> InterpretedVerdict:
     )
 
 
+def parse_risk_scores(verdict: Mapping[str, Any]) -> dict[str, float]:
+    """Extract per-candidate ``risk_score`` from a ``rank_features`` verdict (#493).
+
+    Returns ``{candidate_ref: risk_score}`` for every resolved row carrying a
+    *positive* numeric ``risk_score`` (the graph's rule-based data-flow/DENY
+    risk, ``[0,1]``). Rows with ``risk_score`` ``None`` (unresolved / ambiguous)
+    or ``0.0`` (clean) are omitted so the map stays sparse — a missing ref means
+    "no penalty", which is exactly the ranker's default.
+
+    Unlike :func:`interpret_verdict` this is **lenient and never raises**: the
+    risk signal is a best-effort ranking-telemetry enrichment (#466/#468), never
+    an exposure input, so a malformed payload yields an empty map (the caller
+    degrades to no penalties) rather than a contract failure. ``bool`` is
+    rejected as a score — it is an ``int`` subclass but never a valid risk.
+    """
+    rows = verdict.get("features")
+    if not isinstance(rows, list):
+        return {}
+    scores: dict[str, float] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        ref = row.get("candidate")
+        score = row.get("risk_score")
+        if (
+            not isinstance(ref, str)
+            or isinstance(score, bool)
+            or not isinstance(score, (int, float))
+        ):
+            continue
+        if score > 0.0:
+            scores[ref] = float(score)
+    return scores
+
+
 def filter_tools(
     candidates: list[ExposureCandidate],
     cfg: ExposureConfig,

--- a/src/memtomem_stm/proxy/tool_relevance.py
+++ b/src/memtomem_stm/proxy/tool_relevance.py
@@ -112,7 +112,17 @@ def compose_risk_penalty(native: float, graph: float) -> float:
     *native* is the #465 ``review``-profile demotion (``review_risk_penalty``);
     *graph* is the #493 tool-graph ``risk_score`` scaled by
     ``risk_penalty_scale``.
+
+    The single-source cases short-circuit to the nonzero input *exactly* — the
+    overwhelmingly common path (a tool rarely carries both penalties), and
+    ``1 - (1 - x)`` does not round-trip to ``x`` in float, so the short-circuit
+    keeps a graph-only ``0.2`` recorded as ``0.2`` rather than
+    ``0.19999999999999996``.
     """
+    if native <= 0.0:
+        return graph
+    if graph <= 0.0:
+        return native
     return 1.0 - (1.0 - native) * (1.0 - graph)
 
 

--- a/src/memtomem_stm/proxy/tool_relevance.py
+++ b/src/memtomem_stm/proxy/tool_relevance.py
@@ -18,18 +18,25 @@ The scored document per candidate is what the client actually saw: the
 prefixed tool name (BM25 heading position, 3x weight) plus the advertised —
 post-truncation, post-distill — description and stable-serialized schema.
 
-``risk_penalty`` is the #465 hard filter's demotion input (``review``
-profile flags a tool instead of rejecting it): ``final_score =
+``risk_penalty`` demotes a tool without removing it: ``final_score =
 relevance_score * (1 - risk_penalty)`` and the ordering follows
-``final_score``, so a flagged tool sinks without leaving the record.
+``final_score``, so a penalized tool sinks without leaving the record.
 Multiplicative because BM25 scores are unbounded — an absolute penalty
-would mean nothing across queries. Calls where any nonzero penalty applied
-stamp :data:`RANKER_VERSION_BM25_RISK` so replay can split cohorts; the
-penalties themselves are session-stable (health flags are computed once at
+would mean nothing across queries. Two independent sources feed the penalty,
+composed via :func:`compose_risk_penalty`: the #465 hard filter's
+``review``-profile demotion (a flagged-but-advertised tool), and the #493
+external tool-graph ``risk_score`` mapped onto eligible-but-risky tools in
+*every* profile. Each candidate also carries a ``risk_penalty_source`` tag
+(:func:`penalty_source`) recording which source(s) shaped it, so #468 replay
+can attribute the demotion. Calls stamp :data:`RANKER_VERSION_BM25_GRAPH_RISK`
+when any graph-derived penalty contributed, :data:`RANKER_VERSION_BM25_RISK`
+when only native review demotions did, else :data:`RANKER_VERSION_BM25` — the
+math is identical, but the cohorts must not pool. The penalties themselves
+are session-stable (health flags + the graph consult both run once at
 startup), making records deterministic within a session and self-describing
-across sessions (each candidate carries the penalty that shaped its score).
-A hard-rejected tool never reaches this module at all — ranking runs over
-the filter's output, so it can never resurrect a reject.
+across sessions (each candidate carries the penalty and source that shaped
+its score). A hard-rejected tool never reaches this module at all — ranking
+runs over the filter's output, so it can never resurrect a reject.
 
 Privacy: the derived query is used in memory for scoring only — callers
 persist its sha256/length/source via ``build_candidate_features``, never the
@@ -58,8 +65,27 @@ RANKER_VERSION_BM25 = "v1-bm25-tool-relevance"
 # a nonzero risk penalty — the scoring function then differs from plain v1
 # (final_score = relevance * (1 - penalty)), and replay must not pool the
 # two. With an all-zero penalty map the math degenerates to v1 exactly, so
-# such calls keep the v1 stamp.
+# such calls keep the v1 stamp. v2 is the NATIVE-only cohort: every nonzero
+# penalty came from the #465 ``review``-profile demotion.
 RANKER_VERSION_BM25_RISK = "v2-bm25-risk-penalty"
+
+# Stamped instead of RANKER_VERSION_BM25_RISK when at least one candidate's
+# penalty includes a component derived from the external tool-graph's
+# per-candidate ``risk_score`` (#493). The scoring math is unchanged (still
+# final = relevance * (1 - penalty)), but the penalty PROVENANCE differs — a
+# graph-risk demotion applies to eligible-but-risky tools in EVERY profile,
+# whereas the native v2 demotion is review-profile-only — so #468 replay must
+# split the cohorts. Per-candidate ``risk_penalty_source`` records which
+# source(s) shaped each tool's penalty within the call.
+RANKER_VERSION_BM25_GRAPH_RISK = "v3-bm25-graph-risk-penalty"
+
+# ``risk_penalty_source`` values — the provenance of a candidate's composed
+# penalty, for #468 replay attribution. Every ranked record carries one
+# (``"none"`` when unpenalized), keeping records self-describing.
+PENALTY_SOURCE_NONE = "none"
+PENALTY_SOURCE_REVIEW = "review"  # #465 review-profile demotion only
+PENALTY_SOURCE_GRAPH = "graph"  # #493 tool-graph risk_score only
+PENALTY_SOURCE_BOTH = "review+graph"  # both stacked via compose_risk_penalty
 
 # Bound the schema text folded into each candidate document. Schemas are
 # advertised (possibly distilled) client-facing artifacts, but a pathological
@@ -69,6 +95,42 @@ _MAX_SCHEMA_CHARS = 2000
 
 # Bound the args-derived fallback query the same way.
 _MAX_QUERY_CHARS = 512
+
+
+def compose_risk_penalty(native: float, graph: float) -> float:
+    """Combine two independent demotions into one penalty (complement-product).
+
+    The ranker scores ``final = relevance * (1 - penalty)``. Two independent
+    multiplicative demotions therefore stack: ``relevance * (1 - native) *
+    (1 - graph) = relevance * (1 - combined)`` with ``combined = 1 -
+    (1 - native)(1 - graph)``. This composition is the one consistent with the
+    ranking math itself — commutative, monotone in each input, bounded to
+    ``[0, 1]`` for inputs in ``[0, 1]``, and degenerating to whichever input is
+    nonzero when the other is ``0`` (so an unflagged tool with a graph risk,
+    or a flagged tool the graph scored clean, behaves exactly as before).
+
+    *native* is the #465 ``review``-profile demotion (``review_risk_penalty``);
+    *graph* is the #493 tool-graph ``risk_score`` scaled by
+    ``risk_penalty_scale``.
+    """
+    return 1.0 - (1.0 - native) * (1.0 - graph)
+
+
+def penalty_source(native: float, graph: float) -> str:
+    """Provenance tag for a composed penalty (one of ``PENALTY_SOURCE_*``).
+
+    Lets #468 replay attribute each candidate's demotion to the native review
+    rule, the tool-graph risk signal, or both — the combined ``risk_penalty``
+    value alone cannot distinguish a ``0.5`` that is native-only from one that
+    is graph-derived.
+    """
+    if native > 0.0 and graph > 0.0:
+        return PENALTY_SOURCE_BOTH
+    if graph > 0.0:
+        return PENALTY_SOURCE_GRAPH
+    if native > 0.0:
+        return PENALTY_SOURCE_REVIEW
+    return PENALTY_SOURCE_NONE
 
 
 def derive_query(arguments: dict[str, Any] | None) -> tuple[str, str] | None:
@@ -119,16 +181,22 @@ class ToolRelevanceRanker:
         query: str,
         candidates: list[ProxyToolInfo],
         risk_penalties: Mapping[str, float] | None = None,
+        risk_penalty_sources: Mapping[str, str] | None = None,
     ) -> list[dict[str, Any]]:
         """Rank *candidates* against *query*; order follows ``final_score``.
 
-        *risk_penalties* maps prefixed names to the #465 filter's demotion
-        for tools flagged-but-advertised (``review`` profile); absent tools
-        carry ``0.0`` and the math degenerates to plain relevance order.
+        *risk_penalties* maps prefixed names to the already-composed demotion
+        (native #465 ``review`` demotion stacked with the #493 tool-graph risk
+        via :func:`compose_risk_penalty`); absent tools carry ``0.0`` and the
+        math degenerates to plain relevance order. *risk_penalty_sources* maps
+        the same names to the provenance tag (:func:`penalty_source`) echoed
+        into each record for #468 replay attribution; absent tools record
+        :data:`PENALTY_SOURCE_NONE`.
         """
         if not candidates:
             return []
         penalties = risk_penalties or {}
+        sources = risk_penalty_sources or {}
         sections = [_candidate_document(c) for c in candidates]
         scores = self._scorer.score_sections(query, sections)
         finals = [
@@ -145,6 +213,9 @@ class ToolRelevanceRanker:
                 "rank": rank,
                 "relevance_score": round(scores[i], 6),
                 "risk_penalty": round(penalties.get(candidates[i].prefixed_name, 0.0), 6),
+                "risk_penalty_source": sources.get(
+                    candidates[i].prefixed_name, PENALTY_SOURCE_NONE
+                ),
                 "final_score": round(finals[i], 6),
             }
             for rank, i in enumerate(order[: self._top_n], start=1)

--- a/src/memtomem_stm/proxy/toolgraph_provider.py
+++ b/src/memtomem_stm/proxy/toolgraph_provider.py
@@ -36,8 +36,12 @@ from memtomem_stm.proxy.config import ToolgraphConfig
 
 logger = logging.getLogger(__name__)
 
-# The upstream MCP tool this adapter consults (toolgraph/server/app.py).
+# The upstream MCP tools this adapter consults (toolgraph/server/app.py).
+# ``eligible_tools`` is the authoritative hard-filter verdict (rejects);
+# ``rank_features`` carries the per-candidate ``risk_score`` STM maps onto the
+# relevance ``risk_penalty`` (#493) — a separate, best-effort enrichment.
 _ELIGIBLE_TOOLS = "eligible_tools"
+_RANK_FEATURES = "rank_features"
 
 # Transport failure modes that mean "graph unreachable" rather than a contract
 # mismatch. ``eligible_tools()`` wraps these into ``ToolgraphUnreachableError``;
@@ -170,18 +174,55 @@ class ToolgraphConsultAdapter:
             ToolgraphProtocolError: ``isError`` result, missing tool, or a
                 missing / non-dict structured payload.
         """
-        if self._session is None:
-            raise ToolgraphUnreachableError("tool-graph adapter not started")
-
         args: dict[str, Any] = {
             "agent": self._config.agent_id if agent is None else agent,
             "candidates": candidates,
             "profile": self._config.query_profile if profile is None else profile,
         }
+        return await self._consult(_ELIGIBLE_TOOLS, args)
+
+    async def rank_features(
+        self,
+        candidates: list[str],
+        *,
+        agent: str | None = None,
+    ) -> dict[str, Any]:
+        """Consult the graph's ``rank_features`` for *candidates* (#493).
+
+        Returns the raw structured response
+        ``{agent, agent_found, features, graph_generation}`` (``features`` in
+        input order, each row carrying a ``candidate`` ref and a ``risk_score``
+        in ``[0,1]`` or ``None``). Unlike :meth:`eligible_tools` this is a
+        *best-effort enrichment*: the caller maps a positive ``risk_score`` onto
+        a relevance ``risk_penalty`` and treats any failure as "no penalty"
+        (ranking telemetry only, never exposure). The upstream tool takes no
+        ``profile`` — features are profile-independent facts.
+
+        Raises:
+            ToolgraphUnreachableError: transport down / timeout / not started.
+            ToolgraphProtocolError: ``isError`` result, missing tool, or a
+                missing / non-dict structured payload.
+        """
+        args: dict[str, Any] = {
+            "agent": self._config.agent_id if agent is None else agent,
+            "candidates": candidates,
+        }
+        return await self._consult(_RANK_FEATURES, args)
+
+    async def _consult(self, tool: str, args: dict[str, Any]) -> dict[str, Any]:
+        """Call one upstream tool and return its parsed structured verdict.
+
+        Shared transport/error/parse contract for :meth:`eligible_tools` and
+        :meth:`rank_features`: transport faults map to
+        :class:`ToolgraphUnreachableError`; an ``isError`` result, an unknown
+        tool, or an unparseable payload map to :class:`ToolgraphProtocolError`.
+        """
+        if self._session is None:
+            raise ToolgraphUnreachableError("tool-graph adapter not started")
 
         try:
             result = await asyncio.wait_for(
-                self._session.call_tool(_ELIGIBLE_TOOLS, args),
+                self._session.call_tool(tool, args),
                 timeout=self._config.timeout_seconds,
             )
         except self._TRANSPORT_ERRORS as exc:
@@ -195,7 +236,7 @@ class ToolgraphConsultAdapter:
 
         if result.isError:
             raise ToolgraphProtocolError(
-                f"eligible_tools returned an error result: {_result_error_text(result)}"
+                f"{tool} returned an error result: {_result_error_text(result)}"
             )
 
         # Prefer ``structuredContent`` if the upstream emits it, but mcp 1.27.x
@@ -209,7 +250,7 @@ class ToolgraphConsultAdapter:
             verdict = _parse_text_verdict(result)
         if not isinstance(verdict, dict):
             raise ToolgraphProtocolError(
-                "eligible_tools response carried no parseable verdict "
+                f"{tool} response carried no parseable verdict "
                 "(neither structuredContent nor a JSON text payload)"
             )
         return verdict

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -696,10 +696,14 @@ def _toolgraph_health_lines(status: dict | None) -> list[str]:
         # skipped (no upstream tools discovered). Not "active" enforcement.
         lines.append("  enabled, not consulted (no upstream tools discovered)")
     else:
-        lines.append(
+        line = (
             f"  active (graph generation {status['graph_generation']}, "
-            f"{status['external_reject_count']} tool(s) rejected by the graph)"
+            f"{status['external_reject_count']} tool(s) rejected by the graph"
         )
+        risk_count = status.get("risk_penalty_count", 0)
+        if risk_count:
+            line += f"; {risk_count} carry a graph risk penalty"
+        lines.append(line + ")")
     return lines
 
 

--- a/tests/_fake_toolgraph_server.py
+++ b/tests/_fake_toolgraph_server.py
@@ -22,15 +22,19 @@ Input-driven behaviors (so one fixture covers every adapter path):
   adapter's per-consult ``asyncio.wait_for`` fires → ``ToolgraphUnreachableError``.
 * ``agent == "ghost"`` returns ``agent_found=False`` as a *structured*
   result (NOT an error) — the abort signal the adapter must surface as data.
-* any candidate ending in ``"::blocked"`` comes back as a ``NOT_GRANTED``
-  rejected row; a candidate whose tool part starts with ``"missing"`` comes
-  back as a ``TOOL_NOT_FOUND`` rejected row (the graph's blind spot); all
-  others are eligible, in input order.
+* any candidate ending in ``"::blocked"`` (or whose tool part starts with
+  ``"riskyblocked"``) comes back as a ``NOT_GRANTED`` rejected row; a candidate
+  whose tool part starts with ``"missing"`` comes back as a ``TOOL_NOT_FOUND``
+  rejected row (the graph's blind spot); all others are eligible, in input
+  order.
 * ``rank_features`` mirrors that resolution and stamps a ``risk_score`` per the
   real fixed table (``selector._risk_score``): a tool part starting with
   ``"risky"`` scores ``0.4`` (eligible-but-risky — the case PR #493 demotes),
   ``"missing*"`` scores ``None`` (unresolved), and everything else — including
   ``"::blocked"`` (NOT_GRANTED is grant-only, data-flow clean) — scores ``0.0``.
+  ``"riskyblocked*"`` therefore lands in BOTH (rejected by ``eligible_tools``
+  AND scored ``0.4``): under ``review`` it earns a native demote stacked with
+  the graph penalty — the ``review+graph`` provenance.
 
 Run with: ``python <path-to-this-file>``.
 """
@@ -69,7 +73,9 @@ async def eligible_tools(agent: str, candidates: list[str], profile: str = "stri
     rejected: list[dict] = []
     for candidate in candidates:  # input order is part of the upstream contract
         tool_part = candidate.split("::", 1)[-1]
-        if candidate.endswith("::blocked"):
+        # "riskyblocked*" is BOTH rejected here AND scored >0 by rank_features —
+        # the overlap case (under review: native demote + graph penalty = BOTH).
+        if candidate.endswith("::blocked") or tool_part.startswith("riskyblocked"):
             rejected.append(
                 {"candidate": candidate, "tool_key": candidate, "reason": "NOT_GRANTED"}
             )
@@ -94,7 +100,12 @@ async def rank_features(agent: str, candidates: list[str]) -> dict:
 
     Only the fields STM's ``parse_risk_scores`` reads are populated faithfully
     (``candidate`` + ``risk_score``); the rest of the real row is summarized.
+    ``agent == "rankboom"`` raises (``isError``) so the best-effort enrichment
+    degrade path is exercisable while ``eligible_tools`` still succeeds for the
+    same agent.
     """
+    if agent == "rankboom":
+        raise ValueError("rank_features boom")
     if agent == "ghost":
         return {
             "agent": agent,

--- a/tests/_fake_toolgraph_server.py
+++ b/tests/_fake_toolgraph_server.py
@@ -3,9 +3,11 @@
 Stands in for the real tool-graph MCP server (``toolgraph serve``) so that
 STM's :class:`~memtomem_stm.proxy.toolgraph_provider.ToolgraphConsultAdapter`
 can be exercised end-to-end over a real stdio child without depending on the
-external package or a running Neo4j. It exposes the one tool the adapter
-calls — ``eligible_tools`` — returning the real structured shape
-(``{agent, agent_found, profile, eligible, rejected, graph_generation}``).
+external package or a running Neo4j. It exposes the two tools the adapter
+calls — ``eligible_tools`` (the hard-filter verdict) and ``rank_features`` (the
+per-candidate ``risk_score`` enrichment, #493) — returning the real structured
+shapes (``{agent, agent_found, profile, eligible, rejected, graph_generation}``
+and ``{agent, agent_found, features, graph_generation}``).
 
 Returning a bare ``-> dict`` means mcp serializes the verdict into a
 ``TextContent`` JSON payload (mcp 1.27.x does not emit ``structuredContent``
@@ -24,6 +26,11 @@ Input-driven behaviors (so one fixture covers every adapter path):
   rejected row; a candidate whose tool part starts with ``"missing"`` comes
   back as a ``TOOL_NOT_FOUND`` rejected row (the graph's blind spot); all
   others are eligible, in input order.
+* ``rank_features`` mirrors that resolution and stamps a ``risk_score`` per the
+  real fixed table (``selector._risk_score``): a tool part starting with
+  ``"risky"`` scores ``0.4`` (eligible-but-risky — the case PR #493 demotes),
+  ``"missing*"`` scores ``None`` (unresolved), and everything else — including
+  ``"::blocked"`` (NOT_GRANTED is grant-only, data-flow clean) — scores ``0.0``.
 
 Run with: ``python <path-to-this-file>``.
 """
@@ -77,6 +84,40 @@ async def eligible_tools(agent: str, candidates: list[str], profile: str = "stri
         "profile": profile,
         "eligible": eligible,
         "rejected": rejected,
+        "graph_generation": _GRAPH_GENERATION,
+    }
+
+
+@mcp.tool()
+async def rank_features(agent: str, candidates: list[str]) -> dict:
+    """Canned ``rank_features`` consult mirroring the real per-candidate shape.
+
+    Only the fields STM's ``parse_risk_scores`` reads are populated faithfully
+    (``candidate`` + ``risk_score``); the rest of the real row is summarized.
+    """
+    if agent == "ghost":
+        return {
+            "agent": agent,
+            "agent_found": False,
+            "features": [],
+            "graph_generation": _GRAPH_GENERATION,
+        }
+
+    features: list[dict] = []
+    for candidate in candidates:  # input order is part of the upstream contract
+        tool_part = candidate.split("::", 1)[-1]
+        if tool_part.startswith("missing"):
+            score: float | None = None  # unresolved → no facts to score
+        elif tool_part.startswith("risky"):
+            score = 0.4  # eligible-but-risky (e.g. an unbacked-evidence edge)
+        else:
+            score = 0.0  # clean ALLOW / grant-only reject — data-flow clean
+        features.append({"candidate": candidate, "tool_key": candidate, "risk_score": score})
+
+    return {
+        "agent": agent,
+        "agent_found": True,
+        "features": features,
         "graph_generation": _GRAPH_GENERATION,
     }
 

--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -53,7 +53,11 @@ from memtomem_stm.proxy.tool_eligibility import (
     interpret_verdict,
     parse_risk_scores,
 )
-from memtomem_stm.proxy.tool_relevance import RANKER_VERSION_BM25_RISK
+from memtomem_stm.proxy.tool_relevance import (
+    PENALTY_SOURCE_NONE,
+    PENALTY_SOURCE_REVIEW,
+    RANKER_VERSION_BM25_RISK,
+)
 from memtomem_stm.proxy.toolgraph_provider import ToolgraphProtocolError
 
 
@@ -586,6 +590,7 @@ class TestManagerWireIn:
             if r["tool"] == "test__read_file"
         )
         assert entry["risk_penalty"] == 0.5
+        assert entry["risk_penalty_source"] == PENALTY_SOURCE_REVIEW
         assert entry["final_score"] == round(entry["relevance_score"] * 0.5, 6)
         clean = next(
             r
@@ -593,6 +598,7 @@ class TestManagerWireIn:
             if r["tool"] == "test__send_message"
         )
         assert clean["risk_penalty"] == 0.0
+        assert clean["risk_penalty_source"] == PENALTY_SOURCE_NONE
         assert clean["final_score"] == clean["relevance_score"]
 
     async def test_strict_without_flags_keeps_v1_version(self, tmp_path):

--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -51,6 +51,7 @@ from memtomem_stm.proxy.tool_eligibility import (
     compute_health_flags,
     filter_tools,
     interpret_verdict,
+    parse_risk_scores,
 )
 from memtomem_stm.proxy.tool_relevance import RANKER_VERSION_BM25_RISK
 from memtomem_stm.proxy.toolgraph_provider import ToolgraphProtocolError
@@ -717,6 +718,50 @@ class TestInterpretVerdict:
     def test_reject_row_missing_fields_is_protocol_error(self):
         with pytest.raises(ToolgraphProtocolError):
             interpret_verdict(_verdict(rejected=[{"candidate": "s::x"}]))
+
+
+# ── parse_risk_scores (rank_features risk_score enrichment, #493) ───────────
+
+
+class TestParseRiskScores:
+    def test_keeps_positive_scores_skips_zero_and_none(self):
+        v = {
+            "agent": "stm-proxy",
+            "agent_found": True,
+            "features": [
+                {"candidate": "s::clean", "risk_score": 0.0},
+                {"candidate": "s::risky", "risk_score": 0.4},
+                {"candidate": "s::violation", "risk_score": 1.0},
+                {"candidate": "s::unresolved", "risk_score": None},
+            ],
+            "graph_generation": 11,
+        }
+        assert parse_risk_scores(v) == {"s::risky": 0.4, "s::violation": 1.0}
+
+    def test_int_score_coerced_to_float(self):
+        v = {"features": [{"candidate": "s::a", "risk_score": 1}]}
+        scores = parse_risk_scores(v)
+        assert scores == {"s::a": 1.0}
+        assert isinstance(scores["s::a"], float)
+
+    def test_bool_score_rejected(self):
+        # bool is an int subclass but never a valid risk_score.
+        v = {"features": [{"candidate": "s::a", "risk_score": True}]}
+        assert parse_risk_scores(v) == {}
+
+    def test_lenient_on_malformed_payload(self):
+        # Best-effort enrichment: a malformed shape yields an empty map, never
+        # raises (unlike interpret_verdict's contract failures).
+        assert parse_risk_scores({}) == {}
+        assert parse_risk_scores({"features": "nope"}) == {}
+        assert parse_risk_scores({"features": [None, 42, "x"]}) == {}
+        assert parse_risk_scores({"features": [{"candidate": 5, "risk_score": 0.4}]}) == {}
+        assert parse_risk_scores({"features": [{"candidate": "s::a", "risk_score": "hi"}]}) == {}
+        assert parse_risk_scores({"features": [{"risk_score": 0.4}]}) == {}
+
+    def test_agent_not_found_has_no_features(self):
+        v = {"agent_found": False, "features": [], "graph_generation": 11}
+        assert parse_risk_scores(v) == {}
 
 
 # ── filter_tools external_rejects + withhold_all (#465) ─────────────────────

--- a/tests/test_tool_relevance.py
+++ b/tests/test_tool_relevance.py
@@ -26,14 +26,27 @@ from memtomem_stm.proxy.manager import ProxyManager, ProxyToolInfo, UpstreamConn
 from memtomem_stm.proxy.metrics import TokenTracker
 from memtomem_stm.proxy.selection_log import SelectionTelemetryLog
 from memtomem_stm.proxy.tool_relevance import (
+    PENALTY_SOURCE_BOTH,
+    PENALTY_SOURCE_GRAPH,
+    PENALTY_SOURCE_NONE,
+    PENALTY_SOURCE_REVIEW,
     RANKER_VERSION_BM25,
     ToolRelevanceRanker,
     build_candidate_features,
+    compose_risk_penalty,
     derive_query,
+    penalty_source,
 )
 
 FEATURES_KEYS = {"query_source", "query_sha256", "query_chars", "ranked_candidates"}
-RANKED_ENTRY_KEYS = {"tool", "rank", "relevance_score", "risk_penalty", "final_score"}
+RANKED_ENTRY_KEYS = {
+    "tool",
+    "rank",
+    "relevance_score",
+    "risk_penalty",
+    "risk_penalty_source",
+    "final_score",
+}
 
 
 def _info(name: str, description: str, schema: dict | None = None) -> ProxyToolInfo:
@@ -119,6 +132,7 @@ class TestRanker:
         for entry in ranked:
             assert set(entry) == RANKED_ENTRY_KEYS
             assert entry["risk_penalty"] == 0.0
+            assert entry["risk_penalty_source"] == PENALTY_SOURCE_NONE
             assert entry["final_score"] == entry["relevance_score"]
 
     def test_empty_candidates(self):
@@ -151,6 +165,57 @@ class TestRanker:
         b = ToolRelevanceRanker().rank(query, CANDIDATES, risk_penalties={})
         c = ToolRelevanceRanker().rank(query, CANDIDATES, risk_penalties={"test__read_file": 0.0})
         assert json.dumps(a) == json.dumps(b) == json.dumps(c)
+
+    def test_risk_penalty_source_echoed_into_record(self):
+        """The provenance tag rides each record verbatim; absent tools = none."""
+        query = "send a slack message to the channel"
+        ranked = ToolRelevanceRanker().rank(
+            query,
+            CANDIDATES,
+            risk_penalties={"test__send_message": 0.4, "test__read_file": 0.5},
+            risk_penalty_sources={
+                "test__send_message": PENALTY_SOURCE_GRAPH,
+                "test__read_file": PENALTY_SOURCE_BOTH,
+            },
+        )
+        by_tool = {r["tool"]: r for r in ranked}
+        assert by_tool["test__send_message"]["risk_penalty_source"] == PENALTY_SOURCE_GRAPH
+        assert by_tool["test__read_file"]["risk_penalty_source"] == PENALTY_SOURCE_BOTH
+        # A tool with no source entry records "none" even if a stray penalty
+        # would not apply (default-safe).
+        assert by_tool["test__create_issue"]["risk_penalty_source"] == PENALTY_SOURCE_NONE
+
+
+# ── compose_risk_penalty / penalty_source (#493) ──────────────────────────
+
+
+class TestComposeRiskPenalty:
+    def test_complement_product_stacks_two_demotions(self):
+        # 1 - (1-0.5)(1-0.4) = 1 - 0.30 = 0.70
+        assert compose_risk_penalty(0.5, 0.4) == 0.7
+
+    def test_degenerates_to_single_nonzero_input(self):
+        assert compose_risk_penalty(0.0, 0.4) == 0.4
+        assert compose_risk_penalty(0.6, 0.0) == 0.6
+        assert compose_risk_penalty(0.0, 0.0) == 0.0
+
+    def test_commutative(self):
+        assert compose_risk_penalty(0.3, 0.7) == compose_risk_penalty(0.7, 0.3)
+
+    def test_stays_in_unit_interval(self):
+        # Either input at the 1.0 ceiling saturates the combined penalty to 1.0
+        # (the ranker zeroes final_score — max demotion, still advertised).
+        assert compose_risk_penalty(1.0, 0.4) == 1.0
+        assert compose_risk_penalty(0.4, 1.0) == 1.0
+        assert 0.0 <= compose_risk_penalty(0.99, 0.99) <= 1.0
+
+
+class TestPenaltySource:
+    def test_tags_each_combination(self):
+        assert penalty_source(0.0, 0.0) == PENALTY_SOURCE_NONE
+        assert penalty_source(0.5, 0.0) == PENALTY_SOURCE_REVIEW
+        assert penalty_source(0.0, 0.4) == PENALTY_SOURCE_GRAPH
+        assert penalty_source(0.5, 0.4) == PENALTY_SOURCE_BOTH
 
 
 # ── build_candidate_features ─────────────────────────────────────────────

--- a/tests/test_toolgraph_provider.py
+++ b/tests/test_toolgraph_provider.py
@@ -45,6 +45,11 @@ from memtomem_stm.proxy.tool_eligibility import (
     REASON_TOOLGRAPH_TOOL_NOT_FOUND,
     REASON_TOOLGRAPH_UNREACHABLE,
 )
+from memtomem_stm.proxy.tool_relevance import (
+    PENALTY_SOURCE_BOTH,
+    PENALTY_SOURCE_GRAPH,
+    RANKER_VERSION_BM25_GRAPH_RISK,
+)
 from memtomem_stm.server import _toolgraph_health_lines
 from memtomem_stm.proxy.toolgraph_provider import (
     ToolgraphConsultAdapter,
@@ -278,6 +283,7 @@ class TestToolgraphStartupWiring:
                 "withholding_all": None,
                 "graph_generation": None,
                 "external_reject_count": 0,
+                "risk_penalty_count": 0,
             }
         finally:
             await mgr.stop()
@@ -420,6 +426,85 @@ class TestToolgraphConsultWiring:
         assert advertised == ["srv__read_file", "srv__blocked"]
         assert mgr._advertised_reject_reasons == {}
         assert mgr._advertised_risk_penalties == {}
+
+    # ── #493 graph risk_score → relevance risk_penalty ──────────────────────
+
+    async def test_risky_tool_earns_graph_risk_penalty(self, tmp_path):
+        # An eligible (not rejected) tool with a positive risk_score is demoted
+        # in ranking telemetry — exposure is unchanged (still advertised).
+        mgr, _ = _tg_manager(tmp_path, servers={"srv": ["read_file", "risky_tool"]})
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_risk_penalties == {("srv", "risky_tool"): 0.4}
+        advertised = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        assert advertised == ["srv__read_file", "srv__risky_tool"]  # both advertised
+        assert mgr._advertised_reject_reasons == {}
+        # default scale 1.0 → penalty == risk_score, source is graph-only.
+        assert mgr._advertised_risk_penalties == {"srv__risky_tool": 0.4}
+        assert mgr._advertised_risk_penalty_sources == {"srv__risky_tool": PENALTY_SOURCE_GRAPH}
+        assert mgr.get_toolgraph_status()["risk_penalty_count"] == 1
+
+    async def test_risk_penalty_scale_scales_the_score(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, servers={"srv": ["risky_tool"]}, risk_penalty_scale=0.5)
+        await mgr._consult_toolgraph()
+        # 0.4 * 0.5 = 0.2
+        assert mgr._toolgraph_risk_penalties == {("srv", "risky_tool"): 0.2}
+        mgr.get_proxy_tools()
+        assert mgr._advertised_risk_penalties == {"srv__risky_tool": 0.2}
+
+    async def test_risk_penalty_scale_zero_disables_the_signal(self, tmp_path):
+        # scale 0 skips the rank_features consult entirely → no penalties.
+        mgr, _ = _tg_manager(tmp_path, servers={"srv": ["risky_tool"]}, risk_penalty_scale=0.0)
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_risk_penalties == {}
+        mgr.get_proxy_tools()
+        assert mgr._advertised_risk_penalties == {}
+        assert mgr.get_toolgraph_status()["risk_penalty_count"] == 0
+
+    async def test_review_reject_and_graph_risk_compose_to_both(self, tmp_path):
+        # "riskyblocked" is rejected by eligible_tools (→ native review demote)
+        # AND scored 0.4 by rank_features → under review the two stack via the
+        # complement-product, tagged review+graph.
+        mgr, _ = _tg_manager(
+            tmp_path,
+            servers={"srv": ["riskyblocked_tool"]},
+            exposure=ExposureConfig(profile=ExposureProfile.REVIEW),
+        )
+        await mgr._consult_toolgraph()
+        advertised = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        assert advertised == ["srv__riskyblocked_tool"]  # advertised under review
+        # 1 - (1 - 0.5)(1 - 0.4) = 0.7  (review_risk_penalty default 0.5)
+        assert mgr._advertised_risk_penalties["srv__riskyblocked_tool"] == 0.7
+        assert mgr._advertised_risk_penalty_sources["srv__riskyblocked_tool"] == PENALTY_SOURCE_BOTH
+
+    async def test_rank_features_failure_degrades_to_no_penalties(self, tmp_path, caplog):
+        # rank_features fails (agent rankboom raises) but eligible_tools for the
+        # same agent succeeds → exposure verdict intact, risk penalties empty,
+        # startup NOT aborted, and the skip is logged loudly.
+        mgr, _ = _tg_manager(
+            tmp_path, servers={"srv": ["read_file", "risky_tool"]}, agent_id="rankboom"
+        )
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr._consult_toolgraph()
+        assert mgr._toolgraph_risk_penalties == {}
+        # eligible_tools verdict is unaffected (read_file + risky_tool eligible).
+        advertised = [i.prefixed_name for i in mgr.get_proxy_tools()]
+        assert advertised == ["srv__read_file", "srv__risky_tool"]
+        assert mgr._advertised_risk_penalties == {}
+        assert any("risk enrichment" in r.message for r in caplog.records)
+
+    async def test_graph_risk_stamps_v3_ranker_version(self, tmp_path):
+        # End-to-end: a graph risk penalty splits the v3 replay cohort.
+        mgr, log = _tg_manager(tmp_path, servers={"srv": ["read_file", "risky_tool"]})
+        await mgr._consult_toolgraph()
+        mgr.get_proxy_tools()
+        await mgr.call_tool("srv", "risky_tool", {"task": "do the risky thing now"})
+        selection, execution = _events(log)
+        assert selection["ranker_version"] == RANKER_VERSION_BM25_GRAPH_RISK
+        assert execution["ranker_version"] == RANKER_VERSION_BM25_GRAPH_RISK
+        ranked = selection["candidate_features"]["ranked_candidates"]
+        risky = next(r for r in ranked if r["tool"] == "srv__risky_tool")
+        assert risky["risk_penalty"] == 0.4
+        assert risky["risk_penalty_source"] == PENALTY_SOURCE_GRAPH
 
     async def test_multi_upstream_fan_out_to_one_graph_ref(self, tmp_path):
         # Two upstreams both crawled under graph server "srv", each exposing a

--- a/tests/test_toolgraph_provider.py
+++ b/tests/test_toolgraph_provider.py
@@ -630,10 +630,14 @@ class TestToolgraphConsultWiring:
         mgr, _ = _tg_manager(tmp_path, servers={"srv": ["read_file", "missing_x"]})
         await mgr._consult_toolgraph()  # on_tool_not_found default open
         assert mgr._toolgraph_external_rejects == {}
+        # An uncrawled (blind-spot) tool has no graph facts → risk_score None →
+        # no graph risk penalty, even though it stays advertised.
+        assert mgr._toolgraph_risk_penalties == {}
         assert [i.prefixed_name for i in mgr.get_proxy_tools()] == [
             "srv__read_file",
             "srv__missing_x",
         ]
+        assert mgr._advertised_risk_penalties == {}
 
     async def test_tool_not_found_closed_rejects(self, tmp_path):
         mgr, _ = _tg_manager(
@@ -718,12 +722,33 @@ class TestToolgraphHealthRendering:
                 "withholding_all": None,
                 "graph_generation": 11,
                 "external_reject_count": 2,
+                "risk_penalty_count": 0,
             }
         )
         body = "\n".join(lines)
         assert "active" in body
         assert "11" in body
         assert "2 tool(s) rejected" in body
+        # zero risk penalties → no suffix, line closes cleanly.
+        assert "carry a graph risk penalty" not in body
+        assert body.rstrip().endswith(")")
+
+    def test_active_shows_risk_penalty_count(self):
+        lines = _toolgraph_health_lines(
+            {
+                "enabled": True,
+                "degraded": False,
+                "degraded_reason": None,
+                "withholding_all": None,
+                "graph_generation": 11,
+                "external_reject_count": 2,
+                "risk_penalty_count": 3,
+            }
+        )
+        body = "\n".join(lines)
+        assert "2 tool(s) rejected" in body
+        assert "3 carry a graph risk penalty" in body
+        assert body.rstrip().endswith(")")  # suffix sits inside the closing paren
 
     def test_degraded_is_loud(self):
         lines = _toolgraph_health_lines(

--- a/tests/test_toolgraph_provider.py
+++ b/tests/test_toolgraph_provider.py
@@ -199,6 +199,40 @@ class TestToolgraphConsultAdapter:
         with pytest.raises(ToolgraphUnreachableError):
             await adapter.eligible_tools(["s::a"])
 
+    async def test_rank_features_returns_per_candidate_risk_scores(self):
+        adapter = _adapter()
+        await adapter.start()
+        try:
+            verdict = await adapter.rank_features(
+                ["s::a", "s::risky_tool", "s::missing_x"], agent="planner"
+            )
+        finally:
+            await adapter.stop()
+        assert verdict["agent"] == "planner"
+        assert verdict["agent_found"] is True
+        # input order preserved; risk_score per the fixed table
+        assert [f["candidate"] for f in verdict["features"]] == [
+            "s::a",
+            "s::risky_tool",
+            "s::missing_x",
+        ]
+        assert [f["risk_score"] for f in verdict["features"]] == [0.0, 0.4, None]
+        assert verdict["graph_generation"] == 11
+
+    async def test_rank_features_uses_config_agent_default(self):
+        adapter = _adapter(agent_id="default-agent")
+        await adapter.start()
+        try:
+            verdict = await adapter.rank_features(["s::a"])
+        finally:
+            await adapter.stop()
+        assert verdict["agent"] == "default-agent"
+
+    async def test_rank_features_before_start_raises_unreachable(self):
+        adapter = _adapter()
+        with pytest.raises(ToolgraphUnreachableError):
+            await adapter.rank_features(["s::a"])
+
     async def test_timeout_raises_unreachable(self):
         adapter = _adapter(timeout_seconds=0.3)
         await adapter.start()


### PR DESCRIPTION
Feeds the external tool-graph's per-candidate `risk_score` into the #466
tool-relevance `risk_penalty`, so eligible-but-risky tools are demoted in
ranking telemetry. Replaces the inert `0.0` placeholder behind
`toolgraph.risk_penalty_scale` (PR3 of #465; builds on #492). Issue #493.

## What it does

The graph distinguishes a hard **reject** (consumed by #492) from a soft,
rule-based **`risk_score`** (`[0,1]`) carried on *eligible* candidates — e.g.
an authorized tool whose evidence chain has unbacked edges (`0.4`) passes the
hard filter under every profile yet is genuinely riskier. This PR maps that
score onto the relevance ranker's `risk_penalty` so such tools sink in the
ranking record — **never exposure** (ranking runs over `filter_tools`' output;
it can neither resurrect nor hard-reject).

- **Source — a second `rank_features` consult.** `eligible_tools` returns no
  scores; `risk_score` lives on `rank_features`' per-candidate rows. The
  manager runs a second batch `rank_features` consult **in the same startup
  adapter session** (`_fetch_risk_scores`), keeping `eligible_tools`
  authoritative for the reject verdict (STM never reimplements the upstream
  profile precedence) and the advertised set session-stable. `ToolgraphConsultAdapter`
  factors a shared `_consult(tool, args)` so both calls keep an identical
  transport-error model.
- **Mapping + composition.** `penalty = min(risk_score * risk_penalty_scale,
  1.0)`, composed with the native #465 `review_risk_penalty` via a
  **complement-product** `1 − (1 − native)(1 − graph)` — the composition
  consistent with the ranker's own `final = relevance·(1 − penalty)` model
  (two independent demotions stack). Single-source cases short-circuit to the
  nonzero input *exactly* (avoids `1 − (1 − x)` float drift). Applied at
  ranking-prep time in the manager, **never in `filter_tools`**.
- **Telemetry.** A new `risk_penalty_source` (`none`/`review`/`graph`/`review+graph`)
  rides every ranked record, and calls shaped by a graph-derived penalty stamp
  the new `v3-bm25-graph-risk-penalty` ranker cohort (v2 stays
  native-review-only). `stm_proxy_health` surfaces the per-session count.

## Behavior change

No-op when `toolgraph` is disabled (default) or `risk_penalty_scale == 0` (the
documented "disables the signal" — the second consult is skipped entirely).
When enabled with `scale > 0`: startup pays one extra batch `rank_features`
round-trip, and eligible-but-risky tools carry a `risk_penalty` in #466 ranking
telemetry (ordering only — `tools/list` is unchanged). New selection-log values
appear: the `v3` ranker_version and the per-candidate `risk_penalty_source`
(additive nested field — no `SCHEMA_VERSION` bump).

## Failure model

The risk enrichment is **best-effort** — a `rank_features` failure must never
affect exposure or fail startup (it has no `on_*` knob). `_fetch_risk_scores`
catches `ToolgraphConsultError` internally, logs a WARNING, and proceeds with
no penalties; the proven `eligible_tools` error handling (`on_*` knobs,
`fail_start`) is untouched. A degraded/withhold-all/agent-not-found consult
contributes no risk penalties.

## Tests / gates

End-to-end through the real fake stdio child: a risky tool earns a graph
penalty + `graph` source; `risk_penalty_scale` scales (0.5 halves) and `0`
disables the consult; a graph-rejected + risky tool composes to `review+graph`
under `review`; a `rank_features` failure degrades to no penalties while the
exposure verdict stays intact; the `v3` ranker_version + per-candidate source
reach the log; a blind-spot (TOOL_NOT_FOUND-open) tool carries no penalty;
health-line rendering of the count is pinned. Plus `compose_risk_penalty` /
`penalty_source` / `parse_risk_scores` unit coverage.

Full suite 3533 passed / 3 skipped; `ruff check src` + `ruff format --check src`
clean; mypy at baseline (no new errors).

Docs: `configuration.md` (the `risk_penalty_scale` knob) and
`selection-telemetry.md` (the `v3` cohort + `risk_penalty_source` field).

Follow-up to #465. The remaining track item is #494 (disk-cache the startup
consult by `graph_generation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)