### PR TITLE
fix(proxy): guard primary progressive store call to preserve upstream response

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -2241,10 +2241,13 @@ class ProxyManager:
         # which skips for offset-invariant reasons).
         surfacing_on_progressive_ok: bool | None = None
         surface_error: str | None = None
+        # Set True when the primary PROGRESSIVE path degrades to a full-content
+        # passthrough after a store failure (below). Read at the cache-store
+        # gate to keep that transient-failure-degraded response out of the cache.
+        progressive_passthrough_on_error = False
         _pre_scorer_fb = getattr(self._relevance_scorer, "fallback_count", 0)
         if tc.compression == CompressionStrategy.PROGRESSIVE and tc.progressive:
             pcfg = tc.progressive
-            progressive_passthrough_on_error = False
             if len(cleaned) <= pcfg.chunk_size:
                 # Content fits in one chunk — passthrough
                 compressed = cleaned
@@ -2747,7 +2750,21 @@ class ProxyManager:
         # startup legacy purge in ``ProxyCache.initialize``); a false positive
         # only costs one un-cached response, never correctness.
         if self._cache is not None and not non_text_content:
-            if response_carries_transient_key(compressed):
+            if progressive_passthrough_on_error:
+                # The primary PROGRESSIVE path degraded to a full-content
+                # passthrough after a transient store failure. Caching it would
+                # pin the degraded (non-chunked) response for the cache TTL and
+                # suppress progressive delivery on identical calls even after the
+                # store recovers. Skip the store so the next identical call
+                # re-runs the pipeline and re-attempts progressive delivery —
+                # same rationale as the transient-key skip below.
+                logger.debug(
+                    "Skipping cache store for %s/%s: progressive passthrough "
+                    "degradation (transient store failure)",
+                    server,
+                    tool,
+                )
+            elif response_carries_transient_key(compressed):
                 logger.debug(
                     "Skipping cache store for %s/%s: response carries a transient "
                     "retrieval key (progressive/selective TOC)",

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -2244,13 +2244,36 @@ class ProxyManager:
         _pre_scorer_fb = getattr(self._relevance_scorer, "fallback_count", 0)
         if tc.compression == CompressionStrategy.PROGRESSIVE and tc.progressive:
             pcfg = tc.progressive
+            progressive_passthrough_on_error = False
             if len(cleaned) <= pcfg.chunk_size:
                 # Content fits in one chunk — passthrough
                 compressed = cleaned
             else:
-                compressed = self._apply_progressive(
-                    cleaned, pcfg, server, tool, sel_cfg=tc.selective, trace_id=trace_id
-                )
+                try:
+                    compressed = self._apply_progressive(
+                        cleaned, pcfg, server, tool, sel_cfg=tc.selective, trace_id=trace_id
+                    )
+                except Exception:
+                    # Progressive build/store failed (e.g. a SQLite-backed
+                    # pending/reads store I/O error inside ``_apply_progressive``).
+                    # Degrade to a zero-loss passthrough of the full cleaned
+                    # upstream content instead of letting the exception escape
+                    # ``_call_tool_inner`` — an escape here is recorded as
+                    # INTERNAL_ERROR and DISCARDS an otherwise-successful upstream
+                    # response. The ratio-guard fallback already wraps its Tier-1
+                    # progressive call below; the primary PROGRESSIVE path now
+                    # mirrors that best-effort handling, but stays zero-loss
+                    # (passthrough, not lossy hybrid/truncate) because the
+                    # PROGRESSIVE strategy has no retention floor to satisfy.
+                    logger.warning(
+                        "Progressive delivery failed for %s/%s; returning full "
+                        "cleaned content (passthrough)",
+                        server,
+                        tool,
+                        exc_info=True,
+                    )
+                    compressed = cleaned
+                    progressive_passthrough_on_error = True
             _compress_ms = 0.0
             compressed_chars_for_metrics = len(cleaned)
             # The metrics record at the bottom reads ``metrics_strategy`` on
@@ -2258,6 +2281,10 @@ class ProxyManager:
             # branch (pre-fix this branch left it unbound and every
             # PROGRESSIVE-strategy call died with UnboundLocalError).
             metrics_strategy = effective_compression.value
+            if progressive_passthrough_on_error:
+                # Surface the degradation in telemetry, consistent with the
+                # ``X→Y_fallback`` labels the ratio-guard ladder records below.
+                metrics_strategy = f"{effective_compression.value}→passthrough_on_error"
             # F6: surface on progressive when ``injection_mode`` is append/section.
             # ``prepend`` stays skipped (offset-shift); helper returns ``ok=None``
             # in that case and logs a one-time WARNING.

--- a/tests/test_compression_ratio_guard.py
+++ b/tests/test_compression_ratio_guard.py
@@ -240,6 +240,47 @@ class TestProxyManagerRatioGuard:
         assert row["ratio_violation"] == 0
         store.close()
 
+    async def test_primary_progressive_store_failure_falls_back_to_passthrough(self, tmp_path):
+        """When the *primary* PROGRESSIVE strategy fails to build/store its
+        first chunk (e.g. a SQLite pending/reads-store I/O error inside
+        ``_apply_progressive``), the call must degrade to a zero-loss
+        passthrough of the full cleaned upstream content — not let the
+        exception escape ``_call_tool_inner`` and discard an otherwise
+        successful upstream response.
+
+        Pre-fix only the ratio-guard *fallback* progressive call (Tier 1) was
+        wrapped in try/except; the primary PROGRESSIVE branch was unguarded,
+        so a store error there was recorded as INTERNAL_ERROR and the upstream
+        response was thrown away. This regresses that asymmetry.
+        """
+        mgr, store = _make_manager_with_store(
+            tmp_path,
+            compression=CompressionStrategy.PROGRESSIVE,
+            progressive=ProgressiveConfig(chunk_size=500),
+        )
+        large_text = "content paragraph. " * 200  # > chunk_size → would be chunked
+        mgr._connections["srv"].session.call_tool.return_value = _make_result(large_text)
+        # Force the primary progressive build/store to fail.
+        mgr._apply_progressive = lambda *a, **kw: (_ for _ in ()).throw(
+            RuntimeError("pending store full")
+        )
+
+        # Must NOT raise — the successful upstream response is preserved.
+        result = await mgr.call_tool("srv", "tool", {})
+
+        # Zero-loss passthrough: full content returned, and crucially NO
+        # progressive footer (nothing was stored, so there is no key to read).
+        assert "content paragraph." in result
+        assert len(result) > 3000
+        assert "stm_proxy_read_more" not in result
+
+        row = _latest_row(store)
+        assert row["compression_strategy"] == "progressive→passthrough_on_error"
+        assert row["ratio_violation"] == 0
+        # passthrough keeps the full cleaned content (compressed == cleaned)
+        assert row["compressed_chars"] == row["cleaned_chars"]
+        store.close()
+
     async def test_auto_is_resolved_before_metrics(self, tmp_path):
         """AUTO should be resolved to a concrete strategy before recording.
 

--- a/tests/test_compression_ratio_guard.py
+++ b/tests/test_compression_ratio_guard.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from memtomem_stm.proxy.cache import ProxyCache
 from memtomem_stm.proxy.config import (
     CompressionStrategy,
     ProgressiveConfig,
@@ -279,6 +280,70 @@ class TestProxyManagerRatioGuard:
         assert row["ratio_violation"] == 0
         # passthrough keeps the full cleaned content (compressed == cleaned)
         assert row["compressed_chars"] == row["cleaned_chars"]
+        store.close()
+
+    async def test_progressive_passthrough_on_error_is_not_cached(self, tmp_path):
+        """A passthrough triggered by a *transient* progressive store failure
+        must NOT be cached. Caching it would pin the degraded (non-chunked)
+        full response for the cache TTL and suppress progressive delivery on
+        identical calls even after the store recovers — so the next identical
+        call must miss the cache, re-run the pipeline, and re-attempt
+        progressive delivery.
+        """
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=100)
+        cache.initialize()
+        mgr, store = _make_manager_with_store(
+            tmp_path,
+            compression=CompressionStrategy.PROGRESSIVE,
+            progressive=ProgressiveConfig(chunk_size=500),
+        )
+        mgr._cache = cache
+        large_text = "content paragraph. " * 200  # > chunk_size → would be chunked
+        session = mgr._connections["srv"].session
+        session.call_tool.return_value = _make_result(large_text)
+
+        # Call 1: the primary progressive store fails → passthrough degradation.
+        mgr._apply_progressive = lambda *a, **kw: (_ for _ in ()).throw(
+            RuntimeError("pending store full")
+        )
+        first = await mgr.call_tool("srv", "tool", {})
+        assert "stm_proxy_read_more" not in first  # passthrough, no footer
+        # The degraded passthrough must not have entered the cache.
+        assert cache.get("srv", "tool", {}) is None
+
+        # Call 2: store recovered (real method restored). It must be a cache
+        # MISS that re-runs upstream + progressive — not a replay of the
+        # cached passthrough.
+        del mgr._apply_progressive  # restore the real bound method
+        second = await mgr.call_tool("srv", "tool", {})
+        assert session.call_tool.call_count == 2  # cache miss → upstream re-called
+        assert "stm_proxy_read_more" in second  # progressive delivery re-attempted
+        cache.close()
+        store.close()
+
+    async def test_single_chunk_progressive_passthrough_is_still_cached(self, tmp_path):
+        """The cache skip must apply ONLY to the error-degraded passthrough. A
+        normal single-chunk passthrough (content fits one chunk) is a complete,
+        key-free response and stays cacheable, so an identical second call is a
+        cache hit that does not re-call upstream.
+        """
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=100)
+        cache.initialize()
+        mgr, store = _make_manager_with_store(
+            tmp_path,
+            compression=CompressionStrategy.PROGRESSIVE,
+            progressive=ProgressiveConfig(chunk_size=5000),
+        )
+        mgr._cache = cache
+        small_text = "fits in one chunk. " * 10  # < chunk_size → single-chunk passthrough
+        session = mgr._connections["srv"].session
+        session.call_tool.return_value = _make_result(small_text)
+
+        first = await mgr.call_tool("srv", "tool", {})
+        assert "stm_proxy_read_more" not in first  # single chunk, no footer
+        await mgr.call_tool("srv", "tool", {})  # identical call → should hit cache
+        assert session.call_tool.call_count == 1  # cache hit → upstream NOT re-called
+        cache.close()
         store.close()
 
     async def test_auto_is_resolved_before_metrics(self, tmp_path):


### PR DESCRIPTION
## Summary

The primary `PROGRESSIVE`-strategy delivery in `ProxyManager._call_tool_inner()` called `_apply_progressive` **unguarded** (`manager.py:2251`), while the byte-identical ratio-guard *fallback* progressive call (Tier 1, `manager.py:2367`) was already wrapped in `try`/`except`. Both ultimately reach the pending/reads store's `put()`.

Under the SQLite-backed store (real I/O), a transient error on the primary path escaped `_call_tool_inner`, was recorded as `INTERNAL_ERROR`, and **discarded an otherwise-successful upstream response** — whereas the fallback path on the same failure degrades and still returns content. With the default `InMemoryPendingStore` (a pure dict insert) the primary call effectively cannot fail, so the gap is latent today, but it is a real branch-level asymmetry.

## Fix

Wrap the primary `_apply_progressive` call so a build/store failure degrades to a **zero-loss passthrough** of the full cleaned upstream content. Passthrough (not the fallback's lossy hybrid/truncate) is the correct degradation here because the `PROGRESSIVE` strategy has no retention floor to satisfy — it is identical to the existing single-chunk passthrough branch. The degradation is surfaced in telemetry as `progressive→passthrough_on_error`, consistent with the ratio-guard ladder's `X→Y_fallback` labels.

## Behavior change

A primary-path progressive build/store failure previously surfaced as an `INTERNAL_ERROR` with the upstream response dropped; it now returns the full upstream content (no progressive footer, so no `stm_proxy_read_more` follow-up) and records `compression_strategy = "progressive→passthrough_on_error"`. The downstream surfacing-on-progressive step is unaffected — it already wraps its own failures and is safe on non-chunked content.

## Test plan

- New regression test `test_primary_progressive_store_failure_falls_back_to_passthrough` forces `_apply_progressive` to raise on the primary path and asserts the call returns the full content (with no progressive footer) instead of raising, and records the `progressive→passthrough_on_error` strategy.
- Verified the test **fails pre-fix** with the escaping `RuntimeError` at `manager.py:2251`, and passes post-fix.
- `uv run pytest tests/test_compression_ratio_guard.py` → 21 passed.
- Broad regression (progressive / fallback ladder / proxy manager / pipeline / error paths / error metrics) → 246 passed.
- `ruff check` clean; `ruff format --check` clean on changed files.

## Context

Surfaced by the 2026-06-17 core-logic review (improvement area 7 — the one concrete branch-level asymmetry the prior sweep missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)