### PR TITLE
docs(changelog): record primary progressive store guard (#496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - **Selection-telemetry `execution.cache_hit` is now populated** (#485, issue #467) — the reserved field is set `true`/`false` per call (served from the proxy response cache vs a live upstream call; `null` when a raise escaped before it was attributable), and `stm_selection_stats` reports the cache hit/miss rate. **Behavior change**: when `selection_telemetry.enabled`, execution records now carry a real `cache_hit` value instead of `null` — additive, the schema key set is unchanged.
 
+### Fixed
+
+- **Primary progressive store failures degrade to an uncached passthrough** (#496) — when the primary `PROGRESSIVE` path cannot build or store its first chunk, the proxy now returns the full cleaned upstream response instead of discarding an otherwise successful tool result as an internal error. The degraded response is recorded with a `progressive→passthrough_on_error` strategy label and is **not** cached, so a later identical call re-runs the pipeline and can retry progressive delivery once the pending store recovers. Transient progressive-store failures are uncommon, but when they occur the agent now keeps the full result instead of seeing an error.
+
 ## [0.1.28] — 2026-06-11
 
 A security-hardening, correctness, and tool-selection release. A targeted audit across four issue classes — SQLite file permissions, sensitive-value caching, secret-content persistence, and extraction-call privacy — produced six security fixes. Thirteen correctness fixes address critical paths found in the implementation review (PROGRESSIVE metrics assignment, network LTM reconnects, shutdown ExceptionGroup handling) and the remaining medium and low backlog items across daemon, surfacing, compression, config, and CLI layers. Two new opt-in features instrument the tool-selection path (JSONL telemetry sink and BM25 relevance scoring), and a third hardens what the proxy advertises to MCP clients via an STM-native eligibility filter at exposure time.


### PR DESCRIPTION
## Why

PR #496 (commit `9184288`) guarded the primary `PROGRESSIVE` store path so a transient store failure degrades to a zero-loss passthrough instead of discarding a successful upstream response. The code and regression tests merged, but the `CHANGELOG.md` `[Unreleased]` section was never updated for it — so the v0.1.29 release notes would silently omit a user-visible correctness fix.

This is the "including changelog" deliverable that was outstanding from that work.

## What

Add a `### Fixed` entry under `[Unreleased]` describing:

- the guard around the primary `_apply_progressive()` call,
- the `progressive→passthrough_on_error` strategy label,
- the cache-skip so a later identical call can retry progressive delivery once the pending store recovers.

Docs-only; no code change. The behavior itself is already on `main` (`src/memtomem_stm/proxy/manager.py:2255-2279`, `:2753-2766`) and covered by `tests/test_compression_ratio_guard.py:256-347`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)