### PR TITLE
fix(proxy): surface escaped background index/extract exceptions

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 import time as _time
 import uuid
@@ -740,6 +741,39 @@ class ProxyManager:
         conn.stack = conn_stack
         conn.tools = list(result.tools)
         logger.info("Reconnected to '%s' (%s tools discovered)", name, len(conn.tools))
+
+    def _on_background_task_done(
+        self,
+        stage: str,
+        server: str,
+        tool: str,
+        task: asyncio.Task,
+    ) -> None:
+        """Done-callback for background index/extract tasks.
+
+        Drops the finished task from the tracking set and surfaces any
+        exception that escaped the coroutine's own inner handling. The inner
+        ``auto_index_response`` / ``extract_and_store`` handlers already capture
+        expected failures into their outcome (and log them); this guard catches
+        the residual escapes (mkdir / atomic-write / genuinely unexpected
+        errors) that would otherwise show up only as a non-deterministic,
+        unstructured "Task exception was never retrieved" warning at
+        garbage-collection time. Cancellation during ``stop()`` is expected and
+        is not logged.
+        """
+        self._background_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                "Background %s task failed for %s/%s: %s",
+                stage,
+                server,
+                tool,
+                exc,
+                exc_info=exc,
+            )
 
     async def stop(self) -> None:
         # Cancel and drain background tasks (extraction, etc.). Loop until
@@ -2614,7 +2648,9 @@ class ProxyManager:
                     )
                 )
                 self._background_tasks.add(index_task)
-                index_task.add_done_callback(self._background_tasks.discard)
+                index_task.add_done_callback(
+                    functools.partial(self._on_background_task_done, "auto_index", server, tool)
+                )
                 # index_ok / index_error / chunks_indexed stay None / None / 0
                 # — tri-state matches background extraction. Dashboards filter
                 # background rows with WHERE index_ok IS NULL.
@@ -2687,7 +2723,9 @@ class ProxyManager:
                     )
                 )
                 self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
+                task.add_done_callback(
+                    functools.partial(self._on_background_task_done, "extract", server, tool)
+                )
             else:
                 extract_outcome = await self._extract_and_store(
                     server,

--- a/tests/test_auto_index_background.py
+++ b/tests/test_auto_index_background.py
@@ -209,6 +209,42 @@ class TestBackgroundAutoIndex:
         finally:
             await mgr.stop()
 
+    async def test_background_escaped_exception_surfaces_via_callback(self, tmp_path, caplog):
+        """An exception that ESCAPES the inner ``auto_index_response`` handler
+        (e.g. mkdir / atomic-write failure) is surfaced by the background
+        done-callback as a structured WARNING on the manager logger — not left
+        to a non-deterministic gc-time "Task exception was never retrieved".
+        Regression guard for the background-task exception consumer."""
+        mgr, _ = _bg_manager(tmp_path, background=True)
+        # Replace the whole coroutine so the raise bypasses the inner handler
+        # and propagates to the task — the residual-escape path the callback
+        # exists to catch (the inner handler only covers ``index_file`` errors).
+        mgr._auto_index_response = AsyncMock(side_effect=RuntimeError("escaped past inner handler"))
+        try:
+            with caplog.at_level("WARNING", logger="memtomem_stm.proxy.manager"):
+                result = await mgr.call_tool("srv", "some_tool", {})
+                assert "[Indexing…]" in result
+                assert len(mgr._background_tasks) == 1
+                task = next(iter(mgr._background_tasks))
+                await asyncio.gather(task, return_exceptions=True)
+                # Let the done-callback (scheduled via call_soon) run.
+                await asyncio.sleep(0)
+
+            # The callback dropped the finished task from the tracking set ...
+            assert mgr._background_tasks == set()
+            # ... and surfaced the escaped exception as a structured WARNING
+            # (with traceback) instead of a gc-time un-retrieved warning.
+            matching = [
+                r
+                for r in caplog.records
+                if "Background auto_index task failed for srv/some_tool" in r.getMessage()
+            ]
+            assert matching, "escaped background exception was not logged"
+            assert "escaped past inner handler" in matching[0].getMessage()
+            assert matching[0].exc_info is not None
+        finally:
+            await mgr.stop()
+
 
 class TestBackgroundLatency:
     async def test_background_avoids_indexer_latency(self, tmp_path):


### PR DESCRIPTION
## Why

Background auto-index and extraction tasks were scheduled with `add_done_callback(self._background_tasks.discard)` — the callback only removed the finished task from the tracking set (`manager.py:2617`, `:2690`).

The inner `auto_index_response` / `extract_and_store` coroutines already capture *expected* failures (e.g. an indexer raising inside `index_file`) into their outcome and log a WARNING. But an exception raised **outside** that inner handling — `mkdir` / atomic-write / genuinely unexpected errors — escapes to the task. On the background path nothing ever calls `task.result()` / `task.exception()`, so such an escape surfaces only as Python's non-deterministic, unstructured `Task exception was never retrieved` warning at garbage-collection time. That signal is timing-dependent, untagged, and easy for structured logging / monitoring to miss.

This was confirmed against the code: the only done-callback was `.discard`, and the existing `test_background_failure_does_not_break_response` exercises the *inner* handler path (`memtomem_stm.proxy.memory_ops` logger), not the escape path.

## What

- Add `ProxyManager._on_background_task_done(stage, server, tool, task)`, wired via `functools.partial` at both background create-task sites (auto-index, extract).
- It still discards the finished task; treats cancellation during `stop()` as expected (no log); otherwise retrieves the exception (suppressing the gc-time warning) and logs a structured `WARNING` with traceback + `stage/server/tool` context.

Observability is intentionally **logging-only**: the metrics row for background paths is committed *before* the task completes (`index_ok`/`extract_ok` stay `None` by design — the tri-state dashboards rely on), so it cannot be updated retroactively.

## Test

`tests/test_auto_index_background.py::test_background_escaped_exception_surfaces_via_callback` — replaces `_auto_index_response` with a coroutine that raises (bypassing the inner handler), drives a background call, and asserts the escaped exception is dropped from the tracking set **and** logged as a structured WARNING with traceback on the `memtomem_stm.proxy.manager` logger.

Full file: `8 passed`. `ruff check`/`format` clean; `mypy src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)