### PR TITLE
feat(proxy): surface progressive primary-store degradation in stats

### DIFF
--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -389,6 +389,46 @@ class MetricsStore:
                 )
         return profiles
 
+    def get_progressive_degradations(
+        self, since_seconds: float = 86400.0, tool: str | None = None
+    ) -> dict:
+        """Count progressive-delivery primary-store degradations in the window.
+
+        A row whose ``compression_strategy`` ends in ``→passthrough_on_error``
+        records the proxy degrading a failed primary ``PROGRESSIVE`` store to an
+        uncached full-content passthrough (see ``ProxyManager``). The
+        ``passthrough_on_error`` suffix is unique to this family, so a
+        ``LIKE '%passthrough_on_error'`` match never collides with the other
+        ``X→Y_fallback`` strategy labels (e.g. ``timeout_fallback``).
+
+        Returns ``{"total": int, "by_server_tool": [{"server", "tool",
+        "count"}, ...]}`` (breakdown sorted by count desc) so an operator can
+        answer "is progressive delivery frequently degrading because the
+        backing store is failing, and on which server/tool?".
+        """
+        empty: dict = {"total": 0, "by_server_tool": []}
+        if self._db is None:
+            return empty
+        cutoff = time.time() - since_seconds
+        where = "created_at >= ? AND compression_strategy LIKE '%passthrough_on_error'"
+        params: list = [cutoff]
+        if tool is not None:
+            where += " AND tool = ?"
+            params.append(tool)
+        with self._lock:
+            total = self._db.execute(
+                f"SELECT COUNT(*) FROM proxy_metrics WHERE {where}", params
+            ).fetchone()[0]
+            rows = self._db.execute(
+                f"SELECT server, tool, COUNT(*) AS n FROM proxy_metrics WHERE {where} "
+                "GROUP BY server, tool ORDER BY n DESC, server ASC, tool ASC",
+                params,
+            ).fetchall()
+        return {
+            "total": total,
+            "by_server_tool": [{"server": r[0], "tool": r[1], "count": r[2]} for r in rows],
+        }
+
     def get_tool_error_stats(
         self, since_seconds: float, error_categories: tuple[str, ...]
     ) -> dict[tuple[str, str], tuple[int, int]]:

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -1566,11 +1566,40 @@ async def stm_progressive_stats(
     per cache key so a response with five follow-ups is weighted
     the same as one with none.
 
+    Also surfaces primary-store *degradation*: when the primary
+    ``PROGRESSIVE`` store path fails, the proxy degrades to an
+    uncached full-content passthrough (recorded in the metrics
+    store as ``→passthrough_on_error``). That count is reported
+    here — independently of the reads tracker — so a failing
+    backing store does not go silent.
+
     Args:
         tool: Optional filter by upstream tool name.
     """
     app = _get_ctx(ctx)
+
+    # Primary-store degradation (a failed PROGRESSIVE store path degrading to
+    # an uncached full-content passthrough) is recorded in the metrics store,
+    # independently of the reads tracker. Compute it up front so the fault
+    # stays visible even when reads tracking itself is disabled.
+    degradation = ""
+    metrics_store = app.tracker._metrics_store
+    if metrics_store is not None:
+        deg = metrics_store.get_progressive_degradations(tool=tool)
+        if deg["total"] > 0:
+            deg_lines = [
+                f"\nPrimary-store degradation (last 24h): {deg['total']} passthrough-on-error"
+            ]
+            for entry in deg["by_server_tool"][:10]:
+                deg_lines.append(f"  {entry['server']}/{entry['tool']}: {entry['count']}")
+            degradation = "\n".join(deg_lines)
+
     if app.progressive_reads_tracker is None:
+        if degradation:
+            return (
+                "Progressive Reads Stats\n=======================\n"
+                "(reads tracking disabled)" + degradation
+            )
         return "Progressive reads tracking is not enabled."
 
     stats = app.progressive_reads_tracker.get_stats(tool)
@@ -1595,6 +1624,9 @@ async def stm_progressive_stats(
                 f"  {tool_name}: responses={per_tool['responses']}, "
                 f"follow_up_rate={per_tool['follow_up_rate'] * 100:.1f}%"
             )
+
+    if degradation:
+        lines.append(degradation)
 
     if tool:
         lines.append(f"\n(filtered by tool: {tool})")

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -304,9 +304,7 @@ class TestReadPathConcurrency:
                 for f in futures:
                     f.result(timeout=30)
 
-            final_count = store._db.execute(
-                "SELECT COUNT(*) FROM proxy_metrics"
-            ).fetchone()[0]
+            final_count = store._db.execute("SELECT COUNT(*) FROM proxy_metrics").fetchone()[0]
             assert final_count == total_writes
         finally:
             store.close()
@@ -323,10 +321,14 @@ class TestReadCompressionSummary:
         store.initialize()
         try:
             store.record(
-                CallMetrics(server="c7", tool="query-docs", original_chars=1000, compressed_chars=400)
+                CallMetrics(
+                    server="c7", tool="query-docs", original_chars=1000, compressed_chars=400
+                )
             )
             store.record(
-                CallMetrics(server="c7", tool="query-docs", original_chars=1000, compressed_chars=600)
+                CallMetrics(
+                    server="c7", tool="query-docs", original_chars=1000, compressed_chars=600
+                )
             )
             store.record(
                 CallMetrics(server="lf", tool="search", original_chars=500, compressed_chars=500)
@@ -435,3 +437,64 @@ class TestReadCompressionSummary:
             return {row[1] for row in db.execute("PRAGMA table_info(proxy_metrics)")}
         finally:
             db.close()
+
+
+class TestProgressiveDegradations:
+    """``get_progressive_degradations`` aggregates the ``→passthrough_on_error``
+    family (a primary PROGRESSIVE store failure degrading to an uncached
+    passthrough) without colliding with the other ``X→Y_fallback`` labels."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        s = MetricsStore(tmp_path / "metrics.db")
+        s.initialize()
+        yield s
+        s.close()
+
+    @staticmethod
+    def _row(store, server, tool, strategy):
+        store.record(
+            CallMetrics(
+                server=server,
+                tool=tool,
+                original_chars=100,
+                compressed_chars=100,
+                cleaned_chars=100,
+                compression_strategy=strategy,
+            )
+        )
+
+    def test_empty(self, store):
+        assert store.get_progressive_degradations() == {"total": 0, "by_server_tool": []}
+
+    def test_counts_and_breakdown_ignores_other_strategies(self, store):
+        self._row(store, "gh", "search", "progressive→passthrough_on_error")
+        self._row(store, "gh", "search", "progressive→passthrough_on_error")
+        self._row(store, "fs", "read", "progressive→passthrough_on_error")
+        # Unrelated rows must not count — including the sibling fallback family
+        # that also uses the ``X→Y_fallback`` arrow convention.
+        self._row(store, "gh", "search", "progressive")
+        self._row(store, "gh", "search", "llm_summary→timeout_fallback")
+
+        deg = store.get_progressive_degradations()
+        assert deg["total"] == 3
+        assert deg["by_server_tool"] == [
+            {"server": "gh", "tool": "search", "count": 2},
+            {"server": "fs", "tool": "read", "count": 1},
+        ]
+
+    def test_tool_filter(self, store):
+        self._row(store, "gh", "search", "progressive→passthrough_on_error")
+        self._row(store, "fs", "read", "progressive→passthrough_on_error")
+        deg = store.get_progressive_degradations(tool="read")
+        assert deg["total"] == 1
+        assert deg["by_server_tool"] == [{"server": "fs", "tool": "read", "count": 1}]
+
+    def test_window_excludes_old_rows(self, store):
+        self._row(store, "gh", "search", "progressive→passthrough_on_error")
+        # Backdate the row well outside a 60s look-back window.
+        store._db.execute("UPDATE proxy_metrics SET created_at = created_at - 3600")
+        store._db.commit()
+        deg = store.get_progressive_degradations(since_seconds=60.0)
+        assert deg["total"] == 0
+        assert deg["by_server_tool"] == []

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1082,6 +1082,62 @@ class TestProgressiveStats:
         assert "filtered by tool: docfix:get_doc" in result
         mock_tracker.get_stats.assert_called_once_with("docfix:get_doc")
 
+    @staticmethod
+    def _tracker_with_degradation(tmp_path, server, tool):
+        from memtomem_stm.proxy.metrics import CallMetrics
+        from memtomem_stm.proxy.metrics_store import MetricsStore
+
+        store = MetricsStore(tmp_path / "m.db")
+        store.initialize()
+        store.record(
+            CallMetrics(
+                server=server,
+                tool=tool,
+                original_chars=100,
+                compressed_chars=100,
+                compression_strategy="progressive→passthrough_on_error",
+            )
+        )
+        return TokenTracker(metrics_store=store), store
+
+    async def test_degradation_section_from_metrics_store(self, tmp_path):
+        """Primary-store passthrough-on-error degradations recorded in the
+        metrics store surface in stm_progressive_stats alongside read stats."""
+        tracker, store = self._tracker_with_degradation(tmp_path, "gh", "search")
+        try:
+            mock_tracker = MagicMock()
+            mock_tracker.get_stats.return_value = {
+                "total_reads": 1,
+                "total_responses": 1,
+                "follow_up_rate": 0.0,
+                "avg_chars_served": 9000.0,
+                "avg_total_chars": 9000.0,
+                "avg_coverage": 1.0,
+                "by_tool": {},
+            }
+            ctx = _make_ctx(tracker=tracker, progressive_reads_tracker=mock_tracker)
+            result = await stm_progressive_stats(ctx=ctx)
+
+            assert "Progressive Reads Stats" in result
+            assert "Primary-store degradation (last 24h): 1 passthrough-on-error" in result
+            assert "gh/search: 1" in result
+        finally:
+            store.close()
+
+    async def test_degradation_visible_when_reads_tracking_disabled(self, tmp_path):
+        """A failing primary store must not go silent: the degradation count is
+        reported even when the reads tracker itself is disabled."""
+        tracker, store = self._tracker_with_degradation(tmp_path, "fs", "read")
+        try:
+            ctx = _make_ctx(tracker=tracker, progressive_reads_tracker=None)
+            result = await stm_progressive_stats(ctx=ctx)
+
+            assert "reads tracking disabled" in result
+            assert "Primary-store degradation (last 24h): 1 passthrough-on-error" in result
+            assert "fs/read: 1" in result
+        finally:
+            store.close()
+
 
 # ── stm_selection_stats ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

PR #496 guarded the primary `PROGRESSIVE` store path: a transient store failure degrades to an uncached full-content passthrough, recorded in the metrics DB as `compression_strategy = "progressive→passthrough_on_error"`. But **no observability tool exposed that signal** — an operator could only discover progressive delivery degrading by querying `proxy_metrics.db` directly. This closes the loop from "correctness fix" to "operationally visible".

## What

- **`MetricsStore.get_progressive_degradations(since_seconds=86400, tool=None)`** — counts the `→passthrough_on_error` family within the look-back window and returns `{"total", "by_server_tool": [{server, tool, count}, …]}` (breakdown sorted by count desc). The `passthrough_on_error` suffix is unique, so `LIKE '%passthrough_on_error'` never collides with the sibling `X→Y_fallback` labels (e.g. `timeout_fallback`, whose documented query is `LIKE '%timeout_fallback%'`).
- **`stm_progressive_stats`** gains a `Primary-store degradation (last 24h)` section: total count + top affected server/tool pairs. It is read from the metrics store **independently of the reads tracker** and shown even when reads tracking is disabled — a failing backing store must not go silent. Honors the existing `tool` filter.

### Scope / deferred

Delivers the plan's core (count + affected pairs). The plan's *"last degradation error type"* is **deferred**: the exception class is logged at the failure site but not persisted, so surfacing it needs a new metrics-schema column — out of scope for this read-side change. The vague *"fault bucket in `stm_proxy_stats`"* is dropped in favor of the natural home (`stm_progressive_stats`).

## Tests

- `tests/test_metrics_store.py::TestProgressiveDegradations` — total + per-pair breakdown, **no collision with `timeout_fallback`/`progressive`**, `tool` filter, and look-back window exclusion (backdated row).
- `tests/test_server_tools.py::TestProgressiveStats` — degradation section renders alongside read stats, and stays visible when `progressive_reads_tracker is None`.

`158 passed` across the affected files. `ruff check`/`format` clean; `mypy src` clean. No regression: the existing `stm_progressive_stats` tests use a default `TokenTracker` whose `_metrics_store` is `None`, so the new branch is inert there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)