### PR TITLE
feat(proxy): disk-cache the tool-graph startup consult (#494)

### DIFF
--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -773,6 +773,17 @@ class ToolgraphConfig(BaseModel):
     (or a disabled ``toolgraph`` block) skips the enrichment entirely."""
     timeout_seconds: float = Field(default=5.0, gt=0.0)
     """Per-consult timeout for the startup batch query."""
+    consult_cache_enabled: bool = True
+    """Disk-cache a successful consult's verdict keyed by ``graph_generation``
+    (#494). On restart, a cheap generation probe is still made (so a degraded
+    graph is never masked); only the expensive per-candidate ``eligible_tools`` /
+    ``rank_features`` evaluation is skipped when the generation, candidate set,
+    agent, profile, and backend all match a cached row."""
+    consult_cache_path: Path = Path("~/.memtomem/toolgraph_consult.db")
+    """SQLite path for the consult cache (#494). One DB serves all graph
+    backends, disambiguated by a provider fingerprint over ``command`` / ``args``
+    / env *keys*; point distinct backends sharing identical command/args/env-keys
+    but different env *values* at distinct paths."""
 
 
 # Static context window sizes (tokens) for known model families.

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -679,6 +679,19 @@ class ProxyManager:
                 exc,
             )
             return {}, False
+        # A non-error response whose ``features`` is not a list is a *malformed*
+        # enrichment: ``parse_risk_scores`` leniently yields no penalties, but it
+        # must NOT be cached as a successful "no risk facts" capture (#494) — else
+        # a later same-generation start would skip ``rank_features`` and serve no
+        # penalties forever. Report ``ok=False`` so the cache re-tries (the active
+        # session degrades to no penalties either way).
+        if not isinstance(verdict.get("features"), list):
+            logger.warning(
+                "Tool-graph risk enrichment (rank_features) returned a malformed "
+                "payload (no 'features' list) — ranking proceeds without graph risk "
+                "penalties this session."
+            )
+            return {}, False
         return parse_risk_scores(verdict), True
 
     def _tg_whole_call(self, knob: str, code: str, detail: str) -> None:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -323,9 +323,17 @@ class ProxyManager:
                 logger.debug("Failed to close previous stack in double-start guard", exc_info=True)
             self._connections.clear()
             # Close the consult cache too so a re-entry that changed
-            # ``toolgraph.consult_cache_path`` reopens the right DB (#494).
+            # ``toolgraph.consult_cache_path`` reopens the right DB (#494). Mirror
+            # the stack-close try/except above: always null the handle so a failed
+            # close cannot leave a stale closed connection for the next start.
             if self._toolgraph_cache is not None:
-                self._toolgraph_cache.close()
+                try:
+                    self._toolgraph_cache.close()
+                except Exception:
+                    logger.debug(
+                        "Failed to close tool-graph consult cache in double-start guard",
+                        exc_info=True,
+                    )
                 self._toolgraph_cache = None
         self._stack = AsyncExitStack()
 
@@ -937,8 +945,13 @@ class ProxyManager:
             # the closed instance (whose extract() asserts _client is not None).
             self._extractor = None
         # Close the #494 consult disk cache (re-opened lazily on the next start).
+        # Always null the handle so a failed close cannot leave a stale closed
+        # connection that the next start() would reuse.
         if self._toolgraph_cache is not None:
-            self._toolgraph_cache.close()
+            try:
+                self._toolgraph_cache.close()
+            except Exception:
+                logger.debug("Failed to close tool-graph consult cache", exc_info=True)
             self._toolgraph_cache = None
         for conn in self._connections.values():
             if conn.stack is not None:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -51,6 +51,7 @@ from memtomem_stm.proxy.config import (
     ProxyConfig,
     ProxyConfigLoader,
     SelectiveConfig,
+    ToolgraphConfig,
     TransportType,
     UpstreamServerConfig,
 )
@@ -74,11 +75,13 @@ from memtomem_stm.proxy.tool_eligibility import (
     REASON_TOOLGRAPH_PROTOCOL_ERROR,
     REASON_TOOLGRAPH_UNREACHABLE,
     ExposureCandidate,
+    InterpretedVerdict,
     compute_health_flags,
     filter_tools,
     interpret_verdict,
     parse_risk_scores,
 )
+from memtomem_stm.proxy.toolgraph_cache import GraphConsultCache
 from memtomem_stm.proxy.toolgraph_provider import (
     TRANSPORT_ERRORS as TOOLGRAPH_TRANSPORT_ERRORS,
     ToolgraphConsultAdapter,
@@ -262,6 +265,11 @@ class ProxyManager:
         self._graph_generation: int | None = None
         self._toolgraph_degraded: bool = False
         self._toolgraph_degraded_reason: str | None = None
+        # #494 consult disk cache (lazy-opened per session, closed on stop() and
+        # in the double-start guard so a reconfigured path reopens). ``from_cache``
+        # records whether THIS session's verdict was served from a cache hit.
+        self._toolgraph_cache: GraphConsultCache | None = None
+        self._toolgraph_from_cache: bool = False
         self._connections: dict[str, UpstreamConnection] = {}
         self._stack: AsyncExitStack | None = None
         self._selective_compressor: SelectiveCompressor | None = None
@@ -314,6 +322,11 @@ class ProxyManager:
             except Exception:
                 logger.debug("Failed to close previous stack in double-start guard", exc_info=True)
             self._connections.clear()
+            # Close the consult cache too so a re-entry that changed
+            # ``toolgraph.consult_cache_path`` reopens the right DB (#494).
+            if self._toolgraph_cache is not None:
+                self._toolgraph_cache.close()
+                self._toolgraph_cache = None
         self._stack = AsyncExitStack()
 
         servers = self._config.upstream_servers
@@ -459,6 +472,7 @@ class ProxyManager:
         self._graph_generation = None
         self._toolgraph_degraded = False
         self._toolgraph_degraded_reason = None
+        self._toolgraph_from_cache = False
 
         ref_to_keys, refs = self._build_toolgraph_candidates()
         if not refs:
@@ -477,15 +491,12 @@ class ProxyManager:
                 # ``timeout_seconds`` (the realistic hang is a slow Neo4j query,
                 # which happens during the consult, not during initialize()).
                 await adapter.start()
-                verdict = await adapter.eligible_tools(refs)
-                interp = interpret_verdict(verdict)
-                # #493 risk enrichment in the SAME session (one extra batch
-                # round-trip, still session-stable). Best-effort and gated on a
-                # resolved agent + an enabled scale; its own failures degrade to
-                # "no penalties" inside the helper, so they never reach the on_*
-                # knobs below — a flaky enrichment must not fail startup.
-                if interp.agent_found and cfg.risk_penalty_scale > 0.0:
-                    risk_scores = await self._fetch_risk_scores(adapter, refs)
+                # #494: probe-then-hit/miss. The probe + any full consult run
+                # INSIDE this try, so their transport/protocol faults still ride
+                # the on_* knobs below — the disk cache can never mask a degraded
+                # graph. Returns the same ``(interp, risk_scores)`` the rest of
+                # this method already expects.
+                interp, risk_scores = await self._run_consult(adapter, cfg, refs)
             finally:
                 try:
                     await adapter.stop()
@@ -546,16 +557,118 @@ class ProxyManager:
             )
         self._warn_server_name_mismatch(interp.tool_not_found_refs, ref_to_keys)
 
+    def _open_consult_cache(self, cfg: ToolgraphConfig) -> GraphConsultCache | None:
+        """Lazily open the #494 consult disk cache; ``None`` when disabled.
+
+        Best-effort: a cache that cannot be opened (bad path / perms / disk)
+        degrades to no-cache for the session rather than failing startup — the
+        consult itself is unaffected. Re-used across the session; the
+        double-start guard closes it so a reconfigured path reopens.
+        """
+        if not cfg.consult_cache_enabled:
+            return None
+        if self._toolgraph_cache is None:
+            try:
+                cache = GraphConsultCache(cfg.consult_cache_path.expanduser())
+                cache.initialize()
+            except Exception:
+                logger.warning(
+                    "Tool-graph consult cache could not be opened at %s — consulting "
+                    "without the disk cache this session.",
+                    cfg.consult_cache_path,
+                    exc_info=True,
+                )
+                return None
+            self._toolgraph_cache = cache
+        return self._toolgraph_cache
+
+    async def _run_consult(
+        self, adapter: ToolgraphConsultAdapter, cfg: ToolgraphConfig, refs: list[str]
+    ) -> tuple[InterpretedVerdict, dict[str, float]]:
+        """Probe-then-hit/miss consult (#494). Returns ``(interp, risk_scores)``.
+
+        Model A (strictly-fresh): with the cache enabled, a cheap
+        ``eligible_tools([])`` probe reads the live ``graph_generation`` on EVERY
+        start; the expensive ``eligible_tools(refs)`` + ``rank_features(refs)``
+        evaluation is skipped only when the probed generation (plus provider,
+        agent, profile, and candidate set) matches a cached row. Because the
+        probe always contacts the graph, a degraded/unreachable graph is always
+        re-detected (its fault propagates to the caller's ``on_*`` knobs) and
+        never masked by the cache. Sets ``self._toolgraph_from_cache``.
+
+        Only an agent-found full consult is written; a degraded / agent-not-found
+        verdict is never cached. ``had_risk_scores`` records whether enrichment
+        actually succeeded (not merely that it was wanted), so a transient
+        ``rank_features`` failure is not cached as "no penalties".
+        """
+        want_risk = cfg.risk_penalty_scale > 0.0
+        cache = self._open_consult_cache(cfg)
+        if cache is None:
+            # Cache disabled / unavailable — the pre-#494 path, verbatim.
+            interp = interpret_verdict(await adapter.eligible_tools(refs))
+            risk_scores: dict[str, float] = {}
+            if interp.agent_found and want_risk:
+                risk_scores, _ = await self._fetch_risk_scores(adapter, refs)
+            return interp, risk_scores
+
+        probe = interpret_verdict(await adapter.eligible_tools([]))
+        if not probe.agent_found:
+            # Agent unknown — no full consult; the caller maps this onto
+            # ``on_agent_not_found`` exactly as the full-verdict abort would.
+            return probe, {}
+
+        cand_hash = GraphConsultCache.candidate_hash(refs)
+        prov_fp = GraphConsultCache.provider_fingerprint(cfg)
+        row = cache.get(prov_fp, cfg.agent_id, cfg.query_profile, cand_hash, probe.graph_generation)
+        if row is not None and (row["had_risk_scores"] or not want_risk):
+            self._toolgraph_from_cache = True
+            interp = InterpretedVerdict(
+                agent_found=True,
+                rejects=dict(row["rejects"]),
+                tool_not_found_refs=frozenset(row["tool_not_found_refs"]),
+                graph_generation=probe.graph_generation,
+            )
+            risk_scores = (
+                {ref: float(score) for ref, score in row["risk_scores"].items()}
+                if want_risk
+                else {}
+            )
+            return interp, risk_scores
+
+        # Miss — full consult, then cache the raw facts on agent-found success.
+        interp = interpret_verdict(await adapter.eligible_tools(refs))
+        risk_scores, risk_ok = ({}, False)
+        if interp.agent_found and want_risk:
+            risk_scores, risk_ok = await self._fetch_risk_scores(adapter, refs)
+        if interp.agent_found:
+            cache.put(
+                prov_fp,
+                cfg.agent_id,
+                cfg.query_profile,
+                cand_hash,
+                interp.graph_generation,
+                rejects=interp.rejects,
+                tool_not_found_refs=interp.tool_not_found_refs,
+                risk_scores=risk_scores,
+                had_risk_scores=risk_ok,
+            )
+        return interp, risk_scores
+
     async def _fetch_risk_scores(
         self, adapter: ToolgraphConsultAdapter, refs: list[str]
-    ) -> dict[str, float]:
-        """Best-effort ``rank_features`` enrichment (#493): ``{ref: risk_score}``.
+    ) -> tuple[dict[str, float], bool]:
+        """Best-effort ``rank_features`` enrichment (#493): ``({ref: risk_score}, ok)``.
 
         The graph's per-candidate ``risk_score`` is a ranking-telemetry signal
         only — never exposure, never a startup gate — so unlike the
         ``eligible_tools`` verdict (whose failures ride the ``on_*`` knobs) any
         fault here degrades silently to "no penalties", logged once at WARNING.
-        Returns an empty map on any consult error.
+
+        Returns ``(scores, ok)`` where ``ok`` is ``False`` only on a consult
+        error. The flag lets the #494 disk cache distinguish a *successful empty*
+        enrichment (cacheable as "risk facts captured") from a *transient
+        failure* (must not be cached as success, else a later same-generation
+        start would skip enrichment and serve no penalties forever).
         """
         try:
             verdict = await adapter.rank_features(refs)
@@ -565,8 +678,8 @@ class ProxyManager:
                 "proceeds without graph risk penalties this session.",
                 exc,
             )
-            return {}
-        return parse_risk_scores(verdict)
+            return {}, False
+        return parse_risk_scores(verdict), True
 
     def _tg_whole_call(self, knob: str, code: str, detail: str) -> None:
         """Apply a whole-call tool-graph failure per its ``on_*`` knob.
@@ -810,6 +923,10 @@ class ProxyManager:
             # None, so a stop->start cycle gets a fresh httpx client instead of
             # the closed instance (whose extract() asserts _client is not None).
             self._extractor = None
+        # Close the #494 consult disk cache (re-opened lazily on the next start).
+        if self._toolgraph_cache is not None:
+            self._toolgraph_cache.close()
+            self._toolgraph_cache = None
         for conn in self._connections.values():
             if conn.stack is not None:
                 try:
@@ -1656,6 +1773,7 @@ class ProxyManager:
             "degraded_reason": self._toolgraph_degraded_reason,
             "withholding_all": self._toolgraph_withhold_all,
             "graph_generation": self._graph_generation,
+            "from_cache": self._toolgraph_from_cache,
             "external_reject_count": len(self._toolgraph_external_rejects),
             "risk_penalty_count": len(self._toolgraph_risk_penalties),
         }

--- a/src/memtomem_stm/proxy/toolgraph_cache.py
+++ b/src/memtomem_stm/proxy/toolgraph_cache.py
@@ -165,11 +165,33 @@ class GraphConsultCache:
 
     @staticmethod
     def _row_shape_ok(verdict: object) -> bool:
-        return (
-            isinstance(verdict, dict)
-            and isinstance(verdict.get("rejects"), dict)
-            and isinstance(verdict.get("tool_not_found_refs"), list)
-            and isinstance(verdict.get("risk_scores"), dict)
+        """True only if ``verdict`` matches exactly what :meth:`put` writes.
+
+        Validates **leaf** value types, not just the containers — the caller's
+        on-hit reconstruction does ``dict(rejects)`` / ``frozenset(refs)`` /
+        ``float(score)`` outside the ``on_*``-knob ``try``, so a row that passed a
+        containers-only check but carried e.g. a non-numeric ``risk_score`` would
+        raise ``ValueError`` and crash startup. Matching ``put``'s shape
+        (``rejects: {str: str}``, ``tool_not_found_refs: [str]``, ``risk_scores:
+        {str: number}``) guarantees the reconstruction can never raise on a hit.
+        """
+        if not isinstance(verdict, dict):
+            return False
+        rejects = verdict.get("rejects")
+        refs = verdict.get("tool_not_found_refs")
+        risk_scores = verdict.get("risk_scores")
+        if not (
+            isinstance(rejects, dict) and isinstance(refs, list) and isinstance(risk_scores, dict)
+        ):
+            return False
+        if not all(isinstance(k, str) and isinstance(v, str) for k, v in rejects.items()):
+            return False
+        if not all(isinstance(ref, str) for ref in refs):
+            return False
+        # ``bool`` is an ``int`` subclass but never a valid risk score.
+        return all(
+            isinstance(k, str) and isinstance(v, (int, float)) and not isinstance(v, bool)
+            for k, v in risk_scores.items()
         )
 
     def _delete_scope(self, scope_key: str) -> None:

--- a/src/memtomem_stm/proxy/toolgraph_cache.py
+++ b/src/memtomem_stm/proxy/toolgraph_cache.py
@@ -146,14 +146,42 @@ class GraphConsultCache:
         try:
             verdict = json.loads(row[0])
         except (ValueError, TypeError):
+            verdict = None
+        # Best-effort: a row that is not valid JSON, not a dict, or is missing the
+        # expected raw-fact shape (e.g. an old-schema or externally-corrupted row)
+        # is treated as a MISS and dropped — the caller subscripts these keys, so a
+        # malformed row must never raise during startup. The next consult re-mints
+        # a fresh row.
+        if not self._row_shape_ok(verdict):
             logger.warning(
-                "Corrupt tool-graph consult cache row (scope %s) — treating as miss", key[:12]
+                "Tool-graph consult cache row (scope %s) is malformed — treating as "
+                "a miss and dropping it",
+                key[:12],
             )
-            return None
-        if not isinstance(verdict, dict):
+            self._delete_scope(key)
             return None
         verdict["had_risk_scores"] = bool(row[1])
         return verdict
+
+    @staticmethod
+    def _row_shape_ok(verdict: object) -> bool:
+        return (
+            isinstance(verdict, dict)
+            and isinstance(verdict.get("rejects"), dict)
+            and isinstance(verdict.get("tool_not_found_refs"), list)
+            and isinstance(verdict.get("risk_scores"), dict)
+        )
+
+    def _delete_scope(self, scope_key: str) -> None:
+        """Best-effort drop of a single (corrupt) row by ``scope_key``."""
+        if self._db is None:
+            return
+        try:
+            with self._lock:
+                self._db.execute("DELETE FROM toolgraph_consult WHERE scope_key = ?", (scope_key,))
+                self._db.commit()
+        except sqlite3.Error:
+            logger.debug("Failed to drop malformed consult cache row", exc_info=True)
 
     def put(
         self,

--- a/src/memtomem_stm/proxy/toolgraph_cache.py
+++ b/src/memtomem_stm/proxy/toolgraph_cache.py
@@ -1,0 +1,231 @@
+"""SQLite-backed disk cache for the tool-graph startup consult (#494).
+
+The tool-graph eligibility provider consults the graph once per
+``ProxyManager.start()`` (see ``manager._consult_toolgraph``). The verdict is
+stable for a given ``graph_generation``, so a restart with an unchanged
+generation can reuse it instead of re-running the Neo4j-heavy per-candidate
+evaluation. This store persists the **raw ref-level facts** of a successful,
+agent-found consult, keyed by ``(provider_fingerprint, agent_id, query_profile,
+candidate_hash, graph_generation)``.
+
+Correctness model (Model A, strictly-fresh): the cache is only ever read after a
+*live* cheap generation probe, so it can never mask a degraded/unreachable graph.
+A degraded / agent-not-found verdict is never written.
+
+Stored data is STM/graph-derived only — server-qualified tool refs
+(``"server::tool"``), reason codes, and risk floats. No upstream payloads or
+secrets, so (unlike ``ProxyCache``) there is no privacy scan.
+
+Like the sibling stores, every method does synchronous sqlite I/O on the asyncio
+event loop; accepted for the local single-MCP-client deployment, and lock-ready
+(``self._lock``) for a future off-loop move.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from memtomem_stm.utils.sqlite_private import ensure_private_db_files
+from memtomem_stm.utils.sqlite_tuning import tune_connection
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+    from memtomem_stm.proxy.config import ToolgraphConfig
+
+logger = logging.getLogger(__name__)
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS toolgraph_consult (
+    scope_key            TEXT    PRIMARY KEY,
+    provider_fingerprint TEXT    NOT NULL,
+    agent_id             TEXT    NOT NULL,
+    query_profile        TEXT    NOT NULL,
+    candidate_hash       TEXT    NOT NULL,
+    graph_generation     INTEGER NOT NULL,
+    had_risk_scores      INTEGER NOT NULL DEFAULT 0,
+    verdict_json         TEXT    NOT NULL,
+    created_at           REAL    NOT NULL
+);
+"""
+
+_CREATE_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_toolgraph_consult_scope
+ON toolgraph_consult (provider_fingerprint, agent_id, query_profile, candidate_hash);
+"""
+
+
+def _scope_key(
+    provider_fp: str, agent_id: str, profile: str, candidate_hash: str, generation: int
+) -> str:
+    raw = f"{provider_fp}\x00{agent_id}\x00{profile}\x00{candidate_hash}\x00{generation}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+class GraphConsultCache:
+    """Cross-restart cache of a successful tool-graph consult's raw facts."""
+
+    def __init__(self, db_path: Path, max_scopes: int = 64) -> None:
+        self._db_path = db_path
+        self._max_scopes = max_scopes
+        self._db: sqlite3.Connection | None = None
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def candidate_hash(refs: Iterable[str]) -> str:
+        """Order-independent hash of the candidate ref set."""
+        raw = json.dumps(sorted(refs), separators=(",", ":"))
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    @staticmethod
+    def provider_fingerprint(config: ToolgraphConfig) -> str:
+        """Backend identity: ``command`` + ``args`` + sorted env *keys*.
+
+        Keys only — never env *values* (``NEO4J_PASSWORD`` etc.) — so the
+        fingerprint stays non-secret. Distinguishes a different graph
+        binary/args/backend-shape on the shared user-wide DB so two backends
+        cannot collide on the same ``(agent, profile, refs, generation)``. Two
+        backends with identical command/args/env-keys but different env *values*
+        (e.g. only ``NEO4J_URI`` differs) still collide — such setups should use
+        a distinct ``consult_cache_path``.
+        """
+        env_keys = sorted((config.env or {}).keys())
+        raw = json.dumps([config.command, list(config.args), env_keys], separators=(",", ":"))
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    def initialize(self) -> None:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
+        try:
+            ensure_private_db_files(self._db_path)
+            tune_connection(db)
+            db.execute(_CREATE_TABLE)
+            db.execute(_CREATE_INDEX)
+            db.commit()
+        except Exception:
+            db.close()
+            raise
+        self._db = db
+
+    def close(self) -> None:
+        if self._db:
+            self._db.close()
+            self._db = None
+
+    def get(
+        self,
+        provider_fp: str,
+        agent_id: str,
+        profile: str,
+        candidate_hash: str,
+        generation: int,
+    ) -> dict[str, Any] | None:
+        """Return the cached raw facts for an exact scope+generation, or ``None``.
+
+        The returned dict carries ``rejects`` / ``tool_not_found_refs`` /
+        ``risk_scores`` (the raw graph facts) plus ``had_risk_scores`` (whether
+        risk enrichment succeeded when the row was written).
+        """
+        if self._db is None:
+            return None
+        key = _scope_key(provider_fp, agent_id, profile, candidate_hash, generation)
+        with self._lock:
+            row = self._db.execute(
+                "SELECT verdict_json, had_risk_scores FROM toolgraph_consult WHERE scope_key = ?",
+                (key,),
+            ).fetchone()
+        if row is None:
+            return None
+        try:
+            verdict = json.loads(row[0])
+        except (ValueError, TypeError):
+            logger.warning(
+                "Corrupt tool-graph consult cache row (scope %s) — treating as miss", key[:12]
+            )
+            return None
+        if not isinstance(verdict, dict):
+            return None
+        verdict["had_risk_scores"] = bool(row[1])
+        return verdict
+
+    def put(
+        self,
+        provider_fp: str,
+        agent_id: str,
+        profile: str,
+        candidate_hash: str,
+        generation: int,
+        *,
+        rejects: Mapping[str, str],
+        tool_not_found_refs: Iterable[str],
+        risk_scores: Mapping[str, float],
+        had_risk_scores: bool,
+    ) -> None:
+        """Persist the raw facts of a successful consult (scope-replacing)."""
+        if self._db is None:
+            return
+        key = _scope_key(provider_fp, agent_id, profile, candidate_hash, generation)
+        verdict_json = json.dumps(
+            {
+                "graph_generation": generation,
+                "rejects": dict(rejects),
+                "tool_not_found_refs": list(tool_not_found_refs),
+                "risk_scores": {k: float(v) for k, v in risk_scores.items()},
+            },
+            separators=(",", ":"),
+        )
+        now = time.time()
+        with self._lock:
+            # Scope-replace: a newer generation for the same (provider, agent,
+            # profile, candidate-set) supersedes prior generations — one row per
+            # scope keeps growth bounded.
+            self._db.execute(
+                "DELETE FROM toolgraph_consult WHERE provider_fingerprint = ? AND agent_id = ? "
+                "AND query_profile = ? AND candidate_hash = ? AND graph_generation != ?",
+                (provider_fp, agent_id, profile, candidate_hash, generation),
+            )
+            self._db.execute(
+                """
+                INSERT INTO toolgraph_consult
+                    (scope_key, provider_fingerprint, agent_id, query_profile,
+                     candidate_hash, graph_generation, had_risk_scores, verdict_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(scope_key) DO UPDATE SET
+                    had_risk_scores = excluded.had_risk_scores,
+                    verdict_json    = excluded.verdict_json,
+                    created_at      = excluded.created_at
+                """,
+                (
+                    key,
+                    provider_fp,
+                    agent_id,
+                    profile,
+                    candidate_hash,
+                    generation,
+                    1 if had_risk_scores else 0,
+                    verdict_json,
+                    now,
+                ),
+            )
+            self._db.commit()
+            self._trim()
+
+    def _trim(self) -> None:
+        if self._db is None:
+            return
+        count = self._db.execute("SELECT COUNT(*) FROM toolgraph_consult").fetchone()[0]
+        if count > self._max_scopes:
+            excess = count - self._max_scopes
+            self._db.execute(
+                "DELETE FROM toolgraph_consult WHERE scope_key IN "
+                "(SELECT scope_key FROM toolgraph_consult ORDER BY created_at ASC LIMIT ?)",
+                (excess,),
+            )
+            self._db.commit()

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -696,8 +696,9 @@ def _toolgraph_health_lines(status: dict | None) -> list[str]:
         # skipped (no upstream tools discovered). Not "active" enforcement.
         lines.append("  enabled, not consulted (no upstream tools discovered)")
     else:
+        cache_note = ", from cache" if status.get("from_cache") else ""
         line = (
-            f"  active (graph generation {status['graph_generation']}, "
+            f"  active (graph generation {status['graph_generation']}{cache_note}, "
             f"{status['external_reject_count']} tool(s) rejected by the graph"
         )
         risk_count = status.get("risk_penalty_count", 0)

--- a/tests/_fake_toolgraph_server.py
+++ b/tests/_fake_toolgraph_server.py
@@ -137,6 +137,11 @@ async def rank_features(agent: str, candidates: list[str]) -> dict:
     _record_call("rank_features", len(candidates))
     if agent == "rankboom":
         raise ValueError("rank_features boom")
+    if agent == "rankmalformed":
+        # A non-error response MISSING the 'features' list — the malformed-but-
+        # successful enrichment shape. parse_risk_scores leniently yields no
+        # penalties, but #494 must not cache this as a successful capture.
+        return {"agent": agent, "agent_found": True, "graph_generation": _generation()}
     if agent == "ghost":
         return {
             "agent": agent,

--- a/tests/_fake_toolgraph_server.py
+++ b/tests/_fake_toolgraph_server.py
@@ -42,19 +42,49 @@ Run with: ``python <path-to-this-file>``.
 from __future__ import annotations
 
 import asyncio
+import os
+from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP("fake-toolgraph")
 
 # Arbitrary fixed monotonic graph generation so tests can assert the field is
-# threaded through verbatim.
+# threaded through verbatim. The #494 consult-cache tests need to vary the
+# generation *between* consults of one running server, so it is read from a file
+# (path in ``FAKE_TG_GENERATION_FILE``) when set — mutating the file content
+# bumps the generation without changing the env *keys* (so the provider
+# fingerprint stays stable). Unset → the fixed default below.
 _GRAPH_GENERATION = 11
+
+
+def _generation() -> int:
+    path = os.environ.get("FAKE_TG_GENERATION_FILE")
+    if path:
+        try:
+            return int(Path(path).read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            pass
+    return _GRAPH_GENERATION
+
+
+def _record_call(tool: str, n_candidates: int) -> None:
+    """Append ``<tool>:<n_candidates>`` to ``FAKE_TG_CALL_LOG`` when set.
+
+    Lets the #494 tests assert that a cache hit issued only the cheap
+    ``eligible_tools([])`` probe (``eligible_tools:0``) and skipped the
+    full-candidate ``eligible_tools`` / ``rank_features`` evaluation.
+    """
+    path = os.environ.get("FAKE_TG_CALL_LOG")
+    if path:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(f"{tool}:{n_candidates}\n")
 
 
 @mcp.tool()
 async def eligible_tools(agent: str, candidates: list[str], profile: str = "strict") -> dict:
     """Canned ``eligible_tools`` consult mirroring the real structured shape."""
+    _record_call("eligible_tools", len(candidates))
     if profile == "boom":
         raise ValueError(f"unknown profile {profile!r}")
     if profile == "sleep":
@@ -66,7 +96,7 @@ async def eligible_tools(agent: str, candidates: list[str], profile: str = "stri
             "profile": profile,
             "eligible": [],
             "rejected": [],
-            "graph_generation": _GRAPH_GENERATION,
+            "graph_generation": _generation(),
         }
 
     eligible: list[str] = []
@@ -90,7 +120,7 @@ async def eligible_tools(agent: str, candidates: list[str], profile: str = "stri
         "profile": profile,
         "eligible": eligible,
         "rejected": rejected,
-        "graph_generation": _GRAPH_GENERATION,
+        "graph_generation": _generation(),
     }
 
 
@@ -104,6 +134,7 @@ async def rank_features(agent: str, candidates: list[str]) -> dict:
     degrade path is exercisable while ``eligible_tools`` still succeeds for the
     same agent.
     """
+    _record_call("rank_features", len(candidates))
     if agent == "rankboom":
         raise ValueError("rank_features boom")
     if agent == "ghost":
@@ -111,7 +142,7 @@ async def rank_features(agent: str, candidates: list[str]) -> dict:
             "agent": agent,
             "agent_found": False,
             "features": [],
-            "graph_generation": _GRAPH_GENERATION,
+            "graph_generation": _generation(),
         }
 
     features: list[dict] = []
@@ -129,7 +160,7 @@ async def rank_features(agent: str, candidates: list[str]) -> dict:
         "agent": agent,
         "agent_found": True,
         "features": features,
-        "graph_generation": _GRAPH_GENERATION,
+        "graph_generation": _generation(),
     }
 
 

--- a/tests/test_sqlite_private.py
+++ b/tests/test_sqlite_private.py
@@ -21,6 +21,7 @@ from memtomem_stm.proxy.compression_feedback_store import CompressionFeedbackSto
 from memtomem_stm.proxy.metrics_store import MetricsStore
 from memtomem_stm.proxy.pending_store import SQLitePendingStore
 from memtomem_stm.proxy.progressive_reads_store import ProgressiveReadsStore
+from memtomem_stm.proxy.toolgraph_cache import GraphConsultCache
 from memtomem_stm.surfacing.feedback_store import FeedbackStore
 from memtomem_stm.utils.sqlite_private import ensure_private_db_files
 
@@ -88,6 +89,7 @@ STORE_FACTORIES = [
     pytest.param(CompressionFeedbackStore, id="compression_feedback_store"),
     pytest.param(ProgressiveReadsStore, id="progressive_reads_store"),
     pytest.param(SQLitePendingStore, id="pending_store"),
+    pytest.param(GraphConsultCache, id="graph_consult_cache"),
 ]
 
 

--- a/tests/test_toolgraph_cache.py
+++ b/tests/test_toolgraph_cache.py
@@ -157,3 +157,33 @@ class TestProviderFingerprint:
         assert GraphConsultCache.provider_fingerprint(
             self._cfg(env=None)
         ) == GraphConsultCache.provider_fingerprint(self._cfg(env={}))
+
+
+class TestCorruptRow:
+    """A malformed/old-schema/corrupt row is a best-effort MISS — it must never
+    raise during startup (the caller subscripts the raw-fact keys) and is dropped
+    so the next consult re-mints a fresh row."""
+
+    def test_malformed_dict_row_is_dropped_as_miss(self, cache):
+        _put(cache)  # valid row at scope (gen 11, hashA)
+        cache._db.execute("UPDATE toolgraph_consult SET verdict_json = ?", ('{"rejects":"oops"}',))
+        cache._db.commit()
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None
+        assert cache._db.execute("SELECT COUNT(*) FROM toolgraph_consult").fetchone()[0] == 0
+
+    def test_missing_keys_row_is_dropped_as_miss(self, cache):
+        _put(cache)
+        # Valid JSON dict but missing the required raw-fact keys (old schema).
+        cache._db.execute(
+            "UPDATE toolgraph_consult SET verdict_json = ?", ('{"graph_generation":11}',)
+        )
+        cache._db.commit()
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None
+        assert cache._db.execute("SELECT COUNT(*) FROM toolgraph_consult").fetchone()[0] == 0
+
+    def test_invalid_json_row_is_dropped_as_miss(self, cache):
+        _put(cache)
+        cache._db.execute("UPDATE toolgraph_consult SET verdict_json = ?", ("{not valid json",))
+        cache._db.commit()
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None
+        assert cache._db.execute("SELECT COUNT(*) FROM toolgraph_consult").fetchone()[0] == 0

--- a/tests/test_toolgraph_cache.py
+++ b/tests/test_toolgraph_cache.py
@@ -187,3 +187,31 @@ class TestCorruptRow:
         cache._db.commit()
         assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None
         assert cache._db.execute("SELECT COUNT(*) FROM toolgraph_consult").fetchone()[0] == 0
+
+    @pytest.mark.parametrize(
+        "verdict_json",
+        [
+            # Right containers, wrong LEAF types — would crash the caller's on-hit
+            # float()/frozenset()/dict() reconstruction if returned (it runs outside
+            # the on_* knob try). Each must be dropped as a miss, not raised.
+            '{"rejects":{},"tool_not_found_refs":[],"risk_scores":{"s::a":"not-a-float"}}',
+            '{"rejects":{},"tool_not_found_refs":[123],"risk_scores":{}}',
+            '{"rejects":{"s::a":7},"tool_not_found_refs":[],"risk_scores":{}}',
+            '{"rejects":{},"tool_not_found_refs":[],"risk_scores":{"s::a":true}}',
+        ],
+        ids=["nonfloat_risk", "nonstr_tnf", "nonstr_reject", "bool_risk"],
+    )
+    def test_wrong_leaf_type_row_is_dropped_as_miss(self, cache, verdict_json):
+        _put(cache)
+        cache._db.execute("UPDATE toolgraph_consult SET verdict_json = ?", (verdict_json,))
+        cache._db.commit()
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None
+        assert cache._db.execute("SELECT COUNT(*) FROM toolgraph_consult").fetchone()[0] == 0
+
+    def test_numeric_risk_scores_remain_a_valid_hit(self, cache):
+        # Guard against over-strict leaf validation: a well-formed numeric row must
+        # still be a HIT (not falsely dropped by the new leaf-type check).
+        _put(cache, rejects={"s::a": "X"}, tnf=["s::b"], risk={"s::c": 1, "s::d": 0.5})
+        row = cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11)
+        assert row is not None
+        assert row["risk_scores"] == {"s::c": 1.0, "s::d": 0.5}

--- a/tests/test_toolgraph_cache.py
+++ b/tests/test_toolgraph_cache.py
@@ -1,0 +1,159 @@
+"""Unit tests for ``GraphConsultCache`` (#494) — the tool-graph consult disk cache."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from memtomem_stm.proxy.toolgraph_cache import GraphConsultCache
+
+_PROV = "prov-fp"
+_AGENT = "stm-proxy"
+_PROFILE = "strict"
+
+
+@pytest.fixture
+def cache(tmp_path):
+    c = GraphConsultCache(tmp_path / "tg.db")
+    c.initialize()
+    yield c
+    c.close()
+
+
+def _put(cache, *, generation=11, cand="hashA", rejects=None, tnf=None, risk=None, had_risk=True):
+    cache.put(
+        _PROV,
+        _AGENT,
+        _PROFILE,
+        cand,
+        generation,
+        rejects=rejects or {},
+        tool_not_found_refs=tnf or [],
+        risk_scores=risk or {},
+        had_risk_scores=had_risk,
+    )
+
+
+class TestRoundTrip:
+    def test_put_get_round_trip(self, cache):
+        _put(
+            cache,
+            rejects={"s::a": "TOOLGRAPH_NOT_GRANTED"},
+            tnf=["s::b"],
+            risk={"s::c": 0.5},
+            had_risk=True,
+        )
+        row = cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11)
+        assert row is not None
+        assert row["rejects"] == {"s::a": "TOOLGRAPH_NOT_GRANTED"}
+        assert row["tool_not_found_refs"] == ["s::b"]
+        assert row["risk_scores"] == {"s::c": 0.5}
+        assert row["had_risk_scores"] is True
+
+    def test_had_risk_scores_false_round_trips(self, cache):
+        _put(cache, had_risk=False)
+        row = cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11)
+        assert row is not None
+        assert row["had_risk_scores"] is False
+
+
+class TestMisses:
+    def test_generation_mismatch_misses(self, cache):
+        _put(cache, generation=11)
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 12) is None
+
+    def test_candidate_hash_mismatch_misses(self, cache):
+        _put(cache, cand="hashA")
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashB", 11) is None
+
+    def test_agent_mismatch_misses(self, cache):
+        _put(cache)
+        assert cache.get(_PROV, "other-agent", _PROFILE, "hashA", 11) is None
+
+    def test_profile_mismatch_misses(self, cache):
+        _put(cache)
+        assert cache.get(_PROV, _AGENT, "lenient", "hashA", 11) is None
+
+    def test_provider_fingerprint_mismatch_misses(self, cache):
+        _put(cache)
+        assert cache.get("other-prov", _AGENT, _PROFILE, "hashA", 11) is None
+
+    def test_empty_store_misses(self, cache):
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None
+
+
+class TestScopeReplace:
+    def test_new_generation_supersedes_old(self, cache):
+        _put(cache, generation=11)
+        _put(cache, generation=12)
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None  # superseded
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 12) is not None
+        # Exactly one row remains for the scope.
+        n = cache._db.execute("SELECT COUNT(*) FROM toolgraph_consult").fetchone()[0]
+        assert n == 1
+
+    def test_different_candidate_set_coexists(self, cache):
+        _put(cache, cand="hashA", generation=11)
+        _put(cache, cand="hashB", generation=11)
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is not None
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashB", 11) is not None
+
+
+class TestUninitialized:
+    def test_get_put_no_op_when_uninitialized(self, tmp_path):
+        c = GraphConsultCache(tmp_path / "tg.db")  # no initialize()
+        c.put(
+            _PROV,
+            _AGENT,
+            _PROFILE,
+            "hashA",
+            11,
+            rejects={},
+            tool_not_found_refs=[],
+            risk_scores={},
+            had_risk_scores=True,
+        )
+        assert c.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None
+
+
+class TestCandidateHash:
+    def test_order_independent(self):
+        assert GraphConsultCache.candidate_hash(
+            ["s::b", "s::a"]
+        ) == GraphConsultCache.candidate_hash(["s::a", "s::b"])
+
+    def test_different_set_differs(self):
+        assert GraphConsultCache.candidate_hash(["s::a"]) != GraphConsultCache.candidate_hash(
+            ["s::a", "s::b"]
+        )
+
+
+class TestProviderFingerprint:
+    @staticmethod
+    def _cfg(command="toolgraph", args=("serve",), env=None):
+        return SimpleNamespace(command=command, args=list(args), env=env)
+
+    def test_deterministic(self):
+        assert GraphConsultCache.provider_fingerprint(
+            self._cfg()
+        ) == GraphConsultCache.provider_fingerprint(self._cfg())
+
+    def test_env_values_ignored_keys_matter(self):
+        base = GraphConsultCache.provider_fingerprint(self._cfg(env={"NEO4J_URI": "bolt://a"}))
+        same_keys = GraphConsultCache.provider_fingerprint(self._cfg(env={"NEO4J_URI": "bolt://b"}))
+        added_key = GraphConsultCache.provider_fingerprint(
+            self._cfg(env={"NEO4J_URI": "bolt://a", "EXTRA": "1"})
+        )
+        assert base == same_keys  # value change with same keys → same fingerprint
+        assert base != added_key  # new key → different fingerprint
+
+    def test_command_and_args_matter(self):
+        base = GraphConsultCache.provider_fingerprint(self._cfg())
+        assert base != GraphConsultCache.provider_fingerprint(self._cfg(command="other"))
+        assert base != GraphConsultCache.provider_fingerprint(self._cfg(args=("serve", "--x")))
+
+    def test_none_env_equals_empty_env(self):
+        assert GraphConsultCache.provider_fingerprint(
+            self._cfg(env=None)
+        ) == GraphConsultCache.provider_fingerprint(self._cfg(env={}))

--- a/tests/test_toolgraph_provider.py
+++ b/tests/test_toolgraph_provider.py
@@ -51,6 +51,7 @@ from memtomem_stm.proxy.tool_relevance import (
     RANKER_VERSION_BM25_GRAPH_RISK,
 )
 from memtomem_stm.server import _toolgraph_health_lines
+from memtomem_stm.proxy.toolgraph_cache import GraphConsultCache
 from memtomem_stm.proxy.toolgraph_provider import (
     ToolgraphConsultAdapter,
     ToolgraphProtocolError,
@@ -284,6 +285,7 @@ class TestToolgraphStartupWiring:
                 "degraded_reason": None,
                 "withholding_all": None,
                 "graph_generation": None,
+                "from_cache": False,
                 "external_reject_count": 0,
                 "risk_penalty_count": 0,
             }
@@ -366,7 +368,14 @@ def _tg_manager(tmp_path, *, servers=None, exposure=None, **tg_overrides):
         )
         for name in servers
     }
-    tg_kwargs: dict = {"command": sys.executable, "args": [str(_FAKE_TOOLGRAPH)]}
+    tg_kwargs: dict = {
+        "command": sys.executable,
+        "args": [str(_FAKE_TOOLGRAPH)],
+        # Isolate the #494 consult cache per-test (the production default points
+        # at the real ~/.memtomem). Callers override for cross-restart / disabled
+        # cache scenarios.
+        "consult_cache_path": tmp_path / "tg_consult.db",
+    }
     tg_kwargs.update(tg_overrides)  # callers may override command/args (unreachable tests)
     proxy_cfg = ProxyConfig(
         config_path=tmp_path / "proxy.json",
@@ -709,6 +718,167 @@ class TestToolgraphConsultWiring:
 
 
 # ── stm_proxy_health rendering of the toolgraph status (loud degrade) ─────────
+
+
+def _read_calls(path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+
+
+class TestToolgraphConsultCache:
+    """#494 — disk-cache the startup consult (Model A: cheap generation probe)."""
+
+    async def test_hit_skips_full_consult(self, tmp_path):
+        call_log = tmp_path / "calls.txt"
+        mgr, _ = _tg_manager(tmp_path, env={"FAKE_TG_CALL_LOG": str(call_log)})
+        # First consult: cold cache → miss → full consult (populates the cache).
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_from_cache is False
+        first_rejects = dict(mgr._toolgraph_external_rejects)
+        n_after_first = len(_read_calls(call_log))
+
+        # Second consult: same generation → cache HIT → only the [] probe runs.
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_from_cache is True
+        assert mgr._toolgraph_external_rejects == first_rejects  # identical from cached facts
+        assert mgr._graph_generation == 11
+        second_calls = _read_calls(call_log)[n_after_first:]
+        assert second_calls == [
+            "eligible_tools:0"
+        ]  # only the probe; no full consult / rank_features
+        await mgr.stop()
+
+    async def test_generation_bump_misses(self, tmp_path):
+        gen_file = tmp_path / "gen.txt"
+        gen_file.write_text("11")
+        call_log = tmp_path / "calls.txt"
+        mgr, _ = _tg_manager(
+            tmp_path,
+            env={"FAKE_TG_GENERATION_FILE": str(gen_file), "FAKE_TG_CALL_LOG": str(call_log)},
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._graph_generation == 11
+        n_after_first = len(_read_calls(call_log))
+
+        gen_file.write_text("12")  # the graph mutated → generation bumped
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_from_cache is False
+        assert mgr._graph_generation == 12
+        # The probe read gen 12, missed the gen-11 row, and ran the full consult.
+        assert "eligible_tools:2" in _read_calls(call_log)[n_after_first:]
+        await mgr.stop()
+
+    async def test_degrade_with_populated_cache_stays_loud_and_serves_no_cache(
+        self, tmp_path, caplog
+    ):
+        mgr, _ = _tg_manager(tmp_path)
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_external_rejects  # a real verdict was cached
+        # The graph goes unreachable; the populated cache must NOT mask it.
+        mgr._config.toolgraph.command = "this-binary-does-not-exist-xyz"
+        mgr._config.toolgraph.args = []
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr._consult_toolgraph()
+        assert mgr._toolgraph_degraded is True
+        assert mgr._toolgraph_degraded_reason == REASON_TOOLGRAPH_UNREACHABLE
+        assert mgr._toolgraph_from_cache is False
+        assert mgr._graph_generation is None
+        assert mgr._toolgraph_external_rejects == {}  # cache was not served
+        assert any("DEGRADED" in r.message and "NOT active" in r.message for r in caplog.records)
+        await mgr.stop()
+
+    async def test_agent_not_found_not_cached(self, tmp_path):
+        shared_db = tmp_path / "shared.db"
+        mgr, _ = _tg_manager(
+            tmp_path, agent_id="ghost", on_agent_not_found="open", consult_cache_path=shared_db
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_degraded is True
+        await mgr.stop()
+        # The structured abort wrote no row — a degraded / agent-not-found verdict
+        # is never cached, so it cannot poison a later valid-agent consult.
+        check = GraphConsultCache(shared_db)
+        check.initialize()
+        try:
+            n = check._db.execute("SELECT COUNT(*) FROM toolgraph_consult").fetchone()[0]
+        finally:
+            check.close()
+        assert n == 0
+
+    async def test_probe_protocol_error_routes_to_knob(self, tmp_path):
+        # With the cache enabled, the [] probe is the first call — a protocol
+        # error on it must ride on_protocol_error exactly as the full verdict would.
+        mgr, _ = _tg_manager(tmp_path, query_profile="boom", on_protocol_error="open")
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_degraded is True
+        assert mgr._toolgraph_degraded_reason == REASON_TOOLGRAPH_PROTOCOL_ERROR
+        assert mgr._toolgraph_from_cache is False
+        await mgr.stop()
+
+    async def test_knob_change_remaps_on_hit(self, tmp_path):
+        # Populate under on_tool_not_found=open (missing_x kept), then flip to
+        # closed on a same-generation restart → the hit re-maps the cached RAW
+        # facts under the new knob → missing_x is now rejected.
+        mgr, _ = _tg_manager(tmp_path, servers={"srv": ["read_file", "missing_x"]})
+        await mgr._consult_toolgraph()  # on_tool_not_found default open
+        assert mgr._toolgraph_external_rejects == {}
+        mgr._config.toolgraph.on_tool_not_found = "closed"
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_from_cache is True
+        assert mgr._toolgraph_external_rejects == {
+            ("srv", "missing_x"): REASON_TOOLGRAPH_TOOL_NOT_FOUND
+        }
+        await mgr.stop()
+
+    async def test_risk_scale_change_rescales_on_hit(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path, servers={"srv": ["risky_tool"]})  # scale default 1.0
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_risk_penalties == {("srv", "risky_tool"): 0.4}
+        mgr._config.toolgraph.risk_penalty_scale = 0.5
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_from_cache is True
+        # Re-scaled locally from the cached raw risk_score (0.4 * 0.5).
+        assert mgr._toolgraph_risk_penalties == {("srv", "risky_tool"): 0.2}
+        await mgr.stop()
+
+    async def test_transient_enrichment_failure_not_cached_as_success(self, tmp_path):
+        # rank_features fails (agent "rankboom") while eligible_tools succeeds →
+        # had_risk_scores=False → a later want-risk consult MISSES and re-runs the
+        # full consult instead of serving "no penalties" off the cache forever.
+        call_log = tmp_path / "calls.txt"
+        mgr, _ = _tg_manager(
+            tmp_path,
+            servers={"srv": ["risky_tool"]},
+            agent_id="rankboom",
+            env={"FAKE_TG_CALL_LOG": str(call_log)},
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_risk_penalties == {}  # enrichment failed this session
+        n_after_first = len(_read_calls(call_log))
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_from_cache is False  # had_risk_scores False → miss under want_risk
+        assert "eligible_tools:1" in _read_calls(call_log)[n_after_first:]  # full consult re-ran
+        await mgr.stop()
+
+    async def test_cache_disabled_single_consult(self, tmp_path):
+        call_log = tmp_path / "calls.txt"
+        mgr, _ = _tg_manager(
+            tmp_path, consult_cache_enabled=False, env={"FAKE_TG_CALL_LOG": str(call_log)}
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_from_cache is False
+        calls = _read_calls(call_log)
+        assert "eligible_tools:0" not in calls  # no probe
+        assert "eligible_tools:2" in calls  # one full consult, today's behavior
+        await mgr.stop()
+
+    async def test_health_shows_from_cache(self, tmp_path):
+        mgr, _ = _tg_manager(tmp_path)
+        await mgr._consult_toolgraph()
+        await mgr._consult_toolgraph()  # 2nd consult = cache hit
+        assert mgr._toolgraph_from_cache is True
+        body = "\n".join(_toolgraph_health_lines(mgr.get_toolgraph_status()))
+        assert "from cache" in body
+        await mgr.stop()
 
 
 class TestToolgraphHealthRendering:

--- a/tests/test_toolgraph_provider.py
+++ b/tests/test_toolgraph_provider.py
@@ -859,6 +859,25 @@ class TestToolgraphConsultCache:
         assert "eligible_tools:1" in _read_calls(call_log)[n_after_first:]  # full consult re-ran
         await mgr.stop()
 
+    async def test_malformed_enrichment_not_cached_as_success(self, tmp_path):
+        # rank_features returns a NON-error but malformed payload (no 'features'
+        # list, agent "rankmalformed") → had_risk_scores=False → a later want-risk
+        # consult MISSES and re-runs the full consult, never pinning "no penalties".
+        call_log = tmp_path / "calls.txt"
+        mgr, _ = _tg_manager(
+            tmp_path,
+            servers={"srv": ["risky_tool"]},
+            agent_id="rankmalformed",
+            env={"FAKE_TG_CALL_LOG": str(call_log)},
+        )
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_risk_penalties == {}  # malformed enrichment → no penalties
+        n_after_first = len(_read_calls(call_log))
+        await mgr._consult_toolgraph()
+        assert mgr._toolgraph_from_cache is False
+        assert "eligible_tools:1" in _read_calls(call_log)[n_after_first:]  # full consult re-ran
+        await mgr.stop()
+
     async def test_cache_disabled_single_consult(self, tmp_path):
         call_log = tmp_path / "calls.txt"
         mgr, _ = _tg_manager(

--- a/tests/test_toolgraph_provider.py
+++ b/tests/test_toolgraph_provider.py
@@ -88,6 +88,8 @@ class TestToolgraphConfig:
         assert tg.query_profile == "strict"
         assert tg.risk_penalty_scale == 1.0
         assert tg.timeout_seconds == 5.0
+        assert tg.consult_cache_enabled is True  # #494: strictly-fresh, on by default
+        assert tg.consult_cache_path == Path("~/.memtomem/toolgraph_consult.db")
 
     def test_failure_knob_defaults(self):
         tg = ProxyConfig().toolgraph


### PR DESCRIPTION
Closes #494.

## Why

When `toolgraph.enabled`, `ProxyManager.start()` runs a once-per-start consult (`_consult_toolgraph`): spawn the stdio child + Neo4j, evaluate `eligible_tools(refs)` over the full discovered tool set (the Neo4j-heavy part), optionally `rank_features(refs)`, then map the verdict into the advertised set. Every restart re-pays that graph evaluation even when the graph state hasn't changed.

## Approach — Model A (strictly-fresh, cheap generation probe)

`graph_generation` is an **output** of the consult, so "skip if unchanged" needs to read the live generation **without** the full evaluation. On every start we still contact the graph with a cheap `eligible_tools([])` probe to read the live `graph_generation`; only the expensive `eligible_tools(refs)` + `rank_features(refs)` evaluation is skipped on a cache hit.

**The cache can never mask a degraded graph.** The probe runs inside the existing `try`, so a transport/protocol fault still rides the `on_*` knobs (`DEGRADED … NOT active` stays loud), `agent_found=False` still routes to `on_agent_not_found`, and only an agent-found success is ever written. Because we always probe, a now-degraded/unreachable graph is always re-detected.

Cached facts are stored **raw** (ref-level `rejects` / `tool_not_found_refs` / `risk_scores`) and re-mapped through the unchanged downstream block every start, so `on_tool_not_found` and `risk_penalty_scale` changes take effect on a hit, and a ref-set / `server_name_map` change invalidates via the candidate hash.

## What

- **`GraphConsultCache`** (`proxy/toolgraph_cache.py`) — SQLite store at `~/.memtomem/toolgraph_consult.db`, mirroring `ProxyCache`/`MetricsStore` conventions (`mkdir 0700` + `ensure_private_db_files` 0600 + `tune_connection` + `threading.Lock`). Keyed by `(provider_fingerprint, agent_id, query_profile, candidate_hash, graph_generation)`; scope-replacing `put`; no privacy scan (stores only graph-derived strings/floats). `provider_fingerprint` = `command` + `args` + sorted env **keys** (never values).
- **`ToolgraphConfig`** — `consult_cache_enabled` (default `True`) + `consult_cache_path`.
- **`_consult_toolgraph`** — new `_run_consult` (probe → hit/miss) keeps lines `501-547` unchanged. Cache lazy-opened (best-effort; a failed open degrades to no-cache, never fails startup), closed in `stop()` and the double-start guard.
- **`_fetch_risk_scores` → `(scores, ok)`**; `had_risk_scores` records enrichment *success*, so a transient `rank_features` failure isn't cached as "no penalties".
- **`get_toolgraph_status` / `stm_proxy_health`** surface `from_cache`.

### Codex plan-review findings folded
A pre-implementation Codex review of the design returned NEEDS-FIX (0 blocker); all folded: **M1** `had_risk_scores` from enrichment success; **M2** `provider_fingerprint` in the key (cross-backend collision on the shared DB); **M3** `cache.put` guarded by `agent_found`; **m1** close the cache in the double-start guard.

## ⚠️ For the maintainer to confirm (R1)

Model A assumes the **real** `toolgraph` server: accepts `eligible_tools([])`, stamps `graph_generation`, still validates the agent (unknown agent → `agent_found=False`) on an empty candidate list, and that the empty call is genuinely cheap (no full graph scan). The bundled fake mirrors all four, but STM holds no dependency on the real package, so this is unverifiable in-repo. **If empty candidates is rejected or short-circuits agent validation upstream, switch the probe to a one-ref sentinel** — `eligible_tools([refs[0]])` (lexicographically-first ref), guaranteed-valid and still ~1/N the full cost (one-line change; we read only `graph_generation`/`agent_found` from the probe).

Residual (accepted): no negative caching (a persistently-broken graph re-pays the probe + failure path every start — intended); no TTL (generation is the freshness signal; scope-replace bounds growth).

## Tests

3 commits (store + unit tests → config → wiring + integration). New `tests/test_toolgraph_cache.py` (round-trip, all 5 key dimensions miss, scope-replace, provider-fingerprint env-keys-only, perms via `STORE_FACTORIES`). New `TestToolgraphConsultCache` (hit-skips-full-consult, generation-bump miss, **degrade-with-populated-cache stays loud + serves no cache**, agent-not-found not cached, probe protocol-error routing, knob/scale re-map on hit, transient-enrichment-failure miss, cache-disabled == prior behavior, health `from cache`). Fake server extended with an env-driven generation file + call log.

`uv run pytest -m "not ollama"` → **3572 passed, 3 skipped**. `ruff check`/`format` clean; `mypy src` introduces no new errors (the new files are clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)