### PR TITLE
refactor(proxy): extract _shape_response from _call_tool_inner (A1 PR2)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -68,6 +68,7 @@ from memtomem_stm.proxy.memory_ops import (
     format_fact_md,
     index_content_matches_privacy,
 )
+from memtomem_stm.proxy.pipeline_stages import ShapedResponse, ShapePassthrough
 from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS as PRIVACY_CREDENTIAL_PATTERNS
 from memtomem_stm.proxy.token_estimate import tokens_to_chars
 from memtomem_stm.proxy.tool_eligibility import (
@@ -2286,6 +2287,79 @@ class ProxyManager:
         # this is unreachable but satisfies the type checker.
         raise RuntimeError("unreachable: upstream retry loop exited without a result")
 
+    def _shape_response(
+        self,
+        result: "CallToolResult",
+        server: str,
+        tool: str,
+        *,
+        cfg_snap: ProxyConfig,
+    ) -> ShapedResponse:
+        """Stage 3: split upstream content into text vs non-text under the
+        ``max_upstream_chars`` OOM guard.
+
+        ``max_upstream_chars`` is a hard guard against (mis-)behaving upstreams
+        returning huge payloads — without it, a 100 MB ``ls -R /`` response would
+        be loaded fully into memory and walk through the entire compression
+        pipeline before any ``max_chars`` truncation could apply. ``result.content
+        or []`` tolerates spec-noncompliant upstreams that return ``None`` instead
+        of an empty list.
+
+        Records no metrics and performs no early return: when no text remains it
+        returns a ``ShapedResponse`` whose ``passthrough`` tells the caller to
+        record the non-text passthrough metric (and return the non-text list) or
+        return the ``"[empty response]"`` sentinel. The caller stays the single
+        owner of metric writes and return shapes (R8).
+        """
+        max_upstream = cfg_snap.max_upstream_chars
+        text_parts: list[str] = []
+        non_text_content: list = []
+        total_chars = 0
+        oversize = False
+        for content in result.content or []:
+            if content.type == "text":
+                remaining = max_upstream - total_chars
+                if remaining <= 0:
+                    oversize = True
+                    break
+                # ``content.text or ""`` tolerates spec-noncompliant upstreams
+                # that return ``None`` for a TextContent's ``text`` field.
+                # MCP spec requires ``text: str`` but mirrors the same gap
+                # that PR #114 fixed for ``result.content`` itself.
+                text = content.text or ""
+                if len(text) > remaining:
+                    text_parts.append(text[:remaining])
+                    total_chars += remaining
+                    oversize = True
+                    break
+                text_parts.append(text)
+                total_chars += len(text)
+            else:
+                non_text_content.append(content)
+        if oversize:
+            notice = (
+                f"\n\n[response truncated to {max_upstream} chars at "
+                f"max_upstream_chars guard — upstream returned an oversized payload]"
+            )
+            text_parts.append(notice)
+            logger.warning(
+                "Upstream %s/%s exceeded max_upstream_chars=%d — truncating",
+                server,
+                tool,
+                max_upstream,
+            )
+
+        if not text_parts:
+            return ShapedResponse(
+                original_text="",
+                non_text_content=non_text_content,
+                passthrough=ShapePassthrough(has_non_text=bool(non_text_content)),
+            )
+        return ShapedResponse(
+            original_text="\n".join(text_parts),
+            non_text_content=non_text_content,
+        )
+
     async def _call_tool_inner(
         self,
         server: str,
@@ -2343,54 +2417,14 @@ class ProxyManager:
         # owned entirely by the helper — nothing after the fetch reads them.
         result = await self._fetch_upstream(server, tool, upstream_args, trace_id=trace_id)
 
-        # Separate text and non-text content. ``max_upstream_chars`` is a hard
-        # OOM guard against (mis-)behaving upstreams returning huge payloads —
-        # without it, a 100 MB ``ls -R /`` response would be loaded fully into
-        # memory and walk through the entire compression pipeline before any
-        # ``max_chars`` truncation could apply. ``result.content or []`` also
-        # tolerates spec-noncompliant upstreams that return ``None`` instead
-        # of an empty list — those degrade to ``"[empty response]"``.
-        max_upstream = cfg_snap.max_upstream_chars
-        text_parts: list[str] = []
-        non_text_content: list = []
-        total_chars = 0
-        oversize = False
-        for content in result.content or []:
-            if content.type == "text":
-                remaining = max_upstream - total_chars
-                if remaining <= 0:
-                    oversize = True
-                    break
-                # ``content.text or ""`` tolerates spec-noncompliant upstreams
-                # that return ``None`` for a TextContent's ``text`` field.
-                # MCP spec requires ``text: str`` but mirrors the same gap
-                # that PR #114 fixed for ``result.content`` itself.
-                text = content.text or ""
-                if len(text) > remaining:
-                    text_parts.append(text[:remaining])
-                    total_chars += remaining
-                    oversize = True
-                    break
-                text_parts.append(text)
-                total_chars += len(text)
-            else:
-                non_text_content.append(content)
-        if oversize:
-            notice = (
-                f"\n\n[response truncated to {max_upstream} chars at "
-                f"max_upstream_chars guard — upstream returned an oversized payload]"
-            )
-            text_parts.append(notice)
-            logger.warning(
-                "Upstream %s/%s exceeded max_upstream_chars=%d — truncating",
-                server,
-                tool,
-                max_upstream,
-            )
-
-        # Non-text only → pass through without compression but record metrics
-        if not text_parts:
-            if non_text_content:
+        # ── Stage 3: SHAPE (text/non-text split + max_upstream_chars guard) ──
+        # The helper records no metrics and performs no return; when no text
+        # remains it signals the early-exit via ``shaped.passthrough`` and the
+        # orchestrator owns the metric write + return shape (R8).
+        shaped = self._shape_response(result, server, tool, cfg_snap=cfg_snap)
+        non_text_content = shaped.non_text_content
+        if shaped.passthrough is not None:
+            if shaped.passthrough.has_non_text:
                 self.tracker.record(
                     CallMetrics(
                         server=server,
@@ -2402,8 +2436,7 @@ class ProxyManager:
                 )
                 return non_text_content
             return "[empty response]"
-
-        original_text = "\n".join(text_parts)
+        original_text = shaped.original_text
 
         if result.isError:
             self.tracker.record_error(

--- a/src/memtomem_stm/proxy/pipeline_stages.py
+++ b/src/memtomem_stm/proxy/pipeline_stages.py
@@ -1,0 +1,46 @@
+"""Stage-result dataclasses for the proxy call pipeline.
+
+Each stage of ``ProxyManager._call_tool_inner`` returns one of these small,
+explicit carriers so the cross-stage contract is typed rather than threaded
+through one long method's locals (the A1 refactor). These are pure data with no
+``ProxyManager`` dependency — mirroring ``AutoIndexOutcome`` / ``ExtractOutcome``
+in ``memory_ops`` and ``EligibilityResult`` in ``tool_eligibility``.
+
+Frozen + slotted, with no defaults for branch-set fields: a code path that
+forgets to set a field fails at construction (``TypeError``) instead of silently
+carrying a stale value.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ShapePassthrough:
+    """The stage-3 early-exit verdict — the text/non-text split produced no text.
+
+    ``has_non_text`` True → the caller records the non-text passthrough metric and
+    returns the non-text content list; False → the caller returns the
+    ``"[empty response]"`` sentinel and records nothing. The shaping helper never
+    records metrics or returns itself, so the orchestrator stays the single owner
+    of metric writes and return shapes.
+    """
+
+    has_non_text: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ShapedResponse:
+    """Stage 3 output: the text/non-text split of an upstream tool result.
+
+    ``original_text`` is the joined text payload (``""`` when ``passthrough`` is
+    set). ``non_text_content`` is the preserved non-text content list (consumed
+    by the cache-store gate and the final return shape). When ``passthrough`` is
+    non-None the caller short-circuits.
+    """
+
+    original_text: str
+    non_text_content: list[Any]
+    passthrough: ShapePassthrough | None = None


### PR DESCRIPTION
## Background

PR2 of the behavior-preserving split of `ProxyManager._call_tool_inner()`. Follows **PR0 (#501)** characterization net and **PR1 (#502)** `_fetch_upstream`, both merged.

Series: **PR0 ✅ → PR1 ✅ → PR2 (this) → PR3 `_compress_and_surface` → PR4a index/extract → PR4b `_store_cache`.**

## What changes

Extract the **text/non-text split + `max_upstream_chars` OOM guard** into a new `_shape_response(result, server, tool, *, cfg_snap) -> ShapedResponse` helper.

Introduces **`src/memtomem_stm/proxy/pipeline_stages.py`** — the home for the stage-contract dataclasses this refactor adds (frozen + slotted, no defaults for branch-set fields so a forgotten field fails loudly at construction). This PR adds `ShapedResponse` and `ShapePassthrough`; later PRs add the rest.

### Metric/return ownership (plan R8)
The helper deliberately **records no metrics and performs no early return**. When no text remains it returns a `ShapedResponse` whose `passthrough` field tells the orchestrator what to do:

- `has_non_text=True` → orchestrator records the `0/0` non-text passthrough metric and returns the non-text content list,
- `has_non_text=False` → orchestrator returns the `"[empty response]"` sentinel and records nothing.

So the orchestrator stays the single owner of metric writes and return shapes. `isError → ToolError` handling stays inline (it both records and raises — not worth a helper).

## Behavior preservation

Pure refactor — same metrics, same exceptions, same return shapes:

- **PR0's characterization net passes unchanged** — incl. `test_non_text_only_records_zero_metric` and `test_empty_response_records_nothing` (the exact R8 contract).
- `tests/test_proxy_error_paths.py` (oversize truncation + notice/WARNING, non-text passthrough, mixed, empty, None-coercion) and `tests/test_proxy_manager_pipeline.py` pass unchanged.

## Testing

- `uv run pytest -m "not ollama"` — **3598 passed, 3 skipped** (identical baseline).
- `uv run ruff check src && uv run ruff format --check src` — clean (incl. the new module).
- `uv run mypy src/memtomem_stm/proxy/manager.py src/memtomem_stm/proxy/pipeline_stages.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
