### PR TITLE
refactor(proxy): extract _compress_and_surface from _call_tool_inner (A1 PR3)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -68,7 +68,11 @@ from memtomem_stm.proxy.memory_ops import (
     format_fact_md,
     index_content_matches_privacy,
 )
-from memtomem_stm.proxy.pipeline_stages import ShapedResponse, ShapePassthrough
+from memtomem_stm.proxy.pipeline_stages import (
+    CompressionResult,
+    ShapedResponse,
+    ShapePassthrough,
+)
 from memtomem_stm.proxy.privacy import CREDENTIAL_PATTERNS as PRIVACY_CREDENTIAL_PATTERNS
 from memtomem_stm.proxy.token_estimate import tokens_to_chars
 from memtomem_stm.proxy.tool_eligibility import (
@@ -2360,118 +2364,33 @@ class ProxyManager:
             non_text_content=non_text_content,
         )
 
-    async def _call_tool_inner(
+    async def _compress_and_surface(
         self,
+        *,
         server: str,
         tool: str,
-        arguments: dict[str, Any],
-        *,
-        trace_id: str | None = None,
-    ) -> str | list:
-        # Public entry point ``call_tool`` generates the trace_id and passes
-        # it in so it can match the enclosing Langfuse span. Direct callers
-        # (tests and internal dispatch) that don't care about tracing omit
-        # the argument and we generate one here.
-        if trace_id is None:
-            trace_id = uuid.uuid4().hex[:16]
-        logger.debug("trace_id=%s server=%s tool=%s", trace_id, server, tool)
+        upstream_args: dict[str, Any],
+        cleaned: str,
+        tc: ToolConfig,
+        cfg_snap: ProxyConfig,
+        context_query: str | None,
+        trace_id: str | None,
+    ) -> CompressionResult:
+        """Stages 2+3: compress (or build a progressive first chunk), then surface.
 
-        # Snapshot config once to avoid intra-request inconsistency from
-        # hot-reload changing the config between accesses.
-        cfg_snap = self._config
+        Kept atomic on purpose (R6): the PROGRESSIVE branch surfaces *before* the
+        compress branch runs, and ``progressive_fallback`` (set only in the
+        compress branch's ratio-guard ladder) selects which surfacing helper runs
+        — splitting compress from surface would re-introduce the implicit flag
+        threading this refactor removes.
 
-        # Extract _context_query before forwarding. Coerce non-str values to
-        # None at the single extraction point — the cache-hit path already
-        # sanitizes this way, and without the mirror here the same malformed
-        # argument reaches scorers/compressors raw on a miss but is dropped on
-        # a hit, so whether it raises depends on cache state.
-        raw_context_query = arguments.get("_context_query") if arguments else None
-        context_query = raw_context_query if isinstance(raw_context_query, str) else None
-        upstream_args = (
-            {k: v for k, v in arguments.items() if k != "_context_query"} if arguments else {}
-        )
-
-        # Cache lookup + hit path handled by ``_call_tool_guarded``; by the
-        # time we get here the cache has already missed. Just account the
-        # miss and proceed with the upstream fetch.
-        if self._cache is not None:
-            self.tracker.record_cache_miss()
-
-        # Snapshot the cache-key args BEFORE injecting ``_trace_id`` below.
-        # The cache lookup at L771 used the original args (no ``_trace_id``);
-        # if cache.set uses the mutated args, every stored entry is keyed on
-        # a per-request random hex and is unreachable by any future lookup
-        # (hit rate structurally 0%). Keep upstream args mutated for trace
-        # propagation, but persist under the original key.
-        cache_args = {**upstream_args}
-
-        # Propagate trace context to upstream server for end-to-end correlation.
-        if trace_id is not None:
-            upstream_args["_trace_id"] = trace_id
-
-        # ── Stage 1: UPSTREAM FETCH ──
-        # Bounded retry + reconnect with per-attempt and overall deadlines.
-        # Returns the upstream result or raises after recording the failure
-        # metric (and ``_mark_recorded``-ing the exception so the outer
-        # ``call_tool`` does not double-record). ``conn``/``cfg``/``delay`` are
-        # owned entirely by the helper — nothing after the fetch reads them.
-        result = await self._fetch_upstream(server, tool, upstream_args, trace_id=trace_id)
-
-        # ── Stage 3: SHAPE (text/non-text split + max_upstream_chars guard) ──
-        # The helper records no metrics and performs no return; when no text
-        # remains it signals the early-exit via ``shaped.passthrough`` and the
-        # orchestrator owns the metric write + return shape (R8).
-        shaped = self._shape_response(result, server, tool, cfg_snap=cfg_snap)
-        non_text_content = shaped.non_text_content
-        if shaped.passthrough is not None:
-            if shaped.passthrough.has_non_text:
-                self.tracker.record(
-                    CallMetrics(
-                        server=server,
-                        tool=tool,
-                        original_chars=0,
-                        compressed_chars=0,
-                        trace_id=trace_id,
-                    )
-                )
-                return non_text_content
-            return "[empty response]"
-        original_text = shaped.original_text
-
-        if result.isError:
-            self.tracker.record_error(
-                CallMetrics(
-                    server=server,
-                    tool=tool,
-                    original_chars=len(original_text),
-                    compressed_chars=len(original_text),
-                    is_error=True,
-                    error_category=ErrorCategory.UPSTREAM_ERROR,
-                    error_message=original_text[:MAX_ERROR_MESSAGE_CHARS],
-                    trace_id=trace_id,
-                )
-            )
-            # Propagate upstream isError so FastMCP sets isError=true on the
-            # proxied response instead of silently converting to a normal result.
-            from mcp.server.fastmcp.exceptions import ToolError
-
-            tool_err = ToolError(original_text)
-            _mark_recorded(tool_err)
-            raise tool_err
-
-        # Resolve effective settings (using config snapshot)
-        tc = self._resolve_tool_config(server, tool, proxy_cfg=cfg_snap)
-
-        # ── Stage 1: CLEAN ──
-        with traced(
-            "proxy_call_clean",
-            metadata={"server": server, "tool": tool},
-        ):
-            _t0 = _time.monotonic()
-            cleaned = self._clean_content(original_text, tc.cleaning)
-            _clean_ms = (_time.monotonic() - _t0) * 1000
-
-        # ── Stage 2: COMPRESS (or PROGRESSIVE) ──
+        Returns a ``CompressionResult`` carrying both ``compressed`` (pre-surfacing,
+        the cache payload) and ``surfaced`` (post-surfacing, the return/index
+        input), the branch-dependent ``compressed_chars_for_metrics``, the
+        fully-mutated ``metrics_strategy`` label, and the surfacing outcome. The
+        scorer-fallback delta is computed by the caller (it brackets this call plus
+        the later index/extract stages), so it is intentionally not a field here.
+        """
         # ``effective_compression`` is the strategy actually used (with AUTO
         # already resolved). ``ratio_violation`` is set by the post-compression
         # guard below when the compressor cut more than ``min_result_retention``
@@ -2487,7 +2406,6 @@ class ProxyManager:
         # passthrough after a store failure (below). Read at the cache-store
         # gate to keep that transient-failure-degraded response out of the cache.
         progressive_passthrough_on_error = False
-        _pre_scorer_fb = getattr(self._relevance_scorer, "fallback_count", 0)
         if tc.compression == CompressionStrategy.PROGRESSIVE and tc.progressive:
             pcfg = tc.progressive
             if len(cleaned) <= pcfg.chunk_size:
@@ -2790,6 +2708,159 @@ class ProxyManager:
                         context_query=context_query,
                     )
                     _surface_ms = (_time.monotonic() - _t0) * 1000
+
+        return CompressionResult(
+            compressed=compressed,
+            surfaced=surfaced,
+            compressed_chars_for_metrics=compressed_chars_for_metrics,
+            metrics_strategy=metrics_strategy,
+            ratio_violation=ratio_violation,
+            effective_compression=effective_compression,
+            progressive_passthrough_on_error=progressive_passthrough_on_error,
+            surfacing_on_progressive_ok=surfacing_on_progressive_ok,
+            surface_error=surface_error,
+            compress_ms=_compress_ms,
+            surface_ms=_surface_ms,
+        )
+
+    async def _call_tool_inner(
+        self,
+        server: str,
+        tool: str,
+        arguments: dict[str, Any],
+        *,
+        trace_id: str | None = None,
+    ) -> str | list:
+        # Public entry point ``call_tool`` generates the trace_id and passes
+        # it in so it can match the enclosing Langfuse span. Direct callers
+        # (tests and internal dispatch) that don't care about tracing omit
+        # the argument and we generate one here.
+        if trace_id is None:
+            trace_id = uuid.uuid4().hex[:16]
+        logger.debug("trace_id=%s server=%s tool=%s", trace_id, server, tool)
+
+        # Snapshot config once to avoid intra-request inconsistency from
+        # hot-reload changing the config between accesses.
+        cfg_snap = self._config
+
+        # Extract _context_query before forwarding. Coerce non-str values to
+        # None at the single extraction point — the cache-hit path already
+        # sanitizes this way, and without the mirror here the same malformed
+        # argument reaches scorers/compressors raw on a miss but is dropped on
+        # a hit, so whether it raises depends on cache state.
+        raw_context_query = arguments.get("_context_query") if arguments else None
+        context_query = raw_context_query if isinstance(raw_context_query, str) else None
+        upstream_args = (
+            {k: v for k, v in arguments.items() if k != "_context_query"} if arguments else {}
+        )
+
+        # Cache lookup + hit path handled by ``_call_tool_guarded``; by the
+        # time we get here the cache has already missed. Just account the
+        # miss and proceed with the upstream fetch.
+        if self._cache is not None:
+            self.tracker.record_cache_miss()
+
+        # Snapshot the cache-key args BEFORE injecting ``_trace_id`` below.
+        # The cache lookup at L771 used the original args (no ``_trace_id``);
+        # if cache.set uses the mutated args, every stored entry is keyed on
+        # a per-request random hex and is unreachable by any future lookup
+        # (hit rate structurally 0%). Keep upstream args mutated for trace
+        # propagation, but persist under the original key.
+        cache_args = {**upstream_args}
+
+        # Propagate trace context to upstream server for end-to-end correlation.
+        if trace_id is not None:
+            upstream_args["_trace_id"] = trace_id
+
+        # ── Stage 1: UPSTREAM FETCH ──
+        # Bounded retry + reconnect with per-attempt and overall deadlines.
+        # Returns the upstream result or raises after recording the failure
+        # metric (and ``_mark_recorded``-ing the exception so the outer
+        # ``call_tool`` does not double-record). ``conn``/``cfg``/``delay`` are
+        # owned entirely by the helper — nothing after the fetch reads them.
+        result = await self._fetch_upstream(server, tool, upstream_args, trace_id=trace_id)
+
+        # ── Stage 3: SHAPE (text/non-text split + max_upstream_chars guard) ──
+        # The helper records no metrics and performs no return; when no text
+        # remains it signals the early-exit via ``shaped.passthrough`` and the
+        # orchestrator owns the metric write + return shape (R8).
+        shaped = self._shape_response(result, server, tool, cfg_snap=cfg_snap)
+        non_text_content = shaped.non_text_content
+        if shaped.passthrough is not None:
+            if shaped.passthrough.has_non_text:
+                self.tracker.record(
+                    CallMetrics(
+                        server=server,
+                        tool=tool,
+                        original_chars=0,
+                        compressed_chars=0,
+                        trace_id=trace_id,
+                    )
+                )
+                return non_text_content
+            return "[empty response]"
+        original_text = shaped.original_text
+
+        if result.isError:
+            self.tracker.record_error(
+                CallMetrics(
+                    server=server,
+                    tool=tool,
+                    original_chars=len(original_text),
+                    compressed_chars=len(original_text),
+                    is_error=True,
+                    error_category=ErrorCategory.UPSTREAM_ERROR,
+                    error_message=original_text[:MAX_ERROR_MESSAGE_CHARS],
+                    trace_id=trace_id,
+                )
+            )
+            # Propagate upstream isError so FastMCP sets isError=true on the
+            # proxied response instead of silently converting to a normal result.
+            from mcp.server.fastmcp.exceptions import ToolError
+
+            tool_err = ToolError(original_text)
+            _mark_recorded(tool_err)
+            raise tool_err
+
+        # Resolve effective settings (using config snapshot)
+        tc = self._resolve_tool_config(server, tool, proxy_cfg=cfg_snap)
+
+        # ── Stage 1: CLEAN ──
+        with traced(
+            "proxy_call_clean",
+            metadata={"server": server, "tool": tool},
+        ):
+            _t0 = _time.monotonic()
+            cleaned = self._clean_content(original_text, tc.cleaning)
+            _clean_ms = (_time.monotonic() - _t0) * 1000
+
+        # ── Stages 2+3: COMPRESS (or PROGRESSIVE) + SURFACE ──
+        # Capture the scorer fallback counter BEFORE compression so the metrics
+        # record below sees a delta covering compression and everything after.
+        _pre_scorer_fb = getattr(self._relevance_scorer, "fallback_count", 0)
+        comp = await self._compress_and_surface(
+            server=server,
+            tool=tool,
+            upstream_args=upstream_args,
+            cleaned=cleaned,
+            tc=tc,
+            cfg_snap=cfg_snap,
+            context_query=context_query,
+            trace_id=trace_id,
+        )
+        # Unpack into the locals the downstream INDEX / metrics / cache stages
+        # still read inline (those stages are extracted in later PRs). Behavior
+        # is identical — the helper computes exactly what the inline block did.
+        compressed = comp.compressed
+        surfaced = comp.surfaced
+        compressed_chars_for_metrics = comp.compressed_chars_for_metrics
+        metrics_strategy = comp.metrics_strategy
+        ratio_violation = comp.ratio_violation
+        surfacing_on_progressive_ok = comp.surfacing_on_progressive_ok
+        surface_error = comp.surface_error
+        progressive_passthrough_on_error = comp.progressive_passthrough_on_error
+        _compress_ms = comp.compress_ms
+        _surface_ms = comp.surface_ms
 
         # ── Stage 4: INDEX (optional) ──
         # Track outcome for CallMetrics below. ``None`` means "stage did not

--- a/src/memtomem_stm/proxy/pipeline_stages.py
+++ b/src/memtomem_stm/proxy/pipeline_stages.py
@@ -14,7 +14,10 @@ carrying a stale value.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from memtomem_stm.proxy.config import CompressionStrategy
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,3 +47,32 @@ class ShapedResponse:
     original_text: str
     non_text_content: list[Any]
     passthrough: ShapePassthrough | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CompressionResult:
+    """Stage-2+3 output: the compressed payload, its surfaced form, and the
+    metrics/cache facts the orchestrator consumes.
+
+    Carries BOTH ``compressed`` (pre-surfacing — the cache payload) and
+    ``surfaced`` (post-surfacing — the return/index input) as distinct fields:
+    the cache stores the former while the agent and the index footer see the
+    latter. ``compressed_chars_for_metrics`` is branch-dependent —
+    ``len(compressed)`` on the compress branch but ``len(cleaned)`` on the
+    zero-loss progressive branch. ``metrics_strategy`` is the fully-mutated label
+    (e.g. ``"truncate→progressive_fallback"``). ``progressive_passthrough_on_error``
+    gates the cache store: a transient progressive-store-failure passthrough must
+    not be cached.
+    """
+
+    compressed: str
+    surfaced: str
+    compressed_chars_for_metrics: int
+    metrics_strategy: str
+    ratio_violation: bool
+    effective_compression: CompressionStrategy
+    progressive_passthrough_on_error: bool
+    surfacing_on_progressive_ok: bool | None
+    surface_error: str | None
+    compress_ms: float
+    surface_ms: float

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -311,8 +311,9 @@ class TestProgressiveTraceIdPropagation:
 
     def test_both_apply_progressive_call_sites_pass_trace_id_kwarg(self):
         # manager.py has two _apply_progressive call sites: the normal
-        # PROGRESSIVE branch and the hybrid-fallback branch. Both must pass
-        # trace_id=trace_id. This test source-inspects _call_tool_inner,
+        # PROGRESSIVE branch and the ratio-guard Tier-1 fallback branch. Both
+        # must pass trace_id=trace_id. Both live in _compress_and_surface since
+        # the A1 PR3 stage extraction. This test source-inspects that helper,
         # pins the count of call sites at 2, and asserts each call contains
         # the trace_id= kwarg — cheap regression insurance against a future
         # refactor that drops the kwarg at one site (functionally tight:
@@ -322,7 +323,7 @@ class TestProgressiveTraceIdPropagation:
 
         from memtomem_stm.proxy import manager as manager_module
 
-        src = inspect.getsource(manager_module.ProxyManager._call_tool_inner)
+        src = inspect.getsource(manager_module.ProxyManager._compress_and_surface)
         calls = re.findall(r"self\._apply_progressive\(\s*.*?\)", src, re.DOTALL)
         assert len(calls) == 2, f"expected 2 _apply_progressive call sites, found {len(calls)}"
         for call in calls:

--- a/tests/test_retention_ladder_invariants.py
+++ b/tests/test_retention_ladder_invariants.py
@@ -172,7 +172,9 @@ class TestContextQueryPropagation:
         assert "context_query=context_query" in window
 
     def test_truncate_fallback_passes_context_query(self) -> None:
-        src = inspect.getsource(ProxyManager._call_tool_inner)
+        # The ratio-guard ladder (incl. the Tier-3 truncate fallback) lives in
+        # ``_compress_and_surface`` since the A1 PR3 stage extraction.
+        src = inspect.getsource(ProxyManager._compress_and_surface)
         idx = src.index("→truncate_fallback")
         window = src[max(0, idx - 400) : idx]
         assert "context_query=context_query" in window


### PR DESCRIPTION
## Background

PR3 of the behavior-preserving split of `ProxyManager._call_tool_inner()` — the **largest and highest-risk** stage. Follows **PR0 (#501)**, **PR1 (#502)**, **PR2 (#503)**, all merged.

Series: **PR0 ✅ → PR1 ✅ → PR2 ✅ → PR3 (this) → PR4a index/extract → PR4b `_store_cache`.**

## What changes

Extract the **COMPRESS/PROGRESSIVE branch + dynamic retention floor + AUTO resolution + the 3-tier ratio-guard fallback ladder (progressive → hybrid → truncate) + the inline SURFACE step** into a new `_compress_and_surface(...) -> CompressionResult`.

**Kept atomic on purpose (plan R6):** the PROGRESSIVE branch surfaces *before* the compress branch runs, and `progressive_fallback` (set only in the ratio-guard ladder) selects which surfacing helper runs. Splitting compress from surface would re-introduce the implicit flag threading this refactor removes.

`CompressionResult` (new, in `pipeline_stages.py`) carries:
- **`compressed`** (pre-surfacing — the cache payload) and **`surfaced`** (post-surfacing — return/index input) as **distinct** fields (R3),
- the branch-dependent **`compressed_chars_for_metrics`** (`len(cleaned)` progressive vs `len(compressed)` compress) (R1),
- the fully-mutated **`metrics_strategy`** label (R2),
- `ratio_violation`, `progressive_passthrough_on_error`, `surfacing_on_progressive_ok`, `surface_error`, `compress_ms`, `surface_ms`.

The orchestrator unpacks `comp.*` into the same locals the still-inline INDEX/EXTRACT/metrics/cache stages read (those move in PR4a/PR4b). The **scorer-fallback delta** is captured by the caller (it brackets compress *plus* the later stages), so it is deliberately not a `CompressionResult` field — the measurement window is unchanged.

### Consequent test updates
Two source-inspection pins (`test_observability.py`, `test_retention_ladder_invariants.py`) now inspect `_compress_and_surface` instead of `_call_tool_inner` — the call sites moved, behavior is identical, no assertion loosened.

## Behavior preservation — verified three ways

1. **PR0 characterization net passes unchanged** — exact `metrics_strategy` labels, dual `compressed_chars`, cache-stores-pre-surfacing-compressed, surfacing-helper selection, `surfacing_on_progressive_ok`/`surface_error` per mode.
2. **Full suite: 3598 passed, 3 skipped** (identical baseline).
3. **7-way adversarial behavior-preservation review** — independent checks on line-by-line block equivalence (mechanical diff vs `main`), R1, R2, R3, R6, the scorer-fallback window, and unpack-completeness + per-path field binding. **All preserved, zero regressions.** The equivalence check confirmed the moved block differs from the original only by the three sanctioned changes (header→docstring, `_pre_scorer_fb` hoisted to the caller, trailing `return CompressionResult(...)`).

`uv run ruff check src && uv run ruff format --check src` and `uv run mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
