### PR TITLE
refactor(proxy): extract _store_cache from _call_tool_inner (A1 PR4b)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -2920,6 +2920,77 @@ class ProxyManager:
 
         return ExtractResult(ok=extract_ok, error=extract_error)
 
+    def _store_cache(
+        self,
+        *,
+        server: str,
+        tool: str,
+        cache_args: dict[str, Any],
+        comp: CompressionResult,
+        non_text_content: list,
+        cfg_snap: ProxyConfig,
+    ) -> None:
+        """Stage 5: best-effort cache store of the PRE-surfacing ``comp.compressed``
+        (so memories stay fresh and surfacing re-runs on a hit).
+
+        Cache writes are an optional fast-path: a SQLite lock timeout, disk full,
+        or any other store error must NOT propagate to the agent and discard a
+        successful upstream response — log and continue.
+
+        Two responses are deliberately NOT cached:
+
+        - ``comp.progressive_passthrough_on_error`` — a transient-store-failure
+          passthrough. Caching it would pin the degraded (non-chunked) response
+          for the cache TTL and suppress progressive delivery on identical calls
+          even after the store recovers.
+        - one embedding a TRANSIENT retrieval key (progressive first-chunk,
+          SELECTIVE/HYBRID TOC): ``compressed`` is a pointer into the process-local
+          pending store, whose key dies on restart/eviction or its shorter TTL
+          (progressive 1800s / selective 300s) well before the cache TTL (3600s).
+          A later cache hit would hand back a dead ``stm_proxy_read_more`` /
+          ``stm_proxy_select_chunks`` key.
+
+        Skipping the store makes the next identical call re-run the pipeline and
+        mint a fresh, live key. Detection is marker-based (shared with the startup
+        legacy purge in ``ProxyCache.initialize``); a false positive only costs one
+        un-cached response, never correctness.
+
+        The key uses ``cache_args`` — the pre-``_trace_id`` snapshot — never the
+        trace-mutated upstream args; otherwise every entry is keyed on a per-request
+        hex and is unreachable by any future lookup (hit rate structurally 0%).
+        """
+        if self._cache is not None and not non_text_content:
+            if comp.progressive_passthrough_on_error:
+                logger.debug(
+                    "Skipping cache store for %s/%s: progressive passthrough "
+                    "degradation (transient store failure)",
+                    server,
+                    tool,
+                )
+            elif response_carries_transient_key(comp.compressed):
+                logger.debug(
+                    "Skipping cache store for %s/%s: response carries a transient "
+                    "retrieval key (progressive/selective TOC)",
+                    server,
+                    tool,
+                )
+            else:
+                try:
+                    self._cache.set(
+                        server,
+                        tool,
+                        cache_args,
+                        comp.compressed,
+                        ttl_seconds=cfg_snap.cache.default_ttl_seconds,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Cache store failed for %s/%s — response unaffected",
+                        server,
+                        tool,
+                        exc_info=True,
+                    )
+
     async def _call_tool_inner(
         self,
         server: str,
@@ -3045,17 +3116,15 @@ class ProxyManager:
             context_query=context_query,
             trace_id=trace_id,
         )
-        # Unpack into the locals the downstream INDEX / metrics / cache stages
-        # still read inline (those stages are extracted in later PRs). Behavior
-        # is identical — the helper computes exactly what the inline block did.
-        compressed = comp.compressed
+        # Unpack the fields the metrics record and the INDEX stage read. The
+        # cache store reads ``comp`` directly (compressed + the cache-skip flag),
+        # so those two are not unpacked here.
         surfaced = comp.surfaced
         compressed_chars_for_metrics = comp.compressed_chars_for_metrics
         metrics_strategy = comp.metrics_strategy
         ratio_violation = comp.ratio_violation
         surfacing_on_progressive_ok = comp.surfacing_on_progressive_ok
         surface_error = comp.surface_error
-        progressive_passthrough_on_error = comp.progressive_passthrough_on_error
         _compress_ms = comp.compress_ms
         _surface_ms = comp.surface_ms
 
@@ -3124,59 +3193,15 @@ class ProxyManager:
             )
         )
 
-        # ── Cache store (pre-surfacing content so memories stay fresh on hit) ──
-        # Cache writes are an optional fast-path: a SQLite lock timeout, disk
-        # full, or any other store error must NOT propagate to the agent and
-        # discard a successful upstream response. Log and continue.
-        #
-        # Never cache a response that embeds a TRANSIENT retrieval key
-        # (progressive first-chunk, SELECTIVE/HYBRID TOC): ``compressed`` is a
-        # pointer into the process-local pending store, whose key dies on
-        # restart/eviction or its shorter TTL (progressive 1800s / selective
-        # 300s) well before the cache TTL (3600s). A later cache hit would hand
-        # back a dead ``stm_proxy_read_more`` / ``stm_proxy_select_chunks`` key.
-        # Skipping the store makes the next identical call re-run the pipeline
-        # and mint a fresh, live key. Detection is marker-based (shared with the
-        # startup legacy purge in ``ProxyCache.initialize``); a false positive
-        # only costs one un-cached response, never correctness.
-        if self._cache is not None and not non_text_content:
-            if progressive_passthrough_on_error:
-                # The primary PROGRESSIVE path degraded to a full-content
-                # passthrough after a transient store failure. Caching it would
-                # pin the degraded (non-chunked) response for the cache TTL and
-                # suppress progressive delivery on identical calls even after the
-                # store recovers. Skip the store so the next identical call
-                # re-runs the pipeline and re-attempts progressive delivery —
-                # same rationale as the transient-key skip below.
-                logger.debug(
-                    "Skipping cache store for %s/%s: progressive passthrough "
-                    "degradation (transient store failure)",
-                    server,
-                    tool,
-                )
-            elif response_carries_transient_key(compressed):
-                logger.debug(
-                    "Skipping cache store for %s/%s: response carries a transient "
-                    "retrieval key (progressive/selective TOC)",
-                    server,
-                    tool,
-                )
-            else:
-                try:
-                    self._cache.set(
-                        server,
-                        tool,
-                        cache_args,
-                        compressed,
-                        ttl_seconds=cfg_snap.cache.default_ttl_seconds,
-                    )
-                except Exception:
-                    logger.warning(
-                        "Cache store failed for %s/%s — response unaffected",
-                        server,
-                        tool,
-                        exc_info=True,
-                    )
+        # ── Stage 5: CACHE STORE (pre-surfacing content, keyed on cache_args) ──
+        self._store_cache(
+            server=server,
+            tool=tool,
+            cache_args=cache_args,
+            comp=comp,
+            non_text_content=non_text_content,
+            cfg_snap=cfg_snap,
+        )
 
         # Combine compressed text with preserved non-text content
         if non_text_content:


### PR DESCRIPTION
## Background

**Final PR** of the behavior-preserving split of `ProxyManager._call_tool_inner()`. Follows **PR0 (#501)**, **PR1 (#502)**, **PR2 (#503)**, **PR3 (#504)**, **PR4a (#505)**, all merged.

Series: **PR0 ✅ → PR1 ✅ → PR2 ✅ → PR3 ✅ → PR4a ✅ → PR4b (this).**

## What changes

Extract the cache-store gate into `_store_cache(*, server, tool, cache_args, comp, non_text_content, cfg_snap)`: the `self._cache is not None and not non_text_content` guard, the two skip branches (progressive passthrough-on-error degradation; transient-key-bearing response) with their distinct debug logs, and the best-effort `cache.set` with warn-and-continue.

This **isolates the cache invariants the refactor cared about most** for a laser-focused review (the plan made this a mandatory standalone PR):
- **R3**: stores `comp.compressed` (pre-surfacing), never `surfaced`;
- **R5**: keys on `cache_args` (the pre-`_trace_id` snapshot), never the trace-mutated upstream args — a swap silently drops the hit rate to 0%;
- **R10**: receives `cache_args` explicitly, not `upstream_args`.

The `compressed` / `progressive_passthrough_on_error` locals are no longer unpacked in the orchestrator — `_store_cache` reads them off `comp`.

## Result: `_call_tool_inner` is now a thin orchestrator

**~862 → ~219 lines.** The dozen+ stage-local flags that were threaded through one scope are now explicit dataclass contracts (`ShapedResponse`, `CompressionResult`, `IndexResult`, `ExtractResult` in `pipeline_stages.py`). The body reads:

```
setup → _fetch_upstream → _shape_response → CLEAN → _compress_and_surface
      → _run_index_stage → _run_extract_stage → metrics → _store_cache → return
```

## Behavior preservation

Pure refactor — same metrics, exceptions, return shapes:

- **PR0 characterization net passes unchanged** — the R3 (cache-stores-pre-surfacing), R5 (no-`_trace_id`-in-key), and R10 (args-routing) tests directly lock this gate's invariants against the extracted helper.
- The ratio-guard cache-skip tests (`test_progressive_passthrough_on_error_is_not_cached`, `test_single_chunk_progressive_passthrough_is_still_cached`) and `test_proxy_cache.py` pass unchanged.

## Testing

- `uv run pytest -m "not ollama"` — **3598 passed, 3 skipped** (identical baseline through all six PRs).
- `uv run ruff check src && uv run ruff format --check src` — clean.
- `uv run mypy src/memtomem_stm/proxy/manager.py src/memtomem_stm/proxy/pipeline_stages.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
