### PR TITLE
test(eligibility): e2e seam — derived health flags reach the exposure filter

### DIFF
--- a/tests/test_tool_eligibility.py
+++ b/tests/test_tool_eligibility.py
@@ -632,6 +632,74 @@ class TestManagerWireIn:
             await mgr.stop()
             store.close()
 
+    async def test_start_derived_health_flows_into_exposure(self, tmp_path):
+        """End-to-end seam: failing metrics history → ``start()`` *derives*
+        ``_unhealthy_tools`` → ``get_proxy_tools()`` drops the unhealthy tool
+        from exposure and records ``REASON_UNHEALTHY`` — with the set never
+        injected.
+
+        The two existing tests cover the halves in isolation:
+        ``test_start_computes_health_flags_from_metrics_store`` proves
+        derivation→set, and ``test_unhealthy_strict_rejected_and_recorded``
+        proves injected-set→exposure. Neither joins them, so a key-format
+        drift between ``compute_health_flags`` (which keys by upstream-server
+        name) and the exposure-filter lookup would pass both yet silently stop
+        filtering. This pins the join: derived ``("srv", "broken")`` must reach
+        the filter that advertises by prefix.
+        """
+        store = MetricsStore(tmp_path / "metrics.db")
+        store.initialize()
+        for _ in range(5):
+            _record(store, "broken", error=ErrorCategory.UPSTREAM_ERROR)
+
+        server_cfg = UpstreamServerConfig(
+            prefix="test",
+            compression=CompressionStrategy.NONE,
+            max_retries=0,
+            reconnect_delay_seconds=0.0,
+        )
+        # upstream_servers empty + a non-existent config_path → start() makes no
+        # real connection (and the fresh-manager path skips the double-start
+        # guard), so the injected connection below survives into derivation.
+        cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={},
+            exposure=ExposureConfig(),  # strict default profile
+        )
+        mgr = ProxyManager(cfg, TokenTracker(metrics_store=store))
+
+        session = AsyncMock()
+        session.call_tool.return_value = _make_result("ok!")
+        mgr._connections["srv"] = UpstreamConnection(
+            name="srv",
+            config=server_cfg,
+            session=session,
+            tools=[
+                SimpleNamespace(
+                    name="broken",
+                    description="A flaky tool",
+                    inputSchema={"type": "object"},
+                ),
+                SimpleNamespace(
+                    name="send_message",
+                    description="Send a message to a Slack channel",
+                    inputSchema={"type": "object"},
+                ),
+            ],
+        )
+
+        await mgr.start()
+        try:
+            # Derivation ran from the seeded store — the set is NOT injected.
+            assert mgr._unhealthy_tools == frozenset({("srv", "broken")})
+            # ...and that derived key actually reaches the exposure filter.
+            advertised = [i.prefixed_name for i in mgr.get_proxy_tools()]
+            assert advertised == ["test__send_message"]
+            assert mgr._advertised_reject_reasons == {"test__broken": REASON_UNHEALTHY}
+        finally:
+            await mgr.stop()
+            store.close()
+
 
 # ── interpret_verdict (pure parse of the external consult, #465) ────────────
 


### PR DESCRIPTION
## What

Adds one end-to-end test (`TestManagerWireIn.test_start_derived_health_flows_into_exposure`)
that drives the full health-based exposure path: real failing metrics history
→ `start()` **derives** `_unhealthy_tools` → `get_proxy_tools()` drops the
unhealthy tool and records `REASON_UNHEALTHY`.

## Why

Health-based exposure is currently covered in two **disjoint halves**:

- `test_start_computes_health_flags_from_metrics_store` proves derivation →
  set (asserts `_unhealthy_tools` equality only).
- `TestManagerWireIn.test_unhealthy_strict_rejected_and_recorded` proves
  injected-set → exposure (the `_make_manager(unhealthy=...)` helper sets
  `mgr._unhealthy_tools` directly).

Neither joins them. `compute_health_flags` keys by **upstream-server name**
(`("srv", "broken")`) while the advertised set is **prefixed** (`test__broken`).
A drift between the derived key and the exposure-filter lookup key would pass
both isolated tests yet silently stop filtering in production. This test pins
the join.

Surfaced by the 2026-06-17 core-logic review (Area 4); the review confirmed
the golden wire-in tests + ranker-version pinning already exist, leaving this
derivation→exposure seam as the genuinely-uncovered piece.

## How it works

On a fresh manager the double-start guard is skipped and empty
`upstream_servers` + a non-existent `config_path` means `start()` opens no real
connection, so an injected connection survives into derivation. The test seeds
5 `UPSTREAM_ERROR` rows for `("srv", "broken")`, injects a connection carrying
`broken` + a healthy `send_message`, calls `start()` (derives — never injects),
then asserts the advertisement is `["test__send_message"]` and rejects are
`{"test__broken": REASON_UNHEALTHY}`.

## Risk

Test-only; no runtime code changed. `uv run pytest tests/test_tool_eligibility.py`
→ 67 passed; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)