### PR TITLE
fix(hook): anchor compression sentinel check to stdout prefix

### DIFF
--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -87,9 +87,12 @@ _SURFACED_CLOSE = "</surfaced-memories>"
 _DEFAULT_SURFACE_TOOLS = frozenset({"Read", "Grep", "Glob", "Bash"})
 
 # Unique marker prepended to compressed ``stdout`` so a re-fired hook recognizes
-# its own output and no-ops (idempotency). Matched *exactly* — never via
-# ``TruncateCompressor``'s generic markers (``(truncated`` / ``(original:`` /
-# ``… omitted``), which appear in real logs and would falsely skip compression.
+# its own output and no-ops (idempotency). Detected as a *prefix* only (see
+# :func:`_already_compressed`) — never via ``TruncateCompressor``'s generic
+# markers (``(truncated`` / ``(original:`` / ``… omitted``), and never by a bare
+# substring match: self-referential output (``git log`` / ``grep`` / ``cat`` over
+# STM's own source, history, or docs that mention this sentinel) would otherwise
+# falsely suppress compression of the whole result.
 _COMPRESS_SENTINEL = "⟦stm-compressed⟧"
 
 # Hard cap on the ``tool_response`` text forwarded to surfacing, independent of
@@ -186,8 +189,16 @@ def _bash_stdout(tool_response: Any) -> tuple[str, dict[str, Any]] | None:
 
 
 def _already_compressed(text: str) -> bool:
-    """Whether ``text`` already carries our compression sentinel (idempotency)."""
-    return _COMPRESS_SENTINEL in text
+    """Whether ``text`` is *our own* prior compression output (idempotency).
+
+    The sentinel is always written as a prefix (``prefix + compressed`` in
+    :func:`maybe_compress_builtin`), so the check is anchored to the start of the
+    text. A bare ``in`` substring match false-positives on any tool output that
+    merely *mentions* the sentinel — e.g. ``git log`` / ``grep`` / ``cat`` over
+    STM's own source, history, or docs — silently skipping compression of the
+    whole result.
+    """
+    return text.startswith(_COMPRESS_SENTINEL)
 
 
 def maybe_compress_builtin(

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -454,6 +454,18 @@ def test_compress_no_false_positive_on_truncate_marker():
     assert out is not None and out["stdout"].startswith(_COMPRESS_SENTINEL)
 
 
+def test_compress_no_false_positive_on_embedded_sentinel():
+    # Self-referential output (``git log`` / ``grep`` / ``cat`` over STM's own
+    # repo, history, or docs) can legitimately contain the sentinel string
+    # mid-text. Idempotency keys on OUR prefix only, so such output must still be
+    # compressed. Regression: a bare ``in`` match left the whole result
+    # uncompressed (observed on ``git log --stat`` whose commit body names the
+    # sentinel).
+    embedded = f"a commit body mentioning the {_COMPRESS_SENTINEL} sentinel\n" + _BIG_STDOUT
+    out = maybe_compress_builtin(_bash_payload({"stdout": embedded}), _CFG)
+    assert out is not None and out["stdout"].startswith(_COMPRESS_SENTINEL)
+
+
 def test_compress_never_raises(monkeypatch: pytest.MonkeyPatch):
     class _Boom:
         def compress(self, *a, **k):


### PR DESCRIPTION
## Problem

`_already_compressed` (`cli/hook_cmd.py`) gates the PostToolUse Bash-compression
stage's idempotency with a **bare substring** match:

```python
return _COMPRESS_SENTINEL in text
```

But the sentinel (`⟦stm-compressed⟧`) is always written as a **prefix**
(`prefix + compressed` in `maybe_compress_builtin`). So any tool output that
merely *mentions* the sentinel string anywhere false-positives as "already
compressed" and the whole result is left uncompressed.

This bites **self-referential** commands — `git log` / `grep` / `cat` over STM's
own source, history, or docs that name the sentinel. Concretely, a 958 KB
`git log --stat -n 400` in this repo carries the sentinel once (a commit body
documenting the feature), so the entire output skipped compression. With the fix
it compresses to ~3 KB (99.7%).

## Fix

Anchor the check to the start of the text:

```python
return text.startswith(_COMPRESS_SENTINEL)
```

Idempotency is preserved — our own compressed output always begins with the
prefix, so a re-fired hook still no-ops — while embedded mentions no longer
suppress compression.

## Behavior change

When Bash compression is enabled (`MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED=1`,
opt-in), outputs that contain the sentinel mid-text are now compressed where they
were previously passed through untouched. No change to the default-off path or to
genuinely re-fired (prefix-sentinel) outputs.

## Tests

- New `test_compress_no_false_positive_on_embedded_sentinel` — a stdout that names
  the sentinel mid-text must still compress (mirrors the existing
  `test_compress_no_false_positive_on_truncate_marker` guard).
- `test_compress_is_idempotent_on_sentinel` (unchanged) still passes — prefix
  detection keeps idempotency intact.
- Full `tests/cli/test_hook_cmd.py` green (60 passed); `ruff check src` +
  `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
