### PR TITLE
feat(hook): record native built-in tool calls into proxy_metrics.db

### DIFF
--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -100,6 +100,13 @@ _COMPRESS_SENTINEL = "⟦stm-compressed⟧"
 # ``tool_input``), so capping costs nothing for relevance.
 _SAFE_DAEMON_BUDGET = 256 * 1024
 
+# Connect + busy timeout for the best-effort native-tool metrics write. The hook
+# runs synchronously inside the host's PostToolUse, so a locked shared
+# ``proxy_metrics.db`` (e.g. the live ``mms`` server writing) must fast-fail and
+# degrade to "no row" rather than stall the tool call up to the store's shared
+# 3000 ms busy timeout. Generous vs. a sub-ms WAL write, tiny vs. host latency.
+_METRICS_BUSY_TIMEOUT_MS = 250
+
 
 def _surface_tools() -> frozenset[str]:
     """Allowlist of tool names to surface for, overridable via env.
@@ -552,6 +559,7 @@ def _record_hook_metrics(
         store = MetricsStore(
             config.proxy.metrics.db_path.expanduser(),
             max_history=config.proxy.metrics.max_history,
+            busy_timeout_ms=_METRICS_BUSY_TIMEOUT_MS,
         )
         store.initialize()
         try:

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -511,6 +511,67 @@ async def _run_hook(
     return await run_surfacing_hook(payload)
 
 
+def _record_hook_metrics(
+    payload: dict[str, Any],
+    updated: dict[str, Any] | None,
+    additional_context: str | None,
+    config: "STMConfig",
+) -> None:
+    """Record one native built-in tool call into ``proxy_metrics.db`` (``source='hook'``).
+
+    Makes native-tool spend — which never reaches the MCP proxy — visible next
+    to proxied calls. Persists **sizes only** (original / compressed / surfaced
+    chars + the tool name): never ``tool_input`` and never the output text,
+    mirroring the hook's no-query-text privacy posture (a ``Bash`` command may
+    carry secrets). Gated on ``config.hook.metrics_enabled`` (independent of
+    ``proxy.metrics.enabled`` so a hook-only deployment still measures), reusing
+    the proxy's ``metrics.db_path`` / ``max_history``. A short-lived store is
+    opened per call — the hook is a one-shot subprocess, so there is no
+    long-lived tracker to write through. **Never raises**: any failure degrades
+    to no row, so metrics can't disrupt the host.
+    """
+    try:
+        if not config.hook.metrics_enabled:
+            return
+        tool_name = payload.get("tool_name")
+        if not isinstance(tool_name, str) or not tool_name:
+            return
+        original_chars = len(_tool_response_to_text(payload.get("tool_response")))
+        if original_chars == 0:
+            return  # nothing observed (empty / malformed result) — skip
+        compressed_chars = (
+            len(_tool_response_to_text(updated)) if updated is not None else original_chars
+        )
+        surfaced_chars = len(additional_context) if additional_context else 0
+
+        # Lazy import: keep ``mms hook --help`` and the metrics-disabled path off
+        # the metrics / sqlite import cost.
+        from memtomem_stm.proxy.metrics import CallMetrics
+        from memtomem_stm.proxy.metrics_store import MetricsStore
+
+        store = MetricsStore(
+            config.proxy.metrics.db_path.expanduser(),
+            max_history=config.proxy.metrics.max_history,
+        )
+        store.initialize()
+        try:
+            store.record(
+                CallMetrics(
+                    server="builtin",
+                    tool=tool_name,
+                    original_chars=original_chars,
+                    compressed_chars=compressed_chars,
+                    surfaced_chars=surfaced_chars,
+                    compression_strategy="truncate" if updated is not None else None,
+                    source="hook",
+                )
+            )
+        finally:
+            store.close()
+    except Exception:
+        logger.debug("hook metrics recording failed — no row written", exc_info=True)
+
+
 async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
     """Resolve the full hook output: in-process Bash *compression* merged with
     LTM *surfacing*, as one ``hookSpecificOutput``.
@@ -524,7 +585,9 @@ async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
     surfacing whether or not compression ran. Surfacing is wrapped so a
     failure degrades to "no memories" while still returning the compression
     half (``maybe_compress_builtin`` is itself non-raising). The CLI wrapper
-    backstops the whole call.
+    backstops the whole call. A non-raising metrics row (``source='hook'``) is
+    recorded afterwards via :func:`_record_hook_metrics`, regardless of whether
+    either stage produced output.
     """
     from memtomem_stm.config import STMConfig
 
@@ -535,7 +598,9 @@ async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
         surf_out = await _run_hook(_bounded_surfacing_payload(payload), config=config)
     except Exception:
         logger.debug("surfacing failed — keeping the compression half", exc_info=True)
-    return _build_hook_output(updated, _extract_surfaced_context(surf_out))
+    additional_context = _extract_surfaced_context(surf_out)
+    _record_hook_metrics(payload, updated, additional_context, config)
+    return _build_hook_output(updated, additional_context)
 
 
 @click.command(name="hook")

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -775,8 +775,22 @@ def _render_surfacing_block(summary: dict[str, Any]) -> None:
 @cli.command()
 @click.option("--config", "config_path", default=str(_DEFAULT_CONFIG), show_default=True)
 @click.option("--tool", "tool_filter", default=None, help="Filter to one upstream tool name.")
+@click.option(
+    "--source",
+    "source_filter",
+    type=click.Choice(["mcp", "hook"]),
+    default=None,
+    help="Filter compression rows by provenance: 'mcp' (proxied upstream tools) "
+    "or 'hook' (native built-in tools recorded by 'mms hook').",
+)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
-def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = False) -> None:
+def stats(
+    config_path: str,
+    *,
+    tool_filter: str | None = None,
+    source_filter: str | None = None,
+    as_json: bool = False,
+) -> None:
     """Show proxy compression and surfacing stats from the persistent stores.
 
     Reads ``proxy_metrics.db`` and ``stm_feedback.db`` read-only (it never
@@ -829,7 +843,9 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
         config_status = "invalid"
         proxy_cfg = ProxyConfig()
 
-    compression = read_compression_summary(proxy_cfg.metrics.db_path, tool=tool_filter)
+    compression = read_compression_summary(
+        proxy_cfg.metrics.db_path, tool=tool_filter, source=source_filter
+    )
     surfacing = read_surfacing_summary(feedback_path, tool=tool_filter)
 
     if as_json:
@@ -841,6 +857,7 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
                     "enabled": proxy_cfg.enabled,
                     "servers": len(proxy_cfg.upstream_servers),
                     "tool_filter": tool_filter,
+                    "source_filter": source_filter,
                     "compression": compression,
                     "surfacing": surfacing,
                 },
@@ -855,6 +872,8 @@ def stats(config_path: str, *, tool_filter: str | None = None, as_json: bool = F
     click.echo(f"Servers: {len(proxy_cfg.upstream_servers)}")
     if tool_filter:
         click.echo(f"Filter : tool={tool_filter}")
+    if source_filter:
+        click.echo(f"Source : {source_filter}")
     click.echo("")
     _render_compression_block(compression)
     click.echo("")

--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -118,6 +118,15 @@ class HookConfig(BaseModel):
     compression: HookCompressionConfig = Field(default_factory=HookCompressionConfig)
     """Built-in tool *output compression* (P1a — Bash). Independent of surfacing:
     see :class:`HookCompressionConfig`. Env: ``MEMTOMEM_STM_HOOK__COMPRESSION__*``."""
+    metrics_enabled: bool = True
+    """Record one per-call row (sizes + timings only, never tool input) into the
+    shared ``proxy_metrics.db`` with ``source='hook'`` for every native built-in
+    tool call the hook sees. Default ``True`` makes otherwise-invisible
+    native-tool spend measurable (`mms stats --source hook`). Deliberately
+    independent of ``proxy.metrics.enabled`` so a hook-only deployment (proxy
+    disabled) still gets metrics; it reuses ``proxy.metrics.db_path`` /
+    ``max_history`` for storage. Opt out with
+    ``MEMTOMEM_STM_HOOK__METRICS_ENABLED=0``."""
 
 
 class DaemonConfig(BaseModel):

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -195,6 +195,13 @@ class CallMetrics:
     # progressive surfacing ran successfully or failed.
     surfacing_on_progressive_ok: bool | None = None
     surface_error: str | None = None
+    # Provenance of the row in the shared ``proxy_metrics.db``. ``"mcp"`` (the
+    # default) is a proxied upstream MCP tool call written by ``ProxyManager``;
+    # ``"hook"`` is a native/built-in tool call (Read/Bash/Grep/…) recorded by
+    # ``mms hook``, which never reaches the MCP proxy. The column lets readers
+    # (CLI/stats, the tuner) separate native-tool spend — otherwise invisible —
+    # from proxied spend without splitting the store.
+    source: str = "mcp"
 
 
 class RPSTracker:

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -104,7 +104,12 @@ def read_compression_summary(
             return summary
         has_is_error = "is_error" in cols
         has_source = "source" in cols
-        summary["schema_outdated"] = not has_is_error or not has_source
+        # ``schema_outdated`` flags ONLY the missing ``is_error`` column (its
+        # historical meaning: "error counts degraded to 0"). A DB that has
+        # ``is_error`` but predates ``source`` still reports accurate error
+        # counts, so it must not raise this flag — the missing-``source`` case is
+        # handled by the ``source``-filter guard below, not this flag.
+        summary["schema_outdated"] = not has_is_error
         error_expr = "SUM(is_error)" if has_is_error else "0"
 
         if source is not None and not has_source and source != "mcp":
@@ -172,9 +177,17 @@ def read_compression_summary(
 class MetricsStore:
     """SQLite-backed persistent metrics for proxy calls."""
 
-    def __init__(self, db_path: Path, max_history: int = 10000) -> None:
+    def __init__(
+        self, db_path: Path, max_history: int = 10000, *, busy_timeout_ms: int | None = None
+    ) -> None:
         self._db_path = db_path
         self._max_history = max_history
+        # Best-effort writers (the ``mms hook`` native-tool metrics path) pass a
+        # small ``busy_timeout_ms`` so a locked shared ``proxy_metrics.db`` makes
+        # initialize/record fast-fail (degrade to no row) instead of stalling the
+        # host's synchronous tool call up to the shared 3000 ms busy timeout.
+        # ``None`` keeps the long-lived-store default (5 s connect + 3000 ms busy).
+        self._busy_timeout_ms = busy_timeout_ms
         self._db: sqlite3.Connection | None = None
         # Readers and writers share ``self._lock`` defensively. Current
         # callers are all asyncio single-thread, but the connection uses
@@ -187,10 +200,18 @@ class MetricsStore:
 
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=5.0)
+        connect_timeout = (
+            self._busy_timeout_ms / 1000.0 if self._busy_timeout_ms is not None else 5.0
+        )
+        db = sqlite3.connect(str(self._db_path), check_same_thread=False, timeout=connect_timeout)
         try:
             ensure_private_db_files(self._db_path)
             tune_connection(db)
+            if self._busy_timeout_ms is not None:
+                # Override tune_connection's shared 3000 ms busy timeout so a
+                # best-effort writer fast-fails on a locked DB. Lower bound only —
+                # the DDL/INSERT below then raise quickly and the caller degrades.
+                db.execute(f"PRAGMA busy_timeout={int(self._busy_timeout_ms)}")
             db.execute(_CREATE)
             db.execute(_INDEX)
             db.commit()
@@ -345,6 +366,11 @@ class MetricsStore:
         Only non-error rows with ``cleaned_chars > 0`` contribute to
         ``avg_ratio``.  ``p95_original_chars`` is approximated by taking
         the value at the 95th percentile rank within each group.
+
+        Scoped to ``source = 'mcp'``: the tuner adjusts *proxy* compression
+        budgets for upstream MCP tools, so native built-in tool rows written by
+        ``mms hook`` (``source='hook'``) must not be aggregated here — otherwise
+        an unrelated ``builtin/Bash`` row would yield a bogus recommendation.
         """
         if self._db is None:
             return []
@@ -365,7 +391,7 @@ class MetricsStore:
                     )                                                 AS avg_ratio,
                     SUM(is_error)                                     AS error_count
                 FROM proxy_metrics
-                WHERE created_at >= ?
+                WHERE created_at >= ? AND source = 'mcp'
                 GROUP BY server, tool
                 """,
                 (cutoff,),
@@ -377,11 +403,11 @@ class MetricsStore:
                 p95_row = self._db.execute(
                     """
                     SELECT original_chars FROM proxy_metrics
-                    WHERE server = ? AND tool = ? AND created_at >= ?
+                    WHERE server = ? AND tool = ? AND created_at >= ? AND source = 'mcp'
                     ORDER BY original_chars ASC
                     LIMIT 1 OFFSET MAX(0, CAST(
                         (SELECT COUNT(*) FROM proxy_metrics
-                         WHERE server = ? AND tool = ? AND created_at >= ?)
+                         WHERE server = ? AND tool = ? AND created_at >= ? AND source = 'mcp')
                         * 0.95 AS INTEGER) - 1)
                     """,
                     (server, tool, cutoff, server, tool, cutoff),
@@ -391,7 +417,7 @@ class MetricsStore:
                     """
                     SELECT compression_strategy FROM proxy_metrics
                     WHERE server = ? AND tool = ? AND created_at >= ?
-                        AND compression_strategy IS NOT NULL
+                        AND compression_strategy IS NOT NULL AND source = 'mcp'
                     GROUP BY compression_strategy
                     ORDER BY COUNT(*) DESC
                     LIMIT 1
@@ -433,7 +459,13 @@ class MetricsStore:
         if self._db is None:
             return empty
         cutoff = time.time() - since_seconds
-        where = "created_at >= ? AND compression_strategy LIKE '%passthrough_on_error'"
+        # ``source = 'mcp'``: progressive delivery is a proxy-only path; native
+        # built-in (``source='hook'``) rows never carry this strategy, but scope
+        # explicitly so the count can't drift if that ever changes.
+        where = (
+            "created_at >= ? AND source = 'mcp' "
+            "AND compression_strategy LIKE '%passthrough_on_error'"
+        )
         params: list = [cutoff]
         if tool is not None:
             where += " AND tool = ?"
@@ -470,11 +502,15 @@ class MetricsStore:
         cutoff = time.time() - since_seconds
         placeholders = ",".join("?" for _ in error_categories) or "NULL"
         with self._lock:
+            # ``source = 'mcp'``: the exposure health filter (#465) gauges
+            # upstream tool health; native built-in (``source='hook'``) rows must
+            # not enter the per-(server, tool) call/error counts.
             rows = self._db.execute(
                 "SELECT server, tool, COUNT(*), "
                 "SUM(CASE WHEN is_error = 1 AND error_category IN "
                 f"({placeholders}) THEN 1 ELSE 0 END) "
-                "FROM proxy_metrics WHERE created_at >= ? GROUP BY server, tool",
+                "FROM proxy_metrics WHERE created_at >= ? AND source = 'mcp' "
+                "GROUP BY server, tool",
                 (*error_categories, cutoff),
             ).fetchall()
         return {(r[0], r[1]): (r[2], r[3] or 0) for r in rows}

--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -48,7 +48,9 @@ def _saved_ratio(original: int, compressed: int) -> float:
     return round(1.0 - (compressed / original), 4)
 
 
-def read_compression_summary(db_path: Path, tool: str | None = None) -> dict[str, object]:
+def read_compression_summary(
+    db_path: Path, tool: str | None = None, source: str | None = None
+) -> dict[str, object]:
     """Aggregate per-``(server, tool)`` compression stats read-only from disk.
 
     Unlike :meth:`MetricsStore.initialize`, this NEVER creates or migrates the
@@ -65,7 +67,11 @@ def read_compression_summary(db_path: Path, tool: str | None = None) -> dict[str
     which case ``error_count`` degrades to ``0`` rather than crashing.
 
     The optional ``tool`` filter matches the raw tool name, so it can span
-    multiple servers that expose a same-named tool.
+    multiple servers that expose a same-named tool. The optional ``source``
+    filter selects a provenance (``'mcp'`` proxied calls vs. ``'hook'`` native
+    built-in tools). On a pre-``source`` DB the column is absent: a request for
+    any source other than the legacy ``'mcp'`` default returns an empty (but
+    ``available``) summary, since no row can carry that source.
     """
     resolved = db_path.expanduser().resolve()
     summary: dict[str, object] = {
@@ -97,14 +103,26 @@ def read_compression_summary(db_path: Path, tool: str | None = None) -> dict[str
             # means the file exists but isn't a recognizable metrics DB.
             return summary
         has_is_error = "is_error" in cols
-        summary["schema_outdated"] = not has_is_error
+        has_source = "source" in cols
+        summary["schema_outdated"] = not has_is_error or not has_source
         error_expr = "SUM(is_error)" if has_is_error else "0"
 
+        if source is not None and not has_source and source != "mcp":
+            # Pre-``source`` DB: every row is the legacy ``'mcp'`` default, so a
+            # request for any other provenance matches nothing. Report an empty
+            # but available summary rather than over-counting every legacy row.
+            summary["available"] = True
+            return summary
+
+        conditions: list[str] = []
         params: list[object] = []
-        where = ""
         if tool is not None:
-            where = " WHERE tool = ?"
+            conditions.append("tool = ?")
             params.append(tool)
+        if source is not None and has_source:
+            conditions.append("source = ?")
+            params.append(source)
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
         rows = db.execute(
             "SELECT server, tool, COUNT(*), SUM(original_chars), "
             f"SUM(compressed_chars), {error_expr} "
@@ -235,6 +253,10 @@ class MetricsStore:
             "error_message": (
                 "ALTER TABLE proxy_metrics ADD COLUMN error_message TEXT DEFAULT NULL"
             ),
+            # Provenance: pre-existing rows are all proxied MCP calls, so the
+            # backfill default is ``'mcp'``; ``mms hook`` writes ``'hook'`` for
+            # native built-in tools. NOT NULL + DEFAULT keeps old rows readable.
+            "source": "ALTER TABLE proxy_metrics ADD COLUMN source TEXT NOT NULL DEFAULT 'mcp'",
         }
         for col, ddl in migrations.items():
             if col not in existing:
@@ -271,8 +293,8 @@ class MetricsStore:
                 "compression_strategy, ratio_violation, scorer_fallback, "
                 "index_ok, index_error, chunks_indexed, "
                 "extract_ok, extract_error, "
-                "surfacing_on_progressive_ok, surface_error, created_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "surfacing_on_progressive_ok, surface_error, source, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     metrics.server,
                     metrics.tool,
@@ -294,6 +316,7 @@ class MetricsStore:
                     metrics.extract_error,
                     _tristate(metrics.surfacing_on_progressive_ok),
                     metrics.surface_error,
+                    metrics.source,
                     now,
                 ),
             )

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -32,6 +32,7 @@ from memtomem_stm.cli.hook_cmd import (
     _daemon_enabled,
     _extract_surfaced_block,
     _orchestrate,
+    _record_hook_metrics,
     _run_hook,
     _tool_response_to_text,
     maybe_compress_builtin,
@@ -461,6 +462,83 @@ def test_compress_never_raises(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr("memtomem_stm.proxy.compression.TruncateCompressor", _Boom)
     assert maybe_compress_builtin(_bash_payload({"stdout": _BIG_STDOUT}), _CFG) is None
+
+
+# ── native-tool metrics (A1 — proxy_metrics.db row with source='hook') ───────
+
+
+def _metrics_config(tmp_path: Path, *, enabled: bool = True):
+    """Minimal duck-typed STMConfig for ``_record_hook_metrics`` — only the two
+    attributes it reads, so no env/file/frozen-model coupling."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        hook=SimpleNamespace(metrics_enabled=enabled),
+        proxy=SimpleNamespace(
+            metrics=SimpleNamespace(db_path=tmp_path / "metrics.db", max_history=10000)
+        ),
+    )
+
+
+def test_record_hook_metrics_writes_source_hook_row(tmp_path: Path):
+    from memtomem_stm.proxy.metrics_store import read_compression_summary
+
+    cfg = _metrics_config(tmp_path)
+    updated = {"stdout": f"{_COMPRESS_SENTINEL}\nshort", "stderr": ""}
+    _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), updated, _BLOCK, cfg)
+
+    summary = read_compression_summary(tmp_path / "metrics.db", source="hook")
+    assert summary["available"] is True
+    assert summary["total_calls"] == 1
+    row = summary["by_tool"][0]
+    assert (row["server"], row["tool"]) == ("builtin", "Bash")
+    assert row["original_chars"] == len(_BIG_STDOUT)
+    assert row["compressed_chars"] == len(f"{_COMPRESS_SENTINEL}\nshort")
+
+
+def test_record_hook_metrics_no_compression_original_equals_compressed(tmp_path: Path):
+    from memtomem_stm.proxy.metrics_store import read_compression_summary
+
+    cfg = _metrics_config(tmp_path)
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/x"},
+        "tool_response": {"content": "y" * 4000},
+    }
+    # Both stages no-op (Read is never compressed; no surfaced context).
+    _record_hook_metrics(payload, None, None, cfg)
+
+    row = read_compression_summary(tmp_path / "metrics.db", source="hook")["by_tool"][0]
+    assert row["tool"] == "Read"
+    assert row["original_chars"] == 4000
+    assert row["compressed_chars"] == 4000
+    assert row["saved_ratio"] == 0.0
+
+
+def test_record_hook_metrics_disabled_writes_nothing(tmp_path: Path):
+    cfg = _metrics_config(tmp_path, enabled=False)
+    _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), None, None, cfg)
+    assert not (tmp_path / "metrics.db").exists()  # store never opened
+
+
+def test_record_hook_metrics_skips_empty_output(tmp_path: Path):
+    # A result that flattens to nothing carries no spend to record.
+    cfg = _metrics_config(tmp_path)
+    _record_hook_metrics({"hook_event_name": "PostToolUse", "tool_name": "Bash"}, None, None, cfg)
+    assert not (tmp_path / "metrics.db").exists()
+
+
+def test_record_hook_metrics_never_raises_on_bad_store(tmp_path: Path):
+    from types import SimpleNamespace
+
+    # db_path is a directory → MetricsStore.initialize() raises; must be swallowed
+    # so metrics can never disrupt the host.
+    bad = SimpleNamespace(
+        hook=SimpleNamespace(metrics_enabled=True),
+        proxy=SimpleNamespace(metrics=SimpleNamespace(db_path=tmp_path, max_history=10000)),
+    )
+    _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), None, None, bad)
 
 
 # ── bounded surfacing payload + merge builder ────────────────────────────────

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -541,6 +541,38 @@ def test_record_hook_metrics_never_raises_on_bad_store(tmp_path: Path):
     _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), None, None, bad)
 
 
+def test_record_hook_metrics_degrades_quickly_when_db_locked(tmp_path: Path):
+    import sqlite3
+    import time
+
+    from memtomem_stm.proxy.metrics_store import MetricsStore, read_compression_summary
+
+    db = tmp_path / "metrics.db"
+    # Create the schema first so the lock contention is purely on the write.
+    seed = MetricsStore(db)
+    seed.initialize()
+    seed.close()
+
+    # Hold an EXCLUSIVE write lock from another connection so the hook's writer
+    # contends. Its 250 ms busy timeout must make it fail fast (no row, no raise,
+    # no multi-second stall up to the shared 3000 ms budget).
+    blocker = sqlite3.connect(str(db), timeout=0.1)
+    blocker.execute("BEGIN EXCLUSIVE")
+    try:
+        cfg = _metrics_config(tmp_path)  # db_path == db
+        start = time.monotonic()
+        _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), None, None, cfg)
+        elapsed = time.monotonic() - start
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    # Fast-fail: comfortably under the shared 3000 ms busy timeout (generous
+    # bound to stay non-flaky in CI) and nothing persisted.
+    assert elapsed < 2.0
+    assert read_compression_summary(db, source="hook")["total_calls"] == 0
+
+
 # ── bounded surfacing payload + merge builder ────────────────────────────────
 
 

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -249,6 +249,75 @@ class TestRecordPersistsNewFields:
         )
         assert rows == {"builtin": "hook", "lf": "mcp"}
 
+    def test_get_tool_profiles_excludes_hook_source(self, store):
+        # The tuner adjusts proxy compression budgets for upstream tools; a
+        # native-tool hook row (source='hook') must never surface as a profile,
+        # else the tuner emits a bogus 'builtin/Bash compression=truncate' rec.
+        store.record(
+            CallMetrics(
+                server="lf",
+                tool="search",
+                original_chars=1000,
+                compressed_chars=400,
+                cleaned_chars=900,
+                compression_strategy="truncate",
+            )
+        )
+        store.record(
+            CallMetrics(
+                server="builtin",
+                tool="Bash",
+                original_chars=900,
+                compressed_chars=300,
+                cleaned_chars=900,
+                compression_strategy="truncate",
+                source="hook",
+            )
+        )
+        profiles = store.get_tool_profiles(since_seconds=3600.0)
+        keys = {(p["server"], p["tool"]) for p in profiles}
+        assert ("lf", "search") in keys
+        assert ("builtin", "Bash") not in keys
+
+    def test_error_stats_exclude_hook_source(self, store):
+        # The exposure health filter (#465) is proxy analytics; hook rows must
+        # not enter its per-(server, tool) call/error counts.
+        store.record(CallMetrics(server="gh", tool="search", original_chars=10, compressed_chars=5))
+        store.record(
+            CallMetrics(
+                server="builtin",
+                tool="Bash",
+                original_chars=10,
+                compressed_chars=5,
+                source="hook",
+            )
+        )
+        err = store.get_tool_error_stats(since_seconds=3600.0, error_categories=("upstream_error",))
+        assert ("builtin", "Bash") not in err
+        assert ("gh", "search") in err
+
+
+class TestBusyTimeout:
+    """The hook passes a small ``busy_timeout_ms`` so a locked shared DB
+    fast-fails instead of stalling the host's tool call."""
+
+    def test_override_is_applied(self, tmp_path):
+        store = MetricsStore(tmp_path / "m.db", busy_timeout_ms=250)
+        store.initialize()
+        try:
+            assert store._db.execute("PRAGMA busy_timeout").fetchone()[0] == 250
+        finally:
+            store.close()
+
+    def test_default_keeps_shared_timeout(self, tmp_path):
+        store = MetricsStore(tmp_path / "m.db")
+        store.initialize()
+        try:
+            # tune_connection's shared BUSY_TIMEOUT_MS (3000) is untouched.
+            assert store._db.execute("PRAGMA busy_timeout").fetchone()[0] == 3000
+        finally:
+            store.close()
+
 
 class TestReadPathConcurrency:
     """Cross-thread reader/writer safety.
@@ -467,6 +536,35 @@ class TestReadCompressionSummary:
         # 'mcp' on a legacy DB still sees the legacy rows (all implicitly mcp).
         mcp = read_compression_summary(db_path, source="mcp")
         assert mcp["total_calls"] == 1
+
+    def test_schema_outdated_false_when_only_source_missing(self, tmp_path):
+        # A DB that has ``is_error`` but predates ``source``: error counts are
+        # available, so ``schema_outdated`` (which flags is_error only) must be
+        # False — otherwise the CLI shows a misleading "error counts" warning.
+        db_path = tmp_path / "post_is_error_pre_source.db"
+        db = sqlite3.connect(db_path)
+        db.execute(
+            "CREATE TABLE proxy_metrics ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, server TEXT, tool TEXT, "
+            "original_chars INTEGER, compressed_chars INTEGER, "
+            "cleaned_chars INTEGER DEFAULT 0, created_at REAL, "
+            "is_error INTEGER NOT NULL DEFAULT 0)"
+        )
+        db.execute(
+            "INSERT INTO proxy_metrics "
+            "(server, tool, original_chars, compressed_chars, created_at, is_error) "
+            "VALUES ('s', 't', 100, 40, 0, 0)"
+        )
+        db.commit()
+        db.close()
+
+        summary = read_compression_summary(db_path)
+        assert summary["available"] is True
+        assert summary["schema_outdated"] is False  # is_error present → up to date
+        assert summary["total_calls"] == 1
+        # source filter still degrades correctly without the column:
+        assert read_compression_summary(db_path, source="hook")["total_calls"] == 0
+        assert read_compression_summary(db_path, source="mcp")["total_calls"] == 1
 
     def test_missing_db_is_unavailable_and_not_created(self, tmp_path):
         db_path = tmp_path / "does_not_exist.db"

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -27,6 +27,7 @@ NEW_COLUMNS = {
     "extract_error",
     "surfacing_on_progressive_ok",
     "surface_error",
+    "source",
 }
 
 
@@ -230,6 +231,24 @@ class TestRecordPersistsNewFields:
         assert failures == 1
         assert unobserved == 1
 
+    def test_source_defaults_to_mcp_and_persists_hook(self, store):
+        # Proxied calls omit ``source`` → stored as 'mcp'; ``mms hook`` passes
+        # 'hook' so native built-in tool spend is separable in the shared store.
+        store.record(CallMetrics(server="lf", tool="search", original_chars=1, compressed_chars=1))
+        store.record(
+            CallMetrics(
+                server="builtin",
+                tool="Bash",
+                original_chars=900,
+                compressed_chars=300,
+                source="hook",
+            )
+        )
+        rows = dict(
+            store._db.execute("SELECT server, source FROM proxy_metrics ORDER BY server").fetchall()
+        )
+        assert rows == {"builtin": "hook", "lf": "mcp"}
+
 
 class TestReadPathConcurrency:
     """Cross-thread reader/writer safety.
@@ -373,6 +392,81 @@ class TestReadCompressionSummary:
 
         assert summary["total_calls"] == 2
         assert {r["tool"] for r in summary["by_tool"]} == {"search"}
+
+    def _seed_mixed_sources(self, db_path):
+        store = MetricsStore(db_path)
+        store.initialize()
+        try:
+            store.record(
+                CallMetrics(server="lf", tool="search", original_chars=1000, compressed_chars=400)
+            )
+            store.record(
+                CallMetrics(
+                    server="builtin",
+                    tool="Bash",
+                    original_chars=900,
+                    compressed_chars=300,
+                    source="hook",
+                )
+            )
+            store.record(
+                CallMetrics(
+                    server="builtin",
+                    tool="Read",
+                    original_chars=5000,
+                    compressed_chars=5000,
+                    source="hook",
+                )
+            )
+        finally:
+            store.close()
+
+    def test_source_filter(self, tmp_path):
+        db_path = tmp_path / "metrics.db"
+        self._seed_mixed_sources(db_path)
+
+        hook = read_compression_summary(db_path, source="hook")
+        assert hook["total_calls"] == 2
+        assert {r["server"] for r in hook["by_tool"]} == {"builtin"}
+        assert hook["total_original_chars"] == 5900
+
+        mcp = read_compression_summary(db_path, source="mcp")
+        assert mcp["total_calls"] == 1
+        assert {r["tool"] for r in mcp["by_tool"]} == {"search"}
+
+        # tool + source compose
+        bash = read_compression_summary(db_path, tool="Bash", source="hook")
+        assert bash["total_calls"] == 1
+        assert bash["by_tool"][0]["saved_ratio"] == round(1 - 300 / 900, 4)
+
+    def test_source_filter_on_pre_source_db_returns_empty_for_hook(self, tmp_path):
+        # A DB created before the ``source`` column existed has only legacy
+        # ('mcp') rows. ``source='hook'`` must report empty-but-available rather
+        # than over-counting every legacy row (which a dropped guard would do).
+        db_path = tmp_path / "legacy.db"
+        db = sqlite3.connect(db_path)
+        db.execute(
+            "CREATE TABLE proxy_metrics ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, server TEXT, tool TEXT, "
+            "original_chars INTEGER, compressed_chars INTEGER, "
+            "cleaned_chars INTEGER DEFAULT 0, created_at REAL)"
+        )
+        db.execute(
+            "INSERT INTO proxy_metrics (server, tool, original_chars, compressed_chars, created_at) "
+            "VALUES ('s', 't', 100, 40, 0)"
+        )
+        db.commit()
+        db.close()
+
+        hook = read_compression_summary(db_path, source="hook")
+        assert hook["available"] is True
+        assert hook["schema_outdated"] is True
+        assert hook["total_calls"] == 0
+        assert hook["by_tool"] == []
+
+        # 'mcp' on a legacy DB still sees the legacy rows (all implicitly mcp).
+        mcp = read_compression_summary(db_path, source="mcp")
+        assert mcp["total_calls"] == 1
 
     def test_missing_db_is_unavailable_and_not_created(self, tmp_path):
         db_path = tmp_path / "does_not_exist.db"


### PR DESCRIPTION
## Why

Native/built-in tool calls (`Read` / `Bash` / `Grep` / `Glob` / `WebFetch`)
execute inside the host and **never reach the MCP proxy**, so their token spend
is invisible to STM — `proxy_metrics.db` only ever held proxied MCP rows. A
quick measurement over this repo's transcripts found native-tool output
dominates context (Read alone ≈ 1.5M tokens across 58 sessions) yet none of it
is recorded. This is the first step of bringing native tools under STM (the
`mms hook` track): **make the spend measurable** before deciding what to
compress/cache.

## What

`mms hook` now records one per-call row for the native tool it sees.

- **`CallMetrics.source`** — `"mcp"` (default, proxied calls written by
  `ProxyManager`) vs `"hook"` (native built-ins). `MetricsStore._migrate` adds an
  additive `source TEXT NOT NULL DEFAULT 'mcp'` column, so existing rows backfill
  to `mcp` and existing readers (which `SELECT` named columns) are unaffected.
- **`_record_hook_metrics`** (in `_orchestrate`) records `server="builtin"`, the
  tool name, and `original` / `compressed` / `surfaced` char counts. **Sizes
  only** — never `tool_input` and never output text — mirroring the hook's
  existing no-query-text privacy posture (a `Bash` command may carry secrets). It
  **never raises**: any failure degrades to "no row" so metrics can't disrupt the
  host (consistent with the hook's always-exit-0 contract).
- **`HookConfig.metrics_enabled`** (default `True`) gates it, independent of
  `proxy.metrics.enabled` so a hook-only deployment (proxy disabled) still
  measures. Reuses `proxy.metrics.db_path` / `max_history`. Opt out with
  `MEMTOMEM_STM_HOOK__METRICS_ENABLED=0`.
- **`mms stats --source <mcp|hook>`** — `read_compression_summary` gains a
  `source` filter so native-tool spend is separable from proxied. On a
  pre-`source` DB the column is absent: a request for a non-`mcp` source reports
  empty-but-`available` rather than over-counting every legacy row.

## Behavior change

Additive observability only — no model-visible change. When the hook is
registered, every native tool call it sees now writes a sizes-only row into the
shared `proxy_metrics.db` (a short-lived store open per call; bounded by
`max_history`). Disable via `metrics_enabled`.

## Tests

`tests/test_metrics_store.py`: `source` migration (fresh / pre-migration /
idempotent via `NEW_COLUMNS`), persist round-trip, `--source` filter compose with
`--tool`, and the pre-source-DB empty-for-hook degrade. `tests/cli/test_hook_cmd.py`:
`_record_hook_metrics` positive (Bash + compression), no-compression
(`original == compressed`), disabled (no DB created), empty-output skip, and
never-raises-on-bad-store. Full suite green (3624 passed); `ruff` + `mypy` clean.

End-to-end smoke (metrics → `/tmp`, real DB untouched): a `Bash` PostToolUse
payload produced `mms stats --source hook` → `total_calls=1, ('builtin','Bash')`.

Note: stacks cleanly with #511 (sentinel-prefix fix); they touch different
functions in `hook_cmd.py`. Independent of it — A1 records the call regardless of
whether compression fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
