### PR TITLE
test(fixtures): add B0 host hook-contract golden fixtures for Cursor/Kimi/Codex

### DIFF
--- a/tests/fixtures/hooks/README.md
+++ b/tests/fixtures/hooks/README.md
@@ -1,0 +1,52 @@
+# Host hook contract fixtures (`tests/fixtures/hooks/`)
+
+Golden inbound-payload + expected-output fixtures for the per-host hook adapters
+(Track B, plan `mcp-serene-pinwheel.md`). Each `<host>/` directory captures, for one host:
+
+- `inbound_<tool>_posttooluse.json` — a realistic **inbound** PostToolUse payload the host
+  writes to the hook subprocess on stdin.
+- `expected_surfacing_*.{json,txt}` — the **correct stdout** `mms hook` should emit to inject
+  surfaced memories (the *surfacing* channel) for that host's contract.
+
+These are the golden files for the B1 `HostHookAdapter` `parse()` / `render()` tests
+(`inbound → CanonicalHookCall`, and a canonical surfaced block `→` host-shaped stdout).
+
+## Provenance — B0 (verified 2026-06-23)
+
+Field names, event names, output shapes, and config locations here are pinned to current
+official docs and adversarially re-verified. Full report + citations + corrected capability
+matrix: `docs/reports/b0-host-hook-contract-verification-2026-06-23.md`.
+
+In each fixture, **field _names_ are doc-verified; field _values_ are illustrative** (test
+data), except where a value is itself documented verbatim (e.g. Cursor's `tool_name: "Shell"`
+example). Per-host caveats and the verified/unverified marks live in each `<host>/README.md`.
+
+## Scope — what these fixtures do and do NOT cover
+
+- **Surfacing only.** B0 verified that native-tool output **compression (replacement) ports
+  to NO non-Claude host** (Cursor `updated_mcp_tool_output` = MCP-only; Kimi = no field;
+  Codex `updatedMCPToolOutput` = "parsed but not supported yet" + MCP-only). So no host
+  fixture emits an output-replace field — compression stays Claude-Code-only.
+- **Canonical surfaced block (shared across hosts).** All three `expected_surfacing_*`
+  fixtures carry the **same** surfaced-memories text, so a B1 render test can feed one
+  canonical block and assert each host wraps it correctly. The canonical block is:
+
+  ```
+  Relevant memories (memtomem LTM):
+  - Rotate the service token with `mms rotate`; do not edit config.toml by hand.
+  - Point integration-test feedback_db_path at /tmp, never ~/.memtomem.
+  ```
+
+  (This mirrors the content `mms hook` puts in Claude Code's
+  `hookSpecificOutput.additionalContext` — the `<surfaced-memories>` delimiters are sliced
+  off by `SurfacingFormatter`, so the channel carries just the memories.)
+
+## Hosts present / absent
+
+| Host | Status | Surfacing channel |
+|---|---|---|
+| `cursor/` | ✅ fixtured | flat `additional_context` (string) — **runtime no-op today, staff-confirmed bug** |
+| `kimi/` | ✅ fixtured | raw **stdout** text on exit 0 (not a JSON key) |
+| `codex/` | ✅ fixtured | `hookSpecificOutput.additionalContext` (same shape as Claude) |
+| **Claude Code** | not here | in-code baseline — covered by `tests/cli/test_hook_cmd.py` |
+| **Antigravity** | ❌ **deliberately absent** | unfixturable: PostToolUse tool-output stdin field is undocumented and the official docs are an unreadable SPA. Writing a fixture now would encode guesses (the exact risk B0 exists to prevent). Documented gap — see the B0 report. |

--- a/tests/fixtures/hooks/README.md
+++ b/tests/fixtures/hooks/README.md
@@ -14,8 +14,11 @@ These are the golden files for the B1 `HostHookAdapter` `parse()` / `render()` t
 ## Provenance — B0 (verified 2026-06-23)
 
 Field names, event names, output shapes, and config locations here are pinned to current
-official docs and adversarially re-verified. Full report + citations + corrected capability
-matrix: `docs/reports/b0-host-hook-contract-verification-2026-06-23.md`.
+official docs and adversarially re-verified (the B0 doc-verification gate). **Per-field
+citations — source URLs + verbatim quotes — live in each `<host>/README.md`.** (The full B0
+verification report, with the corrected cross-host capability matrix, is kept as a local
+working note under `docs/reports/` and is intentionally not committed — matching this repo's
+convention that `docs/reports/` holds uncommitted working artifacts.)
 
 In each fixture, **field _names_ are doc-verified; field _values_ are illustrative** (test
 data), except where a value is itself documented verbatim (e.g. Cursor's `tool_name: "Shell"`
@@ -28,18 +31,28 @@ example). Per-host caveats and the verified/unverified marks live in each `<host
   Codex `updatedMCPToolOutput` = "parsed but not supported yet" + MCP-only). So no host
   fixture emits an output-replace field — compression stays Claude-Code-only.
 - **Canonical surfaced block (shared across hosts).** All three `expected_surfacing_*`
-  fixtures carry the **same** surfaced-memories text, so a B1 render test can feed one
-  canonical block and assert each host wraps it correctly. The canonical block is:
+  fixtures carry the **byte-identical** surfaced-memories block below, so a B1 render test can
+  feed one canonical block and assert each host wraps it correctly. It mirrors what `mms hook`
+  actually places in Claude Code's `hookSpecificOutput.additionalContext`: the block is
+  **wrapped in `<surfaced-memories>…</surfaced-memories>` delimiters**, and those delimiters are
+  part of the channel content — `_extract_surfaced_block()` in
+  `src/memtomem_stm/cli/hook_cmd.py` returns the block *including* its delimiters (it slices the
+  block out of the full tool response; it does **not** strip the delimiters). The canonical
+  block is:
 
   ```
+  <surfaced-memories>
   Relevant memories (memtomem LTM):
   - Rotate the service token with `mms rotate`; do not edit config.toml by hand.
   - Point integration-test feedback_db_path at /tmp, never ~/.memtomem.
+  </surfaced-memories>
   ```
 
-  (This mirrors the content `mms hook` puts in Claude Code's
-  `hookSpecificOutput.additionalContext` — the `<surfaced-memories>` delimiters are sliced
-  off by `SurfacingFormatter`, so the channel carries just the memories.)
+  The three expected outputs carry this block byte-for-byte — Cursor/Codex as a JSON string
+  value, Kimi as literal stdout. Note: a live Kimi hook prints to stdout and so emits one
+  trailing newline *after* the block; that newline is stdout framing, not part of the block, so
+  the `.txt` fixture stores the block bytes only (no trailing newline) to keep the three
+  byte-identical. The Kimi adapter's `render()` owns that framing.
 
 ## Hosts present / absent
 

--- a/tests/fixtures/hooks/codex/README.md
+++ b/tests/fixtures/hooks/codex/README.md
@@ -1,0 +1,47 @@
+# Codex CLI hook fixtures
+
+Source: `developers.openai.com/codex/hooks` + `github.com/openai/codex/blob/main/docs/config.md`
+(verified 2026-06-23). Confidence: high (research-needs-correction — two provisional cells
+corrected; see B0 report).
+
+## Contract (verified)
+
+- **Event:** `PostToolUse` (distinct from the older `notify`, which fires only on
+  `agent-turn-complete`). Runs after Bash, apply_patch, and MCP tool calls. ⚠️ Does **not**
+  intercept WebSearch or other non-shell/non-MCP tools; only "simple" shell calls
+  (apply_patch/MCP firing is community-reported as flaky). Enabled by default
+  (`[features] hooks = false` to disable).
+- **Inbound (stdin JSON, snake_case):** `tool_name` (`Bash` / `apply_patch` /
+  `mcp__<server>__<tool>`), `tool_input`, `tool_response` (output field), `tool_use_id`,
+  `turn_id` + common fields (`session_id`, `transcript_path`, `cwd`, `hook_event_name`,
+  `model`, `permission_mode`). ✅ field list verified (no full verbatim sample in docs).
+- **Surfacing channel — `hookSpecificOutput.additionalContext`** (same shape & field name as
+  Claude Code). ✅ verified verbatim:
+  `{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"…"}}` +
+  "That additionalContext text is added as extra developer context."
+- **Output replace — does NOT port.** `updatedMCPToolOutput` exists in the schema but is
+  **"parsed but not supported yet"** AND MCP-only; native (Bash/apply_patch) has no rewrite
+  field. The only working post-tool substitution is `decision:"block"+reason`
+  (block-feedback text, not transparent rewrite). ❌ no output-replace fixture.
+- **Exit:** `0` = continue · `2` = block (reason to stderr) · other = fail-open-ish.
+- **Config:** `~/.codex/config.toml` `[hooks]` or `~/.codex/hooks.json` (+ project-level),
+  TOML; managed governance via `requirements.toml allow_managed_hooks_only`.
+
+## ⚠️ Caveats (load-bearing)
+
+1. **Plain stdout is IGNORED for PostToolUse** (unlike Kimi). Verbatim: "Plain text on stdout
+   is ignored." The stdout-as-context behavior applies only to SessionStart / UserPromptSubmit
+   / SubagentStart. → the surfacing fixture MUST use the structured `additionalContext` field,
+   never bare stdout.
+2. **Standalone (non-block) `additionalContext` is undocumented.** Every official example
+   nests `additionalContext` under `decision:"block"`. This fixture emits the **standalone
+   exit-0** shape (the natural mms-hook surfacing emission); a B1 runtime check must confirm
+   Codex honors `additionalContext` without `decision:"block"` before enabling by default.
+
+## Files
+
+- `inbound_bash_posttooluse.json` — PostToolUse payload for a Bash tool call (documented
+  field names; illustrative values).
+- `expected_surfacing_output.json` — correct surfacing emission:
+  `{ hookSpecificOutput: { hookEventName: "PostToolUse", additionalContext } }`, carrying the
+  canonical surfaced block.

--- a/tests/fixtures/hooks/codex/expected_surfacing_output.json
+++ b/tests/fixtures/hooks/codex/expected_surfacing_output.json
@@ -1,0 +1,6 @@
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "Relevant memories (memtomem LTM):\n- Rotate the service token with `mms rotate`; do not edit config.toml by hand.\n- Point integration-test feedback_db_path at /tmp, never ~/.memtomem."
+  }
+}

--- a/tests/fixtures/hooks/codex/expected_surfacing_output.json
+++ b/tests/fixtures/hooks/codex/expected_surfacing_output.json
@@ -1,6 +1,6 @@
 {
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
-    "additionalContext": "Relevant memories (memtomem LTM):\n- Rotate the service token with `mms rotate`; do not edit config.toml by hand.\n- Point integration-test feedback_db_path at /tmp, never ~/.memtomem."
+    "additionalContext": "<surfaced-memories>\nRelevant memories (memtomem LTM):\n- Rotate the service token with `mms rotate`; do not edit config.toml by hand.\n- Point integration-test feedback_db_path at /tmp, never ~/.memtomem.\n</surfaced-memories>"
   }
 }

--- a/tests/fixtures/hooks/codex/inbound_bash_posttooluse.json
+++ b/tests/fixtures/hooks/codex/inbound_bash_posttooluse.json
@@ -1,0 +1,13 @@
+{
+  "hook_event_name": "PostToolUse",
+  "session_id": "sess_demo",
+  "transcript_path": "/tmp/codex/transcript.jsonl",
+  "cwd": "/project",
+  "turn_id": "turn_1",
+  "tool_name": "Bash",
+  "tool_use_id": "call_demo",
+  "tool_input": { "command": "pytest -q" },
+  "tool_response": "12 passed in 3.4s",
+  "model": "demo-model",
+  "permission_mode": "default"
+}

--- a/tests/fixtures/hooks/cursor/README.md
+++ b/tests/fixtures/hooks/cursor/README.md
@@ -1,0 +1,43 @@
+# Cursor hook fixtures
+
+Source: `cursor.com/docs/hooks` (verified 2026-06-23, schema `version: 1`). Confidence: high.
+
+## Contract (verified)
+
+- **Event:** `postToolUse` — generic command-based hook, fires for ALL tools
+  (Shell/Read/Write/MCP). Communicates "over stdio using JSON in both directions".
+- **Inbound (stdin JSON):** `tool_name` (snake_case key; value capitalized — `"Shell"`,
+  `"Read"`, `"Write"`), `tool_input` (object), `tool_output` (**JSON-stringified string**),
+  `tool_use_id`, `cwd`, `duration` (ms) + base fields. ✅ verified verbatim.
+- **Output (stdout JSON) — FLAT top-level keys, snake_case** (NOT nested under
+  `hookSpecificOutput`):
+  - `additional_context` (string) — surfacing channel. ✅ field/type/scope verified verbatim
+    ("Extra context injected into the conversation after the tool result"; not MCP-scoped).
+  - `updated_mcp_tool_output` (object) — output replace, **MCP-tools ONLY** ("For MCP tools
+    only: replaces the tool output seen by the model"). ❌ no native-tool equivalent →
+    **omitted from these fixtures** (compression does not port).
+- **Exit:** `0` = use JSON output · `2` = block (== permission deny) · other = fail-open
+  pass-through.
+- **Config:** `~/.cursor/hooks.json` or `<proj>/.cursor/hooks.json`, JSON
+  `{version:1, hooks:{<event>:[{command}]}}`.
+
+## ⚠️ Runtime caveat (load-bearing)
+
+`additional_context` is **documented but currently a runtime no-op** — staff-confirmed bug
+(Cursor forum, Mohit Jain 2026-03-24): the value is "accepted and validated by the hook
+runner... but never actually injected into the model's conversation context." Reported
+v2.6.20 → still broken v3.7.36 (Jun 2026). The fixture encodes the **documented-correct
+contract**; a B1 runtime check must confirm injection actually works before enabling Cursor
+surfacing by default. Track: forum thread `t/155689`.
+
+## Unverified
+
+stdout strictness for interleaved non-JSON text; `additional_context` on `postToolUseFailure`;
+merge-vs-replace semantics of `updated_mcp_tool_output`; full native tool-name enumeration.
+
+## Files
+
+- `inbound_shell_posttooluse.json` — verbatim-shaped Shell PostToolUse payload (the docs'
+  own example, plus base fields).
+- `expected_surfacing_output.json` — correct surfacing emission: `{ additional_context }`,
+  flat top-level, carrying the canonical surfaced block.

--- a/tests/fixtures/hooks/cursor/expected_surfacing_output.json
+++ b/tests/fixtures/hooks/cursor/expected_surfacing_output.json
@@ -1,0 +1,3 @@
+{
+  "additional_context": "Relevant memories (memtomem LTM):\n- Rotate the service token with `mms rotate`; do not edit config.toml by hand.\n- Point integration-test feedback_db_path at /tmp, never ~/.memtomem."
+}

--- a/tests/fixtures/hooks/cursor/expected_surfacing_output.json
+++ b/tests/fixtures/hooks/cursor/expected_surfacing_output.json
@@ -1,3 +1,3 @@
 {
-  "additional_context": "Relevant memories (memtomem LTM):\n- Rotate the service token with `mms rotate`; do not edit config.toml by hand.\n- Point integration-test feedback_db_path at /tmp, never ~/.memtomem."
+  "additional_context": "<surfaced-memories>\nRelevant memories (memtomem LTM):\n- Rotate the service token with `mms rotate`; do not edit config.toml by hand.\n- Point integration-test feedback_db_path at /tmp, never ~/.memtomem.\n</surfaced-memories>"
 }

--- a/tests/fixtures/hooks/cursor/inbound_shell_posttooluse.json
+++ b/tests/fixtures/hooks/cursor/inbound_shell_posttooluse.json
@@ -1,0 +1,14 @@
+{
+  "hook_event_name": "postToolUse",
+  "tool_name": "Shell",
+  "tool_input": { "command": "npm test" },
+  "tool_output": "{\"exitCode\":0,\"stdout\":\"All tests passed\"}",
+  "tool_use_id": "abc123",
+  "cwd": "/project",
+  "duration": 5432,
+  "conversation_id": "conv_demo",
+  "generation_id": "gen_demo",
+  "model": "demo-model",
+  "cursor_version": "3.7.36",
+  "workspace_roots": ["/project"]
+}

--- a/tests/fixtures/hooks/kimi/README.md
+++ b/tests/fixtures/hooks/kimi/README.md
@@ -34,6 +34,9 @@ assume arbitrary text is injected verbatim).
 
 - `inbound_shell_posttooluse.json` — PostToolUse payload (documented field names; `Shell`
   tool value; illustrative field values).
-- `expected_surfacing_stdout.txt` — the **literal stdout** (+ exit 0) the hook emits to
-  surface the canonical block. NOTE: the channel is plain stdout, not a JSON wrapper — so the
-  expected artifact is `.txt`, byte-for-byte what the process should print.
+- `expected_surfacing_stdout.txt` — the canonical surfaced block as **literal stdout** (the
+  hook prints it and exits 0; the channel is plain stdout, not a JSON key). The file stores the
+  block bytes only — **byte-identical** to the Cursor/Codex `additional_context` values. A live
+  hook additionally emits one trailing newline (stdout framing from `print`/`echo`); that
+  newline is not part of the canonical block, so it is omitted here to keep the three fixtures
+  byte-identical. The Kimi adapter's `render()` is responsible for that stdout framing.

--- a/tests/fixtures/hooks/kimi/README.md
+++ b/tests/fixtures/hooks/kimi/README.md
@@ -1,0 +1,39 @@
+# Kimi Code hook fixtures
+
+Source: `moonshotai.github.io/kimi-cli/en/customization/hooks` + `.../configuration/config-files`
++ repo `github.com/MoonshotAI/kimi-cli` (verified 2026-06-23). Confidence: high.
+
+## Contract (verified)
+
+- **Event:** `PostToolUse` (one of 13 lifecycle events; `PostToolUseFailure` is distinct).
+  Genuine post-tool external-command hook.
+- **Inbound (stdin JSON, snake_case):** `session_id`, `cwd`, `hook_event_name`, `tool_name`
+  (values **PascalCase** — `Shell` / `WriteFile` / `StrReplaceFile` / `ReadFile`),
+  `tool_input`, `tool_output`. ✅ field list verified (no full verbatim sample in docs).
+- **Surfacing channel — raw stdout on exit 0.** Verbatim exit-code row:
+  `| 0 | Allow | stdout content (if non-empty) is added to context |`. The hook prints the
+  surfaced block to **stdout** and exits 0 — there is **no `additionalContext` JSON key**
+  (it appears nowhere in Kimi docs). ✅ verified.
+- **Output replace — NONE.** The only structured stdout JSON is
+  `hookSpecificOutput { hookEventName, permissionDecision: "allow"|"deny",
+  permissionDecisionReason }` — an allow/deny gate, not a rewrite. ❌ no compression channel
+  (native or MCP) → no output-replace fixture.
+- **Exit:** `0` = allow (stdout → context) · `2` = block (stderr → LLM as correction) ·
+  other = allow (stderr logged only).
+- **Config:** `~/.kimi/config.toml`, TOML `[[hooks]]` array (`event`/`matcher`/`command`/`timeout`).
+  MCP at `~/.kimi/mcp.json`. ⚠️ base dir is **`~/.kimi/`**, NOT the plan's provisional
+  `~/.kimi-code/`.
+
+## Unverified
+
+Whether `PostToolUse` fires for MCP tools vs native-only; whether the exit-0 stdout inject
+must be pure JSON or arbitrary text injected verbatim (strictness unspecified — these fixtures
+assume arbitrary text is injected verbatim).
+
+## Files
+
+- `inbound_shell_posttooluse.json` — PostToolUse payload (documented field names; `Shell`
+  tool value; illustrative field values).
+- `expected_surfacing_stdout.txt` — the **literal stdout** (+ exit 0) the hook emits to
+  surface the canonical block. NOTE: the channel is plain stdout, not a JSON wrapper — so the
+  expected artifact is `.txt`, byte-for-byte what the process should print.

--- a/tests/fixtures/hooks/kimi/expected_surfacing_stdout.txt
+++ b/tests/fixtures/hooks/kimi/expected_surfacing_stdout.txt
@@ -1,0 +1,3 @@
+Relevant memories (memtomem LTM):
+- Rotate the service token with `mms rotate`; do not edit config.toml by hand.
+- Point integration-test feedback_db_path at /tmp, never ~/.memtomem.

--- a/tests/fixtures/hooks/kimi/expected_surfacing_stdout.txt
+++ b/tests/fixtures/hooks/kimi/expected_surfacing_stdout.txt
@@ -1,3 +1,5 @@
+<surfaced-memories>
 Relevant memories (memtomem LTM):
 - Rotate the service token with `mms rotate`; do not edit config.toml by hand.
 - Point integration-test feedback_db_path at /tmp, never ~/.memtomem.
+</surfaced-memories>

--- a/tests/fixtures/hooks/kimi/inbound_shell_posttooluse.json
+++ b/tests/fixtures/hooks/kimi/inbound_shell_posttooluse.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "PostToolUse",
+  "session_id": "sess_demo",
+  "cwd": "/project",
+  "tool_name": "Shell",
+  "tool_input": { "command": "pytest -q" },
+  "tool_output": "12 passed in 3.4s"
+}


### PR DESCRIPTION
## What

Adds golden hook-contract fixtures under `tests/fixtures/hooks/` for three
non-Claude MCP hosts — **Cursor, Kimi Code, Codex CLI**. These are the data
deliverable of the Track B **B0 doc-verification gate**: each host's PostToolUse
hook contract was pinned to current official docs (research + independent
adversarial verification) and captured here so the upcoming `HostHookAdapter`
`parse()` / `render()` tests have golden inputs/outputs to assert against.

Pure data + docs — no code, no `src/` change, no behavior change.

## Layout

```
tests/fixtures/hooks/
├── README.md                 # set overview, provenance, canonical block, Antigravity gap
├── cursor/  {README, inbound_shell_posttooluse.json, expected_surfacing_output.json}
├── kimi/    {README, inbound_shell_posttooluse.json, expected_surfacing_stdout.txt}
└── codex/   {README, inbound_bash_posttooluse.json, expected_surfacing_output.json}
```

Each host dir has: an inbound PostToolUse payload, the expected surfacing
emission, and a README with verbatim citations + verified/unverified marks.

## Key design decisions (preempting review questions)

- **One canonical surfaced block, three host wrappings.** All three
  `expected_surfacing_*` artifacts carry a **byte-identical** surfaced-memories
  block (verified), so a future `render()` test can feed one canonical input and
  assert each host's shape:
  - Cursor → flat `additional_context` (string)
  - Kimi → raw **stdout** text on exit 0 (not a JSON key)
  - Codex → `hookSpecificOutput.additionalContext`
- **Surfacing-only — no output-replace fixture.** B0 found native-tool output
  *replacement* (compression) ports to **no** non-Claude host: Cursor
  `updated_mcp_tool_output` is MCP-only; Kimi has no replace field (allow/deny
  gate only); Codex `updatedMCPToolOutput` is "parsed but not supported yet" +
  MCP-only. So compression stays Claude-Code-only and no fixture emits a replace
  field.
- **Antigravity deliberately absent.** Its PostToolUse tool-output stdin field is
  undocumented and the official docs are a JS-rendered SPA unreadable to fetchers;
  a fixture would encode guesses (the exact risk B0 exists to prevent). Recorded
  as a documented gap in the top-level README.
- **Honesty marks.** Field *names* are doc-verified; field *values* are
  illustrative (noted per README). Runtime caveats are flagged for B1 to
  re-verify: Cursor's `additional_context` is a **runtime no-op today**
  (staff-confirmed bug); Codex ignores plain stdout for PostToolUse and its
  standalone (non-`decision:block`) `additionalContext` is undocumented.

## Not in this PR

- No adapter code — that is B1 (`HostHookAdapter` parse/render). These fixtures
  are the inputs B1 will consume; no test references them yet.
- The full B0 verification report (corrected capability matrix + all citations)
  lives in a local working note, not this PR.

## Verification

- All 5 JSON fixtures parse cleanly; the canonical surfaced block is byte-identical
  across cursor/codex/kimi (checked).
- Data-only under `tests/fixtures/` — not collected by pytest; `ruff` gate is
  `src`-only, so lint/test gates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
