### PR TITLE
refactor(hook): extract HostHookAdapter seam (Claude-only, B1)

### DIFF
--- a/src/memtomem_stm/cli/hook_adapter.py
+++ b/src/memtomem_stm/cli/hook_adapter.py
@@ -1,0 +1,146 @@
+"""Host-shaped hook adapters — the parse/render seam for ``mms hook``.
+
+``mms hook`` (see :mod:`memtomem_stm.cli.hook_cmd`) bridges a host's built-in
+tool calls into STM's surfacing/compression pipeline. The *pipeline* is
+host-agnostic; only two things are host-shaped:
+
+* **parse** — read the host's PostToolUse payload keys into a normalized
+  :class:`CanonicalHookCall`.
+* **render** — turn the pipeline's ``(updated_tool_output, additional_context)``
+  result into the host's expected stdout shape.
+
+Isolating those two means adding a host (B2: Cursor/Kimi/Codex) is one adapter,
+leaving the shared core untouched. B1 ships only :class:`ClaudeHookAdapter`; its
+parse/render delegate to the existing helpers in :mod:`hook_cmd` (imported
+lazily to avoid an import cycle, since ``hook_cmd`` imports this module), so
+behavior is byte-identical to the pre-adapter code.
+
+Capability flag — ``can_replace_output``. Per the B0 host-contract
+verification, output *replacement* (the compression channel,
+``updatedToolOutput``) ports to **no** non-Claude host (Cursor's field is
+MCP-only, Kimi has none, Codex's is parsed-but-unsupported). Only Claude can
+rewrite a native tool's output, so compression is gated on this flag; a B2
+adapter sets it ``False`` and the orchestrator skips compression for that host.
+*Surfacing* (context injection) is the universal channel and flows through
+``render`` for every host.
+
+Scope B1 does NOT cover (deferred to B2, per the daemon-boundary decision): the
+shared surfacing core still reads the raw payload, and the daemon still receives
+the raw payload over the wire (``PROTOCOL_VERSION`` unchanged) — it already
+treats that payload opaquely, so a Claude-only ship needs no wire change. The
+:class:`CanonicalHookCall` is the normalized contract a B2 wire change will send
+and have the core consume; in B1 it is produced by :meth:`parse` and drives
+adapter dispatch, the compression gate, native-tool metrics, and :meth:`render`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalHookCall:
+    """A host's PostToolUse tool call, normalized into a host-agnostic shape.
+
+    Produced by :meth:`HostHookAdapter.parse`. Fields are the union of what the
+    surfacing query (``tool_input``), the size gate / metrics
+    (``tool_response_text``), and the compression channel (``tool_response`` —
+    the *original* object, so a Bash result's ``stdout`` can be replaced while
+    ``stderr`` / exit / ``interrupted`` survive verbatim) need, so a consumer
+    never has to re-touch the raw payload.
+    """
+
+    event_type: str
+    tool_name: str
+    tool_input: dict[str, Any] = field(default_factory=dict)
+    tool_response: Any = None
+    tool_response_text: str = ""
+    host_tag: str = "claude"
+
+
+class HostHookAdapter(ABC):
+    """The host-shaped seam: parse a host payload in, render a host output out.
+
+    Subclasses are the *only* place that knows a host's payload keys and output
+    shape. ``host_tag`` identifies the host (dispatch + provenance);
+    ``can_replace_output`` declares whether the host honors output replacement
+    (compression) — see the module docstring.
+    """
+
+    host_tag: ClassVar[str]
+    can_replace_output: ClassVar[bool]
+
+    @abstractmethod
+    def parse(self, payload: dict[str, Any]) -> CanonicalHookCall | None:
+        """Normalize the host's stdin payload into a :class:`CanonicalHookCall`.
+
+        Returns ``None`` for an unusable payload (e.g. not a dict) — the caller
+        treats that as a clean no-op, mirroring ``_read_payload``. **Never
+        raises.** Permissive by design: eligibility gating (PostToolUse, the
+        surface allowlist) stays in the shared core, not here.
+        """
+
+    @abstractmethod
+    def render(
+        self, *, updated_tool_output: Any | None, additional_context: str | None
+    ) -> dict[str, Any]:
+        """Build the host's hook output from the pipeline's two optional halves.
+
+        ``updated_tool_output`` is the compression result (or ``None``);
+        ``additional_context`` is the surfaced-memories block (or ``None``).
+        Returns ``{}`` when both are absent (the tool output passes through).
+        """
+
+
+class ClaudeHookAdapter(HostHookAdapter):
+    """Claude Code PostToolUse adapter — the code-verified baseline.
+
+    ``parse`` reads Claude's snake_case payload keys; ``render`` emits the
+    ``hookSpecificOutput`` envelope. Both delegate to the existing
+    :mod:`hook_cmd` helpers (lazy import) so the refactor is behavior-preserving.
+    Claude is the one host that can replace native tool output, so
+    ``can_replace_output`` is ``True``.
+    """
+
+    host_tag: ClassVar[str] = "claude"
+    can_replace_output: ClassVar[bool] = True
+
+    def parse(self, payload: dict[str, Any]) -> CanonicalHookCall | None:
+        if not isinstance(payload, dict):
+            return None
+        # Lazy import: avoid a cycle (hook_cmd imports this module at top level)
+        # and keep ``mms hook --help`` off the surfacing import cost.
+        from memtomem_stm.cli.hook_cmd import _tool_response_to_text
+
+        tool_name = payload.get("tool_name")
+        tool_input = payload.get("tool_input")
+        tool_response = payload.get("tool_response")
+        return CanonicalHookCall(
+            event_type=payload.get("hook_event_name") or "PostToolUse",
+            tool_name=tool_name if isinstance(tool_name, str) else "",
+            tool_input=tool_input if isinstance(tool_input, dict) else {},
+            tool_response=tool_response,
+            tool_response_text=_tool_response_to_text(tool_response),
+            host_tag=self.host_tag,
+        )
+
+    def render(
+        self, *, updated_tool_output: Any | None, additional_context: str | None
+    ) -> dict[str, Any]:
+        from memtomem_stm.cli.hook_cmd import _build_hook_output
+
+        return _build_hook_output(updated_tool_output, additional_context)
+
+
+# Single-entry registry in B1; B2 adds Cursor/Kimi/Codex keyed by host_tag.
+_ADAPTERS: dict[str, HostHookAdapter] = {ClaudeHookAdapter.host_tag: ClaudeHookAdapter()}
+
+
+def get_adapter(host_tag: str = "claude") -> HostHookAdapter:
+    """Return the adapter for ``host_tag`` (falls back to Claude).
+
+    B1 only registers Claude; the indirection is the B2 dispatch seam.
+    """
+    return _ADAPTERS.get(host_tag) or _ADAPTERS["claude"]

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -68,7 +68,10 @@ from typing import TYPE_CHECKING, Any, TextIO
 
 import click
 
+from memtomem_stm.cli.hook_adapter import get_adapter
+
 if TYPE_CHECKING:
+    from memtomem_stm.cli.hook_adapter import CanonicalHookCall
     from memtomem_stm.config import HookCompressionConfig, STMConfig
 
 logger = logging.getLogger(__name__)
@@ -530,7 +533,7 @@ async def _run_hook(
 
 
 def _record_hook_metrics(
-    payload: dict[str, Any],
+    call: "CanonicalHookCall",
     updated: dict[str, Any] | None,
     additional_context: str | None,
     config: "STMConfig",
@@ -538,10 +541,12 @@ def _record_hook_metrics(
     """Record one native built-in tool call into ``proxy_metrics.db`` (``source='hook'``).
 
     Makes native-tool spend — which never reaches the MCP proxy — visible next
-    to proxied calls. Persists **sizes only** (original / compressed / surfaced
-    chars + the tool name): never ``tool_input`` and never the output text,
-    mirroring the hook's no-query-text privacy posture (a ``Bash`` command may
-    carry secrets). Gated on ``config.hook.metrics_enabled`` (independent of
+    to proxied calls. Reads the normalized :class:`CanonicalHookCall` (``tool_name``
+    + the once-flattened ``tool_response_text``), so the raw payload is parsed
+    exactly once. Persists **sizes only** (original / compressed / surfaced chars
+    + the tool name): never ``tool_input`` and never the output text, mirroring
+    the hook's no-query-text privacy posture (a ``Bash`` command may carry
+    secrets). Gated on ``config.hook.metrics_enabled`` (independent of
     ``proxy.metrics.enabled`` so a hook-only deployment still measures), reusing
     the proxy's ``metrics.db_path`` / ``max_history``. A short-lived store is
     opened per call — the hook is a one-shot subprocess, so there is no
@@ -551,10 +556,10 @@ def _record_hook_metrics(
     try:
         if not config.hook.metrics_enabled:
             return
-        tool_name = payload.get("tool_name")
-        if not isinstance(tool_name, str) or not tool_name:
+        tool_name = call.tool_name
+        if not tool_name:
             return
-        original_chars = len(_tool_response_to_text(payload.get("tool_response")))
+        original_chars = len(call.tool_response_text)
         if original_chars == 0:
             return  # nothing observed (empty / malformed result) — skip
         compressed_chars = (
@@ -595,31 +600,51 @@ async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
     """Resolve the full hook output: in-process Bash *compression* merged with
     LTM *surfacing*, as one ``hookSpecificOutput``.
 
-    The two stages are independent. Compression is an opt-in, Bash-only
-    ``updatedToolOutput`` stage that clones the payload — it never alters
-    what surfacing (or the daemon) receives, and it still runs when
-    surfacing is disabled or Bash is not in the *surface* allowlist.
-    Daemon-frame protection comes solely from ``_bounded_surfacing_payload``
-    (:data:`_SAFE_DAEMON_BUDGET`), which caps the payload copy handed to
-    surfacing whether or not compression ran. Surfacing is wrapped so a
-    failure degrades to "no memories" while still returning the compression
-    half (``maybe_compress_builtin`` is itself non-raising). The CLI wrapper
-    backstops the whole call. A non-raising metrics row (``source='hook'``) is
-    recorded afterwards via :func:`_record_hook_metrics`, regardless of whether
+    The host-shaped edges go through a :class:`HostHookAdapter` (B1, Claude
+    only): :meth:`parse` normalizes the payload into a :class:`CanonicalHookCall`
+    and :meth:`render` builds the host output. *Compression* is gated on the
+    adapter's ``can_replace_output`` capability — only hosts that honor output
+    replacement (Claude today; see B0) run it; for others it is skipped and only
+    the surfacing half renders. It is otherwise an opt-in, Bash-only
+    ``updatedToolOutput`` stage that clones the payload — it never alters what
+    surfacing (or the daemon) receives, and it still runs when surfacing is
+    disabled or Bash is not in the *surface* allowlist.
+
+    The two stages are independent. Daemon-frame protection comes solely from
+    ``_bounded_surfacing_payload`` (:data:`_SAFE_DAEMON_BUDGET`), which caps the
+    payload copy handed to surfacing whether or not compression ran. Surfacing is
+    wrapped so a failure degrades to "no memories" while still returning the
+    compression half (``maybe_compress_builtin`` is itself non-raising). The CLI
+    wrapper backstops the whole call. A non-raising metrics row (``source='hook'``)
+    is recorded afterwards via :func:`_record_hook_metrics`, regardless of whether
     either stage produced output.
+
+    Note (B1, deferred to B2): surfacing and compression still read the *raw*
+    ``payload``; the ``CanonicalHookCall`` drives adapter dispatch, the
+    compression gate, and metrics today. Having the shared core consume the
+    canonical (and sending it over the daemon wire) is the B2 step — the daemon
+    already treats the payload opaquely, so a Claude-only ship needs no wire change.
     """
     from memtomem_stm.config import STMConfig
 
     config = STMConfig()
-    updated = maybe_compress_builtin(payload, config.hook.compression)
+    adapter = get_adapter()
+    call = adapter.parse(payload)
+    if call is None:  # unusable payload → pass the tool output through untouched
+        return {}
+    updated = (
+        maybe_compress_builtin(payload, config.hook.compression)
+        if adapter.can_replace_output
+        else None
+    )
     surf_out: dict[str, Any] = {}
     try:
         surf_out = await _run_hook(_bounded_surfacing_payload(payload), config=config)
     except Exception:
         logger.debug("surfacing failed — keeping the compression half", exc_info=True)
     additional_context = _extract_surfaced_context(surf_out)
-    _record_hook_metrics(payload, updated, additional_context, config)
-    return _build_hook_output(updated, additional_context)
+    _record_hook_metrics(call, updated, additional_context, config)
+    return adapter.render(updated_tool_output=updated, additional_context=additional_context)
 
 
 @click.command(name="hook")

--- a/tests/cli/test_hook_adapter.py
+++ b/tests/cli/test_hook_adapter.py
@@ -1,0 +1,125 @@
+"""Tests for ``cli/hook_adapter.py`` — the host-shaped parse/render seam.
+
+B1 ships only :class:`ClaudeHookAdapter`. These pin that ``parse`` normalizes a
+Claude PostToolUse payload into a :class:`CanonicalHookCall` (and no-ops on a
+bad payload), and that ``render`` is byte-identical to the existing
+``_build_hook_output`` envelope (it delegates to it). The capability flag
+(``can_replace_output``) and the registry dispatch are pinned too. A
+source-inspection test that the wiring routes through the adapter lives
+alongside the wire-in commit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem_stm.cli.hook_adapter import (
+    CanonicalHookCall,
+    ClaudeHookAdapter,
+    get_adapter,
+)
+from memtomem_stm.cli.hook_cmd import _build_hook_output, _tool_response_to_text
+
+_CLAUDE = ClaudeHookAdapter()
+
+
+# ── parse ────────────────────────────────────────────────────────────────────
+
+
+def test_adapter_parse_claude_valid_payload():
+    response = {"content": "JWT handler. " * 20}
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/src/auth/jwt.py"},
+        "tool_response": response,
+    }
+    call = _CLAUDE.parse(payload)
+    assert isinstance(call, CanonicalHookCall)
+    assert call.event_type == "PostToolUse"
+    assert call.tool_name == "Read"
+    assert call.tool_input == {"file_path": "/src/auth/jwt.py"}
+    # The ORIGINAL response object is preserved (compression needs the real dict).
+    assert call.tool_response is response
+    # tool_response_text is the flattened text, identical to the shared helper.
+    assert call.tool_response_text == _tool_response_to_text(response)
+    assert call.host_tag == "claude"
+
+
+def test_adapter_parse_defaults_event_to_posttooluse():
+    call = _CLAUDE.parse({"tool_name": "Bash", "tool_response": {"stdout": "ok"}})
+    assert call is not None
+    assert call.event_type == "PostToolUse"
+
+
+@pytest.mark.parametrize("bad", [None, "not a dict", [1, 2, 3], 42])
+def test_adapter_parse_non_dict_is_none(bad):
+    # Mirrors _read_payload's None no-op; never raises.
+    assert _CLAUDE.parse(bad) is None
+
+
+def test_adapter_parse_coerces_missing_and_wrong_typed_fields():
+    # Permissive: missing tool_name -> "", non-dict tool_input -> {}, missing
+    # tool_response -> None/"" — eligibility gating stays in the core, not parse.
+    call = _CLAUDE.parse({"hook_event_name": "PostToolUse", "tool_input": "oops"})
+    assert call is not None
+    assert call.tool_name == ""
+    assert call.tool_input == {}
+    assert call.tool_response is None
+    assert call.tool_response_text == ""
+
+
+def test_canonical_hook_call_is_frozen():
+    call = _CLAUDE.parse({"tool_name": "Read", "tool_response": "x"})
+    assert call is not None
+    with pytest.raises((AttributeError, TypeError)):
+        call.tool_name = "Write"  # type: ignore[misc]
+
+
+# ── render (delegates to _build_hook_output — must stay byte-identical) ────────
+
+_BLOCK = "<surfaced-memories>\nMEM\n</surfaced-memories>"
+
+
+def test_adapter_render_compression_only():
+    updated = {"stdout": "compressed"}
+    out = _CLAUDE.render(updated_tool_output=updated, additional_context=None)
+    assert out == _build_hook_output(updated, None)
+    assert out["hookSpecificOutput"].keys() == {"hookEventName", "updatedToolOutput"}
+
+
+def test_adapter_render_surfacing_only():
+    out = _CLAUDE.render(updated_tool_output=None, additional_context=_BLOCK)
+    assert out == _build_hook_output(None, _BLOCK)
+    assert out["hookSpecificOutput"].keys() == {"hookEventName", "additionalContext"}
+
+
+def test_adapter_render_both_halves():
+    updated = {"stdout": "c"}
+    out = _CLAUDE.render(updated_tool_output=updated, additional_context=_BLOCK)
+    assert out == _build_hook_output(updated, _BLOCK)
+    hso = out["hookSpecificOutput"]
+    assert hso["hookEventName"] == "PostToolUse"
+    assert hso["updatedToolOutput"] == updated
+    assert hso["additionalContext"] == _BLOCK
+
+
+def test_adapter_render_neither_is_empty():
+    assert _CLAUDE.render(updated_tool_output=None, additional_context=None) == {}
+
+
+# ── capability + registry dispatch ────────────────────────────────────────────
+
+
+def test_claude_capability_and_tag():
+    # Claude is the one host that can replace native tool output (B0). Surfacing
+    # is universal; compression is gated on this flag in the orchestrator.
+    assert _CLAUDE.host_tag == "claude"
+    assert _CLAUDE.can_replace_output is True
+
+
+def test_get_adapter_returns_claude_and_falls_back():
+    assert get_adapter().host_tag == "claude"
+    assert get_adapter("claude").host_tag == "claude"
+    # Unknown host tag falls back to Claude (B1 registers only Claude).
+    assert get_adapter("cursor").host_tag == "claude"

--- a/tests/cli/test_hook_adapter.py
+++ b/tests/cli/test_hook_adapter.py
@@ -11,8 +11,11 @@ alongside the wire-in commit.
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
+from memtomem_stm.cli import hook_cmd
 from memtomem_stm.cli.hook_adapter import (
     CanonicalHookCall,
     ClaudeHookAdapter,
@@ -123,3 +126,32 @@ def test_get_adapter_returns_claude_and_falls_back():
     assert get_adapter("claude").host_tag == "claude"
     # Unknown host tag falls back to Claude (B1 registers only Claude).
     assert get_adapter("cursor").host_tag == "claude"
+
+
+# ── source pins (shape-identical routing a behavior spy can't see) ────────────
+
+
+def test_render_delegates_to_build_hook_output():
+    # The Claude output envelope (hookSpecificOutput / hookEventName /
+    # updatedToolOutput / additionalContext) must live in exactly ONE place
+    # (_build_hook_output), so render delegating to it — not inlining the keys —
+    # keeps a future B2 host from silently inheriting Claude's shape.
+    src = inspect.getsource(ClaudeHookAdapter.render)
+    assert "_build_hook_output(" in src
+    assert "hookSpecificOutput" not in src  # envelope built only in the helper
+
+
+def test_parse_delegates_flattening_to_shared_helper():
+    src = inspect.getsource(ClaudeHookAdapter.parse)
+    assert "_tool_response_to_text(" in src
+
+
+def test_orchestrate_routes_through_adapter():
+    # Pin the shape-identical routing: _orchestrate must dispatch via
+    # get_adapter() and use the adapter's parse/render, and gate compression on
+    # the capability flag rather than running it unconditionally.
+    src = inspect.getsource(hook_cmd._orchestrate)
+    assert "get_adapter(" in src
+    assert ".parse(" in src
+    assert ".render(" in src
+    assert "can_replace_output" in src

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 import pytest
 from click.testing import CliRunner
 
+from memtomem_stm.cli.hook_adapter import ClaudeHookAdapter
 from memtomem_stm.cli.hook_cmd import (
     _COMPRESS_SENTINEL,
     _SAFE_DAEMON_BUDGET,
@@ -492,12 +493,17 @@ def _metrics_config(tmp_path: Path, *, enabled: bool = True):
     )
 
 
+def _hook_call(payload: dict):
+    """Parse a raw payload into the CanonicalHookCall ``_record_hook_metrics`` now consumes."""
+    return ClaudeHookAdapter().parse(payload)
+
+
 def test_record_hook_metrics_writes_source_hook_row(tmp_path: Path):
     from memtomem_stm.proxy.metrics_store import read_compression_summary
 
     cfg = _metrics_config(tmp_path)
     updated = {"stdout": f"{_COMPRESS_SENTINEL}\nshort", "stderr": ""}
-    _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), updated, _BLOCK, cfg)
+    _record_hook_metrics(_hook_call(_bash_payload({"stdout": _BIG_STDOUT})), updated, _BLOCK, cfg)
 
     summary = read_compression_summary(tmp_path / "metrics.db", source="hook")
     assert summary["available"] is True
@@ -519,7 +525,7 @@ def test_record_hook_metrics_no_compression_original_equals_compressed(tmp_path:
         "tool_response": {"content": "y" * 4000},
     }
     # Both stages no-op (Read is never compressed; no surfaced context).
-    _record_hook_metrics(payload, None, None, cfg)
+    _record_hook_metrics(_hook_call(payload), None, None, cfg)
 
     row = read_compression_summary(tmp_path / "metrics.db", source="hook")["by_tool"][0]
     assert row["tool"] == "Read"
@@ -530,14 +536,16 @@ def test_record_hook_metrics_no_compression_original_equals_compressed(tmp_path:
 
 def test_record_hook_metrics_disabled_writes_nothing(tmp_path: Path):
     cfg = _metrics_config(tmp_path, enabled=False)
-    _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), None, None, cfg)
+    _record_hook_metrics(_hook_call(_bash_payload({"stdout": _BIG_STDOUT})), None, None, cfg)
     assert not (tmp_path / "metrics.db").exists()  # store never opened
 
 
 def test_record_hook_metrics_skips_empty_output(tmp_path: Path):
     # A result that flattens to nothing carries no spend to record.
     cfg = _metrics_config(tmp_path)
-    _record_hook_metrics({"hook_event_name": "PostToolUse", "tool_name": "Bash"}, None, None, cfg)
+    _record_hook_metrics(
+        _hook_call({"hook_event_name": "PostToolUse", "tool_name": "Bash"}), None, None, cfg
+    )
     assert not (tmp_path / "metrics.db").exists()
 
 
@@ -550,7 +558,7 @@ def test_record_hook_metrics_never_raises_on_bad_store(tmp_path: Path):
         hook=SimpleNamespace(metrics_enabled=True),
         proxy=SimpleNamespace(metrics=SimpleNamespace(db_path=tmp_path, max_history=10000)),
     )
-    _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), None, None, bad)
+    _record_hook_metrics(_hook_call(_bash_payload({"stdout": _BIG_STDOUT})), None, None, bad)
 
 
 def test_record_hook_metrics_degrades_quickly_when_db_locked(tmp_path: Path):
@@ -573,7 +581,7 @@ def test_record_hook_metrics_degrades_quickly_when_db_locked(tmp_path: Path):
     try:
         cfg = _metrics_config(tmp_path)  # db_path == db
         start = time.monotonic()
-        _record_hook_metrics(_bash_payload({"stdout": _BIG_STDOUT}), None, None, cfg)
+        _record_hook_metrics(_hook_call(_bash_payload({"stdout": _BIG_STDOUT})), None, None, cfg)
         elapsed = time.monotonic() - start
     finally:
         blocker.rollback()


### PR DESCRIPTION
## What

B1 of the host-hook-adapter track (plan `mcp-serene-pinwheel.md`): extract the
**host-shaped parse/render seam** out of `hook_cmd.py` behind a `HostHookAdapter`
abstraction, so adding a host later (B2: Cursor/Kimi/Codex) is one adapter, not a
`hook_cmd` rewrite. **Claude-only and behavior-preserving** — the shared
surfacing/compression core is untouched.

New `src/memtomem_stm/cli/hook_adapter.py`:
- `CanonicalHookCall` — a frozen, normalized PostToolUse call (event/tool_name/
  tool_input/tool_response/tool_response_text/host_tag).
- `HostHookAdapter` ABC — `parse(payload) -> CanonicalHookCall | None`,
  `render(*, updated_tool_output, additional_context) -> dict`, plus class vars
  `host_tag` and `can_replace_output`.
- `ClaudeHookAdapter` — `parse`/`render` delegate to the existing
  `_tool_response_to_text` / `_build_hook_output` (lazy import to avoid a cycle),
  so output is byte-identical to the pre-adapter code.
- `get_adapter(host_tag="claude")` — single-entry registry (the B2 dispatch seam).

`_orchestrate` now routes through the adapter: `parse` → gate compression on
`adapter.can_replace_output` → `render`. `_record_hook_metrics` consumes the
`CanonicalHookCall` (so the raw payload is parsed exactly once).

## Two design decisions (called out because one departs from the plan)

**1. Compression is Claude-gated via `can_replace_output` (B0).** B0 verified
native-tool output *replacement* ports to no non-Claude host (Cursor's field is
MCP-only, Kimi has none, Codex's is parsed-but-unsupported). So compression is
gated on the adapter capability — Claude `True`, future hosts `False` → skipped.
*Surfacing* (context injection) is the universal channel and flows through
`render` for every host. (This is the `HostCapabilities` split the plan's B2
describes, seeded now.)

**2. Daemon-boundary: defer the wire change to B2 (the plan said normalize in
B1).** The plan called for normalizing before the daemon socket + a
`PROTOCOL_VERSION` bump in B1. Verified in code that this buys nothing for a
Claude-only ship and adds risk: `daemon/server.py` `_dispatch` already treats the
`OP_SURFACE` payload as **opaque** and hands it straight to
`run_surfacing_hook(payload, engine)` — it reads no Claude keys; all host-shaped
parsing lives in the shared core, called identically by the daemon and cold
paths. `daemon/client.py:surface` has no `resp.get("v")` gate, so a bump would
only force new guard code to police a skew the bump itself introduces, plus an
old-daemon/new-CLI cold-fallback window — for zero functional benefit since the
Claude wire content is unchanged. So B1 keeps `PROTOCOL_VERSION=1`, touches no
daemon/client/server code, and seeds `CanonicalHookCall` + `host_tag` +
source-pins; the wire normalization is owed once in B2, when a second host
actually exists. (Decision confirmed with the maintainer.)

## Not in this PR (B2)

- Per-host adapters (Cursor/Kimi/Codex) — they consume the B0 golden fixtures
  merged in #513.
- The daemon-wire normalization + having the shared core consume the
  `CanonicalHookCall` directly (today the surfacing/compression core still reads
  the raw payload; the canonical drives dispatch, the compression gate, metrics,
  and render). This is the documented, intentional B1→B2 boundary.

## Behavior preservation

- `render` delegates to `_build_hook_output` and `parse` to
  `_tool_response_to_text`, so the merged `hookSpecificOutput` is byte-identical;
  the shared core (`run_surfacing_hook`, `maybe_compress_builtin`,
  `_extract_surfaced_block`) is unchanged.
- New `tests/cli/test_hook_adapter.py` (17 tests): parse normalization + no-op,
  render parity with `_build_hook_output`, capability/registry, and
  `inspect.getsource` source-pins (render delegates and does not inline the
  envelope keys; `_orchestrate` routes through `get_adapter`/`parse`/`render` and
  gates on `can_replace_output`).
- Full suite green: **3648 passed, 3 skipped** (3631 baseline + 17 new). `ruff`
  clean. `mypy` clean on the two changed source files (the repo's pre-existing
  advisory mypy errors are unrelated).

## Commits

1. `refactor(hook)`: add the `HostHookAdapter` abstraction (pure addition).
2. `test(hook)`: unit-test parse/render/capability.
3. `refactor(hook)`: route `_orchestrate` through the adapter + metrics consumes
   the canonical.
4. `test(hook)`: source-pin the routing and single envelope source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
