### PR TITLE
feat(hook): add CodexHookAdapter (B2 step3, surfacing-only)

### DIFF
--- a/src/memtomem_stm/cli/hook_adapter.py
+++ b/src/memtomem_stm/cli/hook_adapter.py
@@ -219,8 +219,90 @@ class ClaudeHookAdapter(HostHookAdapter):
         return _build_hook_output(updated_tool_output, additional_context)
 
 
-# Single-entry registry today; B2 adds Cursor/Kimi/Codex keyed by host_tag.
-_ADAPTERS: dict[str, HostHookAdapter] = {ClaudeHookAdapter.host_tag: ClaudeHookAdapter()}
+class CodexHookAdapter(HostHookAdapter):
+    """Codex CLI PostToolUse adapter — surfacing-only (B0: no output replace).
+
+    Codex's hook payload shares Claude's shape: snake_case keys with the tool
+    output under ``tool_response`` and ``hook_event_name`` = ``PostToolUse``. Its
+    surfacing channel is the *same* ``hookSpecificOutput.additionalContext``
+    envelope as Claude (doc-verified, B0), so :meth:`render` delegates to the one
+    shared ``_build_hook_output`` helper rather than re-spelling the envelope —
+    the Claude shape then lives in exactly one place.
+
+    Two host facts (B0) shape it:
+
+    * **Compression does not port.** Codex's ``updatedMCPToolOutput`` is "parsed
+      but not supported yet" *and* MCP-only — native Bash/apply_patch has no
+      rewrite field — so ``can_replace_output`` is ``False`` and the orchestrator
+      skips compression for Codex (surfacing still flows through ``render``).
+    * **Only Bash + apply_patch fire a native PostToolUse hook.** Codex has no
+      separate Read/Grep/Glob/WebFetch built-ins (it shells out; WebSearch is not
+      intercepted), so ``native_tool_map`` maps just those two; every other name
+      canonicalizes to ``""`` (never surfaced/compressed). In practice only
+      ``Bash`` (→ ``shell``) lands in the read-like surface allowlist.
+
+    Rollout caveat (not an adapter-shape concern): the *standalone* exit-0
+    ``additionalContext`` shape — without ``decision:"block"`` — is undocumented
+    (every official example nests it under a block), so a runtime check should
+    confirm Codex honors it before the host-selection step enables Codex
+    surfacing by default. The adapter still emits the documented field.
+    """
+
+    host_tag: ClassVar[str] = "codex"
+    can_replace_output: ClassVar[bool] = False
+    # Codex's only native (non-MCP) tools that fire PostToolUse. ``apply_patch``
+    # is a diff/patch apply → canonical ``edit``; ``Bash`` → ``shell``. No native
+    # Read/Grep/Glob/WebFetch (Codex shells out), so they are absent here and
+    # canonicalize to ``""``.
+    native_tool_map: ClassVar[dict[str, str]] = {
+        "Bash": "shell",
+        "apply_patch": "edit",
+    }
+
+    def parse(self, payload: dict[str, Any]) -> CanonicalHookCall | None:
+        if not isinstance(payload, dict):
+            return None
+        raw_name = payload.get("tool_name")
+        tool_name = raw_name if isinstance(raw_name, str) else ""
+        if tool_name.startswith("mcp__"):
+            return None  # proxied MCP tool — already runs through the pipeline
+        # Lazy import (as in ClaudeHookAdapter): avoid the hook_cmd import cycle
+        # and keep ``mms hook --help`` off the surfacing import cost. Codex shares
+        # Claude's snake_case / ``tool_response`` payload shape — only the
+        # native_tool_map and host_tag differ — so this mirrors Claude's parse.
+        from memtomem_stm.cli.hook_cmd import _tool_response_to_text
+
+        tool_input = payload.get("tool_input")
+        tool_response = payload.get("tool_response")
+        return CanonicalHookCall(
+            event_type=payload.get("hook_event_name") or "PostToolUse",
+            tool_name=tool_name,
+            canonical_tool=self.native_tool_map.get(tool_name, ""),
+            tool_input=tool_input if isinstance(tool_input, dict) else {},
+            tool_response=tool_response,
+            tool_response_text=_tool_response_to_text(tool_response),
+            host_tag=self.host_tag,
+        )
+
+    def render(
+        self, *, updated_tool_output: Any | None, additional_context: str | None
+    ) -> dict[str, Any]:
+        # Codex's surfacing envelope is identical to Claude's — delegate to the
+        # single shared helper so the output shape lives in exactly one place.
+        # ``updated_tool_output`` is always ``None`` for Codex
+        # (can_replace_output=False) but is honored generically.
+        from memtomem_stm.cli.hook_cmd import _build_hook_output
+
+        return _build_hook_output(updated_tool_output, additional_context)
+
+
+# Registry keyed by host_tag. B1 shipped Claude; B2 step3 adds the non-Claude
+# adapters one host at a time (Codex first). Cursor/Kimi follow; Antigravity is
+# deferred (unfixturable — see tests/fixtures/hooks/README.md).
+_ADAPTERS: dict[str, HostHookAdapter] = {
+    ClaudeHookAdapter.host_tag: ClaudeHookAdapter(),
+    CodexHookAdapter.host_tag: CodexHookAdapter(),
+}
 
 # STM's canonical built-in tool vocabulary — the codomain of every adapter's
 # ``native_tool_map``. The surface allowlist + compression gate are expressed in
@@ -233,7 +315,9 @@ CANONICAL_TOOLS: frozenset[str] = frozenset(
 def get_adapter(host_tag: str = "claude") -> HostHookAdapter:
     """Return the adapter for ``host_tag`` (falls back to Claude).
 
-    Only Claude is registered today; the indirection is the B2 dispatch seam.
+    Claude and Codex are registered (B2 step3 adds the rest); an unknown
+    ``host_tag`` falls back to Claude. Host selection (which tag the live hook
+    passes) is wired in a later step — today every caller uses the default.
     """
     return _ADAPTERS.get(host_tag) or _ADAPTERS["claude"]
 

--- a/tests/cli/test_hook_adapter.py
+++ b/tests/cli/test_hook_adapter.py
@@ -12,6 +12,8 @@ alongside the wire-in commit.
 from __future__ import annotations
 
 import inspect
+import json
+from pathlib import Path
 
 import pytest
 
@@ -19,11 +21,16 @@ from memtomem_stm.cli import hook_cmd
 from memtomem_stm.cli.hook_adapter import (
     CanonicalHookCall,
     ClaudeHookAdapter,
+    CodexHookAdapter,
     get_adapter,
 )
 from memtomem_stm.cli.hook_cmd import _build_hook_output, _tool_response_to_text
 
 _CLAUDE = ClaudeHookAdapter()
+_CODEX = CodexHookAdapter()
+
+# Golden host-contract fixtures (B0): tests/fixtures/hooks/<host>/.
+_HOOK_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "hooks"
 
 
 # ── parse ────────────────────────────────────────────────────────────────────
@@ -214,11 +221,12 @@ def test_claude_capability_and_tag():
     assert _CLAUDE.can_replace_output is True
 
 
-def test_get_adapter_returns_claude_and_falls_back():
-    assert get_adapter().host_tag == "claude"
+def test_get_adapter_returns_registered_and_falls_back():
+    assert get_adapter().host_tag == "claude"  # default
     assert get_adapter("claude").host_tag == "claude"
-    # Unknown host tag falls back to Claude (B1 registers only Claude).
-    assert get_adapter("cursor").host_tag == "claude"
+    assert get_adapter("codex").host_tag == "codex"  # B2 step3
+    # An unregistered host tag falls back to Claude.
+    assert get_adapter("nonexistent-host").host_tag == "claude"
 
 
 # ── source pins (shape-identical routing a behavior spy can't see) ────────────
@@ -248,3 +256,124 @@ def test_orchestrate_routes_through_adapter():
     assert ".parse(" in src
     assert ".render(" in src
     assert "can_replace_output" in src
+
+
+# ── Codex adapter (B2 step3 — surfacing-only) ──────────────────────────────────
+
+_CODEX_DIR = _HOOK_FIXTURES / "codex"
+
+
+def test_codex_parse_golden_inbound():
+    # Golden: the host's documented inbound PostToolUse payload → CanonicalHookCall.
+    payload = json.loads((_CODEX_DIR / "inbound_bash_posttooluse.json").read_text())
+    call = _CODEX.parse(payload)
+    assert isinstance(call, CanonicalHookCall)
+    assert call.event_type == "PostToolUse"
+    assert call.tool_name == "Bash"  # host-native preserved (engine query input)
+    assert call.canonical_tool == "shell"  # Bash → canonical shell (allowlisted)
+    assert call.tool_input == {"command": "pytest -q"}
+    # Codex puts the tool output under ``tool_response`` (same key as Claude).
+    assert call.tool_response == "12 passed in 3.4s"
+    assert call.tool_response_text == "12 passed in 3.4s"
+    assert call.host_tag == "codex"
+
+
+def test_codex_render_golden_surfacing():
+    # Golden: feed the canonical surfaced block from the fixture and assert render
+    # reproduces the committed Codex surfacing emission exactly — the same
+    # ``hookSpecificOutput.additionalContext`` envelope as Claude.
+    expected = json.loads((_CODEX_DIR / "expected_surfacing_output.json").read_text())
+    block = expected["hookSpecificOutput"]["additionalContext"]
+    out = _CODEX.render(updated_tool_output=None, additional_context=block)
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    ("native", "canonical"),
+    [
+        ("Bash", "shell"),
+        ("apply_patch", "edit"),
+        ("Read", ""),  # Codex shells out — no native Read/Grep/Glob/WebFetch
+        ("WebSearch", ""),  # not intercepted by Codex's PostToolUse hook
+        ("SomeFutureTool", ""),
+    ],
+)
+def test_codex_parse_canonicalizes_tool_name(native: str, canonical: str):
+    call = _CODEX.parse({"tool_name": native, "tool_response": "x"})
+    assert call is not None
+    assert call.tool_name == native  # host-native preserved
+    assert call.canonical_tool == canonical
+
+
+@pytest.mark.parametrize("mcp_tool", ["mcp__memtomem__mem_search", "mcp__github__create_issue"])
+def test_codex_parse_rejects_mcp_tools(mcp_tool: str):
+    # mcp__-prefixed tools already flow through the MCP proxy — the native-tool
+    # hook must not double-handle them.
+    assert _CODEX.parse({"tool_name": mcp_tool, "tool_response": "x"}) is None
+
+
+@pytest.mark.parametrize("bad", [None, "not a dict", [1, 2, 3], 42])
+def test_codex_parse_non_dict_is_none(bad):
+    assert _CODEX.parse(bad) is None
+
+
+def test_codex_parse_defaults_event_to_posttooluse():
+    call = _CODEX.parse({"tool_name": "Bash", "tool_response": {"stdout": "ok"}})
+    assert call is not None
+    assert call.event_type == "PostToolUse"
+
+
+def test_codex_parse_flattens_dict_response_via_shared_helper():
+    # The common Bash-result shape is a dict, not a string. The golden fixture
+    # uses a string ``tool_response`` (for which the flatten is identity), so pin
+    # the dict path explicitly: parse must flatten through the shared helper —
+    # identical to Claude — so surfacing's ``min_response_chars`` gate sees real
+    # text and the ORIGINAL object is preserved (mirrors the Claude coverage).
+    response = {"stdout": "ok", "stderr": "", "exitCode": 0}
+    call = _CODEX.parse({"tool_name": "Bash", "tool_response": response})
+    assert call is not None
+    assert call.tool_response_text == _tool_response_to_text(response)
+    assert call.tool_response_text == "ok"
+    assert call.tool_response is response
+
+
+@pytest.mark.parametrize("bad_input", [["x"], "weird", 42, 0, False])
+def test_codex_parse_coerces_non_dict_tool_input(bad_input):
+    # A non-dict ``tool_input`` must coerce to ``{}`` (not leak through): it flows
+    # to the surfacing query extractor, which calls ``.items()`` on it, so a
+    # leaked non-dict would raise at runtime. Permissive parse, gating in the core.
+    call = _CODEX.parse({"tool_name": "Bash", "tool_input": bad_input, "tool_response": "x"})
+    assert call is not None
+    assert call.tool_input == {}
+
+
+def test_codex_to_wire_carries_host_tag():
+    # Provenance survives the hook→daemon wire so the daemon attributes the call
+    # to Codex without any host knowledge.
+    call = _CODEX.parse(
+        {"tool_name": "Bash", "tool_input": {"command": "ls"}, "tool_response": "ok"}
+    )
+    assert call is not None
+    assert call.to_wire()["host_tag"] == "codex"
+
+
+def test_codex_capability_and_tag():
+    # B0: compression (output replacement) does NOT port to Codex
+    # (``updatedMCPToolOutput`` is parsed-but-unsupported + MCP-only), so Codex is
+    # surfacing-only — the orchestrator skips compression on this flag.
+    assert _CODEX.host_tag == "codex"
+    assert _CODEX.can_replace_output is False
+
+
+def test_codex_render_delegates_to_build_hook_output():
+    # The Codex surfacing envelope is identical to Claude's — it must delegate to
+    # the single shared helper, not re-spell ``hookSpecificOutput`` (which would
+    # let the two shapes drift apart silently).
+    src = inspect.getsource(CodexHookAdapter.render)
+    assert "_build_hook_output(" in src
+    assert "hookSpecificOutput" not in src
+
+
+def test_codex_parse_delegates_flattening_to_shared_helper():
+    src = inspect.getsource(CodexHookAdapter.parse)
+    assert "_tool_response_to_text(" in src


### PR DESCRIPTION
## What

First non-Claude host adapter on the B1 `HostHookAdapter` seam — **B2 step3** of the
Track-B plan (`mms hook` generalized across CLI agents). Adds `CodexHookAdapter` to
`cli/hook_adapter.py` and registers it in `_ADAPTERS`. **Surfacing-only by design.**

## Why now

B2 step1 (canonical tool vocabulary) and step2 (`CanonicalHookCall` over the daemon
wire, `PROTOCOL_VERSION` 2) made the daemon host-agnostic and the `get_adapter()`
registry ready for new hosts. B2 step3 fills in the non-Claude adapters one host at a
time; Codex is first because its contract is the closest to Claude's (lowest risk —
it reuses the exact render envelope), which proves the multi-adapter golden-test
harness with the smallest possible contract surface.

## Contract (B0-verified)

Codex's PostToolUse payload shares Claude's shape — snake_case keys, tool output under
`tool_response`, `hook_event_name = PostToolUse` — and its surfacing channel is the
**same** `hookSpecificOutput.additionalContext` envelope, so `render()` delegates to the
one shared `_build_hook_output` helper (the envelope shape stays in exactly one place; a
source-pin test enforces it).

Two B0 host facts shape the adapter:

- **Compression does not port.** Codex's `updatedMCPToolOutput` is "parsed but not
  supported yet" *and* MCP-only; native Bash/apply_patch has no rewrite field. So
  `can_replace_output = False` → `_orchestrate` already skips compression for any adapter
  without the capability. Codex is surfacing-only.
- **Only Bash + apply_patch fire a native PostToolUse hook** (Codex shells out for
  read/search; WebSearch is not intercepted), so `native_tool_map = {Bash→shell,
  apply_patch→edit}`; every other name canonicalizes to `""` and never
  surfaces/compresses. In practice only `Bash` is in the read-like surface allowlist.

These were re-confirmed against the official OpenAI Codex Hooks docs during review.

## Behavior change

**None.** The adapter is not yet reachable from stdin — `_orchestrate` still calls
`get_adapter()` with no argument (→ Claude). Host selection (`--host` + shape auto-detect)
is a deliberate later step in B2 step3, at which point this adapter and the Cursor/Kimi
ones go live together. Until then it is exercised only by the golden parse/render tests
against the B0 fixtures (`tests/fixtures/hooks/codex/`), mirroring how B1 shipped the seam
ahead of its wire-in.

## Tests

Golden parse (inbound payload → `CanonicalHookCall`) and render (canonical surfaced block →
host-shaped emission) against `tests/fixtures/hooks/codex/`, plus canonicalization,
`mcp__` rejection, non-dict no-op, wire-provenance (`host_tag` survives `to_wire`),
capability/registry, and `inspect.getsource` routing pins. Codex parse coverage is brought
to **parity with Claude**: a dict-`tool_response` flatten assertion and non-dict
`tool_input → {}` coercion (both gaps caught by the review's mutation testing).

- `uv run pytest -m "not ollama"` → **3704 passed, 3 skipped** (pre-amend; the +6 parity
  tests pass locally: `tests/cli/test_hook_adapter.py` 61 passed)
- `ruff check` + `ruff format --check` clean; `mypy` clean

## Review

- **codex** verified the parse/render contract against the official OpenAI Codex Hooks
  documentation (`PostToolUse` / `Bash` / `apply_patch` / `tool_response` /
  `additionalContext` / output-replacement unsupported — all matching).
- **Adversarial multi-lens Workflow** (contract · side-effects · tool-map · tests, each
  skeptic-verified) → **SHIP**. Its only two findings were test-coverage gaps (proven by
  mutation testing, production code correct); both folded into this PR as the parity tests
  above.

## Rollout caveat (for the host-selection step, not this PR)

Codex's *standalone* exit-0 `additionalContext` (without `decision:"block"`) is
undocumented, so a runtime check should confirm Codex honors it before enabling Codex
surfacing by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)