### PR TITLE
test(daemon): Windows-skip POSIX-only foreign-orphan reporting tests (#518 gap)

### DIFF
--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -673,7 +673,13 @@ class TestDaemonStatusCli:
 class TestDaemonForeignOrphans:
     """`#517` — daemons orphaned under a stale fingerprint (config/protocol drift)
     must be visible to ``status`` and stoppable via ``stop --all``, even when
-    pinned with ``idle_timeout_seconds=0`` (so they never self-clear)."""
+    pinned with ``idle_timeout_seconds=0`` (so they never self-clear).
+
+    The tests that assert live-foreign *reporting* are POSIX-only: on Windows
+    ``daemon_cmd._live_foreign_daemons`` short-circuits to ``[]`` (``is_pid_alive``
+    can't distinguish a live foreign daemon from a dead handshake there — no
+    signal-0), so they carry a per-method ``skipif`` (#519). The tests that pin the
+    Windows-disabled behavior / empty cases still run on every platform."""
 
     def _write_foreign(self, tmp_path: Path, fingerprint: str, pid: int) -> None:
         discovery.write_handshake(
@@ -686,6 +692,10 @@ class TestDaemonForeignOrphans:
             created_at=0.0,
         )
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="live foreign-orphan reporting is POSIX-only (#519)",
+    )
     def test_status_reports_foreign(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         import json
 
@@ -777,6 +787,10 @@ class TestDaemonForeignOrphans:
         assert [pid for pid, _ in killed] == [4321]
         assert f"fp={old_fp}" in result.output
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="live foreign-orphan reporting is POSIX-only (#519)",
+    )
     def test_dead_pid_foreign_filtered_and_sorted(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -842,6 +856,10 @@ class TestDaemonForeignOrphans:
         assert "could not signal daemon pid=1001" in result.output
         assert "sent SIGTERM to daemon pid=3003" in result.output
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="live foreign-orphan reporting is POSIX-only (#519)",
+    )
     def test_status_running_with_foreign(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """A live current daemon AND a foreign orphan: the running-branch `info`
         must still carry `foreign`, and the token must never leak."""


### PR DESCRIPTION
## Problem

`main`'s Windows `test` job is **red** — and has been since the **#518** merge (every
commit before it had green Windows CI). Three tests fail:

```
tests/daemon/test_internals.py::TestDaemonForeignOrphans::test_status_reports_foreign
tests/daemon/test_internals.py::TestDaemonForeignOrphans::test_dead_pid_foreign_filtered_and_sorted
tests/daemon/test_internals.py::TestDaemonForeignOrphans::test_status_running_with_foreign
```
each `AssertionError: assert [] == [{...}]`.

## Root cause

#518 made live foreign-orphan detection **POSIX-only**: `cli/daemon_cmd.py::_live_foreign_daemons`
short-circuits to `[]` on Windows (`if os.name == "nt": return []`), because `is_pid_alive`
returns `True` for any positive pid there (no portable signal-0) and so can't distinguish a
live foreign daemon from a long-dead handshake — reporting every stale file as "running" would
be worse than not reporting. The **feature** was gated; three of its **tests** were not, so they
assert live-foreign reporting and fail on Windows.

This red state masks any *real* Windows regression in subsequent PRs (it hides among the 3
known failures), which is why it's worth fixing before continuing the B2-step3 adapter work.

## Fix

Per-method `@pytest.mark.skipif(sys.platform == "win32", reason="live foreign-orphan reporting
is POSIX-only (#519)")` on exactly those three tests — mirroring this file's existing POSIX-only
skips (`SIGTERM path is POSIX-only`, `POSIX flock re-entrancy semantics`) and the `os.name == "nt"`
short-circuit they exercise.

**Scoped to the three reporting assertions.** The class has 9 tests; the other six still run on
every platform — including `test_foreign_detection_is_posix_only` (which pins the Windows `[]`
path) and the empty-case / `stop --all` tests — so Windows coverage of the *disabled* behavior is
preserved. A class-level skip would have wrongly dropped that.

## Lifecycle

These skips come off when the cross-platform connect-probe re-enables Windows foreign detection
(**#519**).

## Verification

- macOS: `TestDaemonForeignOrphans` → 9 passed, 0 skipped (darwin ≠ win32); full `tests/daemon` → 79 passed.
- Windows CI on this PR is the authoritative proof: the 3 go to **skipped**, 0 failed.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)