### PR TITLE
feat(hook): add CursorHookAdapter (B2 step3, surfacing-only)

### DIFF
--- a/src/memtomem_stm/cli/hook_adapter.py
+++ b/src/memtomem_stm/cli/hook_adapter.py
@@ -296,12 +296,96 @@ class CodexHookAdapter(HostHookAdapter):
         return _build_hook_output(updated_tool_output, additional_context)
 
 
+class CursorHookAdapter(HostHookAdapter):
+    """Cursor PostToolUse adapter — surfacing-only (B0: no native output replace).
+
+    Unlike Codex, Cursor's contract diverges from Claude's in two ways that this
+    adapter absorbs so the shared core stays host-agnostic:
+
+    * **Event name is camelCase ``postToolUse``.** The core gates on the canonical
+      ``"PostToolUse"`` (:func:`_run_surfacing_hook_inner` etc.), so :meth:`parse`
+      normalizes it; a missing event defaults to ``"PostToolUse"`` (as for Claude),
+      and any other event passes through unchanged so the core rejects it.
+    * **Output is a *flat* top-level ``additional_context`` string** (snake_case),
+      not the nested ``hookSpecificOutput`` envelope. So :meth:`render` builds its
+      own shape rather than delegating to ``_build_hook_output``: ``{}`` when
+      nothing surfaced, else ``{"additional_context": <block>}``.
+
+    Other B0 facts: the tool output arrives under ``tool_output`` (a
+    JSON-stringified string), not ``tool_response``; ``can_replace_output`` is
+    ``False`` because Cursor's only output-replace field, ``updated_mcp_tool_output``,
+    is **MCP-tools-only** (no native equivalent), so compression is skipped and
+    ``render`` never emits a replace field. Verified native tool names are
+    ``Shell`` / ``Read`` / ``Write`` (the docs don't enumerate the rest), so
+    ``native_tool_map`` maps those; unknown names canonicalize to ``""``.
+
+    Rollout caveat (for the host-selection step, not an adapter-shape issue):
+    ``additional_context`` is documented but a **runtime no-op on Cursor today**
+    (staff-confirmed bug), so a runtime check should confirm injection works
+    before enabling Cursor surfacing by default.
+    """
+
+    host_tag: ClassVar[str] = "cursor"
+    can_replace_output: ClassVar[bool] = False
+    # Cursor's verified native built-in tool names (capitalized values) → canonical
+    # vocabulary. Only Shell/Read are in the read-like surface allowlist; the docs
+    # don't enumerate Grep/Glob/WebFetch/Edit equivalents, so they're absent and
+    # canonicalize to ``""``.
+    native_tool_map: ClassVar[dict[str, str]] = {
+        "Shell": "shell",
+        "Read": "read",
+        "Write": "write",
+    }
+
+    def parse(self, payload: dict[str, Any]) -> CanonicalHookCall | None:
+        if not isinstance(payload, dict):
+            return None
+        raw_name = payload.get("tool_name")
+        tool_name = raw_name if isinstance(raw_name, str) else ""
+        if tool_name.startswith("mcp__"):
+            return None  # proxied MCP tool — already runs through the pipeline
+        from memtomem_stm.cli.hook_cmd import _tool_response_to_text
+
+        # Normalize Cursor's camelCase event to the canonical "PostToolUse" the
+        # core gates on; missing → default; any other event passes through (and is
+        # then rejected by the core, which is correct — we only bridge post-tool).
+        raw_event = payload.get("hook_event_name")
+        event_type = "PostToolUse" if raw_event == "postToolUse" else (raw_event or "PostToolUse")
+        tool_input = payload.get("tool_input")
+        # Cursor carries the tool output under ``tool_output`` (a JSON-stringified
+        # string), not ``tool_response``. For surfacing-only we just need its text
+        # for the size gate, so flatten it through the shared helper verbatim.
+        tool_output = payload.get("tool_output")
+        return CanonicalHookCall(
+            event_type=event_type,
+            tool_name=tool_name,
+            canonical_tool=self.native_tool_map.get(tool_name, ""),
+            tool_input=tool_input if isinstance(tool_input, dict) else {},
+            tool_response=tool_output,
+            tool_response_text=_tool_response_to_text(tool_output),
+            host_tag=self.host_tag,
+        )
+
+    def render(
+        self, *, updated_tool_output: Any | None, additional_context: str | None
+    ) -> dict[str, Any]:
+        # Cursor's surfacing channel is a FLAT top-level ``additional_context``
+        # string (a different shape than Claude/Codex), so build it here directly.
+        # ``updated_tool_output`` is ignored: Cursor has no native output-replace
+        # field (can_replace_output=False), and emitting a guessed one could
+        # disrupt the host — omit it.
+        if not additional_context:
+            return {}
+        return {"additional_context": additional_context}
+
+
 # Registry keyed by host_tag. B1 shipped Claude; B2 step3 adds the non-Claude
-# adapters one host at a time (Codex first). Cursor/Kimi follow; Antigravity is
+# adapters one host at a time (Codex, then Cursor). Kimi follows; Antigravity is
 # deferred (unfixturable — see tests/fixtures/hooks/README.md).
 _ADAPTERS: dict[str, HostHookAdapter] = {
     ClaudeHookAdapter.host_tag: ClaudeHookAdapter(),
     CodexHookAdapter.host_tag: CodexHookAdapter(),
+    CursorHookAdapter.host_tag: CursorHookAdapter(),
 }
 
 # STM's canonical built-in tool vocabulary — the codomain of every adapter's
@@ -315,9 +399,9 @@ CANONICAL_TOOLS: frozenset[str] = frozenset(
 def get_adapter(host_tag: str = "claude") -> HostHookAdapter:
     """Return the adapter for ``host_tag`` (falls back to Claude).
 
-    Claude and Codex are registered (B2 step3 adds the rest); an unknown
-    ``host_tag`` falls back to Claude. Host selection (which tag the live hook
-    passes) is wired in a later step — today every caller uses the default.
+    Claude, Codex, and Cursor are registered (B2 step3 adds the rest); an
+    unknown ``host_tag`` falls back to Claude. Host selection (which tag the live
+    hook passes) is wired in a later step — today every caller uses the default.
     """
     return _ADAPTERS.get(host_tag) or _ADAPTERS["claude"]
 

--- a/tests/cli/test_hook_adapter.py
+++ b/tests/cli/test_hook_adapter.py
@@ -22,12 +22,14 @@ from memtomem_stm.cli.hook_adapter import (
     CanonicalHookCall,
     ClaudeHookAdapter,
     CodexHookAdapter,
+    CursorHookAdapter,
     get_adapter,
 )
 from memtomem_stm.cli.hook_cmd import _build_hook_output, _tool_response_to_text
 
 _CLAUDE = ClaudeHookAdapter()
 _CODEX = CodexHookAdapter()
+_CURSOR = CursorHookAdapter()
 
 # Golden host-contract fixtures (B0): tests/fixtures/hooks/<host>/.
 _HOOK_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "hooks"
@@ -225,6 +227,7 @@ def test_get_adapter_returns_registered_and_falls_back():
     assert get_adapter().host_tag == "claude"  # default
     assert get_adapter("claude").host_tag == "claude"
     assert get_adapter("codex").host_tag == "codex"  # B2 step3
+    assert get_adapter("cursor").host_tag == "cursor"  # B2 step3
     # An unregistered host tag falls back to Claude.
     assert get_adapter("nonexistent-host").host_tag == "claude"
 
@@ -376,4 +379,164 @@ def test_codex_render_delegates_to_build_hook_output():
 
 def test_codex_parse_delegates_flattening_to_shared_helper():
     src = inspect.getsource(CodexHookAdapter.parse)
+    assert "_tool_response_to_text(" in src
+
+
+# ── Cursor adapter (B2 step3 — surfacing-only; camelCase event + flat render) ──
+
+_CURSOR_DIR = _HOOK_FIXTURES / "cursor"
+
+
+def test_cursor_parse_golden_inbound():
+    # Golden: documented inbound payload → CanonicalHookCall. Exercises the two
+    # Cursor-specific edges: the camelCase event normalizes, and the output is
+    # read from ``tool_output`` (a JSON-stringified string), not ``tool_response``.
+    payload = json.loads((_CURSOR_DIR / "inbound_shell_posttooluse.json").read_text())
+    call = _CURSOR.parse(payload)
+    assert isinstance(call, CanonicalHookCall)
+    assert call.event_type == "PostToolUse"  # normalized from "postToolUse"
+    assert call.tool_name == "Shell"  # host-native preserved
+    assert call.canonical_tool == "shell"  # Shell → canonical shell (allowlisted)
+    assert call.tool_input == {"command": "npm test"}
+    # tool_output is a JSON-stringified string; flattened verbatim for the gate.
+    assert call.tool_response == '{"exitCode":0,"stdout":"All tests passed"}'
+    assert call.tool_response_text == '{"exitCode":0,"stdout":"All tests passed"}'
+    assert call.host_tag == "cursor"
+
+
+def test_cursor_render_golden_surfacing():
+    # Golden: feed the canonical surfaced block and assert render reproduces the
+    # committed Cursor emission exactly — a FLAT top-level ``additional_context``
+    # string (not the ``hookSpecificOutput`` envelope).
+    expected = json.loads((_CURSOR_DIR / "expected_surfacing_output.json").read_text())
+    block = expected["additional_context"]
+    out = _CURSOR.render(updated_tool_output=None, additional_context=block)
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    ("raw_event", "expected"),
+    [
+        ("postToolUse", "PostToolUse"),  # camelCase normalized to canonical
+        (None, "PostToolUse"),  # missing → default (as for Claude/Codex)
+        ("preToolUse", "preToolUse"),  # other event passes through (core rejects it)
+    ],
+)
+def test_cursor_parse_normalizes_event(raw_event, expected: str):
+    payload = {"tool_name": "Shell", "tool_output": "x"}
+    if raw_event is not None:
+        payload["hook_event_name"] = raw_event
+    call = _CURSOR.parse(payload)
+    assert call is not None
+    assert call.event_type == expected
+
+
+@pytest.mark.parametrize(
+    ("native", "canonical"),
+    [
+        ("Shell", "shell"),
+        ("Read", "read"),
+        ("Write", "write"),
+        ("Grep", ""),  # not in Cursor's verified native names
+        ("SomeFutureTool", ""),
+    ],
+)
+def test_cursor_parse_canonicalizes_tool_name(native: str, canonical: str):
+    call = _CURSOR.parse({"tool_name": native, "tool_output": "x"})
+    assert call is not None
+    assert call.tool_name == native  # host-native preserved
+    assert call.canonical_tool == canonical
+
+
+@pytest.mark.parametrize("mcp_tool", ["mcp__memtomem__mem_search", "mcp__github__create_issue"])
+def test_cursor_parse_rejects_mcp_tools(mcp_tool: str):
+    assert _CURSOR.parse({"tool_name": mcp_tool, "tool_output": "x"}) is None
+
+
+@pytest.mark.parametrize("bad", [None, "not a dict", [1, 2, 3], 42])
+def test_cursor_parse_non_dict_is_none(bad):
+    assert _CURSOR.parse(bad) is None
+
+
+@pytest.mark.parametrize("payload", [{}, {"tool_name": 123}, {"tool_name": None}, {"tool_name": []}])
+def test_cursor_parse_coerces_missing_or_non_str_tool_name(payload):
+    # Permissive + never-raises contract: a missing/non-str tool_name must coerce
+    # to "" before the `tool_name.startswith("mcp__")` guard (which would raise on
+    # a non-str). Pins the load-bearing coercion the sibling Claude suite already
+    # pins — without this, a dropped guard passes every test yet crashes on real
+    # host stdin.
+    call = _CURSOR.parse({**payload, "tool_output": "x"})
+    assert call is not None
+    assert call.tool_name == ""
+    assert call.canonical_tool == ""
+
+
+def test_cursor_parse_flattens_dict_output_via_shared_helper():
+    # tool_output is usually Cursor's JSON-stringified string, but stay permissive:
+    # a dict shape must flatten through the shared helper (the size-gate input).
+    response = {"stdout": "ok", "stderr": ""}
+    call = _CURSOR.parse({"tool_name": "Shell", "tool_output": response})
+    assert call is not None
+    assert call.tool_response_text == _tool_response_to_text(response)
+    assert call.tool_response_text == "ok"
+    assert call.tool_response is response
+
+
+@pytest.mark.parametrize("bad_input", [["x"], "weird", 42, 0, False])
+def test_cursor_parse_coerces_non_dict_tool_input(bad_input):
+    call = _CURSOR.parse({"tool_name": "Shell", "tool_input": bad_input, "tool_output": "x"})
+    assert call is not None
+    assert call.tool_input == {}
+
+
+def test_cursor_to_wire_carries_host_tag():
+    call = _CURSOR.parse(
+        {"tool_name": "Shell", "tool_input": {"command": "ls"}, "tool_output": "ok"}
+    )
+    assert call is not None
+    assert call.to_wire()["host_tag"] == "cursor"
+
+
+def test_cursor_render_surfacing_only_flat_shape():
+    block = "<surfaced-memories>\nMEM\n</surfaced-memories>"
+    out = _CURSOR.render(updated_tool_output=None, additional_context=block)
+    # Flat top-level, snake_case — NOT nested under hookSpecificOutput.
+    assert out == {"additional_context": block}
+
+
+def test_cursor_render_neither_is_empty():
+    assert _CURSOR.render(updated_tool_output=None, additional_context=None) == {}
+
+
+def test_cursor_render_ignores_updated_tool_output():
+    # Cursor has no native output-replace field (can_replace_output=False); render
+    # must NEVER emit one (a guessed field could disrupt the host), even if handed
+    # an updated output — only the surfacing half renders.
+    block = "<surfaced-memories>\nMEM\n</surfaced-memories>"
+    out = _CURSOR.render(updated_tool_output={"stdout": "compressed"}, additional_context=block)
+    assert out == {"additional_context": block}
+    assert "updated_mcp_tool_output" not in out
+    # And with no surfaced block, an updated output alone yields a pass-through {}.
+    assert _CURSOR.render(updated_tool_output={"stdout": "x"}, additional_context=None) == {}
+
+
+def test_cursor_capability_and_tag():
+    # B0: Cursor's only output-replace field (updated_mcp_tool_output) is MCP-only,
+    # so native compression does not port — surfacing-only.
+    assert _CURSOR.host_tag == "cursor"
+    assert _CURSOR.can_replace_output is False
+
+
+def test_cursor_render_builds_flat_shape_not_envelope():
+    # Cursor's render owns a DIFFERENT shape than Claude/Codex: it must NOT delegate
+    # to _build_hook_output nor emit hookSpecificOutput, and must use the flat
+    # snake_case additional_context key.
+    src = inspect.getsource(CursorHookAdapter.render)
+    assert "hookSpecificOutput" not in src
+    assert "_build_hook_output" not in src
+    assert "additional_context" in src
+
+
+def test_cursor_parse_delegates_flattening_to_shared_helper():
+    src = inspect.getsource(CursorHookAdapter.parse)
     assert "_tool_response_to_text(" in src


### PR DESCRIPTION
## What

Second non-Claude host adapter on the B1 `HostHookAdapter` seam — **B2 step3** (after
`CodexHookAdapter`, #520). Adds `CursorHookAdapter` to `cli/hook_adapter.py` and registers it.
**Surfacing-only by design.**

## Why Cursor is meatier than Codex

Codex mirrored Claude's shape exactly; Cursor diverges in **two** ways the adapter absorbs so
the shared core stays host-agnostic:

1. **Event name is camelCase `postToolUse`.** The core gates on the canonical `"PostToolUse"`
   (`_run_surfacing_hook_inner`, `_hook_eligible`), so `parse` normalizes it. Missing → default
   `"PostToolUse"` (as for Claude/Codex); any other event passes through so the core rejects it.
2. **Surfacing output is a FLAT top-level `additional_context` string** (snake_case), not the
   nested `hookSpecificOutput` envelope — so `render` builds its own shape rather than delegating
   to `_build_hook_output`: `{}` when nothing surfaced, else `{"additional_context": <block>}`.

## Other B0 facts

- Tool output arrives under `tool_output` (a JSON-stringified string), not `tool_response`.
- `can_replace_output = False` — Cursor's only output-replace field, `updated_mcp_tool_output`,
  is **MCP-tools-only** (no native equivalent). So compression is skipped and `render` never
  emits a replace field (a guessed one could disrupt the host); `updated_tool_output` is ignored.
- Verified native tool names are `Shell` / `Read` / `Write` (docs don't enumerate the rest), so
  `native_tool_map` maps those; unknown names canonicalize to `""`.

## Behavior change

**None.** Not yet reachable from stdin — `_orchestrate` calls `get_adapter()` with no argument
(→ Claude). Host selection (`--host` + auto-detect) is a deliberate later B2-step3 step, at which
point Codex/Cursor/Kimi go live together. Exercised only by the golden tests until then.

## Tests

Golden parse/render against `tests/fixtures/hooks/cursor/`, plus: event-normalization
(`postToolUse`→`PostToolUse`, missing→default, other-event pass-through), flat-render + never-emit
output-replace pins, `tool_output` sourcing, the `{Shell,Read,Write}` map, and parity coverage
(dict-output flatten, non-dict `tool_input` coercion, **missing/non-str `tool_name` coercion** —
the "never raises" guard).

- `uv run pytest -m "not ollama"` → **3739 passed, 3 skipped** (pre-amend; `test_hook_adapter.py`
  → 94 passed after the +4 coercion-pin amend)
- `ruff` + `mypy` clean

## Review

- **Adversarial multi-lens Workflow** (event-norm · render · side-effects · parse-field · tests,
  each skeptic-verified) → **SHIP**. Its one confirmed finding — the `tool_name` coercion guard was
  unpinned in the new Cursor suite (proven by mutation: dropping the guard passed 90/90 yet crashed
  on `{}`/`{"tool_name":123}`) — is folded in as `test_cursor_parse_coerces_missing_or_non_str_tool_name`
  (mutation-verified to bite).
- codex explored the full diff + fixtures + core gate with no objection, but its CLI repeatedly cut
  off before emitting a formal verdict this session (a tooling flush flake), so the Workflow is the
  authoritative review here.

## Rollout caveat (host-selection step, not this PR)

Cursor's `additional_context` is documented but a **runtime no-op today** (staff-confirmed bug), so
a runtime check should confirm injection works before enabling Cursor surfacing by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)