### PR TITLE
feat(hook): add KimiHookAdapter + per-host serialize seam (B2 step3)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Hook golden fixtures are byte-exact (compared via read_bytes); pin LF so a
+# Windows checkout (core.autocrlf=true) can't CRLF-convert them and break the
+# byte-identity assertion (test_kimi_render_then_serialize_golden_raw_stdout).
+# The raw-stdout goldens are *.txt; the JSON goldens are parsed structurally so
+# are EOL-agnostic, but pinning the whole tree keeps future B2 host fixtures safe.
+tests/fixtures/hooks/** text eol=lf

--- a/src/memtomem_stm/cli/hook_adapter.py
+++ b/src/memtomem_stm/cli/hook_adapter.py
@@ -49,6 +49,7 @@ canonical; the daemon rehydrates and surfaces.
 
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
@@ -160,6 +161,19 @@ class HostHookAdapter(ABC):
         ``additional_context`` is the surfaced-memories block (or ``None``).
         Returns ``{}`` when both are absent (the tool output passes through).
         """
+
+    def serialize(self, rendered: dict[str, Any]) -> str:
+        """Serialize :meth:`render`'s output to the host's stdout payload.
+
+        The default is the JSON every Claude-shaped host reads — both the nested
+        ``hookSpecificOutput`` envelope (Claude/Codex) and Cursor's flat top-level
+        keys are JSON — so those hosts inherit it unchanged and byte-identical to
+        the pre-seam ``json.dumps`` emit. A host whose surfacing channel is *not*
+        JSON overrides this: Kimi prints the surfaced block as **raw stdout** on
+        exit 0 (no JSON envelope, no key). The caller appends the trailing newline
+        (via ``click.echo``), so this returns the content without one.
+        """
+        return json.dumps(rendered, ensure_ascii=False)
 
 
 class ClaudeHookAdapter(HostHookAdapter):
@@ -379,13 +393,89 @@ class CursorHookAdapter(HostHookAdapter):
         return {"additional_context": additional_context}
 
 
+class KimiHookAdapter(HostHookAdapter):
+    """Kimi Code PostToolUse adapter — surfacing-only, **raw-stdout** channel.
+
+    Kimi is the first host whose surfacing channel is not JSON: it injects context
+    by printing the surfaced block to **stdout and exiting 0** (Kimi adds non-empty
+    stdout to the model's context) — there is no ``additionalContext`` key. So it
+    is the host that exercises the :meth:`~HostHookAdapter.serialize` seam:
+    :meth:`render` produces the same logical ``{additional_context: <block>}``
+    payload as Cursor, and :meth:`serialize` emits that block as **raw text**
+    rather than JSON (the trailing newline is the caller's ``click.echo``).
+
+    Inbound shape is otherwise Claude-like: snake_case keys, ``hook_event_name`` =
+    ``PostToolUse`` (PascalCase — no event normalization, unlike Cursor). The tool
+    output is under ``tool_output`` (like Cursor), not ``tool_response``.
+    ``can_replace_output`` is ``False`` — Kimi has **no** output-replace field at
+    all (its only structured stdout JSON is an allow/deny gate), so compression is
+    skipped and ``serialize`` never emits a replace channel. Verified native tool
+    names: ``Shell`` / ``ReadFile`` / ``WriteFile`` / ``StrReplaceFile``.
+
+    Rollout caveat (host-selection step, not an adapter-shape issue): whether
+    Kimi's exit-0 stdout inject requires pure JSON or accepts arbitrary text is
+    unverified (the fixtures assume verbatim text); a runtime check should confirm
+    before enabling Kimi surfacing by default.
+    """
+
+    host_tag: ClassVar[str] = "kimi"
+    can_replace_output: ClassVar[bool] = False
+    native_tool_map: ClassVar[dict[str, str]] = {
+        "Shell": "shell",
+        "ReadFile": "read",
+        "WriteFile": "write",
+        "StrReplaceFile": "edit",
+    }
+
+    def parse(self, payload: dict[str, Any]) -> CanonicalHookCall | None:
+        if not isinstance(payload, dict):
+            return None
+        raw_name = payload.get("tool_name")
+        tool_name = raw_name if isinstance(raw_name, str) else ""
+        if tool_name.startswith("mcp__"):
+            return None  # proxied MCP tool — already runs through the pipeline
+        from memtomem_stm.cli.hook_cmd import _tool_response_to_text
+
+        tool_input = payload.get("tool_input")
+        # Kimi carries the tool output under ``tool_output`` (like Cursor), not
+        # ``tool_response``; its event is PascalCase ``PostToolUse`` (no normalize).
+        tool_output = payload.get("tool_output")
+        return CanonicalHookCall(
+            event_type=payload.get("hook_event_name") or "PostToolUse",
+            tool_name=tool_name,
+            canonical_tool=self.native_tool_map.get(tool_name, ""),
+            tool_input=tool_input if isinstance(tool_input, dict) else {},
+            tool_response=tool_output,
+            tool_response_text=_tool_response_to_text(tool_output),
+            host_tag=self.host_tag,
+        )
+
+    def render(
+        self, *, updated_tool_output: Any | None, additional_context: str | None
+    ) -> dict[str, Any]:
+        # Same logical payload as Cursor (the surfaced block, or nothing); the
+        # wire format is serialize()'s job. ``updated_tool_output`` is ignored:
+        # Kimi has no output-replace channel (can_replace_output=False).
+        if not additional_context:
+            return {}
+        return {"additional_context": additional_context}
+
+    def serialize(self, rendered: dict[str, Any]) -> str:
+        # Kimi's surfacing channel is RAW stdout on exit 0 — emit the block text
+        # itself, never JSON. Nothing surfaced → empty stdout (no context added).
+        # The trailing-newline framing is the caller's ``click.echo``.
+        ctx = rendered.get("additional_context")
+        return ctx if isinstance(ctx, str) else ""
+
+
 # Registry keyed by host_tag. B1 shipped Claude; B2 step3 adds the non-Claude
-# adapters one host at a time (Codex, then Cursor). Kimi follows; Antigravity is
-# deferred (unfixturable — see tests/fixtures/hooks/README.md).
+# adapters one host at a time (Codex, Cursor, Kimi). Antigravity is deferred
+# (unfixturable — see tests/fixtures/hooks/README.md).
 _ADAPTERS: dict[str, HostHookAdapter] = {
     ClaudeHookAdapter.host_tag: ClaudeHookAdapter(),
     CodexHookAdapter.host_tag: CodexHookAdapter(),
     CursorHookAdapter.host_tag: CursorHookAdapter(),
+    KimiHookAdapter.host_tag: KimiHookAdapter(),
 }
 
 # STM's canonical built-in tool vocabulary — the codomain of every adapter's
@@ -399,7 +489,7 @@ CANONICAL_TOOLS: frozenset[str] = frozenset(
 def get_adapter(host_tag: str = "claude") -> HostHookAdapter:
     """Return the adapter for ``host_tag`` (falls back to Claude).
 
-    Claude, Codex, and Cursor are registered (B2 step3 adds the rest); an
+    Claude, Codex, Cursor, and Kimi are registered (Antigravity is deferred); an
     unknown ``host_tag`` falls back to Claude. Host selection (which tag the live
     hook passes) is wired in a later step — today every caller uses the default.
     """

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -723,4 +723,12 @@ def hook_command() -> None:
         except Exception:
             logger.warning("hook processing failed — passing tool output through", exc_info=True)
             output = {}
-    click.echo(adapter.serialize(output))
+    serialized = adapter.serialize(output)
+    # ``serialize`` returns "" only when nothing is emitted (Kimi's raw-stdout
+    # channel with nothing surfaced). An unconditional ``click.echo`` would still
+    # append a newline, making stdout "\n" — non-empty, which Kimi injects into
+    # the model context — so the "empty stdout" pass-through contract requires
+    # suppressing the newline on an empty payload. JSON hosts always serialize to
+    # a non-empty string ("{}" or more), so their trailing newline (and the
+    # pre-seam byte-identity) is unchanged.
+    click.echo(serialized, nl=bool(serialized))

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -74,7 +74,7 @@ import click
 from memtomem_stm.cli.hook_adapter import CANONICAL_TOOLS, canonicalize_tool_token, get_adapter
 
 if TYPE_CHECKING:
-    from memtomem_stm.cli.hook_adapter import CanonicalHookCall
+    from memtomem_stm.cli.hook_adapter import CanonicalHookCall, HostHookAdapter
     from memtomem_stm.config import HookCompressionConfig, STMConfig
 
 logger = logging.getLogger(__name__)
@@ -641,13 +641,14 @@ def _record_hook_metrics(
         logger.debug("hook metrics recording failed — no row written", exc_info=True)
 
 
-async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
+async def _orchestrate(payload: dict[str, Any], adapter: "HostHookAdapter") -> dict[str, Any]:
     """Resolve the full hook output: in-process Bash *compression* merged with
-    LTM *surfacing*, as one ``hookSpecificOutput``.
+    LTM *surfacing*, as one host-shaped output.
 
-    The host-shaped edges go through a :class:`HostHookAdapter` (Claude only
-    today): :meth:`parse` normalizes the payload into a :class:`CanonicalHookCall`
-    and :meth:`render` builds the host output. The normalized ``call`` drives the
+    The host-shaped edges go through the caller-supplied :class:`HostHookAdapter`
+    (resolved in :func:`hook_command`; Claude is the only one reachable today):
+    :meth:`parse` normalizes the payload into a :class:`CanonicalHookCall` and
+    :meth:`render` builds the host output. The normalized ``call`` drives the
     whole pipeline — the compression gate, the surfacing core, and metrics all
     consume it, so the raw payload is parsed exactly once. *Compression* is gated
     on the adapter's ``can_replace_output`` capability — only hosts that honor
@@ -675,7 +676,6 @@ async def _orchestrate(payload: dict[str, Any]) -> dict[str, Any]:
     from memtomem_stm.config import STMConfig
 
     config = STMConfig()
-    adapter = get_adapter()
     call = adapter.parse(payload)
     if call is None:  # unusable payload → pass the tool output through untouched
         return {}
@@ -706,15 +706,21 @@ def hook_command() -> None:
     use; set ``MEMTOMEM_STM_HOOK__USE_DAEMON=0`` for the legacy cold in-process
     path. Always exits 0; on any problem the tool output passes through unchanged
     (prints ``{}``).
+
+    The host adapter resolved here owns both the output *shape* (``render``) and
+    its *stdout serialization* (``serialize`` — JSON for Claude/Codex/Cursor, raw
+    stdout for Kimi). Today ``get_adapter()`` always returns Claude; host selection
+    (``--host`` / payload auto-detect) plugs in here in a later step.
     """
     payload = _read_payload(sys.stdin)
+    adapter = get_adapter()
     output: dict[str, Any] = {}
     if payload is not None:
         try:
             output = asyncio.run(
-                asyncio.wait_for(_orchestrate(payload), timeout=_hook_budget_seconds())
+                asyncio.wait_for(_orchestrate(payload, adapter), timeout=_hook_budget_seconds())
             )
         except Exception:
             logger.warning("hook processing failed — passing tool output through", exc_info=True)
             output = {}
-    click.echo(json.dumps(output, ensure_ascii=False))
+    click.echo(adapter.serialize(output))

--- a/tests/cli/test_hook_adapter.py
+++ b/tests/cli/test_hook_adapter.py
@@ -23,6 +23,7 @@ from memtomem_stm.cli.hook_adapter import (
     ClaudeHookAdapter,
     CodexHookAdapter,
     CursorHookAdapter,
+    KimiHookAdapter,
     get_adapter,
 )
 from memtomem_stm.cli.hook_cmd import _build_hook_output, _tool_response_to_text
@@ -30,6 +31,7 @@ from memtomem_stm.cli.hook_cmd import _build_hook_output, _tool_response_to_text
 _CLAUDE = ClaudeHookAdapter()
 _CODEX = CodexHookAdapter()
 _CURSOR = CursorHookAdapter()
+_KIMI = KimiHookAdapter()
 
 # Golden host-contract fixtures (B0): tests/fixtures/hooks/<host>/.
 _HOOK_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "hooks"
@@ -228,6 +230,7 @@ def test_get_adapter_returns_registered_and_falls_back():
     assert get_adapter("claude").host_tag == "claude"
     assert get_adapter("codex").host_tag == "codex"  # B2 step3
     assert get_adapter("cursor").host_tag == "cursor"  # B2 step3
+    assert get_adapter("kimi").host_tag == "kimi"  # B2 step3
     # An unregistered host tag falls back to Claude.
     assert get_adapter("nonexistent-host").host_tag == "claude"
 
@@ -251,14 +254,29 @@ def test_parse_delegates_flattening_to_shared_helper():
 
 
 def test_orchestrate_routes_through_adapter():
-    # Pin the shape-identical routing: _orchestrate must dispatch via
-    # get_adapter() and use the adapter's parse/render, and gate compression on
-    # the capability flag rather than running it unconditionally.
+    # Pin the shape-identical routing: _orchestrate consumes the supplied adapter's
+    # parse/render and gates compression on the capability flag rather than running
+    # it unconditionally. (Adapter resolution + serialization live in hook_command.)
     src = inspect.getsource(hook_cmd._orchestrate)
-    assert "get_adapter(" in src
-    assert ".parse(" in src
-    assert ".render(" in src
+    assert "adapter.parse(" in src
+    assert "adapter.render(" in src
     assert "can_replace_output" in src
+    # And it must NOT re-resolve its own adapter (that resolution is hook_command's
+    # job — the host-selection plug-in point). Re-internalizing get_adapter() here
+    # would silently ignore the supplied adapter; pin against it.
+    assert "get_adapter(" not in src
+
+
+def test_hook_command_resolves_adapter_and_serializes():
+    # hook_command owns adapter selection (get_adapter() — the host-selection
+    # plug-in point) and per-host stdout serialization (adapter.serialize), so the
+    # raw-stdout (Kimi) vs JSON (Claude/Codex/Cursor) decision is the adapter's,
+    # not a hardcoded json.dumps in the CLI. (hook_command is a click Command —
+    # inspect its underlying callback.)
+    src = inspect.getsource(hook_cmd.hook_command.callback)
+    assert "get_adapter(" in src
+    assert "adapter.serialize(" in src
+    assert "json.dumps(" not in src  # serialization delegated to the adapter
 
 
 # ── Codex adapter (B2 step3 — surfacing-only) ──────────────────────────────────
@@ -539,4 +557,165 @@ def test_cursor_render_builds_flat_shape_not_envelope():
 
 def test_cursor_parse_delegates_flattening_to_shared_helper():
     src = inspect.getsource(CursorHookAdapter.parse)
+    assert "_tool_response_to_text(" in src
+
+
+# ── serialize seam (per-host stdout: JSON for Claude/Codex/Cursor, raw for Kimi) ─
+
+
+@pytest.mark.parametrize("adapter", [_CLAUDE, _CODEX, _CURSOR])
+def test_json_hosts_serialize_is_json_dumps_byte_identical(adapter):
+    # The default serialize() must stay byte-identical to the pre-seam emit
+    # (`json.dumps(output, ensure_ascii=False)`) for every JSON host — both the
+    # nested Claude/Codex envelope and Cursor's flat keys. The non-ASCII payload
+    # pins the ``ensure_ascii=False`` half: with only-ASCII inputs a regression to
+    # ``ensure_ascii=True`` is invisible, yet it would `\uXXXX`-escape the Korean
+    # LTM blocks this project routinely surfaces.
+    for rendered in (
+        {},
+        {"additional_context": "<surfaced-memories>\nMEM\n</surfaced-memories>"},
+        {"additional_context": "<surfaced-memories>\n한국어 메모\n</surfaced-memories>"},
+        {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "x"}},
+    ):
+        assert adapter.serialize(rendered) == json.dumps(rendered, ensure_ascii=False)
+        # Guard the escape directly: a non-ASCII block must NOT be \uXXXX-escaped.
+        if "한국어" in str(rendered):
+            assert "한국어" in adapter.serialize(rendered)
+            assert "\\ud55c" not in adapter.serialize(rendered)
+
+
+# ── Kimi adapter (B2 step3 — raw-stdout surfacing channel) ─────────────────────
+
+_KIMI_DIR = _HOOK_FIXTURES / "kimi"
+
+
+def test_kimi_parse_golden_inbound():
+    payload = json.loads((_KIMI_DIR / "inbound_shell_posttooluse.json").read_text())
+    call = _KIMI.parse(payload)
+    assert isinstance(call, CanonicalHookCall)
+    # Kimi's event is PascalCase PostToolUse already — no normalization needed.
+    assert call.event_type == "PostToolUse"
+    assert call.tool_name == "Shell"
+    assert call.canonical_tool == "shell"
+    assert call.tool_input == {"command": "pytest -q"}
+    # Output is under ``tool_output`` (like Cursor), not ``tool_response``.
+    assert call.tool_response == "12 passed in 3.4s"
+    assert call.tool_response_text == "12 passed in 3.4s"
+    assert call.host_tag == "kimi"
+
+
+def test_kimi_render_then_serialize_golden_raw_stdout():
+    # The golden: render → serialize must reproduce the committed RAW stdout
+    # fixture exactly (the surfaced block, NOT JSON). Byte-identical to the .txt
+    # (which stores the block with no trailing newline — the live newline is the
+    # caller's click.echo).
+    raw_path = _KIMI_DIR / "expected_surfacing_stdout.txt"
+    block = raw_path.read_text()
+    rendered = _KIMI.render(updated_tool_output=None, additional_context=block)
+    out = _KIMI.serialize(rendered)
+    assert out == block
+    assert out.encode("utf-8") == raw_path.read_bytes()  # byte-identical, no framing
+    # It is RAW text, not a JSON envelope — none of the JSON-host markers.
+    assert not out.startswith("{")
+    assert "additionalContext" not in out
+    assert "hookSpecificOutput" not in out
+
+
+def test_kimi_serialize_is_raw_not_json_vs_claude():
+    block = "<surfaced-memories>\nMEM\n</surfaced-memories>"
+    rendered = {"additional_context": block}
+    # Kimi emits the block verbatim; the JSON hosts emit json.dumps of the dict.
+    assert _KIMI.serialize(rendered) == block
+    assert _CLAUDE.serialize(rendered) == json.dumps(rendered, ensure_ascii=False)
+    assert _CLAUDE.serialize(rendered).startswith("{")
+
+
+def test_kimi_serialize_empty_is_empty_stdout():
+    # Nothing surfaced → empty stdout (Kimi adds only non-empty stdout to context).
+    assert _KIMI.serialize({}) == ""
+    assert _KIMI.serialize(_KIMI.render(updated_tool_output=None, additional_context=None)) == ""
+
+
+def test_kimi_serialize_ignores_updated_output_no_replace_field():
+    # Kimi has no output-replace channel: an updated output never appears in stdout;
+    # only the surfaced block (raw) is emitted.
+    block = "<surfaced-memories>\nMEM\n</surfaced-memories>"
+    rendered = _KIMI.render(updated_tool_output={"stdout": "compressed"}, additional_context=block)
+    assert _KIMI.serialize(rendered) == block
+
+
+@pytest.mark.parametrize(
+    ("native", "canonical"),
+    [
+        ("Shell", "shell"),
+        ("ReadFile", "read"),
+        ("WriteFile", "write"),
+        ("StrReplaceFile", "edit"),
+        ("Bash", ""),  # Claude's name, not Kimi's → unmapped
+        ("SomeFutureTool", ""),
+    ],
+)
+def test_kimi_parse_canonicalizes_tool_name(native: str, canonical: str):
+    call = _KIMI.parse({"tool_name": native, "tool_output": "x"})
+    assert call is not None
+    assert call.tool_name == native
+    assert call.canonical_tool == canonical
+
+
+@pytest.mark.parametrize("mcp_tool", ["mcp__memtomem__mem_search", "mcp__github__create_issue"])
+def test_kimi_parse_rejects_mcp_tools(mcp_tool: str):
+    assert _KIMI.parse({"tool_name": mcp_tool, "tool_output": "x"}) is None
+
+
+@pytest.mark.parametrize("bad", [None, "not a dict", [1, 2, 3], 42])
+def test_kimi_parse_non_dict_is_none(bad):
+    assert _KIMI.parse(bad) is None
+
+
+@pytest.mark.parametrize("payload", [{}, {"tool_name": 123}, {"tool_name": None}, {"tool_name": []}])
+def test_kimi_parse_coerces_missing_or_non_str_tool_name(payload):
+    # Never-raises contract: a missing/non-str tool_name coerces to "" before the
+    # mcp__ startswith guard.
+    call = _KIMI.parse({**payload, "tool_output": "x"})
+    assert call is not None
+    assert call.tool_name == ""
+    assert call.canonical_tool == ""
+
+
+@pytest.mark.parametrize("bad_input", [["x"], "weird", 42, 0, False])
+def test_kimi_parse_coerces_non_dict_tool_input(bad_input):
+    call = _KIMI.parse({"tool_name": "Shell", "tool_input": bad_input, "tool_output": "x"})
+    assert call is not None
+    assert call.tool_input == {}
+
+
+def test_kimi_parse_flattens_dict_output_via_shared_helper():
+    response = {"stdout": "ok", "stderr": ""}
+    call = _KIMI.parse({"tool_name": "Shell", "tool_output": response})
+    assert call is not None
+    assert call.tool_response_text == _tool_response_to_text(response)
+    assert call.tool_response_text == "ok"
+
+
+def test_kimi_to_wire_carries_host_tag():
+    call = _KIMI.parse({"tool_name": "Shell", "tool_input": {"command": "ls"}, "tool_output": "ok"})
+    assert call is not None
+    assert call.to_wire()["host_tag"] == "kimi"
+
+
+def test_kimi_capability_and_tag():
+    # B0: Kimi has no output-replace field at all → surfacing-only.
+    assert _KIMI.host_tag == "kimi"
+    assert _KIMI.can_replace_output is False
+
+
+def test_kimi_serialize_emits_raw_not_json():
+    # The seam pin: Kimi's serialize must NOT json.dumps — it emits the block text.
+    src = inspect.getsource(KimiHookAdapter.serialize)
+    assert "json.dumps" not in src
+    assert "additional_context" in src
+
+
+def test_kimi_parse_delegates_flattening_to_shared_helper():
+    src = inspect.getsource(KimiHookAdapter.parse)
     assert "_tool_response_to_text(" in src

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 import pytest
 from click.testing import CliRunner
 
-from memtomem_stm.cli.hook_adapter import ClaudeHookAdapter
+from memtomem_stm.cli.hook_adapter import ClaudeHookAdapter, CodexHookAdapter
 from memtomem_stm.cli.hook_cmd import (
     _COMPRESS_SENTINEL,
     _SAFE_DAEMON_BUDGET,
@@ -706,7 +706,7 @@ def test_orchestrate_merges_compression_and_surfacing(monkeypatch: pytest.Monkey
     monkeypatch.setattr(
         "memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value=surfaced)
     )
-    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT})))
+    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT}), ClaudeHookAdapter()))
     hso = out["hookSpecificOutput"]
     assert hso["updatedToolOutput"]["stdout"].startswith(_COMPRESS_SENTINEL)
     assert hso["additionalContext"] == "<surfaced-memories>m</surfaced-memories>"
@@ -721,10 +721,26 @@ def test_orchestrate_compression_runs_when_surfacing_yields_nothing(
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__MAX_CHARS", "2000")
     monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
     monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value={}))
-    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT})))
+    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT}), ClaudeHookAdapter()))
     hso = out["hookSpecificOutput"]
     assert hso["updatedToolOutput"]["stdout"].startswith(_COMPRESS_SENTINEL)
     assert "additionalContext" not in hso
+
+
+def test_orchestrate_honors_supplied_adapter_capability(monkeypatch: pytest.MonkeyPatch):
+    # _orchestrate must use the SUPPLIED adapter, not re-resolve Claude internally:
+    # a can_replace_output=False adapter (Codex) skips compression even with the
+    # same compressible Bash payload + compression env that Claude DOES compress
+    # (test_orchestrate_merges_*). Pins this PR's seam against re-internalizing
+    # get_adapter() — a mutation re-adding it would compress here and fail.
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED", "1")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__COMPRESSION__MAX_CHARS", "2000")
+    monkeypatch.setenv("MEMTOMEM_STM_HOOK__USE_DAEMON", "0")
+    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.run_surfacing_hook", AsyncMock(return_value={}))
+    # Codex maps Bash→shell (so it reaches the compression gate) but
+    # can_replace_output is False → compression is skipped, output passes through.
+    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT}), CodexHookAdapter()))
+    assert out == {}  # no updatedToolOutput — the supplied adapter's capability won
 
 
 def test_orchestrate_keeps_compression_when_surfacing_raises(monkeypatch: pytest.MonkeyPatch):
@@ -737,7 +753,7 @@ def test_orchestrate_keeps_compression_when_surfacing_raises(monkeypatch: pytest
         "memtomem_stm.cli.hook_cmd.run_surfacing_hook",
         AsyncMock(side_effect=RuntimeError("surfacing exploded")),
     )
-    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT})))
+    out = asyncio.run(_orchestrate(_bash_payload({"stdout": _BIG_STDOUT}), ClaudeHookAdapter()))
     hso = out["hookSpecificOutput"]
     assert hso["updatedToolOutput"]["stdout"].startswith(_COMPRESS_SENTINEL)
     assert "additionalContext" not in hso

--- a/tests/cli/test_hook_cmd.py
+++ b/tests/cli/test_hook_cmd.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 import pytest
 from click.testing import CliRunner
 
-from memtomem_stm.cli.hook_adapter import ClaudeHookAdapter, CodexHookAdapter
+from memtomem_stm.cli.hook_adapter import ClaudeHookAdapter, CodexHookAdapter, KimiHookAdapter
 from memtomem_stm.cli.hook_cmd import (
     _COMPRESS_SENTINEL,
     _SAFE_DAEMON_BUDGET,
@@ -305,6 +305,20 @@ def test_cli_surfacing_disabled_is_noop(monkeypatch: pytest.MonkeyPatch):
     assert result.exit_code == 0
     assert json.loads(result.output) == {}
     assert spawns == []  # surfacing disabled → no daemon spawn
+
+
+def test_cli_kimi_empty_surfacing_emits_truly_empty_stdout(monkeypatch: pytest.MonkeyPatch):
+    # Kimi's surfacing channel is RAW stdout: a non-empty stdout is injected into
+    # the model context, so "nothing surfaced" must emit a *truly* empty stdout —
+    # not the "\n" an unconditional ``click.echo`` appends to an empty payload.
+    # ``KimiHookAdapter.serialize({}) == ""``, so this pins the CLI emit (not just
+    # serialize's return) once host selection can route to Kimi. A regression to
+    # ``click.echo(serialize(output))`` makes ``result.output == "\n"`` and fails.
+    monkeypatch.setattr("memtomem_stm.cli.hook_cmd.get_adapter", lambda *a, **k: KimiHookAdapter())
+    monkeypatch.setattr("memtomem_stm.cli.hook_cmd._orchestrate", AsyncMock(return_value={}))
+    result = CliRunner().invoke(cli, ["hook"], input=json.dumps(_READ_PAYLOAD))
+    assert result.exit_code == 0
+    assert result.output == ""
 
 
 # ── Daemon routing + degradation ladder ──────────────────────────────────────


### PR DESCRIPTION
## What

Third non-Claude host adapter — and the **architectural** PR of B2 step3. Kimi's surfacing
channel is **raw stdout on exit 0** (Kimi adds non-empty stdout to the model's context), not a
JSON key, so the single `click.echo(json.dumps(output))` emit could not express it.

## Per-host serialize seam

- New `HostHookAdapter.serialize(rendered: dict) -> str`, default `json.dumps(rendered,
  ensure_ascii=False)`. **Claude/Codex/Cursor inherit it unchanged** — byte-identical to the
  pre-seam emit (verified e2e: the default hook still prints `{}`).
- `KimiHookAdapter` overrides `serialize` to emit the surfaced block as **raw text** (no JSON
  envelope); nothing surfaced → empty stdout. Its `render` returns the same logical
  `{additional_context: <block>}` payload as Cursor — the *wire format* is `serialize`'s job. The
  trailing newline is the caller's `click.echo` (the `.txt` fixture stores the block without one).
- `hook_command` now owns adapter resolution (`get_adapter()` — the host-selection plug-in point)
  and calls `adapter.serialize(output)`; `_orchestrate(payload, adapter)` takes the adapter as a
  parameter instead of resolving it internally.

## Kimi parse facts (B0)

snake_case keys; `hook_event_name` = `PostToolUse` (PascalCase — **no** normalization, unlike
Cursor); output under `tool_output` (like Cursor), not `tool_response`; `can_replace_output = False`
(Kimi has **no** output-replace field at all); native names `Shell`/`ReadFile`/`WriteFile`/`StrReplaceFile`.

## Behavior change

**None.** Not yet reachable from stdin — `get_adapter()` still returns Claude; host selection
(`--host` / auto-detect) is the next B2-step3 step, which flips Codex/Cursor/Kimi live together.

## Tests

Golden parse + a raw-stdout `render→serialize` golden (**byte-identical to the `.txt` fixture**),
serialize-is-raw-vs-JSON contrast, the empty / ignore-updated-output cases, the
`{Shell,ReadFile,WriteFile,StrReplaceFile}` map, parity coercion (incl. missing/non-str
`tool_name`), and source pins. Updated the three `_orchestrate(...)` call sites + the routing
source-pin for the new seam.

- `uv run pytest -m "not ollama"` → **3778 passed, 3 skipped** (pre-amend)
- `ruff` + `mypy` clean

## Review

**Adversarial multi-lens Workflow** (byte-identity · kimi-serialize · wiring · parse/side-effects ·
tests, each skeptic-verified) → **SHIP**. Its two confirmed findings — both minor test-coverage
gaps on the PR's load-bearing contracts (production code correct), proven by mutation — are folded in:

1. The byte-identity test now includes a **non-ASCII (Korean) payload**, pinning the
   `ensure_ascii=False` half (a regression to `ensure_ascii=True` would `\uXXXX`-escape Korean LTM
   blocks while ASCII-only tests stayed green). Mutation-verified to bite.
2. A **negative source-pin** (`_orchestrate` must not re-resolve `get_adapter()`) **plus a
   behavioral test** (`_orchestrate(bash_payload, CodexHookAdapter())` → no compression, since
   `can_replace_output=False`), pinning that `_orchestrate` honors its supplied adapter. Both
   mutation-verified to bite (re-internalizing `get_adapter()` fails them).

codex explored the full diff + fixtures across the session but its CLI repeatedly cut off before a
formal verdict (a tooling flush flake), so the Workflow is the authoritative review.

## Rollout caveat (host-selection step)

Whether Kimi's exit-0 stdout inject requires pure JSON or accepts arbitrary text is unverified; a
runtime check should confirm before enabling Kimi surfacing by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)