### PR TITLE
fix(daemon): gate foreign/stale orphan reaping on a connect-probe (#519)

### DIFF
--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -329,6 +329,7 @@ def _stop_foreign_daemons(config: STMConfig) -> None:
     coincidence (pid recycled *and* its ephemeral port reassigned to another
     listener); ``--all`` stays opt-in for that narrow window.
     """
+    from memtomem_stm.daemon import client
     from memtomem_stm.daemon.discovery import is_pid_alive
 
     foreign = _live_foreign_daemons(config)
@@ -337,8 +338,13 @@ def _stop_foreign_daemons(config: STMConfig) -> None:
         return
     for d in foreign:
         pid = d["pid"]
-        if not is_pid_alive(pid):
-            continue  # raced to exit between enumeration and now
+        # Re-confirm the *same* two-factor gate at action time, not just
+        # `is_pid_alive`: the daemon may have exited since enumeration and the OS
+        # recycled its pid onto an unrelated process. A pid-only recheck is too
+        # weak for that race (and a no-op on Windows, where is_pid_alive is always
+        # True), so re-run the connect-probe — a recycled pid's endpoint is gone.
+        if not (is_pid_alive(pid) and client.probe_listening(d["host"], d["port"])):
+            continue  # raced to exit / pid recycled between enumeration and now
         try:
             os.kill(pid, signal.SIGTERM)
             click.echo(_ok(f"sent SIGTERM to daemon pid={pid} (fp={d['fingerprint']})"))

--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -96,28 +96,26 @@ def _live_foreign_daemons(config: STMConfig) -> list[dict[str, Any]]:
     never look. A daemon with a finite ``idle_timeout_seconds`` clears itself, but
     a pinned ``idle_timeout_seconds=0`` one lingers — this surfaces it.
 
-    Liveness is the recorded pid (:func:`is_pid_alive`): a foreign daemon may
-    speak an older protocol, so a socket ``ping`` would fail the version gate.
-    This is a weaker signal than the current-config path's socket ``ping`` — a
-    daemon that crashed (SIGKILL/OOM, not a graceful teardown) leaves its
-    handshake on disk, and the OS may recycle its pid to an unrelated process,
-    which would then look "alive" here. Closing that window (a process-identity
-    cross-check before acting) is tracked as a follow-up; the residual risk is
-    the same one the current-config SIGTERM fallback already carries. Each entry
-    carries only non-sensitive fields (``fingerprint``/``pid``/``host``/``port``)
-    — never the auth ``token`` — so callers can render them.
+    Liveness is **two-factor**: the recorded pid must exist
+    (:func:`is_pid_alive`) *and* a bare TCP connect to its endpoint must succeed
+    (:func:`~memtomem_stm.daemon.client.probe_listening`). A foreign daemon may
+    speak an older protocol, so a token ``ping`` would fail the version gate —
+    but it is still *accepting*, so a connect-probe reaches it without sending a
+    frame. The pid alone is too weak: a daemon that crashed (SIGKILL/OOM, not a
+    graceful teardown) leaves its handshake on disk, and the OS may recycle its
+    pid to an unrelated process that would then look "alive". Requiring the
+    endpoint to also accept rejects that recycled-pid case (its port is not
+    bound) — a strictly stronger check than pid alone (the residual is a double
+    coincidence: the pid recycled *and* its ephemeral port reassigned to another
+    listener). Each entry carries only non-sensitive fields
+    (``fingerprint``/``pid``/``host``/``port``) — never the auth ``token`` — so
+    callers can render them.
 
-    **POSIX-only.** On Windows :func:`is_pid_alive` returns ``True`` for any
-    positive pid (no signal-0; it defers to a socket ``ping`` that the foreign
-    path can't make across a protocol gap), so it cannot tell a live foreign
-    daemon from a long-dead handshake. Rather than report every stale file as
-    "running", foreign detection is disabled there until a cross-platform
-    connect-probe lands (the follow-up above, which also closes the recycling
-    window).
+    Cross-platform: the connect-probe is what makes Windows viable too, where
+    :func:`is_pid_alive` is uninformative (returns ``True`` for any positive pid,
+    no signal-0) — there the connect carries the whole signal (#519).
     """
-    if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
-        return []
-
+    from memtomem_stm.daemon.client import probe_listening
     from memtomem_stm.daemon.discovery import (
         config_fingerprint,
         is_pid_alive,
@@ -128,13 +126,18 @@ def _live_foreign_daemons(config: STMConfig) -> list[dict[str, Any]]:
     live: list[dict[str, Any]] = []
     for fingerprint, hs in iter_foreign_handshakes(config.data_dir, current):
         pid = _as_int(hs.get("pid", -1))
-        if is_pid_alive(pid):
+        host = hs.get("host")
+        port = hs.get("port")
+        # Cheap pid filter first (drops dead/garbage pids and, on POSIX, the
+        # bulk of stale handshakes without a connect); the probe then confirms
+        # something still accepts on the recorded endpoint.
+        if is_pid_alive(pid) and probe_listening(host, port):
             live.append(
                 {
                     "fingerprint": fingerprint,
                     "pid": pid,
-                    "host": hs.get("host"),
-                    "port": hs.get("port"),
+                    "host": host,
+                    "port": port,
                 }
             )
     return live
@@ -251,8 +254,8 @@ def start_cmd() -> None:
     is_flag=True,
     help="Also stop daemons running under a different config fingerprint "
     "(orphans left after a config or PROTOCOL_VERSION change). Off by default: a "
-    "live daemon under another config may be intentional, and a crash-orphaned "
-    "handshake can name a since-recycled pid.",
+    "live daemon under another config may be intentional. Targets are gated by a "
+    "connect-probe so a stale handshake naming a recycled pid is not signalled.",
 )
 def stop_cmd(stop_all: bool) -> None:
     """Ask a running daemon to shut down gracefully.
@@ -290,7 +293,13 @@ def _stop_current_config_daemon(config: STMConfig) -> None:
         click.echo("no running daemon")
         return
     pid = _as_int(raw.get("pid", -1))
-    if os.name != "nt" and is_pid_alive(pid):
+    # Graceful shutdown declined, but a handshake remains. Only SIGTERM when the
+    # endpoint still accepts a connect — a bare probe (no token) tells "daemon
+    # there but unresponsive to OP_SHUTDOWN" from "stale handshake naming a dead
+    # or OS-recycled pid", so we don't signal an unrelated process. Replaces the
+    # old POSIX-only ``is_pid_alive`` gate, which over-reported on Windows; the
+    # probe makes the fallback safe cross-platform (#519).
+    if is_pid_alive(pid) and client.probe_listening(raw.get("host"), raw.get("port")):
         try:
             os.kill(pid, signal.SIGTERM)
             click.echo(_ok(f"sent SIGTERM to daemon pid={pid}"))
@@ -313,12 +322,12 @@ def _stop_foreign_daemons(config: STMConfig) -> None:
     pinned daemon exits. The daemon removes its own handshake on teardown, so we
     do not unlink it here (that could hide a survivor that ignored the signal).
 
-    Caveat (see :func:`_live_foreign_daemons`): without a socket handshake the
-    target is identified only by its recorded pid, so a crash-orphaned handshake
-    naming a since-recycled pid would signal an unrelated process. This is why
-    ``--all`` is opt-in; a process-identity cross-check is a tracked follow-up.
-    POSIX-only in practice: :func:`_live_foreign_daemons` yields nothing on
-    Windows (no verifiable foreign liveness there), so the loop never runs.
+    Targets come from :func:`_live_foreign_daemons`, whose two-factor check
+    (recorded pid alive *and* its endpoint accepting a connect) already rejects a
+    crash-orphaned handshake naming a since-recycled pid — so ``--all`` does not
+    signal an unrelated process in the common case. The residual is a double
+    coincidence (pid recycled *and* its ephemeral port reassigned to another
+    listener); ``--all`` stays opt-in for that narrow window.
     """
     from memtomem_stm.daemon.discovery import is_pid_alive
 

--- a/src/memtomem_stm/daemon/client.py
+++ b/src/memtomem_stm/daemon/client.py
@@ -144,3 +144,55 @@ async def shutdown(config: STMConfig, *, timeout: float = 5.0) -> bool:
         return False
     resp = await _request(hs, OP_SHUTDOWN, None, timeout=timeout)
     return resp is not None and bool(resp.get("ok"))
+
+
+# Bare connect-probe — the cross-platform liveness discriminator for the
+# foreign-orphan and same-config SIGTERM paths (see #519). Unlike ``ping``, it
+# sends no protocol frame and needs no token, so it tells a *listening* daemon
+# (any ``PROTOCOL_VERSION``) apart from a stale handshake naming a dead or
+# OS-recycled pid: the former still accepts a connect, the latter's port is not
+# bound. It proves only that *something* accepts on ``host:port`` — not that it
+# is the recorded pid (an ephemeral port could be reassigned) — so callers pair
+# it with ``is_pid_alive`` for a two-factor check, materially stronger than pid
+# alone yet still a heuristic, not identity proof.
+PROBE_TIMEOUT_SECONDS = 1.0
+
+
+async def _can_connect(host: object, port: object, *, timeout: float) -> bool:
+    """Open then immediately close a TCP connection to ``host:port``.
+
+    ``True`` iff the connect succeeds within ``timeout``. No bytes are sent, so a
+    foreign daemon at an incompatible protocol still answers. Any failure
+    (refused, unreachable, malformed endpoint, over-budget) is a quiet ``False``;
+    on loopback a closed port is refused instantly, so the timeout only bites a
+    genuinely wedged peer.
+    """
+    if not isinstance(host, str) or not isinstance(port, int) or port <= 0:
+        return False
+    writer: asyncio.StreamWriter | None = None
+    try:
+        async with asyncio.timeout(timeout):
+            _reader, writer = await asyncio.open_connection(host, port, limit=MAX_MESSAGE_BYTES)
+        return True
+    except (OSError, asyncio.TimeoutError):
+        return False
+    except Exception:
+        logger.debug("connect probe failed (%s:%s)", host, port, exc_info=True)
+        return False
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await asyncio.wait_for(writer.wait_closed(), timeout=1.0)
+            except Exception:
+                pass
+
+
+def probe_listening(host: object, port: object, *, timeout: float = PROBE_TIMEOUT_SECONDS) -> bool:
+    """Sync wrapper over :func:`_can_connect` for the CLI ops paths.
+
+    ``True`` iff a TCP connect to ``host:port`` succeeds — i.e. a daemon (of any
+    protocol version) is still accepting there. Used by ``mms daemon status`` /
+    ``stop`` to gate action on a recorded pid behind proof its endpoint is live.
+    """
+    return asyncio.run(_can_connect(host, port, timeout=timeout))

--- a/src/memtomem_stm/daemon/discovery.py
+++ b/src/memtomem_stm/daemon/discovery.py
@@ -18,9 +18,12 @@ primitive — preventing a second *same-config* daemon is the (likewise
 fingerprint-keyed) lock's job (see :mod:`~memtomem_stm.daemon.locking`).
 Liveness for a *current-config* daemon is proven by a successful ``ping`` over
 the socket — not by the recorded ``pid`` — so a recycled PID can't be mistaken
-for the daemon. The foreign-orphan path (:func:`iter_foreign_handshakes`) is the
-one exception: it can't ``ping`` a daemon at an incompatible ``PROTOCOL_VERSION``,
-so it falls back to the recorded pid and carries the matching recycling caveat.
+for the daemon. The foreign-orphan path (:func:`iter_foreign_handshakes`) can't
+``ping`` a daemon at an incompatible ``PROTOCOL_VERSION``, so it cross-checks the
+recorded pid against a bare TCP connect-probe to the endpoint (``is_pid_alive``
+*and* something still accepting) — a stale handshake naming a recycled pid fails
+the connect because its port is unbound. See
+:func:`~memtomem_stm.cli.daemon_cmd._live_foreign_daemons`.
 
 A config change (or a ``PROTOCOL_VERSION`` bump) leaves the old fingerprint's
 handshake behind as an orphan. No reader keys to it anymore, so it is harmless

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -452,6 +452,32 @@ def test_is_pid_alive():
         assert discovery.is_pid_alive(10**1000) is False
 
 
+def test_probe_listening():
+    """The cross-platform connect-probe (#519): True iff something accepts on
+    host:port, False for a closed port or a malformed endpoint."""
+    import socket
+
+    from memtomem_stm.daemon import client
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen()
+    host, port = srv.getsockname()
+    try:
+        # A listening socket — connect succeeds even though we never speak the
+        # protocol (mirrors a foreign daemon at an incompatible PROTOCOL_VERSION).
+        assert client.probe_listening(host, port) is True
+    finally:
+        srv.close()
+    # Same port, now closed (the daemon's process is gone) — connect refused.
+    assert client.probe_listening(host, port, timeout=0.5) is False
+    # Malformed endpoints from a corrupted/partial handshake → quiet False.
+    assert client.probe_listening(None, port) is False
+    assert client.probe_listening(host, None) is False
+    assert client.probe_listening(host, 0) is False
+    assert client.probe_listening(host, -1) is False
+
+
 # ── locking ─────────────────────────────────────────────────────────────────
 
 
@@ -572,16 +598,20 @@ class TestDaemonStopCli:
         assert not hs.exists()
         assert killed == []
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="SIGTERM path is POSIX-only")
     def test_stale_handshake_alive_pid_gets_sigterm(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
+        """Graceful shutdown declined but the endpoint still accepts a connect →
+        the daemon is there-but-unresponsive, so SIGTERM its recorded pid."""
         from click.testing import CliRunner
 
         monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
         _no_daemon(monkeypatch)
-        _write_handshake({"pid": 12345, "port": 1, "token": "t"})
+        _write_handshake({"pid": 12345, "host": "127.0.0.1", "port": 1, "token": "t"})
         monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)
+        monkeypatch.setattr(
+            "memtomem_stm.daemon.client.probe_listening", lambda host, port, **kw: True
+        )
         killed: list[tuple[int, int]] = []
         monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append((pid, sig)))
 
@@ -592,6 +622,31 @@ class TestDaemonStopCli:
         import signal as _signal
 
         assert killed == [(12345, _signal.SIGTERM)]
+
+    def test_stale_handshake_recycled_pid_not_sigtermed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """#519 same-config hardening: graceful declined, the handshake's pid is
+        alive (recycled to an unrelated process) but its endpoint no longer
+        accepts → do NOT SIGTERM; clean the stale handshake instead."""
+        from click.testing import CliRunner
+
+        monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+        _no_daemon(monkeypatch)
+        hs = _write_handshake({"pid": 12345, "host": "127.0.0.1", "port": 1, "token": "t"})
+        monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)
+        monkeypatch.setattr(
+            "memtomem_stm.daemon.client.probe_listening", lambda host, port, **kw: False
+        )
+        killed: list[tuple[int, int]] = []
+        monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+        result = CliRunner().invoke(_cli(), ["daemon", "stop"])
+
+        assert result.exit_code == 0, result.output
+        assert "cleaned stale handshake" in result.output
+        assert killed == []  # recycled pid never signalled
+        assert not hs.exists()
 
 
 class TestDaemonStatusCli:
@@ -670,32 +725,40 @@ class TestDaemonStatusCli:
         assert "stopped" in result.output
 
 
+def _probe_all(monkeypatch: pytest.MonkeyPatch, listening: bool = True) -> None:
+    """Pin the connect-probe so the two-factor liveness check (#519) is decided
+    by ``is_pid_alive`` alone — ``listening=True`` simulates a daemon still
+    accepting on its endpoint, ``False`` a stale handshake whose port is gone."""
+    monkeypatch.setattr(
+        "memtomem_stm.daemon.client.probe_listening", lambda host, port, **kw: listening
+    )
+
+
 class TestDaemonForeignOrphans:
     """`#517` — daemons orphaned under a stale fingerprint (config/protocol drift)
     must be visible to ``status`` and stoppable via ``stop --all``, even when
     pinned with ``idle_timeout_seconds=0`` (so they never self-clear).
 
-    The tests that assert live-foreign *reporting* are POSIX-only: on Windows
-    ``daemon_cmd._live_foreign_daemons`` short-circuits to ``[]`` (``is_pid_alive``
-    can't distinguish a live foreign daemon from a dead handshake there — no
-    signal-0), so they carry a per-method ``skipif`` (#519). The tests that pin the
-    Windows-disabled behavior / empty cases still run on every platform."""
+    Liveness is two-factor (#519): the recorded pid must be alive *and* its
+    endpoint must accept a connect. These tests mock both factors
+    (``is_pid_alive`` + ``client.probe_listening``), so they are platform-agnostic
+    — the connect-probe is what re-enabled Windows, where ``is_pid_alive`` alone
+    is uninformative. ``test_foreign_detection_cross_platform`` pins that, and
+    ``test_recycled_pid_skipped_by_connect_probe`` pins the recycled-pid gate."""
 
-    def _write_foreign(self, tmp_path: Path, fingerprint: str, pid: int) -> None:
+    def _write_foreign(
+        self, tmp_path: Path, fingerprint: str, pid: int, *, port: int = 4242
+    ) -> None:
         discovery.write_handshake(
             discovery.handshake_path(tmp_path, fingerprint),
             pid=pid,
             host="127.0.0.1",
-            port=4242,
+            port=port,
             token="secret-token",
             config_fingerprint=fingerprint,
             created_at=0.0,
         )
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="live foreign-orphan reporting is POSIX-only (#519)",
-    )
     def test_status_reports_foreign(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         import json
 
@@ -707,6 +770,7 @@ class TestDaemonForeignOrphans:
         self._write_foreign(tmp_path, "foreignfp000000", pid=98765)
         _no_daemon(monkeypatch)
         monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)
+        _probe_all(monkeypatch)
 
         # JSON surface: a `foreign` array with non-sensitive fields (never token).
         result = CliRunner().invoke(_cli(), ["daemon", "status", "--json"])
@@ -741,7 +805,6 @@ class TestDaemonForeignOrphans:
         assert "no running daemon" in result.output
         assert killed == []  # default scope never reaches a different-config daemon
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="SIGTERM path is POSIX-only")
     def test_stop_all_sigterms_foreign(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         import signal as _signal
 
@@ -751,6 +814,7 @@ class TestDaemonForeignOrphans:
         self._write_foreign(tmp_path, "foreignfp000000", pid=98765)
         _no_daemon(monkeypatch)
         monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)
+        _probe_all(monkeypatch)
         killed: list[tuple[int, int]] = []
         monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append((pid, sig)))
 
@@ -760,7 +824,6 @@ class TestDaemonForeignOrphans:
         assert killed == [(98765, _signal.SIGTERM)]
         assert "sent SIGTERM to daemon pid=98765 (fp=foreignfp000000)" in result.output
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="SIGTERM path is POSIX-only")
     def test_pinned_fingerprint_change_is_reachable(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -778,6 +841,7 @@ class TestDaemonForeignOrphans:
         self._write_foreign(tmp_path, old_fp, pid=4321)
         _no_daemon(monkeypatch)
         monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)
+        _probe_all(monkeypatch)
         killed: list[tuple[int, int]] = []
         monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append((pid, sig)))
 
@@ -787,10 +851,6 @@ class TestDaemonForeignOrphans:
         assert [pid for pid, _ in killed] == [4321]
         assert f"fp={old_fp}" in result.output
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="live foreign-orphan reporting is POSIX-only (#519)",
-    )
     def test_dead_pid_foreign_filtered_and_sorted(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -807,6 +867,7 @@ class TestDaemonForeignOrphans:
         self._write_foreign(tmp_path, "cccc000000000000", pid=3003)  # alive
         _no_daemon(monkeypatch)
         monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: pid != 2002)
+        _probe_all(monkeypatch)
 
         result = CliRunner().invoke(_cli(), ["daemon", "status", "--json"])
         assert result.exit_code == 0, result.output
@@ -824,7 +885,6 @@ class TestDaemonForeignOrphans:
         assert "pid=1001 fp=aaaa000000000000, pid=3003 fp=cccc000000000000" in result.output
         assert "2002" not in result.output
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="SIGTERM path is POSIX-only")
     def test_stop_all_skips_dead_and_continues_on_oserror(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -840,6 +900,7 @@ class TestDaemonForeignOrphans:
         self._write_foreign(tmp_path, "cccc000000000000", pid=3003)  # alive, kill succeeds
         _no_daemon(monkeypatch)
         monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: pid != 2002)
+        _probe_all(monkeypatch)
         killed: list[tuple[int, int]] = []
 
         def fake_kill(pid: int, sig: int) -> None:
@@ -856,10 +917,6 @@ class TestDaemonForeignOrphans:
         assert "could not signal daemon pid=1001" in result.output
         assert "sent SIGTERM to daemon pid=3003" in result.output
 
-    @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="live foreign-orphan reporting is POSIX-only (#519)",
-    )
     def test_status_running_with_foreign(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """A live current daemon AND a foreign orphan: the running-branch `info`
         must still carry `foreign`, and the token must never leak."""
@@ -882,6 +939,7 @@ class TestDaemonForeignOrphans:
         monkeypatch.setattr("memtomem_stm.daemon.client.ping", fake_ping)
         self._write_foreign(tmp_path, "foreignfp000000", pid=98765)
         monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)
+        _probe_all(monkeypatch)
 
         result = CliRunner().invoke(_cli(), ["daemon", "status", "--json"])
         assert result.exit_code == 0, result.output
@@ -910,19 +968,85 @@ class TestDaemonForeignOrphans:
         assert result.exit_code == 0, result.output
         assert "no daemons running under a different config" in result.output
 
-    def test_foreign_detection_is_posix_only(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-        """On Windows `is_pid_alive` is True for any positive pid (no signal-0,
-        and the foreign path can't ping), so it would report every stale
-        handshake as live. Foreign detection must yield nothing there instead."""
+    def test_foreign_detection_cross_platform(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The connect-probe re-enables Windows (#519): `_live_foreign_daemons` no
+        longer branches on the platform, so with Windows' `is_pid_alive` (always
+        True for a positive pid) the *connect* carries the whole signal — a
+        listening endpoint is detected, a dead one is not."""
         from memtomem_stm.cli import daemon_cmd
 
         monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
         self._write_foreign(tmp_path, "foreignfp000000", pid=98765)
-        # Even with a maximally-permissive liveness probe + simulated Windows,
-        # the POSIX-only gate returns [] (so no false-positive foreign daemons).
+        # Windows-like: is_pid_alive can't discriminate (always True for a positive
+        # pid). No `os.name` patch — that would poison pathlib (WindowsPath); the
+        # point is precisely that the code path is now platform-independent.
         monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)
-        monkeypatch.setattr(daemon_cmd.os, "name", "nt")
 
+        # Endpoint accepting → reported (previously [] on Windows).
+        _probe_all(monkeypatch, listening=True)
+        assert daemon_cmd._live_foreign_daemons(STMConfig()) == [
+            {"fingerprint": "foreignfp000000", "pid": 98765, "host": "127.0.0.1", "port": 4242}
+        ]
+        # Endpoint gone → still nothing (no false positive from the always-True pid).
+        _probe_all(monkeypatch, listening=False)
+        assert daemon_cmd._live_foreign_daemons(STMConfig()) == []
+
+    def test_recycled_pid_skipped_by_connect_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The #519 gate: an alive pid (recycled to an unrelated process) whose
+        recorded endpoint no longer accepts must NOT be reported as running, and
+        ``stop --all`` must not SIGTERM it."""
+        from click.testing import CliRunner
+
+        from memtomem_stm.cli import daemon_cmd
+
+        monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+        self._write_foreign(tmp_path, "foreignfp000000", pid=98765)
+        _no_daemon(monkeypatch)
+        monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)  # alive
+        _probe_all(monkeypatch, listening=False)  # but nothing accepts on its port
+        killed: list[tuple[int, int]] = []
+        monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+        assert daemon_cmd._live_foreign_daemons(STMConfig()) == []
+
+        result = CliRunner().invoke(_cli(), ["daemon", "stop", "--all"])
+        assert result.exit_code == 0, result.output
+        assert killed == []  # recycled pid never signalled
+        assert "no daemons running under a different config" in result.output
+
+    def test_listening_foreign_detected_end_to_end(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """No mocks on the probe: a real listening socket + this process's own
+        (alive) pid is detected via the actual TCP connect, and a since-closed
+        port is not — pins the probe wired through ``_live_foreign_daemons``."""
+        import socket
+
+        from memtomem_stm.cli import daemon_cmd
+
+        monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen()
+        _host, port = srv.getsockname()
+        # A genuine foreign daemon: alive pid (ours) + a real accepting endpoint.
+        self._write_foreign(tmp_path, "foreignfp000000", pid=os.getpid(), port=port)
+        try:
+            assert daemon_cmd._live_foreign_daemons(STMConfig()) == [
+                {
+                    "fingerprint": "foreignfp000000",
+                    "pid": os.getpid(),
+                    "host": "127.0.0.1",
+                    "port": port,
+                }
+            ]
+        finally:
+            srv.close()
+        # Endpoint now closed → the alive pid alone is not enough to report it.
         assert daemon_cmd._live_foreign_daemons(STMConfig()) == []
 
 

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -1018,6 +1018,34 @@ class TestDaemonForeignOrphans:
         assert killed == []  # recycled pid never signalled
         assert "no daemons running under a different config" in result.output
 
+    def test_stop_all_reprobes_before_kill(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """TOCTOU between enumeration and `os.kill` (#519): a foreign daemon passes
+        the enumeration probe, then exits and its pid is recycled before the kill.
+        The action-time re-probe (not just `is_pid_alive`, a no-op on Windows) must
+        catch it so `stop --all` does not SIGTERM the recycled pid."""
+        from click.testing import CliRunner
+
+        monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+        self._write_foreign(tmp_path, "foreignfp000000", pid=98765)
+        _no_daemon(monkeypatch)
+        monkeypatch.setattr("memtomem_stm.daemon.discovery.is_pid_alive", lambda pid: True)
+        # True at enumeration, False at the action-time re-check (endpoint vanished).
+        calls = {"n": 0}
+
+        def flaky_probe(host, port, **kw):
+            calls["n"] += 1
+            return calls["n"] == 1
+
+        monkeypatch.setattr("memtomem_stm.daemon.client.probe_listening", flaky_probe)
+        killed: list[tuple[int, int]] = []
+        monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+        result = CliRunner().invoke(_cli(), ["daemon", "stop", "--all"])
+
+        assert result.exit_code == 0, result.output
+        assert killed == []  # re-probe failed → recycled pid not signalled
+        assert calls["n"] == 2  # probed at enumeration AND again before the kill
+
     def test_listening_foreign_detected_end_to_end(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):


### PR DESCRIPTION
Closes #519.

## Problem

`mms daemon status` / `mms daemon stop --all` identified a foreign-fingerprint
daemon by its **recorded pid alone** (`is_pid_alive`). A non-graceful exit
(SIGKILL/OOM/crash) never runs the daemon's teardown, so its
`stm-daemon-<fp>.json` lingers on disk naming a now-dead pid. If the OS later
**recycles** that pid to an unrelated process:

- `status` reported a phantom "running" foreign daemon, and
- `stop --all` sent it `SIGTERM`.

`is_pid_alive` only confirms *a* process with that pid exists (it even returns
`True` on `EPERM`) — never that it is still our daemon. The same exposure lived
in the pre-existing same-config SIGTERM fallback (`_stop_current_config_daemon`).

## Fix

Add a bare TCP **connect-probe** (`client.probe_listening`) and gate every
foreign/stale action on **`is_pid_alive` AND the endpoint still accepts a
connect**:

- A foreign daemon (any `PROTOCOL_VERSION`) is still *listening*, so a connect
  reaches it **without sending a frame** — no token, no version negotiation.
- A recycled pid's handshake names an **unbound** port, so the connect is
  refused and the entry is skipped.

The probe is cross-platform, so it also **re-enables foreign detection on
Windows** (where `is_pid_alive` is uninformative — always `True`, no signal-0).
That lets us drop the POSIX-only short-circuit in `_live_foreign_daemons` and
the `os.name != "nt"` guard in the same-config fallback; the connect now carries
the whole signal there.

Applied consistently to all three sites: `_live_foreign_daemons` (status +
`--all` enumeration) and `_stop_current_config_daemon` (same-config fallback).

## Residual / approaches considered

The remaining false-positive needs a **double coincidence** — the pid recycled
*and* its ephemeral port reassigned to another listener — so `--all` stays
opt-in. Full pid identity (approach #2, process start-time cross-check) was
rejected: it needs `psutil` or per-platform `/proc` plumbing for a far narrower
window than the connect-probe already closes.

## Tests

- `test_probe_listening` — unit: real listening socket → `True`; closed port /
  malformed endpoint → `False`.
- `test_recycled_pid_skipped_by_connect_probe` — alive pid, dead endpoint:
  not reported by `status`, not SIGTERMed by `stop --all`.
- `test_stale_handshake_recycled_pid_not_sigtermed` — same gate on the
  same-config fallback (clean handshake, no kill).
- `test_listening_foreign_detected_end_to_end` — genuine listening foreign
  daemon (real socket, no mocks) still reaped.
- `test_foreign_detection_cross_platform` — detection no longer branches on
  `os.name`; the connect decides.
- Foreign-orphan tests lose their POSIX-only `skipif`.

Full suite: 3838 passed, 3 skipped. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)