### PR TITLE
fix(compression): drop duplicated truncation marker in hybrid truncate tail

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -2400,7 +2400,12 @@ class HybridCompressor:
     """
 
     _SEPARATOR_TEMPLATE = "\n---\nRemaining content ({remaining} chars) — Table of Contents:\n\n"
-    _SEPARATOR_TRUNC_TEMPLATE = "\n---\nRemaining content ({remaining} chars, truncated):\n\n"
+    # The truncate separator is deliberately terse: the tail is run through
+    # TruncateCompressor, whose suffix already reports ``... (truncated, original:
+    # N chars)`` (where N == this remaining count). Repeating ``{remaining} chars,
+    # truncated`` here only duplicated both the count and the word "truncated" in
+    # the wire payload, so this marker just signals the head/tail boundary.
+    _SEPARATOR_TRUNC_TEMPLATE = "\n---\nRemaining content:\n\n"
 
     def __init__(
         self,
@@ -2452,7 +2457,7 @@ class HybridCompressor:
         if self._tail_mode == TailMode.TOC:
             separator = self._SEPARATOR_TEMPLATE.format(remaining=remaining)
         else:
-            separator = self._SEPARATOR_TRUNC_TEMPLATE.format(remaining=remaining)
+            separator = self._SEPARATOR_TRUNC_TEMPLATE
 
         toc_budget = max_chars - len(head) - len(separator)
         if toc_budget < _MIN_TAIL:

--- a/tests/test_hybrid_truncate_separator.py
+++ b/tests/test_hybrid_truncate_separator.py
@@ -1,0 +1,42 @@
+"""HybridCompressor truncate-tail separator must not double the truncation marker.
+
+In ``tail_mode=truncate`` the tail is run through TruncateCompressor, whose suffix
+already reports ``... (truncated, original: N chars)``. The hybrid separator used
+to ALSO say ``Remaining content (N chars, truncated):``, so the same char count
+and the word "truncated" appeared twice in the wire payload. The separator is now
+terse (``Remaining content:``); the inner suffix remains the single source of the
+truncation signal. The default TOC mode is unaffected.
+"""
+
+from __future__ import annotations
+
+from memtomem_stm.proxy.compression import HybridCompressor
+from memtomem_stm.proxy.config import TailMode
+
+# Plain prose tail (no headings/code/lists) so TruncateCompressor takes its
+# position-based fallback and appends the ``... (truncated, original: N chars)``
+# suffix — the marker the separator must not duplicate.
+_TEXT = "# Intro\n\n" + "Important head context here. " * 8 + (
+    "\n\nTail prose sentence number that keeps going on and on. " * 200
+)
+
+
+def test_truncate_tail_emits_single_truncation_marker() -> None:
+    c = HybridCompressor(head_chars=100, tail_mode=TailMode.TRUNCATE)
+    result = c.compress(_TEXT, max_chars=600)
+
+    # Boundary marker present, but terse — the old duplicated wording is gone.
+    assert "Remaining content:" in result
+    assert "chars, truncated" not in result, "separator must not repeat count+word"
+    # The truncation is still signaled exactly once, by the inner suffix.
+    assert "truncated, original:" in result
+    assert result.count("truncated") == 1, "the word 'truncated' must appear once"
+
+
+def test_toc_tail_separator_unchanged() -> None:
+    # No-regression: the default TOC separator still carries the char count and
+    # the Table-of-Contents label.
+    c = HybridCompressor(head_chars=100, tail_mode=TailMode.TOC)
+    result = c.compress(_TEXT, max_chars=600)
+    assert "Table of Contents:" in result
+    assert "Remaining content (" in result, "TOC separator keeps the (N chars) count"


### PR DESCRIPTION
## Problem

`HybridCompressor` with `tail_mode=truncate` signals truncation **twice** in the wire payload:

1. The separator template (`compression.py:2403`) renders `\n---\nRemaining content (N chars, truncated):\n\n`.
2. The tail is then run through `TruncateCompressor` (via `_plain_truncate`, `compression.py:2466`), whose position-based fallback suffix (`compression.py:249`) appends `... (truncated, original: N chars)` — where `N` is the **same** remaining count.

So both the char count and the word "truncated" appear twice for one tail. Example:

```
<head kept verbatim>
---
Remaining content (3067 chars, truncated):

<~360 chars of tail>
... (truncated, original: 3067 chars)
```

This is gated: the default `tail_mode` is `TOC` (whose separator has no "truncated"), so only the non-default `tail_mode=truncate` + `HYBRID` path is affected. Low severity, but a genuine removable duplication.

## Fix

Make the truncate separator terse — `\n---\nRemaining content:\n\n` — so it only marks the head/tail boundary. The inner `TruncateCompressor` suffix stays the single source of the truncation signal (and keeps its unique structural summary, e.g. `[1 headings]`, which the separator never had). The shared `_plain_truncate` / `TruncateCompressor` suffix is **not** touched — other callers have no outer separator and need it.

Budget math is safe: `toc_budget = max_chars - len(head) - len(separator)` is recomputed from the actual separator length (`compression.py:2457`), so the shorter marker self-adjusts. The TOC template is unchanged.

## Tests

`tests/test_hybrid_truncate_separator.py`:
- truncate tail emits the word "truncated" exactly once and no `chars, truncated` separator fragment, while still signaling truncation via the inner suffix
- TOC tail separator unchanged (still carries `(N chars)` + `Table of Contents:`)

All 460 `-k "compress or hybrid or truncate or tool_metadata or information_loss"` tests pass; `ruff check src` clean.

## Provenance

Found by a multi-agent wire-response duplication audit, confirmed REAL (gated) by an independent codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)