### PR TITLE
fix(toolgraph): best-effort guard get/put/_trim against runtime sqlite faults

### DIFF
--- a/src/memtomem_stm/proxy/toolgraph_cache.py
+++ b/src/memtomem_stm/proxy/toolgraph_cache.py
@@ -136,11 +136,27 @@ class GraphConsultCache:
         if self._db is None:
             return None
         key = _scope_key(provider_fp, agent_id, profile, candidate_hash, generation)
-        with self._lock:
-            row = self._db.execute(
-                "SELECT verdict_json, had_risk_scores FROM toolgraph_consult WHERE scope_key = ?",
-                (key,),
-            ).fetchone()
+        try:
+            with self._lock:
+                row = self._db.execute(
+                    "SELECT verdict_json, had_risk_scores FROM toolgraph_consult WHERE scope_key = ?",
+                    (key,),
+                ).fetchone()
+        except sqlite3.Error:
+            # Best-effort: a runtime sqlite fault on the lookup (database locked,
+            # disk I/O error, page-level corruption) must degrade to a plain MISS,
+            # never raise. get()/put() run inside ``_consult_toolgraph`` — the last
+            # statement of ``ProxyManager.start()`` — whose callers do NOT catch
+            # sqlite3.Error, so an escaping fault would crash proxy startup and take
+            # every proxied tool down for a non-fatal cache problem. A miss instead
+            # re-runs the live full consult (strictly-fresh preserved). Mirrors the
+            # _delete_scope guard below and the initialize()-time best-effort contract.
+            logger.warning(
+                "Tool-graph consult cache read failed (scope %s) — treating as a miss",
+                key[:12],
+                exc_info=True,
+            )
+            return None
         if row is None:
             return None
         try:
@@ -232,40 +248,59 @@ class GraphConsultCache:
             separators=(",", ":"),
         )
         now = time.time()
-        with self._lock:
-            # Scope-replace: a newer generation for the same (provider, agent,
-            # profile, candidate-set) supersedes prior generations — one row per
-            # scope keeps growth bounded.
-            self._db.execute(
-                "DELETE FROM toolgraph_consult WHERE provider_fingerprint = ? AND agent_id = ? "
-                "AND query_profile = ? AND candidate_hash = ? AND graph_generation != ?",
-                (provider_fp, agent_id, profile, candidate_hash, generation),
+        try:
+            with self._lock:
+                # Scope-replace: a newer generation for the same (provider, agent,
+                # profile, candidate-set) supersedes prior generations — one row per
+                # scope keeps growth bounded.
+                self._db.execute(
+                    "DELETE FROM toolgraph_consult WHERE provider_fingerprint = ? AND agent_id = ? "
+                    "AND query_profile = ? AND candidate_hash = ? AND graph_generation != ?",
+                    (provider_fp, agent_id, profile, candidate_hash, generation),
+                )
+                self._db.execute(
+                    """
+                    INSERT INTO toolgraph_consult
+                        (scope_key, provider_fingerprint, agent_id, query_profile,
+                         candidate_hash, graph_generation, had_risk_scores, verdict_json, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(scope_key) DO UPDATE SET
+                        had_risk_scores = excluded.had_risk_scores,
+                        verdict_json    = excluded.verdict_json,
+                        created_at      = excluded.created_at
+                    """,
+                    (
+                        key,
+                        provider_fp,
+                        agent_id,
+                        profile,
+                        candidate_hash,
+                        generation,
+                        1 if had_risk_scores else 0,
+                        verdict_json,
+                        now,
+                    ),
+                )
+                self._db.commit()
+                self._trim()
+        except sqlite3.Error:
+            # Best-effort write (covers the DELETE/INSERT/commit and the _trim sweep
+            # it calls under the same lock): a runtime sqlite fault must no-op, never
+            # raise. See the get() guard above for why an escaping fault is fatal to
+            # startup. A skipped write just means the next consult re-mints the row.
+            # A fault mid-transaction (e.g. the DELETE commits implicitly-open work,
+            # then INSERT/commit/_trim raises) can leave a transaction holding the
+            # write lock; roll it back so the connection stays cleanly reusable.
+            try:
+                self._db.rollback()
+            except sqlite3.Error:
+                logger.debug("Tool-graph consult cache rollback failed", exc_info=True)
+            logger.warning(
+                "Tool-graph consult cache write failed (scope %s) — consult not cached",
+                key[:12],
+                exc_info=True,
             )
-            self._db.execute(
-                """
-                INSERT INTO toolgraph_consult
-                    (scope_key, provider_fingerprint, agent_id, query_profile,
-                     candidate_hash, graph_generation, had_risk_scores, verdict_json, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(scope_key) DO UPDATE SET
-                    had_risk_scores = excluded.had_risk_scores,
-                    verdict_json    = excluded.verdict_json,
-                    created_at      = excluded.created_at
-                """,
-                (
-                    key,
-                    provider_fp,
-                    agent_id,
-                    profile,
-                    candidate_hash,
-                    generation,
-                    1 if had_risk_scores else 0,
-                    verdict_json,
-                    now,
-                ),
-            )
-            self._db.commit()
-            self._trim()
+            return
 
     def _trim(self) -> None:
         if self._db is None:

--- a/tests/test_toolgraph_cache.py
+++ b/tests/test_toolgraph_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from types import SimpleNamespace
 
 import pytest
@@ -215,3 +216,53 @@ class TestCorruptRow:
         row = cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11)
         assert row is not None
         assert row["risk_scores"] == {"s::c": 1.0, "s::d": 0.5}
+
+
+class _RaisingConn:
+    """Stand-in connection whose ``execute`` always raises a sqlite fault.
+
+    ``sqlite3.Connection.execute`` is a read-only C attribute and cannot be
+    monkeypatched, so we swap the whole handle to simulate a runtime fault
+    (database locked / disk I/O error / page-level corruption) during a live op.
+    """
+
+    def __init__(self, exc: sqlite3.Error) -> None:
+        self._exc = exc
+        self.rolled_back = False
+
+    def execute(self, *_a, **_k):
+        raise self._exc
+
+    def commit(self, *_a, **_k):  # pragma: no cover - never reached past execute
+        raise self._exc
+
+    def rollback(self) -> None:
+        # The put() guard rolls back a possibly-open transaction; model a clean
+        # rollback so the no-op write path completes without raising.
+        self.rolled_back = True
+
+    def close(self) -> None:
+        pass
+
+
+class TestSqliteFaultIsBestEffort:
+    """A runtime sqlite fault on get()/put() must degrade to a miss / no-op, never
+    raise — these run inside ``_consult_toolgraph`` (the last statement of
+    ``ProxyManager.start()``), whose callers don't catch ``sqlite3.Error``, so an
+    escaping fault would crash proxy startup. Distinct from the corrupt-ROW tests
+    above: those cover a successful read of malformed data; these cover ``execute``
+    itself raising (database locked / disk I/O error / page-level corruption)."""
+
+    def test_get_returns_miss_when_execute_raises(self, cache):
+        _put(cache)  # real DB write while the handle is still live
+        cache._db = _RaisingConn(sqlite3.OperationalError("database is locked"))
+        assert cache.get(_PROV, _AGENT, _PROFILE, "hashA", 11) is None
+
+    def test_put_no_ops_when_execute_raises(self, cache):
+        conn = _RaisingConn(sqlite3.OperationalError("disk I/O error"))
+        cache._db = conn
+        # Must not raise; the consult simply goes uncached.
+        _put(cache)
+        # A fault mid-write must roll back any possibly-open transaction so the
+        # connection does not retain the write lock.
+        assert conn.rolled_back is True


### PR DESCRIPTION
## Background

Caching audit of the proxy (this branch is part 1 of a small series) surfaced a robustness gap in the tool-graph consult disk cache (#494).

`GraphConsultCache.get()` and `put()`/`_trim()` ran sqlite `execute`/`commit` with **no error handling**, while the sibling `_delete_scope()` *is* wrapped in `try/except sqlite3.Error` — proving the per-call DB ops were meant to be best-effort too, and that the unguarded `get`/`put`/`_trim` were an oversight.

## Why it matters

These run inside `_consult_toolgraph`, the **last statement of `ProxyManager.start()`**. The only `except` clauses on that path catch toolgraph-unreachable / protocol errors, not `sqlite3.Error` (which is **not** an `OSError` subclass), and `server.py` `await`s `start()` with no wrapping `except`. So a transient/recoverable sqlite fault during a consult HIT lookup or a post-miss write — `database is locked`, `disk I/O error`, disk-full on commit, or a page-level `database disk image is malformed` — **escaped `app_lifespan` and crashed proxy startup**, taking *every proxied tool* down for a non-fatal cache problem.

This contradicted the documented best-effort contract in `_open_consult_cache` ("degrades to no-cache for the session rather than failing startup"), which only protected `initialize()`, not the per-call `get`/`put`.

> Reachability note: the whole tool-graph path is gated behind `toolgraph.enabled=False` (opt-in external Neo4j), so this is latent unless that provider is configured — but when active the blast radius is total (no startup at all).

## Change

- `get()`: wrap the DB read → log WARNING + return `None` (a miss that re-runs the live full consult, **preserving Model-A strictly-fresh** — more re-evaluation, never masking a degraded graph).
- `put()`/`_trim()`: wrap the DELETE/INSERT/commit + the `_trim` sweep it calls under the same lock → log WARNING + no-op (the consult simply goes uncached).
- Mirrors `_delete_scope`; the "cache never fails startup" guarantee now holds end-to-end regardless of caller. No protected invariant (privacy gate, transient-key skip, stampede guard, trace-free key, strictly-fresh consult) is touched — the gate only narrows failure handling.

## Test

`TestSqliteFaultIsBestEffort` swaps the connection handle for one whose `execute()` raises (`sqlite3.Connection.execute` is a read-only C attribute and cannot be monkeypatched) and asserts `get()` misses and `put()` does not raise. The existing corrupt-row tests only cover a *successful read of malformed data*, not a *raising `execute()`*.

`uv run pytest tests/test_toolgraph_cache.py` → 27 passed. `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)