### PR TITLE
feat(cache): gate response cache on tool annotations to stop replaying mutating tools

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -38,7 +38,8 @@ The key insight: **the cache stores pre-surfacing content**. Surfacing runs on e
     "enabled": true,
     "db_path": "~/.memtomem/proxy_cache.db",
     "default_ttl_seconds": 3600,
-    "max_entries": 10000
+    "max_entries": 10000,
+    "tool_annotation_policy": "conservative"
   }
 }
 ```
@@ -47,10 +48,16 @@ Key details:
 
 - Cache key = SHA-256 of `server:tool:args` (argument order independent)
 - **Pre-surfacing content is cached** — surfacing is re-applied on cache hit, so memories stay fresh
+- **Mutating tools are not cached** — the cache is on by default for *every* tool of *every* upstream, so without a gate a write tool (`create_*` / `send_*` / `write_*` / `delete_*`) called twice with identical args within the TTL would be served the first call's cached success *without re-executing the side effect*. The `tool_annotation_policy` gates eligibility on the upstream tool's MCP annotations (`readOnlyHint` / `destructiveHint`):
+  - `conservative` (default) — cache everything except tools that self-declare as writers (`readOnlyHint: false` or `destructiveHint: true`). Keeps caching for read-only and un-annotated tools.
+  - `strict` — cache only tools that explicitly declare `readOnlyHint: true` (un-annotated tools default to may-mutate per the MCP spec).
+  - `ignore` — pre-gate behavior; cache every tool regardless of annotations.
+- **Per-tool / per-server cache override** — set `cache: true|false` on a `tool_overrides` entry or on an `UpstreamServerConfig` to force a tool/server in or out of the cache, overriding the annotation policy (precedence: tool > server > policy). Use `cache: false` for a volatile read tool or a writer on an upstream that omits annotations; `cache: true` to re-enable caching for a tool an upstream mis-annotates.
+- **Privacy exclusion** — responses that look like secrets are never persisted to the cache; see [SECURITY.md](../SECURITY.md). This guard always applies on top of the policy/override above.
 - **Transient-key exclusion** — to prevent serving expired progressive/selective keys on a cache hit (which would drop the response tail), the cache automatically skips storing any response carrying a transient-key marker (like a `PROGRESSIVE_FOOTER_TOKEN` or a `selection_key` JSON field). The next identical call re-runs the pipeline to generate live keys.
 - Expired entries are purged on startup; oldest entries evicted when `max_entries` is exceeded
 - Clear cache via MCP tool: `stm_proxy_cache_clear(server="gh", tool="search_code")`
-- TTL is global (`cache.default_ttl_seconds`); `tool_overrides` only tune compression, sizing, and indexing — not cache TTL
+- TTL is global (`cache.default_ttl_seconds`); `tool_overrides` tune compression, sizing, indexing, and cache eligibility (`cache: true|false`) — but not per-tool cache TTL
 
 ## Auto-Indexing
 

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -417,6 +417,14 @@ class ToolOverrideConfig(BaseModel):
     cleaning: CleaningConfig | None = None
     auto_index: bool | None = None
     extraction: bool | None = None
+    cache: bool | None = None
+    """Per-tool response-cache opt-in/out. ``None`` (default) defers to the
+    server-level ``cache``, then to the global
+    ``CacheConfig.tool_annotation_policy``. ``True`` force-caches this tool
+    (overriding the annotation policy — e.g. to re-enable caching for a tool an
+    upstream mis-annotates as a writer); ``False`` never caches it (e.g. a
+    volatile read tool, or a writer on an upstream that omits annotations). The
+    privacy / transient-key store guards still apply when ``True``."""
     hidden: bool = False
     description_override: str | None = None
     expose_in_profiles: list[ExposureProfile] | None = None
@@ -498,6 +506,11 @@ class UpstreamServerConfig(BaseModel):
     tool_overrides: dict[str, ToolOverrideConfig] = {}
     auto_index: bool | None = None
     extraction: bool | None = None
+    cache: bool | None = None
+    """Per-server response-cache opt-in/out (see ``ToolOverrideConfig.cache``).
+    ``None`` (default) defers to the global ``CacheConfig.tool_annotation_policy``;
+    ``True``/``False`` force every tool on this upstream in/out of the cache. A
+    per-tool ``cache`` override wins over this."""
     expose_in_profiles: list[ExposureProfile] | None = None
     """Exposure profiles in which this upstream's tools are advertised
     (#465). ``None`` (default) means every profile. Per-tool
@@ -572,6 +585,29 @@ class CacheConfig(BaseModel):
     db_path: Path = Path("~/.memtomem/proxy_cache.db")
     default_ttl_seconds: float | None = Field(default=3600.0, ge=0.0)
     max_entries: int = Field(default=10000, gt=0)
+    tool_annotation_policy: Literal["conservative", "strict", "ignore"] = "conservative"
+    """Which proxied tool responses are eligible for the response cache, based on
+    the upstream tool's MCP annotations (``readOnlyHint`` / ``destructiveHint``).
+
+    The proxy sits transparently in front of every upstream tool, so without a
+    gate a mutating tool (``create_*`` / ``send_*`` / ``write_*`` / ``delete_*``)
+    called twice with identical args within the TTL is served the first call's
+    cached success WITHOUT re-executing the side effect — the agent is told it
+    mutated when it did not.
+
+    - ``conservative`` (default): cache every tool EXCEPT those that explicitly
+      self-declare as writers (``readOnlyHint is False`` or
+      ``destructiveHint is True``). Keeps caching for the un-annotated majority
+      and for declared read-only tools, while refusing to memoize a side effect
+      the upstream itself flags as mutating.
+    - ``strict``: cache ONLY tools that explicitly declare ``readOnlyHint=True``.
+      Safest (the MCP spec treats a missing ``readOnlyHint`` as may-mutate), but
+      drops caching for every upstream that omits annotations.
+    - ``ignore``: pre-gate behavior — cache every tool regardless of annotations.
+
+    A per-tool / per-server ``cache`` override (``ToolOverrideConfig.cache`` /
+    ``UpstreamServerConfig.cache``) takes precedence over this policy. The privacy
+    and transient-key store guards always apply on top, regardless of this knob."""
 
 
 class MetricsConfig(BaseModel):

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -2094,20 +2094,29 @@ class ProxyManager:
         Returns ``(result, cache_hit)`` so ``call_tool`` can stamp the
         selection-telemetry execution event (#467): ``True`` on either
         cache-hit return path, ``False`` on a live ``_call_tool_inner``
-        call (including the no-cache configuration)."""
+        call (including the no-cache configuration and cache-ineligible tools)."""
         upstream_args = (
             {k: v for k, v in arguments.items() if k != "_context_query"} if arguments else {}
         )
 
-        # Fast-path: cache hit without lock contention.
-        if self._cache is not None:
-            cached = self._cache.get(server, tool, upstream_args)
-            if cached is not None:
-                return await self._on_cache_hit(cached, server, tool, arguments, trace_id), True
-
         # No cache configured — stampede protection N/A, go straight through.
         if self._cache is None:
             return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id), False
+
+        # Cache-eligibility gate (MCP annotations / per-tool|server ``cache``
+        # override): a tool the policy deems non-cacheable — e.g. a self-declared
+        # writer under the default conservative policy — is never served from nor
+        # stored in the cache. Behave as if no cache exists: straight through with
+        # NO stampede lock, so every call re-runs and its side effect re-executes.
+        # Gating the lookup (not just the store in ``_store_cache``) also refuses
+        # to serve any row cached before this gate existed.
+        if not self._tool_cache_eligible(server, tool, cfg_snap=self._config):
+            return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id), False
+
+        # Fast-path: cache hit without lock contention.
+        cached = self._cache.get(server, tool, upstream_args)
+        if cached is not None:
+            return await self._on_cache_hit(cached, server, tool, arguments, trace_id), True
 
         cache_key = _cache_key(server, tool, upstream_args)
         lock = self._key_locks.setdefault(cache_key, asyncio.Lock())
@@ -2920,6 +2929,63 @@ class ProxyManager:
 
         return ExtractResult(ok=extract_ok, error=extract_error)
 
+    @staticmethod
+    def _tool_annotations(conn: UpstreamConnection, tool: str) -> Any:
+        """Raw MCP ``ToolAnnotations`` for ``tool`` on ``conn`` (``None`` if the
+        tool is unknown or carries no annotations). The objects in ``conn.tools``
+        are the upstream ``Tool`` records from ``session.list_tools()``, each
+        retaining ``.name`` and ``.annotations`` (populated at connect/reconnect)."""
+        for t in conn.tools:
+            if getattr(t, "name", None) == tool:
+                return getattr(t, "annotations", None)
+        return None
+
+    def _tool_cache_eligible(self, server: str, tool: str, *, cfg_snap: ProxyConfig) -> bool:
+        """Whether a ``(server, tool)`` response may enter / be served from the
+        response cache.
+
+        Orthogonal to the privacy and transient-key store guards, which always
+        apply in ``_store_cache`` regardless of this verdict. Resolution order:
+
+          1. explicit per-tool ``cache`` override (``ToolOverrideConfig.cache``),
+          2. explicit per-server ``cache`` override (``UpstreamServerConfig.cache``),
+          3. the global ``CacheConfig.tool_annotation_policy`` applied to the
+             upstream tool's ``readOnlyHint`` / ``destructiveHint``.
+
+        An unknown server (direct dispatch / tests with no registered connection)
+        is treated as eligible, preserving the pre-gate behavior on that path."""
+        conn = self._connections.get(server)
+        if conn is None:
+            return True
+        # Per-tool / per-server ``cache`` overrides are read from ``conn.config``
+        # (the connection's connect-time snapshot), mirroring ``_resolve_tool_config``
+        # which resolves every other per-server/tool field (``compression``,
+        # ``tool_overrides.*``, ...) from the same source. Like those, an override
+        # edited AFTER startup is picked up on the next reconnect/restart, not via
+        # mtime hot-reload — connections hold their connect-time config. The
+        # annotation POLICY below, by contrast, is read from the hot-reloaded
+        # ``cfg_snap``, so the safety-critical writer gate tracks config edits even
+        # though the manual override escape-hatch follows the existing per-server
+        # reload semantics.
+        override = conn.config.tool_overrides.get(tool)
+        if override is not None and override.cache is not None:
+            return override.cache
+        if conn.config.cache is not None:
+            return conn.config.cache
+
+        policy = cfg_snap.cache.tool_annotation_policy
+        if policy == "ignore":
+            return True
+        ann = self._tool_annotations(conn, tool)
+        read_only = getattr(ann, "readOnlyHint", None)
+        destructive = getattr(ann, "destructiveHint", None)
+        if policy == "strict":
+            # Only an explicit read-only declaration qualifies; a missing
+            # readOnlyHint defaults to may-mutate per the MCP spec.
+            return read_only is True
+        # conservative: cache unless the tool self-declares as a writer.
+        return not (read_only is False or destructive is True)
+
     def _store_cache(
         self,
         *,
@@ -2937,7 +3003,12 @@ class ProxyManager:
         or any other store error must NOT propagate to the agent and discard a
         successful upstream response — log and continue.
 
-        Two responses are deliberately NOT cached:
+        A response from a tool the cache-eligibility gate rejects
+        (``_tool_cache_eligible``: a self-declared writer under the conservative/
+        strict annotation policy, or an explicit ``cache: false`` override) is
+        skipped too — the lookup path in ``_call_tool_guarded`` mirrors this so the
+        tool is neither stored nor served. Beyond that, two responses are
+        deliberately NOT cached even for an eligible tool:
 
         - ``comp.progressive_passthrough_on_error`` — a transient-store-failure
           passthrough. Caching it would pin the degraded (non-chunked) response
@@ -2960,7 +3031,14 @@ class ProxyManager:
         hex and is unreachable by any future lookup (hit rate structurally 0%).
         """
         if self._cache is not None and not non_text_content:
-            if comp.progressive_passthrough_on_error:
+            if not self._tool_cache_eligible(server, tool, cfg_snap=cfg_snap):
+                logger.debug(
+                    "Skipping cache store for %s/%s: tool is not cache-eligible "
+                    "(mutating tool under the annotation policy, or cache override=false)",
+                    server,
+                    tool,
+                )
+            elif comp.progressive_passthrough_on_error:
                 logger.debug(
                     "Skipping cache store for %s/%s: progressive passthrough "
                     "degradation (transient store failure)",

--- a/tests/test_cache_eligibility.py
+++ b/tests/test_cache_eligibility.py
@@ -1,0 +1,257 @@
+"""Tests for the response-cache eligibility gate.
+
+The proxy sits transparently in front of every upstream tool, and the response
+cache is on by default. Without a gate, a mutating tool called twice with
+identical args within the TTL is served the first call's cached success without
+re-executing the side effect. ``ProxyManager._tool_cache_eligible`` gates both
+the lookup (``_call_tool_guarded``) and the store (``_store_cache``) on the
+tool's MCP annotations (``readOnlyHint`` / ``destructiveHint``) plus per-tool /
+per-server ``cache`` overrides.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memtomem_stm.proxy.cache import ProxyCache
+from memtomem_stm.proxy.config import (
+    CacheConfig,
+    ProxyConfig,
+    ToolOverrideConfig,
+    UpstreamServerConfig,
+)
+from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
+from memtomem_stm.proxy.metrics import TokenTracker
+from memtomem_stm.proxy.metrics_store import MetricsStore
+
+
+def _ann(*, read_only=None, destructive=None):
+    """A stand-in for MCP ``ToolAnnotations`` carrying only the two hints the gate
+    reads (``getattr``-based, so a SimpleNamespace matches the real model)."""
+    return SimpleNamespace(readOnlyHint=read_only, destructiveHint=destructive)
+
+
+def _tool(name, ann=None):
+    return SimpleNamespace(name=name, annotations=ann)
+
+
+def _text_result(text="ok"):
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=text)], isError=False)
+
+
+def _build(
+    tmp_path: Path,
+    *,
+    policy: str = "conservative",
+    server_cache: bool | None = None,
+    tool_overrides: dict | None = None,
+    tools=(),
+    with_cache: bool = True,
+):
+    store = MetricsStore(tmp_path / "m.db")
+    store.initialize()
+    server_cfg = UpstreamServerConfig(
+        prefix="t",
+        max_retries=0,
+        reconnect_delay_seconds=0.0,
+        cache=server_cache,
+        tool_overrides=tool_overrides or {},
+    )
+    proxy_cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={"srv": server_cfg},
+        cache=CacheConfig(tool_annotation_policy=policy),
+    )
+    mgr = ProxyManager(proxy_cfg, TokenTracker(metrics_store=store))
+    mgr._connections["srv"] = UpstreamConnection(
+        name="srv", config=server_cfg, session=AsyncMock(), tools=list(tools)
+    )
+    cache: ProxyCache | None = None
+    if with_cache:
+        cache = ProxyCache(tmp_path / "c.db", max_entries=100)
+        cache.initialize()
+        mgr._cache = cache
+    return mgr, store, cache
+
+
+@pytest.fixture
+def build(tmp_path):
+    opened: list[tuple[MetricsStore, ProxyCache | None]] = []
+
+    def _factory(**kwargs):
+        mgr, store, cache = _build(tmp_path, **kwargs)
+        opened.append((store, cache))
+        return mgr, store, cache
+
+    yield _factory
+    for store, cache in opened:
+        try:
+            store.close()
+        except Exception:
+            pass
+        if cache is not None:
+            try:
+                cache.close()
+            except Exception:
+                pass
+
+
+def _eligible(mgr, tool):
+    return mgr._tool_cache_eligible("srv", tool, cfg_snap=mgr._config)
+
+
+# ── Unit: annotation policy ──────────────────────────────────────────────
+
+
+class TestConservativePolicy:
+    """Default policy: cache everything EXCEPT self-declared writers."""
+
+    def test_unannotated_tool_is_eligible(self, build):
+        mgr, _, _ = build(tools=[_tool("t")])
+        assert _eligible(mgr, "t") is True
+
+    def test_unknown_tool_is_eligible(self, build):
+        # No matching tool record at all → no writer signal → cached as before.
+        mgr, _, _ = build(tools=[])
+        assert _eligible(mgr, "whatever") is True
+
+    def test_explicit_read_only_is_eligible(self, build):
+        mgr, _, _ = build(tools=[_tool("t", _ann(read_only=True))])
+        assert _eligible(mgr, "t") is True
+
+    def test_read_only_false_is_not_eligible(self, build):
+        mgr, _, _ = build(tools=[_tool("t", _ann(read_only=False))])
+        assert _eligible(mgr, "t") is False
+
+    def test_destructive_is_not_eligible(self, build):
+        mgr, _, _ = build(tools=[_tool("t", _ann(destructive=True))])
+        assert _eligible(mgr, "t") is False
+
+    def test_destructive_wins_over_read_only_claim(self, build):
+        # Contradictory annotations → treat as a writer (safe default).
+        mgr, _, _ = build(tools=[_tool("t", _ann(read_only=True, destructive=True))])
+        assert _eligible(mgr, "t") is False
+
+
+class TestStrictPolicy:
+    """Cache ONLY explicit read-only tools; a missing hint defaults to may-mutate."""
+
+    def test_read_only_true_is_eligible(self, build):
+        mgr, _, _ = build(policy="strict", tools=[_tool("t", _ann(read_only=True))])
+        assert _eligible(mgr, "t") is True
+
+    def test_unannotated_is_not_eligible(self, build):
+        mgr, _, _ = build(policy="strict", tools=[_tool("t")])
+        assert _eligible(mgr, "t") is False
+
+    def test_read_only_false_is_not_eligible(self, build):
+        mgr, _, _ = build(policy="strict", tools=[_tool("t", _ann(read_only=False))])
+        assert _eligible(mgr, "t") is False
+
+
+class TestIgnorePolicy:
+    """Pre-gate behavior: every tool eligible regardless of annotations."""
+
+    def test_writer_is_eligible_under_ignore(self, build):
+        mgr, _, _ = build(
+            policy="ignore", tools=[_tool("t", _ann(read_only=False, destructive=True))]
+        )
+        assert _eligible(mgr, "t") is True
+
+
+class TestOverridePrecedence:
+    def test_tool_override_false_beats_read_only_annotation(self, build):
+        mgr, _, _ = build(
+            tools=[_tool("t", _ann(read_only=True))],
+            tool_overrides={"t": ToolOverrideConfig(cache=False)},
+        )
+        assert _eligible(mgr, "t") is False
+
+    def test_tool_override_true_beats_writer_annotation(self, build):
+        mgr, _, _ = build(
+            tools=[_tool("t", _ann(read_only=False))],
+            tool_overrides={"t": ToolOverrideConfig(cache=True)},
+        )
+        assert _eligible(mgr, "t") is True
+
+    def test_server_override_false_applies_when_no_tool_override(self, build):
+        mgr, _, _ = build(server_cache=False, tools=[_tool("t", _ann(read_only=True))])
+        assert _eligible(mgr, "t") is False
+
+    def test_tool_override_wins_over_server_override(self, build):
+        mgr, _, _ = build(
+            server_cache=False,
+            tools=[_tool("t")],
+            tool_overrides={"t": ToolOverrideConfig(cache=True)},
+        )
+        assert _eligible(mgr, "t") is True
+
+
+class TestUnknownServer:
+    def test_unknown_server_is_eligible(self, build):
+        # Direct dispatch / tests with no registered connection → preserve
+        # pre-gate behavior rather than refusing the cache.
+        mgr, _, _ = build(tools=[])
+        assert mgr._tool_cache_eligible("nope", "t", cfg_snap=mgr._config) is True
+
+
+# ── Integration: the side effect actually re-executes ────────────────────
+
+
+@pytest.mark.asyncio
+class TestCallToolHonoursEligibility:
+    async def test_writer_is_force_forwarded_each_call(self, build):
+        """A readOnlyHint=False tool called twice with identical args must hit the
+        upstream BOTH times (side effect re-executes) and never be cached."""
+        mgr, _, cache = build(tools=[_tool("writer", _ann(read_only=False))])
+        session = mgr._connections["srv"].session
+        session.call_tool.return_value = _text_result("done")
+
+        await mgr.call_tool("srv", "writer", {"x": 1})
+        await mgr.call_tool("srv", "writer", {"x": 1})
+
+        assert session.call_tool.await_count == 2  # not served from cache
+        assert cache.get("srv", "writer", {"x": 1}) is None  # not stored
+
+    async def test_read_only_tool_is_served_from_cache(self, build):
+        """A readOnlyHint=True tool hits the upstream once; the identical repeat is
+        served from cache (regression guard: the gate must not over-block)."""
+        mgr, _, cache = build(tools=[_tool("reader", _ann(read_only=True))])
+        session = mgr._connections["srv"].session
+        session.call_tool.return_value = _text_result("payload")
+
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+
+        assert session.call_tool.await_count == 1  # second served from cache
+        assert cache.get("srv", "reader", {"q": "a"}) is not None
+
+    async def test_unannotated_tool_still_cached_default(self, build):
+        """Behavior preservation: the un-annotated majority is cached as before
+        under the default conservative policy."""
+        mgr, _, cache = build(tools=[_tool("plain")])
+        session = mgr._connections["srv"].session
+        session.call_tool.return_value = _text_result("payload")
+
+        await mgr.call_tool("srv", "plain", {})
+        await mgr.call_tool("srv", "plain", {})
+
+        assert session.call_tool.await_count == 1
+
+    async def test_override_false_force_forwards_unannotated(self, build):
+        mgr, _, cache = build(
+            tools=[_tool("vol")],
+            tool_overrides={"vol": ToolOverrideConfig(cache=False)},
+        )
+        session = mgr._connections["srv"].session
+        session.call_tool.return_value = _text_result("now")
+
+        await mgr.call_tool("srv", "vol", {})
+        await mgr.call_tool("srv", "vol", {})
+
+        assert session.call_tool.await_count == 2
+        assert cache.get("srv", "vol", {}) is None


### PR DESCRIPTION
## Background

Part of a small caching-audit series (sibling: #534 toolgraph sqlite guard). This is the headline finding, corroborated by an independent Codex review (Verdict: NEEDS-FIX / Blocker) and a multi-agent audit.

The proxy sits transparently in front of **every** upstream tool and the response cache is **on by default** (`enabled=True`, `default_ttl_seconds=3600`). The store and lookup never consulted the tool's MCP annotations — `readOnlyHint`/`destructiveHint` were preserved on `ProxyToolInfo` and used **only for advertising** (`_fastmcp_compat.py`).

So a mutating tool (`create_*` / `send_*` / `write_*` / `delete_*`) called twice with identical args within the TTL was served the first call's cached success on the fast-path **without re-entering the upstream** — the side effect never re-executed, yet the agent received a success as if it had. Silent data-integrity exposure for any github / filesystem / messaging upstream proxied through STM.

## Change

Add `_tool_cache_eligible(server, tool)` and gate **both** the lookup (`_call_tool_guarded`) and the store (`_store_cache`). Resolution order:

1. per-tool `cache` override (`ToolOverrideConfig.cache`),
2. per-server `cache` override (`UpstreamServerConfig.cache`),
3. global `CacheConfig.tool_annotation_policy` on `readOnlyHint` / `destructiveHint`.

**`tool_annotation_policy`** (new, default `conservative`):

| policy | cached |
|---|---|
| `conservative` (default) | everything **except** self-declared writers (`readOnlyHint is False` or `destructiveHint is True`) |
| `strict` | only `readOnlyHint is True` (un-annotated → may-mutate per MCP spec) |
| `ignore` | pre-gate behavior — cache regardless of annotations |

An ineligible tool is neither served from nor stored in the cache; the lookup goes straight through with **no stampede lock** so every call re-runs and its side effect re-executes. Gating the lookup (not just the store) also refuses to serve any row cached before this gate existed.

The **privacy** and **transient-key** store guards are orthogonal and still apply on top. An unknown server (direct dispatch / tests) stays eligible, preserving prior behavior.

Also adds per-tool / per-server **`cache: bool | None`** overrides so an operator can force a volatile read tool out (`cache: false`) or re-enable a mis-annotated tool (`cache: true`) without disabling the whole cache.

## Behavior change

Default flips from "cache every tool" to "cache every tool **except self-declared writers**". The un-annotated majority and declared read-only tools are unaffected (still cached). Operators who want the old behavior can set `tool_annotation_policy: ignore`.

> Note: miss accounting is unchanged — an ineligible tool still records a cache *miss* via the existing `_call_tool_inner` path (cache configured ⇒ miss recorded). Refining per-tool cache stats is deferred to the observability follow-up.

## Tests

`tests/test_cache_eligibility.py` covers the policy matrix, override precedence, and the key regression via the `call_tool` seam:
- `readOnlyHint=False` tool called twice with identical args → upstream hit **both** times (`await_count == 2`), never cached;
- `readOnlyHint=True` tool → served from cache on the repeat (`await_count == 1`);
- un-annotated tool → still cached under the default.

Full suite: **3880 passed, 3 skipped**. `ruff check`/`format` clean. (Pre-existing unrelated `mypy` advisory in `config.py:135/144` only.)

`docs/caching.md` documents the policy, the override, and cross-links `SECURITY.md` for the privacy exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)