### PR TITLE
feat(cache): surface response-cache hit-rate/occupancy + stop wasting I/O on ttl<=0

### DIFF
--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -103,6 +103,10 @@ class ProxyCache:
         self._max_entries = max_entries
         self._db: sqlite3.Connection | None = None
         self._lock = threading.Lock()
+        # Process-lifetime count of rows dropped by ``_trim`` (max_entries
+        # overflow). Surfaced via ``stats()`` so an operator can see the cache
+        # thrashing instead of it evicting silently. Resets on restart.
+        self._evictions = 0
 
     def initialize(self) -> None:
         self._db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -221,6 +225,24 @@ class ProxyCache:
     ) -> None:
         if self._db is None:
             return
+        if ttl_seconds is not None and ttl_seconds <= 0:
+            # A non-positive TTL makes every row born-expired (``is_expired`` is
+            # ``now >= created_at + 0`` → always true), so storing one only burns
+            # write+trim I/O for a guaranteed miss — a "cache enabled, 0% hits"
+            # footgun. Treat it as do-not-store: set ``cache.enabled=False`` to turn
+            # caching off, or a positive TTL to cache. (``None`` is the distinct
+            # "never expires" sentinel and still stores.)
+            #
+            # Still INVALIDATE any existing row for this key: an earlier call may
+            # have cached it under a positive TTL (e.g. before the TTL was lowered
+            # to 0 via hot-reload), and leaving that live row would keep serving
+            # stale content. This mirrors the pre-short-circuit behavior, which
+            # overwrote the key with a born-expired row.
+            key = _make_key(server, tool, args)
+            with self._lock:
+                self._db.execute("DELETE FROM proxy_cache WHERE cache_key = ?", (key,))
+                self._db.commit()
+            return
         if contains_sensitive_content(result):
             # SECURITY.md: responses that look like secrets are never
             # persisted to the response cache. Enforced at the store
@@ -255,12 +277,13 @@ class ProxyCache:
         count = self._db.execute("SELECT COUNT(*) FROM proxy_cache").fetchone()[0]
         if count > self._max_entries:
             excess = count - self._max_entries
-            self._db.execute(
+            cur = self._db.execute(
                 "DELETE FROM proxy_cache WHERE cache_key IN "
                 "(SELECT cache_key FROM proxy_cache ORDER BY created_at ASC LIMIT ?)",
                 (excess,),
             )
             self._db.commit()
+            self._evictions += cur.rowcount
 
     def clear(self, *, server: str | None = None, tool: str | None = None) -> int:
         if self._db is None:
@@ -293,7 +316,7 @@ class ProxyCache:
 
     def stats(self) -> dict[str, int]:
         if self._db is None:
-            return {"total_entries": 0, "expired_entries": 0}
+            return {"total_entries": 0, "expired_entries": 0, "evictions": self._evictions}
         now = time.time()
         with self._lock:
             total = self._db.execute("SELECT COUNT(*) FROM proxy_cache").fetchone()[0]
@@ -301,4 +324,4 @@ class ProxyCache:
                 "SELECT COUNT(*) FROM proxy_cache WHERE ttl_seconds IS NOT NULL AND created_at + ttl_seconds <= ?",
                 (now,),
             ).fetchone()[0]
-        return {"total_entries": total, "expired_entries": expired}
+        return {"total_entries": total, "expired_entries": expired, "evictions": self._evictions}

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -2099,8 +2099,16 @@ class ProxyManager:
             {k: v for k, v in arguments.items() if k != "_context_query"} if arguments else {}
         )
 
-        # No cache configured — stampede protection N/A, go straight through.
-        if self._cache is None:
+        # No cache configured, OR a non-positive configured TTL disables it: go
+        # straight through (no lookup, no store, no stampede lock). The TTL check
+        # is on the LOOKUP path on purpose — a row cached earlier under a positive
+        # TTL is still "live" on disk after the TTL is lowered to 0 (per-row TTL is
+        # frozen at write time), so without bypassing the lookup that stale row
+        # would keep serving. Skipping the lookup makes ttl<=0 behave like
+        # ``cache.enabled=false``; the store-side ``ProxyCache.set`` short-circuit
+        # additionally deletes such a row when the forced upstream call re-stores.
+        cache_ttl = self._config.cache.default_ttl_seconds
+        if self._cache is None or (cache_ttl is not None and cache_ttl <= 0):
             return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id), False
 
         # Cache-eligibility gate (MCP annotations / per-tool|server ``cache``
@@ -2127,6 +2135,13 @@ class ProxyManager:
                 cached = self._cache.get(server, tool, upstream_args)
                 if cached is not None:
                     return await self._on_cache_hit(cached, server, tool, arguments, trace_id), True
+                # Eligible cache lookup confirmed missing (the lock-free fast-path
+                # AND this in-lock double-check). This is the SINGLE eligible-miss
+                # exit, so account the miss here. The ineligible and no-cache paths
+                # above deliberately record NOTHING — no lookup was attempted, and
+                # counting a forced-forward writer (or a ``cache: false`` tool) as a
+                # miss would skew the hit-rate diagnostics.
+                self.tracker.record_cache_miss()
                 return await self._call_tool_inner(
                     server, tool, arguments, trace_id=trace_id
                 ), False
@@ -3100,11 +3115,13 @@ class ProxyManager:
             {k: v for k, v in arguments.items() if k != "_context_query"} if arguments else {}
         )
 
-        # Cache lookup + hit path handled by ``_call_tool_guarded``; by the
-        # time we get here the cache has already missed. Just account the
-        # miss and proceed with the upstream fetch.
-        if self._cache is not None:
-            self.tracker.record_cache_miss()
+        # Cache lookup, hit path, and miss accounting are all owned by
+        # ``_call_tool_guarded``: a hit returns there, an ELIGIBLE miss is
+        # recorded there, and the ineligible / no-cache paths intentionally
+        # record nothing. By the time we reach here the call is already past that
+        # gate, so we just proceed with the upstream fetch. Direct callers (tests)
+        # that invoke ``_call_tool_inner`` bypass the lookup and therefore the
+        # miss counter too, matching the no-lookup semantics.
 
         # Snapshot the cache-key args BEFORE injecting ``_trace_id`` below.
         # The cache lookup at L771 used the original args (no ``_trace_id``);

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -481,6 +481,11 @@ async def stm_proxy_stats(
     app = _get_ctx(ctx)
     summary = app.tracker.get_summary()
 
+    cache_hits = summary["cache_hits"]
+    cache_misses = summary["cache_misses"]
+    cache_lookups = cache_hits + cache_misses
+    cache_hit_rate = (cache_hits / cache_lookups * 100) if cache_lookups else 0.0
+
     lines = [
         "STM Proxy Stats",
         "===============",
@@ -489,10 +494,24 @@ async def stm_proxy_stats(
         f"Compressed:      {summary['total_compressed_chars']}",
         f"Savings:         {summary['total_savings_pct']:.1f}%",
         f"Token savings:   {summary.get('total_token_savings_pct', 0):.1f}%",
-        f"Cache hits:      {summary['cache_hits']}",
-        f"Cache misses:    {summary['cache_misses']}",
+        f"Cache hits:      {cache_hits}",
+        f"Cache misses:    {cache_misses}",
+        f"Cache hit rate:  {cache_hit_rate:.1f}%",
         f"Reconnects:      {summary.get('reconnects', 0)}",
     ]
+
+    # Cache occupancy / eviction visibility (size vs max_entries, expired backlog,
+    # lifetime evictions) — distinct from the per-call hit/miss counters above and
+    # only available when the response cache is wired. Read inside this
+    # operator-invoked tool, so the synchronous sqlite COUNT stays off the hot path.
+    pm = getattr(app, "proxy_manager", None)
+    response_cache = getattr(pm, "_cache", None) if pm is not None else None
+    if response_cache is not None:
+        cstats = response_cache.stats()
+        lines.append(
+            f"Cache entries:   {cstats['total_entries']} "
+            f"(expired {cstats['expired_entries']}, evicted {cstats['evictions']})"
+        )
 
     # Error summary
     total_errors = summary.get("total_errors", 0)

--- a/tests/test_cache_eligibility.py
+++ b/tests/test_cache_eligibility.py
@@ -255,3 +255,54 @@ class TestCallToolHonoursEligibility:
 
         assert session.call_tool.await_count == 2
         assert cache.get("srv", "vol", {}) is None
+
+
+@pytest.mark.asyncio
+class TestMissAccountingHonoursEligibility:
+    """A cache MISS is recorded only after an ELIGIBLE lookup actually misses.
+    An ineligible (force-forwarded) tool attempts no lookup, so it must not be
+    counted as a miss — otherwise it skews the hit-rate diagnostic."""
+
+    async def test_ineligible_writer_records_no_miss(self, build):
+        mgr, _, _ = build(tools=[_tool("writer", _ann(read_only=False))])
+        mgr._connections["srv"].session.call_tool.return_value = _text_result("done")
+
+        await mgr.call_tool("srv", "writer", {"x": 1})
+        await mgr.call_tool("srv", "writer", {"x": 1})
+
+        assert mgr.tracker.get_summary()["cache_misses"] == 0
+
+    async def test_eligible_miss_records_one_miss_then_hit(self, build):
+        mgr, _, _ = build(tools=[_tool("reader", _ann(read_only=True))])
+        mgr._connections["srv"].session.call_tool.return_value = _text_result("payload")
+
+        await mgr.call_tool("srv", "reader", {"q": "a"})  # eligible miss → 1
+        await mgr.call_tool("srv", "reader", {"q": "a"})  # served from cache → no miss
+
+        summary = mgr.tracker.get_summary()
+        assert summary["cache_misses"] == 1
+        assert summary["cache_hits"] == 1
+
+
+@pytest.mark.asyncio
+class TestTtlZeroDisablesServing:
+    """Lowering cache.default_ttl_seconds to 0 must stop serving rows cached under
+    a prior positive TTL — per-row TTL is frozen at write time, so the lookup path
+    itself must bypass the cache when the configured TTL is non-positive."""
+
+    async def test_ttl_lowered_to_zero_stops_serving_and_invalidates(self, build):
+        mgr, _, cache = build(tools=[_tool("reader", _ann(read_only=True))])
+        session = mgr._connections["srv"].session
+        session.call_tool.return_value = _text_result("payload")
+
+        await mgr.call_tool("srv", "reader", {"q": "a"})  # cached under default TTL
+        assert session.call_tool.await_count == 1
+        assert cache.get("srv", "reader", {"q": "a"}) is not None
+
+        # Operator lowers the cache TTL to 0 (hot-reload). The previously-cached
+        # live row must no longer be served, and the next call must hit upstream.
+        mgr._config.cache.default_ttl_seconds = 0
+
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+        assert session.call_tool.await_count == 2  # not served from the stale row
+        assert cache.get("srv", "reader", {"q": "a"}) is None  # old row invalidated

--- a/tests/test_proxy_cache.py
+++ b/tests/test_proxy_cache.py
@@ -53,6 +53,28 @@ class TestProxyCacheTTL:
         proxy_cache.set("s", "t", {"a": 1}, "result", ttl_seconds=None)
         assert proxy_cache.get("s", "t", {"a": 1}) == "result"
 
+    def test_zero_ttl_does_not_store(self, proxy_cache: ProxyCache):
+        # A ttl of 0 would make every row born-expired; the store short-circuits
+        # so it does not burn write+trim I/O for a guaranteed miss.
+        proxy_cache.set("s", "t", {"a": 1}, "result", ttl_seconds=0)
+        assert proxy_cache.get("s", "t", {"a": 1}) is None
+        assert proxy_cache.stats()["total_entries"] == 0
+
+    def test_negative_ttl_does_not_store(self, proxy_cache: ProxyCache):
+        proxy_cache.set("s", "t", {"a": 1}, "result", ttl_seconds=-5.0)
+        assert proxy_cache.get("s", "t", {"a": 1}) is None
+        assert proxy_cache.stats()["total_entries"] == 0
+
+    def test_zero_ttl_invalidates_existing_live_row(self, proxy_cache: ProxyCache):
+        # A later ttl<=0 store must not leave a previously-cached LIVE row serving
+        # stale content — it invalidates the key, matching the old behavior of
+        # overwriting it with a born-expired row.
+        proxy_cache.set("s", "t", {"a": 1}, "old", ttl_seconds=60.0)
+        assert proxy_cache.get("s", "t", {"a": 1}) == "old"
+        proxy_cache.set("s", "t", {"a": 1}, "new", ttl_seconds=0)
+        assert proxy_cache.get("s", "t", {"a": 1}) is None
+        assert proxy_cache.stats()["total_entries"] == 0
+
 
 class TestProxyCacheClear:
     def test_clear_all(self, proxy_cache: ProxyCache):
@@ -99,6 +121,17 @@ class TestProxyCacheEviction:
         finally:
             cache.close()
 
+    def test_eviction_counter_tracks_trim(self, tmp_path):
+        cache = ProxyCache(tmp_path / "cache.db", max_entries=3)
+        cache.initialize()
+        try:
+            for i in range(5):
+                cache.set("s", "t", {"i": i}, f"r{i}", ttl_seconds=60.0)
+            # 5 inserts past a cap of 3 → 2 rows evicted, surfaced in stats.
+            assert cache.stats()["evictions"] == 2
+        finally:
+            cache.close()
+
 
 class TestProxyCacheStats:
     def test_stats_counts(self, proxy_cache: ProxyCache):
@@ -106,6 +139,7 @@ class TestProxyCacheStats:
         stats = proxy_cache.stats()
         assert stats["total_entries"] == 1
         assert stats["expired_entries"] == 0
+        assert stats["evictions"] == 0
 
 
 class TestTransientKeyDetector:

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -137,6 +137,40 @@ class TestProxyStats:
         result = await stm_proxy_stats(ctx=ctx)
         assert "LTM hints:" not in result
 
+    async def test_hit_rate_line(self):
+        """Derived hit-rate % is shown alongside the raw hit/miss counts."""
+        tracker = TokenTracker()
+        for _ in range(3):
+            tracker.record_cache_hit()
+        tracker.record_cache_miss()  # 3 hits / 4 lookups → 75.0%
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "Cache hit rate:  75.0%" in result
+
+    async def test_cache_entries_line_when_cache_wired(self, tmp_path):
+        """When the response cache is wired, occupancy/eviction is surfaced."""
+        from memtomem_stm.proxy.cache import ProxyCache
+
+        pm = _make_proxy_manager(tmp_path)
+        cache = ProxyCache(tmp_path / "c.db", max_entries=100)
+        cache.initialize()
+        try:
+            cache.set("s", "t", {"a": 1}, "r", ttl_seconds=60.0)
+            pm._cache = cache
+            ctx = _make_ctx(proxy_manager=pm)
+            result = await stm_proxy_stats(ctx=ctx)
+            assert "Cache entries:   1" in result
+            assert "evicted 0" in result
+        finally:
+            cache.close()
+
+    async def test_cache_entries_line_absent_without_cache(self):
+        """No response cache wired → no occupancy line (hit-rate still shown)."""
+        ctx = _make_ctx()
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "Cache entries:" not in result
+        assert "Cache hit rate:" in result
+
 
 # ── stm_proxy_select_chunks ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Background

Two low-severity response-cache polish items from the caching audit (series with #534, #535).

## 1. Observability

`stm_proxy_stats` printed only raw cache hit/miss counts, while every sibling figure (`Savings`, `error_rate`) is a derived %. `ProxyCache.stats()` (total/expired entries) was never surfaced in `src/`, and `max_entries` eviction was completely silent — an operator could not tell the cache was thrashing.

- Add a derived **`Cache hit rate: NN.N%`** line next to the raw counts.
- When the response cache is wired, append **`Cache entries: N (expired E, evicted V)`** from `ProxyCache.stats()`. Read inside the operator-invoked tool, so the synchronous sqlite `COUNT` stays off the hot path (consistent with the accepted sync-sqlite-on-loop posture).
- Track lifetime evictions in `ProxyCache._trim` (`cur.rowcount`) and expose via `stats()` so overflow churn is visible instead of silent.

## 2. `ttl<=0` footgun

`CacheConfig.default_ttl_seconds` accepts `0` (`Field(ge=0.0)`), but a `0` TTL makes every row **born-expired** (`is_expired` is `now >= created_at + 0`), so `get()` always missed while `set()` still paid the write+trim I/O — a "cache enabled, 0% hits" state.

`ProxyCache.set()` now short-circuits on `ttl <= 0` (do not store): use `cache.enabled=false` to disable, or a positive TTL to cache. `None` stays the distinct "never expires" sentinel and still stores.

> Chosen over a `gt=0` schema bound, which would reject any pre-existing config that persisted `0` (backward-incompatible).

## Tests

`ttl=0`/negative store-skip, eviction counter tracks trim, `stats()` includes `evictions`, and the `stm_proxy_stats` hit-rate + occupancy lines (present when the cache is wired, hit-rate still shown when it is not).

Full suite: **3867 passed, 3 skipped**. `ruff` clean.

> Docs: the `docs/caching.md` cache section is being edited in #535 (mutating-tool gate); a short note on `ttl=0` semantics + the new stats lines can fold in after both merge to avoid a cross-PR hunk conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)