### PR TITLE
feat(surfacing): flush the surfacing cache via stm_proxy_cache_clear

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -56,7 +56,7 @@ Key details:
 - **Privacy exclusion** — responses that look like secrets are never persisted to the cache; see [SECURITY.md](../SECURITY.md). This guard always applies on top of the policy/override above.
 - **Transient-key exclusion** — to prevent serving expired progressive/selective keys on a cache hit (which would drop the response tail), the cache automatically skips storing any response carrying a transient-key marker (like a `PROGRESSIVE_FOOTER_TOKEN` or a `selection_key` JSON field). The next identical call re-runs the pipeline to generate live keys.
 - Expired entries are purged on startup; oldest entries evicted when `max_entries` is exceeded
-- Clear cache via MCP tool: `stm_proxy_cache_clear(server="gh", tool="search_code")`
+- Clear cache via MCP tool: `stm_proxy_cache_clear(server="gh", tool="search_code")` clears matching response-cache entries; an unfiltered `stm_proxy_cache_clear()` flushes the entire response cache **and** the in-memory surfacing result cache
 - TTL is global (`cache.default_ttl_seconds`); `tool_overrides` tune compression, sizing, indexing, and cache eligibility (`cache: true|false`) — but not per-tool cache TTL
 
 ## Auto-Indexing

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -629,25 +629,49 @@ async def stm_proxy_cache_clear(
     tool: str | None = None,
     ctx: CtxType = None,  # type: ignore[assignment]
 ) -> str:
-    """Clear the proxy response cache.
+    """Clear the proxy caches.
+
+    An unfiltered call flushes BOTH the SQLite response cache and the in-memory
+    surfacing result cache. A filtered call (``server`` and/or ``tool``) targets
+    only the response cache — the surfacing cache is keyed by query hash and has
+    no server/tool axis, so it cannot be selectively cleared. The startup-only
+    tool-graph consult disk cache is not touched (it only affects the next
+    restart).
 
     Args:
-        server: If given, only clear entries for this upstream server name (the name used in mms add, not the prefix).
-        tool: If given, only clear entries for this tool (across all servers, or scoped to server if both provided).
+        server: If given, only clear response-cache entries for this upstream server name (the name used in mms add, not the prefix).
+        tool: If given, only clear response-cache entries for this tool (across all servers, or scoped to server if both provided).
     """
     app = _get_ctx(ctx)
     pm = app.proxy_manager
-    if not hasattr(pm, "_cache") or pm._cache is None:
-        return "Cache not enabled. Set proxy.cache.enabled = true in stm_proxy.json."
+    proxy_cache = getattr(pm, "_cache", None)
+    engine = app.surfacing_engine
 
-    removed = pm._cache.clear(server=server, tool=tool)
-    if server and tool:
-        return f"Cleared {removed} cache entries for {server}/{tool}."
-    elif server:
-        return f"Cleared {removed} cache entries for server '{server}'."
-    elif tool:
-        return f"Cleared {removed} cache entries for tool '{tool}'."
-    return f"Cleared all {removed} cache entries."
+    # Filtered: response cache only (surfacing has no server/tool dimension).
+    # Preserve the original proxy-only behavior and messages exactly.
+    if server or tool:
+        if proxy_cache is None:
+            return "Cache not enabled. Set proxy.cache.enabled = true in stm_proxy.json."
+        removed = proxy_cache.clear(server=server, tool=tool)
+        if server and tool:
+            return f"Cleared {removed} cache entries for {server}/{tool}."
+        elif server:
+            return f"Cleared {removed} cache entries for server '{server}'."
+        else:
+            return f"Cleared {removed} cache entries for tool '{tool}'."
+
+    # Unfiltered "clear all": flush each enabled cache independently.
+    parts: list[str] = []
+    if proxy_cache is not None:
+        parts.append(f"{proxy_cache.clear()} response-cache")
+    if engine is not None:
+        parts.append(f"{engine.clear_cache()} surfacing-cache")
+    if not parts:
+        return (
+            "No caches enabled (response cache and surfacing are both not enabled). "
+            "Set proxy.cache.enabled = true and/or surfacing.enabled = true in stm_proxy.json."
+        )
+    return "Cleared all caches: " + ", ".join(parts) + " entries."
 
 
 # ---------------------------------------------------------------------------

--- a/src/memtomem_stm/surfacing/cache.py
+++ b/src/memtomem_stm/surfacing/cache.py
@@ -44,8 +44,11 @@ class SurfacingCache:
             del self._cache[oldest_key]
         self._cache[key] = (time.monotonic(), results)
 
-    def clear(self) -> None:
+    def clear(self) -> int:
+        """Drop every cached entry; returns the number of entries removed."""
+        n = len(self._cache)
         self._cache.clear()
+        return n
 
     @staticmethod
     def _hash(query: str) -> str:

--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -151,6 +151,18 @@ class SurfacingEngine:
         for unconditional recording is not exposed here."""
         return self._observability_public
 
+    def clear_cache(self) -> int:
+        """Flush the in-memory surfacing result cache (operator flush, reached
+        from ``server.py::stm_proxy_cache_clear``). Returns the number of cached
+        query entries dropped.
+
+        Scoped to the result cache ONLY. The cross-session ``_surfaced_ids``
+        dedup set and the ``_invalidated_ids`` feedback set are left intact:
+        clearing the former would resurface memories already shown this session,
+        and the latter is a strict subset of surfacings that is inert once the
+        result cache is empty (it only filters cache hits)."""
+        return self._cache.clear()
+
     def _persistable_query(self, query: str) -> str:
         """Return the form of ``query`` that gets written to
         ``surfacing_events.query`` (#352 part 3).

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -245,6 +245,56 @@ class TestCacheClear:
         assert "srv/t" in result
         mock_cache.clear.assert_called_once_with(server="srv", tool="t")
 
+    async def test_unfiltered_flushes_both_caches(self):
+        """An unfiltered call flushes the response cache AND the surfacing cache."""
+        pm = _make_proxy_manager()
+        mock_cache = MagicMock()
+        mock_cache.clear.return_value = 7
+        pm._cache = mock_cache
+        engine = MagicMock()
+        engine.clear_cache.return_value = 3
+
+        ctx = _make_ctx(proxy_manager=pm, surfacing_engine=engine)
+        result = await stm_proxy_cache_clear(ctx=ctx)
+
+        mock_cache.clear.assert_called_once_with()  # no server/tool filter
+        engine.clear_cache.assert_called_once_with()
+        assert "7" in result and "3" in result
+        assert "response-cache" in result and "surfacing-cache" in result
+
+    async def test_filtered_does_not_touch_surfacing(self):
+        """A server/tool-filtered call targets only the response cache.
+
+        The surfacing cache is keyed by query hash with no server/tool axis, so
+        a filtered clear must leave it untouched (and keep the old wording)."""
+        pm = _make_proxy_manager()
+        mock_cache = MagicMock()
+        mock_cache.clear.return_value = 2
+        pm._cache = mock_cache
+        engine = MagicMock()
+
+        ctx = _make_ctx(proxy_manager=pm, surfacing_engine=engine)
+        result = await stm_proxy_cache_clear(server="srv", ctx=ctx)
+
+        engine.clear_cache.assert_not_called()
+        mock_cache.clear.assert_called_once_with(server="srv", tool=None)
+        assert "server 'srv'" in result
+
+    async def test_unfiltered_flushes_surfacing_when_proxy_cache_disabled(self):
+        """Proxy cache off but surfacing on: the unfiltered call still flushes
+        surfacing (the old handler returned early and could never reach it)."""
+        pm = _make_proxy_manager()
+        pm._cache = None
+        engine = MagicMock()
+        engine.clear_cache.return_value = 4
+
+        ctx = _make_ctx(proxy_manager=pm, surfacing_engine=engine)
+        result = await stm_proxy_cache_clear(ctx=ctx)
+
+        engine.clear_cache.assert_called_once_with()
+        assert "4" in result and "surfacing-cache" in result
+        assert "response-cache" not in result  # proxy cache absent, not reported
+
 
 # ── stm_proxy_health ─────────────────────────────────────────────────────
 

--- a/tests/test_surfacing_cache.py
+++ b/tests/test_surfacing_cache.py
@@ -78,13 +78,14 @@ class TestSurfacingCacheEviction:
 
 
 class TestSurfacingCacheClear:
-    def test_clear_removes_all(self):
+    def test_clear_removes_all_and_returns_count(self):
         cache = SurfacingCache(ttl=60.0)
         cache.set("q1", ["r1"])
         cache.set("q2", ["r2"])
-        cache.clear()
+        assert cache.clear() == 2  # reports how many entries were dropped
         assert cache.get("q1") is None
         assert cache.get("q2") is None
+        assert cache.clear() == 0  # empty cache clears nothing
 
 
 class TestSurfacingCacheHashDeterminism:


### PR DESCRIPTION
## Summary

Gives operators a way to flush the in-memory surfacing result cache through the existing `stm_proxy_cache_clear` MCP tool. Previously the tool only ever cleared the SQLite response cache, so the surfacing cache could only be dropped by restarting the server.

When iterating on surfacing config/behavior (or after LTM writes that should change what surfaces) the stale 60s-TTL surfacing entries kept serving with no operator escape hatch. Worse, the old handler returned early when the response cache was disabled (`pm._cache is None`), so even an unfiltered call could never reach the surfacing cache.

## Behavior change

- **Unfiltered `stm_proxy_cache_clear()`** now flushes **both** the response cache and the in-memory surfacing result cache, and reports both counts (e.g. `Cleared all caches: 7 response-cache, 3 surfacing-cache entries.`). It previously cleared only the response cache.
- **Filtered `stm_proxy_cache_clear(server=…, tool=…)`** is unchanged — response-cache-only, with the exact prior messages. The surfacing cache is keyed by query hash and has no server/tool axis, so it cannot be selectively cleared.
- The both-disabled case still returns a message containing `not enabled`.

## What changed

- `surfacing/cache.py` — `SurfacingCache.clear()` returns the number of entries dropped (`None` → `int`).
- `surfacing/engine.py` — new thin `SurfacingEngine.clear_cache() -> int` wrapper so the handler does not reach into a private `_cache`.
- `server.py` — `stm_proxy_cache_clear` restructured: filtered path stays proxy-only; unfiltered path flushes each enabled cache independently.
- `docs/caching.md` — documents the dual flush.

## Scope notes (preempting review questions)

- **Why not reset `_surfaced_ids` / `_invalidated_ids`?** `clear_cache()` is scoped to the result cache only. Clearing the cross-session `_surfaced_ids` dedup set would resurface memories already shown this session; `_invalidated_ids` is a strict subset of surfacings that only filters cache hits and is inert once the result cache is empty.
- **Why not include the tool-graph consult cache?** That `GraphConsultCache` is a startup-only disk cache with no full-`clear()`; flushing it would only affect the next restart, so it is intentionally excluded.
- **Why one tool, not a `scope` selector?** A selector (flush surfacing without the response cache) is YAGNI for a debug tool whose surfacing TTL is already 60s; can be added later if a need shows up.

## Test plan

- `test_surfacing_cache.py`: `clear()` returns the pre-clear count, then `0` on an empty cache.
- `test_server_tools.py` `TestCacheClear`: unfiltered flushes both (asserts both `clear()` calls + both counts in the message); filtered does NOT touch surfacing and keeps prior wording; proxy-cache-disabled-but-surfacing-enabled still flushes surfacing; both-absent still says `not enabled`.
- `uv run pytest tests/test_surfacing_cache.py tests/test_server_tools.py tests/test_surfacing_engine.py` → all pass; `ruff` clean on changed files. codex review: SHIP, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
