### PR TITLE
security(privacy): mirror LTM secret-class patterns into CREDENTIAL_PATTERNS

### DIFF
--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -1,4 +1,22 @@
-"""Privacy-aware content scanning for proxy compression routing."""
+"""Privacy-aware content scanning for proxy compression routing.
+
+The secret-class set here is kept coherent with memtomem LTM's
+trust-boundary guard (``memtomem/privacy.py``), but the two scanners serve
+different contracts: STM's scan is a compression-ROUTING signal (does this
+block carry anything sensitive enough to skip an external-LLM strategy?),
+while LTM's is a write-REJECTION gate. Sync is asymmetric:
+
+- Secret-class patterns (provider tokens, key formats, PEM headers) are
+  mirrored both ways for routing coherence — a payload LTM would block as
+  secret-bearing should also steer STM's routing.
+- PII-class patterns (email, etc.) do NOT cross over: STM keeps email in
+  ``PII_PATTERNS`` (storage-gating only), and LTM excludes it by design
+  because a PII block default would over-refuse ordinary prose ingress.
+
+The seven provider-token patterns at the end of ``CREDENTIAL_PATTERNS``
+originated at the LTM boundary (issue #1488) and were mirrored back here
+(reverse sync, issue #1491).
+"""
 
 from __future__ import annotations
 
@@ -28,6 +46,54 @@ CREDENTIAL_PATTERNS = [
     # dotted identifiers.
     r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
     r"(?i)(BEGIN\s+(RSA|EC|OPENSSH|DSA|PGP)\s+PRIVATE\s+KEY)",
+    # --- Secret-class patterns mirrored from memtomem LTM (issue #1488) -----
+    # These provider-token patterns originated at the LTM trust boundary and
+    # are mirrored back here for routing coherence (reverse sync, issue
+    # #1491). All are case-SENSITIVE on purpose: provider prefixes are
+    # fixed-case (``sk-``, ``AIza``, ``glpat-``, ``hf_``, ``gh*_``) — wrapping
+    # them under ``(?i)`` reintroduces false positives (``AIZA``, ``GLPAT-``).
+    # Segments are bounded ({20,200}), digit-lookaheads capped ({0,33}), and
+    # the hyphen-inclusive tokens use exact lengths, so scanning stays
+    # linear-time — a crafted ``sk-proj-``/``glpat-`` repetition cannot drive
+    # O(n^2) backtracking.
+    #
+    # Modern OpenAI keys (sk-proj-/sk-svcacct-/sk-admin-): the legacy
+    # ``sk-[a-zA-Z0-9]{20,}`` rule above MISSES these — the hyphen after the
+    # class word halts the alphanumeric run. Anchored on the embedded
+    # ``T3BlbkFJ`` marker (base64 of "OpenAI") between two base64url segments.
+    # The trailing ``(?![A-Za-z0-9_-])`` guard stops the capped greedy from
+    # matching only the first 200 chars of a longer token-char run.
+    r"\bsk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,200}T3BlbkFJ[A-Za-z0-9_-]{20,200}(?![A-Za-z0-9_-])",
+    # Anthropic keys (sk-ant-apiNN-/adminNN-): also missed by the legacy rule.
+    # Anchored on the exact canonical body — 93 base64url chars + the literal
+    # "AA" terminal (a bit-alignment artifact every real key carries). The
+    # exact length + AA terminal rejects digit-bearing kebab slugs like
+    # "sk-ant-api03-release-notes-2026-migration-guide". The terminal guard is
+    # ``(?![A-Za-z0-9_-])``, NOT ``\b``: ``-`` is in the body charset, so a
+    # bare ``\b`` would treat ``AA-`` as a boundary. The OAuth token
+    # (sk-ant-oat01-) has no canonical length and is omitted.
+    r"\bsk-ant-(?:api|admin)\d{2}-[A-Za-z0-9_-]{93}AA(?![A-Za-z0-9_-])",
+    # GitHub token family completion: gho_ (OAuth), ghu_ (user-to-server),
+    # ghs_ (server-to-server / Actions GITHUB_TOKEN), ghr_ (refresh). Same
+    # base62 shape as the already-covered ghp_. {36,} min — ghs_ runs longer.
+    r"\bgh[ousr]_[A-Za-z0-9]{36,}\b",
+    # Google API key (GCP / Firebase / Maps / Gemini): fixed AIza + 35
+    # base64url chars (39 total). Trailing lookahead pins the exact length so
+    # it won't fire on the AIza-prefixed head of a longer blob.
+    r"\bAIza[0-9A-Za-z_-]{35}(?![0-9A-Za-z_-])",
+    # GitLab personal access token: the ``glpat-`` literal + the exact classic
+    # 20-char body with a terminal guard. Exact length rejects digit-bearing
+    # kebab slugs like "glpat-form-builder-component-name-2026". Newer 17.x
+    # routable tokens (longer body + ".<checksum>") are a separate follow-up.
+    r"\bglpat-[0-9A-Za-z_-]{20}(?![0-9A-Za-z_-])",
+    # Hugging Face access token. The short ``hf_`` prefix is collision-prone
+    # (hf_hub, hf_model), so: exact 34-char alnum body, both word boundaries,
+    # and a digit-in-body lookahead to reject letter-only identifiers.
+    r"\bhf_(?=[A-Za-z0-9]{0,33}[0-9])[A-Za-z0-9]{34}\b",
+    # PyPI / TestPyPI upload token. The macaroon header ``AgEIcHlwaS5vcmc`` /
+    # ``AgENdGVzdC5weXBpLm9yZw`` (base64 of "pypi.org" / "test.pypi.org") is
+    # an exact fingerprint → lowest FP of the set.
+    r"\bpypi-Ag(?:EIcHlwaS5vcmc|ENdGVzdC5weXBpLm9yZw)[A-Za-z0-9_-]{50,}",
 ]
 
 # PII that is sensitive to PERSIST but not a credential. Email addresses

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -159,6 +159,19 @@ class TestDefaultPatternCoverage:
             "-----BEGIN RSA PRIVATE KEY-----",
             "-----BEGIN DSA PRIVATE KEY-----",
             "-----BEGIN PGP PRIVATE KEY-----",
+            # --- #1488 LTM-origin mirror (all examples are FAKE; assembled at
+            #     runtime so no contiguous realistic token literal trips GitHub
+            #     push protection) -----------------------------------------
+            # Modern OpenAI key: legacy ``sk-`` rule misses it (hyphen after
+            # "proj" halts the run) — hits via the T3BlbkFJ marker rule.
+            "sk-proj-FAKE0aaaa1111bbbb2222cccc3333T3Blbk" + "FJEXAMPLE0dddd4444eeee5555ffff6666",
+            "sk-ant-api03-" + ("FAKEfake0123456789" * 6)[:93] + "AA",  # Anthropic
+            "ghs_" + "FAKEfake0123456789FAKEfake0123456789",  # GitHub server-to-server
+            "AIza" + "Sy0_-BcdSy0_-BcdSy0_-BcdSy0_-BcdSy0",  # Google API key (AIza + 35)
+            "glpat-" + ("FAKEfake0123456789" * 2)[:20],  # GitLab PAT (exact 20)
+            "hf" + "_FAKEfake0123456789FAKEfake01234567",  # Hugging Face (hf_ + 34)
+            "pypi-Ag"
+            + "EIcHlwaS5vcmcFAKEfake0123456789FAKEfake0123456789FAKEfake0123456789",  # PyPI
         ],
     )
     def test_default_patterns_match_common_secret_shapes(self, sample: str) -> None:
@@ -176,6 +189,15 @@ class TestDefaultPatternCoverage:
             "AKIAshort",  # missing the 16-char IAM suffix
             "github_pat_",  # just the prefix, no body
             "npm_",  # prefix only
+            # --- #1488 mirror false-positive guards: prose / kebab slugs that
+            #     share a provider prefix but must NOT match -----------------
+            "sk-project-management-tool",  # OpenAI prefix, no T3BlbkFJ marker
+            "sk-ant-api03-release-notes-2026-migration-guide",  # Anthropic kebab slug
+            "ghost_writer_mode_enabled",  # starts "gho" but not a gho_ token
+            "AIzaShortKey",  # AIza prefix but body too short
+            "glpat-form-builder-component-name-2026",  # GitLab kebab slug
+            "hf" + "_abcdefghijklmnopqrstuvwxyzabcdefgh",  # hf_ + 34 letters, no digit
+            "pypi-package-name-here",  # pypi- prefix without the macaroon header
         ],
     )
     def test_default_patterns_do_not_match_benign_strings(self, sample: str) -> None:
@@ -208,6 +230,15 @@ class TestCredentialPiiSplit:
         assert privacy.PII_PATTERNS
         assert not set(privacy.CREDENTIAL_PATTERNS) & set(privacy.PII_PATTERNS)
 
+    def test_credential_set_count_pinned(self):
+        # 9 original secret-class patterns + 7 mirrored from memtomem LTM
+        # (#1488 / reverse sync #1491). Bump deliberately when adding a
+        # pattern so a silent add/drop surfaces here and stays coherent with
+        # LTM's matching pin (memtomem DEFAULT_PATTERNS == 16).
+        assert len(privacy.CREDENTIAL_PATTERNS) == 16
+        assert len(privacy.PII_PATTERNS) == 1
+        assert len(privacy.DEFAULT_PATTERNS) == 17
+
     @pytest.mark.parametrize(
         "sample",
         [
@@ -227,6 +258,15 @@ class TestCredentialPiiSplit:
             "psql password=hunter2",
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",
             "-----BEGIN RSA PRIVATE KEY-----",
+            # #1488 mirror: each must classify as a credential (not PII) so the
+            # ACTION gate (external-LLM routing) fires, not just storage.
+            "sk-proj-FAKE0aaaa1111bbbb2222cccc3333T3Blbk" + "FJEXAMPLE0dddd4444eeee5555ffff6666",
+            "sk-ant-api03-" + ("FAKEfake0123456789" * 6)[:93] + "AA",
+            "ghs_" + "FAKEfake0123456789FAKEfake0123456789",
+            "AIza" + "Sy0_-BcdSy0_-BcdSy0_-BcdSy0_-BcdSy0",
+            "glpat-" + ("FAKEfake0123456789" * 2)[:20],
+            "hf" + "_FAKEfake0123456789FAKEfake01234567",
+            "pypi-Ag" + "EIcHlwaS5vcmcFAKEfake0123456789FAKEfake0123456789FAKEfake0123456789",
         ],
     )
     def test_credentials_match_via_credential_set_alone(self, sample: str) -> None:


### PR DESCRIPTION
## What

Mirror the seven secret-class regex patterns added at the memtomem **LTM** trust boundary in memtomem/memtomem#1488 into this proxy's `CREDENTIAL_PATTERNS`, so STM's compression-**routing** privacy gate stays coherent with LTM's write-**rejection** gate.

> Issue/PR numbers prefixed `memtomem/memtomem#` are in the LTM repo, not this one.

The seven: modern OpenAI (`sk-proj`/`svcacct`/`admin`, `T3BlbkFJ`-anchored), Anthropic (`sk-ant-NN-…AA`), the `gh[ousr]_` GitHub token family, Google `AIza`, GitLab `glpat-`, Hugging Face `hf_`, and PyPI macaroon tokens.

## Why

These were added directly at the LTM boundary ahead of STM (LTM-origin, memtomem/memtomem#1488). Until mirrored, STM's routing gate was blind to credentials LTM blocks — a payload carrying one of these tokens could be routed to an external-LLM compression strategy here even though LTM refuses to store it. This is the reverse-sync tracked by memtomem/memtomem#1491.

The regex strings are **byte-identical** to LTM's: after this, `CREDENTIAL_PATTERNS` equals LTM `DEFAULT_PATTERNS` exactly (16 secret-class patterns). PII is **not** crossed over — email stays in `PII_PATTERNS` (storage-gating only), per the asymmetric-sync rule now spelled out in the module docstring.

## Safety

- Case-sensitive provider prefixes + bounded segments / exact-length bodies / digit-lookaheads keep `re.search` linear-time and the false-positive profile tight (kebab slugs sharing a prefix are rejected).
- Verified on this branch: byte-parity vs LTM; full suite green (3951 passed); a 4-lens adversarial pass (false-negative / false-positive / ReDoS / parity) and an independent Codex review (SHIP, 0 findings). FP lens found 0 hits across ~24M chars of Monte Carlo base64url + a realistic dev corpus; ReDoS lens confirmed all seven strictly linear.
- The seven were already cross-checked against gitleaks/trufflehog canonical shapes and Codex-reviewed (4 rounds, SHIP) in LTM PR memtomem/memtomem#1492.

## Tests

- Positive + negative fixture per pattern; each new pattern asserted to classify as a **credential** (not PII), so the external-LLM routing gate fires.
- Count pin (`CREDENTIAL == 16` / `PII == 1` / `DEFAULT == 17`) guards against silent drift from LTM.
- Fake tokens assembled from fragments — no contiguous realistic token literal (push-protection-safe).

## Follow-up (separate change, not this PR)

Once merged, bump the STM SHA pin in LTM's `memtomem/privacy.py` docstring (currently `3e585b5`) to this merge commit and fold its tier-2 "ahead of STM" note into tier-1. The LTM issue memtomem/memtomem#1491 must be closed manually — a PR in this repo can't auto-close a cross-repo issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
