### PR TITLE
docs: close staleness gaps in SECURITY.md, cli.md, configuration.md, README, CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,12 @@ uv run mypy src
   - `surfacing/` — Memory surfacing engine and relevance gating
   - `observability/` — Langfuse tracing and metrics
   - `cli/` — `mms` / `memtomem-stm-proxy` / `memtomem-stm` CLI (all three entry points resolve to the same Click group, see #260)
+  - `daemon/` — Warm surfacing daemon (`mms daemon`): client, discovery, locking, protocol, spawn
+  - `mms/` — `mms import` / `mms host` / `mms project` registry state (`~/.mms/`), drift detection, secret classification
   - `utils/` — Circuit breaker and shared helpers
 - `tests/` — pytest suite
   - `tests/bench/` — `bench_qa` scenario harness (see "Adding a bench_qa scenario" below)
-- `docs/` — User-facing guides (surfacing, compression, caching, configuration, cli)
+- `docs/` — User-facing guides (surfacing, compression, caching, configuration, cli, selection-telemetry)
 
 The LTM core lives in a separate repository: [memtomem/memtomem](https://github.com/memtomem/memtomem). Communication between STM and LTM happens entirely through the MCP protocol — there is no Python-level dependency.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ If you've already configured MCP servers in Claude Desktop, Claude Code, or a pr
 
 ```bash
 mms list      # show what you've added
-mms status    # show full config + connectivity
+mms status    # show full config
+mms health    # check connectivity + surfacing readiness
 ```
 
 ### 2. Connect your AI client to STM
@@ -136,7 +137,8 @@ Or add it to a JSON MCP config for Cursor / Windsurf / Claude Desktop / Gemini:
 Your agent now sees proxied tools (`fs__read_file`, `gh__search_repositories`, etc.). The CLEAN / COMPRESS / SURFACE stages run automatically — responses are cleaned, compressed, cached, and (when an LTM server is configured) enriched with relevant memories. The INDEX stage (auto_index / extraction) is currently inactive in the standalone server; see [#288](https://github.com/memtomem/memtomem-stm/issues/288).
 
 To check connectivity and surfacing readiness from your shell, run
-`mms status` or `mms health`. If you want the agent to call operator-facing MCP
+`mms health` (`mms status` shows the static config only — it doesn't probe
+connectivity). If you want the agent to call operator-facing MCP
 tools such as `stm_proxy_stats`, start STM with
 `MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true`.
 
@@ -171,7 +173,7 @@ To bring file or shell operations under STM, register an MCP server that exposes
 
 A second tier of management lets you decide *which MCP servers a given project sees*, separately from the STM proxy gateway config. State lives in a new dotdir, `~/.mms/`:
 
-- `mms import --from claude-code` — pull existing MCP definitions out of `~/.claude.json`, `~/.cursor/mcp.json`, `~/.codex/config.toml`, or Claude Desktop's config into `~/.mms/registry.toml` (secrets redacted in `--plan`, written verbatim under `--apply`).
+- `mms import --from <host>` — pull existing MCP definitions out of one host's config (`claude-code` → `~/.claude.json` / `<cwd>/.mcp.json`, `cursor` → `~/.cursor/mcp.json`, `codex` → `~/.codex/config.toml`, `claude-desktop` → its config) into `~/.mms/registry.toml` (secrets redacted in `--plan`, written verbatim under `--apply`). `--from all`, the default, scans every host.
 - `mms project init` — create a `<project>/.mms/project.toml` marker (commit-recommended).
 - `mms project enable filesystem github` — declare which MCPs that project wants visible.
 - `mms project list` / `mms project show` — inspect the index and the current project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Please report security issues via [GitHub private vulnerability advisory](https:
 memtomem-stm is an MCP proxy gateway. Its threat surface differs from a server-facing application:
 
 - **Transport**: Default communication is stdio with the AI client (Claude Code, Cursor, etc.); the MCP proxy server itself opens no network port. When the built-in `mms hook` surfacing path is used, an eligible hook call may auto-spawn a local surfacing daemon (`hook.use_daemon`/`hook.auto_spawn` default on) that binds an ephemeral port on `daemon.host` — **`127.0.0.1` (loopback) by default** — and authenticates every connection with a per-start random token rather than network ACLs. Keep `daemon.host` on loopback: a non-loopback `daemon.host` (e.g. `0.0.0.0`, or the empty string — both bind every interface) is rejected at config load unless you explicitly opt in with `MEMTOMEM_STM_DAEMON__ALLOW_NON_LOOPBACK=true`, which deliberately exposes the token-guarded daemon on that interface.
-- **Trust boundary**: memtomem-stm trusts the AI client (local process) and the upstream MCP servers it is configured to proxy. Only configure upstream servers you trust.
+- **Trust boundary**: memtomem-stm trusts the AI client (local process) and the upstream MCP servers it is configured to proxy. Only configure upstream servers you trust. `mms import --apply` and `mms host sync --apply` additionally gate on the *source* of a candidate: entries discovered in project-local config files (`.mcp.json`, `.cursor/mcp.json`) under the current directory — files an untrusted repository checkout can ship — are refused unless `--allow-project-configs` is passed, so a checkout cannot silently register a command that later runs with your privileges.
 - **Data at rest**: The optional selective-compression `PendingStore` defaults to in-memory (`pending_store="memory"`). Other persisted stores — the response cache (`proxy_cache.db`, enabled by default), metrics (`proxy_metrics.db`), and feedback — are local-only SQLite files under `~/.memtomem/`. No store is remote or shared across hosts.
 
 ## Security Measures
@@ -25,6 +25,7 @@ memtomem-stm is an MCP proxy gateway. Its threat surface differs from a server-f
 
 - **Sensitive content auto-detection**: Responses containing patterns that look like secrets (API keys, tokens, private keys) are detected and excluded from the response cache and from being indexed into LTM.
 - **Write-tool skip**: Memory surfacing is automatically disabled for upstream tools that mutate state, reducing the risk of injecting stale context into destructive operations.
+- **CLI output redaction**: `mms status --json` and `mms list --json` mask every `env` and `headers` value (`<REDACTED>`, keys preserved) since that machine-readable output is routinely piped to scripts, CI logs, or issue comments. The human-readable `status`/`list` tables never print `env`/`headers` at all; read the on-disk config directly when a value is genuinely needed.
 
 ### Resilience
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,7 +197,7 @@ Options:
 
 Prints the configured upstream servers in a table — name, prefix, transport, compression strategy, origin, and the command (stdio) or URL (SSE / HTTP). Reads the config only; does not probe connectivity (use `mms health` for that). With `--json` the output becomes `{"config_path": ..., "servers": {...}}` for scripting; a missing config file returns `{"error": "config_not_found", "path": ...}` instead of a text fallthrough so callers can branch on shape.
 
-The ORIGIN column summarizes import provenance: `-` for entries added manually (or imported before provenance capture), otherwise the recorded source kind (`claude-user`, `claude-project`, `mcp-json`, `claude-desktop`). A trailing `*` marks an entry whose recorded host sources — the primary origin **and** any duplicate registrations — were all pruned: it now exists only behind STM, and [`mms eject`](#eject) can restore it. The same condition drives the [`mms remove`](#remove) hint, so the two surfaces never disagree about which entries removal would orphan. In `--json` output the `origin` block appears with `origin.original` redacted (`has_original` tells you whether one was captured) because the verbatim host entry may carry secrets.
+The ORIGIN column summarizes import provenance: `-` for entries added manually (or imported before provenance capture), otherwise the recorded source kind (`claude-user`, `claude-project`, `mcp-json`, `claude-desktop`). A trailing `*` marks an entry whose recorded host sources — the primary origin **and** any duplicate registrations — were all pruned: it now exists only behind STM, and [`mms eject`](#eject) can restore it. The same condition drives the [`mms remove`](#remove) hint, so the two surfaces never disagree about which entries removal would orphan. In `--json` output the `origin` block appears with `origin.original` redacted (`has_original` tells you whether one was captured) because the verbatim host entry may carry secrets. Every server's own active `env` and `headers` values are also masked (`<REDACTED>`, keys preserved) in `--json` output, since that output is routinely piped to scripts, CI logs, or issue comments.
 
 ### `remove`
 
@@ -396,7 +396,7 @@ Options:
   --json         Output as JSON for scripting.
 ```
 
-Shows the current proxy gateway configuration file path, enabled flag, and the list of configured upstream servers with their prefix, transport, command or URL, compression strategy, character budget, and surfacing toggle.
+Shows the current proxy gateway configuration file path, enabled flag, and the list of configured upstream servers with their prefix, transport, command or URL, compression strategy, character budget, and surfacing toggle. In `--json` output, every server's `env` and `headers` values are masked (`<REDACTED>`, keys preserved); the human-readable table never prints those fields at all, so read the on-disk config directly when a value is genuinely needed.
 
 ### `stats`
 
@@ -586,7 +586,7 @@ Options:
 
 ## `mms import` — populate the registry from host configs
 
-`mms import` reads MCP definitions out of your existing host configs (Claude Code, Cursor, Codex CLI, Claude Desktop) and writes them to `~/.mms/registry.toml`. This is the **only** W1 path that mutates the registry — `mms add` writes to `~/.memtomem/stm_proxy.json` (the STM proxy bootstrap), not the mms registry.
+`mms import` reads MCP definitions out of your existing host configs (Claude Code, Cursor, Codex CLI, Claude Desktop) and writes them to `~/.mms/registry.toml`. `mms add` writes to `~/.memtomem/stm_proxy.json` (the STM proxy bootstrap) instead — the mms registry and the STM proxy config are separate files. `mms host sync --apply` (below) also mutates the registry, reconciling it against host config drift.
 
 ```
 Usage: mms import [OPTIONS]
@@ -597,7 +597,14 @@ Options:
   --plan / --apply        --plan (default) prints what would be imported with
                           secrets REDACTED. --apply writes ~/.mms/registry.toml.
   --show-imported         In --plan mode, reveal secret values instead of redacting.
+  --allow-project-configs
+                          Acknowledge and register MCP entries discovered in
+                          project-local config files (.mcp.json /
+                          .cursor/mcp.json) under the current directory.
+                          Without this flag, --apply refuses to register them.
 ```
+
+`--apply` refuses to register candidates discovered in `<cwd>/.mcp.json` or `<cwd>/.cursor/mcp.json` unless `--allow-project-configs` is passed — a repository checkout can ship those files, so adopting them without acknowledgement would let a checkout register a command that later runs with your privileges. `~/.claude.json`-sourced entries (including the `Claude Code (project)` label) are unaffected, since they live in your home directory, not the checkout. The gate only enforces on `--apply`; `--plan` just prints a footer warning that `--apply` will require the flag.
 
 Where each host config lives:
 
@@ -626,7 +633,7 @@ When the same name shows up in two places (two hosts in `--from all`, or already
 * If the entry is **identical** (same `command`, `args`, `env`), it's an idempotent no-op and `--apply` reports `Already up to date.`
 * If the entry **differs**, **first-import-wins** — the existing registry entry is kept, the new one is reported as a conflict and skipped. The scanner order for `--from all` is `claude-code → cursor → codex → claude-desktop`.
 
-A future `--force` flag for refresh-on-rerun is W2/W3.
+`mms import` itself has no refresh-on-rerun flag; for an acknowledged restamp of a changed entry, use `mms host sync --force` (below).
 
 ### Dangerous env keys
 
@@ -652,6 +659,12 @@ Commands:
 observation rather than a CI failure signal. `sync` is the ongoing
 reconciliation path: `--plan` previews, `--apply` writes, `--force` adopts
 entries marked changed, and `--yes` bypasses confirmation prompts for scripts.
+
+`sync --apply` shares the same project-local config gate as `mms import`: new
+(ADD-bucket) entries, and — only under `--force` — RESTAMP-bucket entries,
+discovered in project-local config files under the current directory are
+refused unless `--allow-project-configs` is passed. REMOVE and sidecar
+BACKFILL are not gated, since neither adopts a new registry command.
 
 ## MCP Tools (4 default + 9 opt-in + proxied)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,9 +136,12 @@ export MEMTOMEM_STM_SURFACING__LTM_MCP_HEADERS='{"Authorization":"Bearer ..."}'
 
 See [Surfacing → Surfacing Controls](surfacing.md#surfacing-controls) for the complete table of fields and defaults.
 
-### Claude Code Hook
+### PostToolUse Hook
 
-`mms hook` bridges Claude Code built-in `PostToolUse` events into STM surfacing.
+`mms hook` bridges built-in `PostToolUse` events into STM surfacing, available
+for Claude Code, Codex CLI, Cursor, and Kimi Code (`mms hook --host <name>`
+at runtime, or `mms hook install --host <name>` to register it with a host —
+see [docs/cli.md](cli.md#mms-hook--built-in-tool-bridge--per-host-registration)).
 It is independent of the MCP proxy path and is configured with
 `MEMTOMEM_STM_HOOK__*`.
 
@@ -149,7 +152,8 @@ export MEMTOMEM_STM_HOOK__FALLBACK=skip                # skip | cold
 export MEMTOMEM_STM_HOOK__AUTO_SPAWN=true
 export MEMTOMEM_STM_HOOK__RECORD_FEEDBACK_EVENTS=false # no query text / rating prompt by default
 
-# Built-in Bash stdout compression is opt-in and separate from surfacing.
+# Built-in Bash stdout compression is opt-in, separate from surfacing, and
+# Claude Code only — native output replacement ports to no other host.
 export MEMTOMEM_STM_HOOK__COMPRESSION__ENABLED=false
 export MEMTOMEM_STM_HOOK__COMPRESSION__MAX_CHARS=16000
 
@@ -162,8 +166,13 @@ export MEMTOMEM_STM_HOOK_SURFACE_TOOLS=read,grep,glob,shell
 
 `fallback=skip` returns `{}` immediately when the daemon is unavailable.
 `fallback=cold` runs the older in-process path, which can pay LTM startup cost
-inside the hook call. Hook compression only targets Bash stdout so later
-`Edit` operations are not broken by replacing file reads.
+inside the hook call. Surfacing (LTM context injection for read-like
+built-ins) is the only capability that ports to non-Claude hosts, and each
+host carries its own runtime caveat — see
+[docs/cli.md → `mms hook install`](cli.md#install--uninstall--per-host-registration)
+for the current per-host status. Hook compression only targets Claude Code's
+Bash stdout so later `Edit` operations are not broken by replacing file
+reads.
 
 ### Surfacing Daemon
 
@@ -172,10 +181,14 @@ inside the hook call. Hook compression only targets Bash stdout so later
 ```bash
 export MEMTOMEM_STM_DAEMON__HOST=127.0.0.1
 export MEMTOMEM_STM_DAEMON__IDLE_TIMEOUT_SECONDS=900
+export MEMTOMEM_STM_DAEMON__ALLOW_NON_LOOPBACK=false     # escape hatch, see below
 ```
 
-The daemon binds loopback and authenticates requests with a per-start token.
-`idle_timeout_seconds=0` pins it until explicitly stopped.
+The daemon binds loopback and authenticates requests with a per-start token,
+not network ACLs. A non-loopback `host` (including `0.0.0.0` and `""`, which
+bind every interface) is rejected at config load unless
+`allow_non_loopback=true` is set — see [SECURITY.md](../SECURITY.md) for the
+rationale. `idle_timeout_seconds=0` pins the daemon until explicitly stopped.
 
 ### Langfuse Tracing (optional)
 


### PR DESCRIPTION
## Summary

A documentation staleness audit (3 parallel Explore passes + direct source verification, followed by two rounds of codex review) found several gaps beyond what #551 covered:

- **SECURITY.md / docs/cli.md** never mentioned 2 of the 3 GHSA fixes shipped in v0.1.30: the project-local MCP config gate (`--allow-project-configs`, GHSA-9hjq-vxq2-36px) and CLI `--json` `env`/`headers` masking (GHSA-fpm7-rf53-vjc9). Only the daemon-loopback fix was previously documented.
- **README.md** had two unrelated accuracy bugs: `mms status` was described as checking connectivity (only `mms health` does), and `mms import --from claude-code` was described as scanning all four host sources (`--from` selects one; `--from all` is the default that scans everything).
- **docs/cli.md** had a false "only W1 path that mutates the registry" claim (`mms host sync --apply` also does) and a stale "future `--force` flag ... is W2/W3" sentence contradicting the `mms host sync --force` documented 20 lines later in the same file.
- **docs/configuration.md** predated Track B's multi-host `mms hook` support (still titled "Claude Code Hook") and the v0.1.30 daemon non-loopback rejection.
- **CONTRIBUTING.md**'s Project Structure list was missing the `daemon/` and `mms/` subpackages and `selection-telemetry.md`.

Reviewed with codex (dev-trio `ask-codex.sh`) at both the plan and diff stage; each pass surfaced real issues folded into this PR (plan review: `docs/configuration.md` wrongly marked out-of-scope, a stale `docs/cli.md` sentence; diff review: an overstated cross-host surfacing claim, misleading "use human-readable output" wording).

Docs-only change — no code or behavior changes.

## Test plan

- [x] `uv run pytest tests/test_docs_sync.py -v` — 13/13 passed (before and after the codex-driven diff-stage fixes)
- [x] `git diff --stat` confirmed exactly the 5 intended files changed
- [x] Every new factual claim (CLI flags, error messages, env vars, function names) verified against current source in `src/memtomem_stm/`
- [x] Two codex (dev-trio) review passes — plan-level and diff-level — both NEEDS-FIX, all findings verified and folded in

🤖 Generated with [Claude Code](https://claude.com/claude-code)