### PR TITLE
security(privacy): catch AWS secret material by label (SECRET_ACCESS_KEY / SESSION_TOKEN)

### DIFF
--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -34,6 +34,32 @@ logger = logging.getLogger(__name__)
 CREDENTIAL_PATTERNS = [
     r"(?i)(api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]",
     r"(?i)(password|passwd|pwd)\s*[:=]",
+    # AWS secret material by label. The generic label rule above misses both
+    # spellings the AWS toolchain actually emits: ``secret[_-]?key`` needs its
+    # two words adjacent (``secret_access_key`` splits them) and
+    # ``access[_-]?token`` needs the literal ``access`` (``session_token`` has
+    # neither). Two alternatives in one rule:
+    #
+    # - quoted form — ``"SessionToken": "…"`` / ``"SecretAccessKey": "…"``
+    #   (STS JSON, python-dict repr). The quote must sit DIRECTLY on both
+    #   sides of the label and the value must open as a string: a JSON-Schema
+    #   property (``"session_token": {"type"…`` — object value) and a
+    #   prefixed key (``"aws.get_session_token": "unhealthy"`` — telemetry
+    #   dicts keyed by tool name) must NOT fire, or the eligibility scanner
+    #   hides benign tools and the selection log drops whole records. The
+    #   pre-existing label rules never fire on bare JSON keys (the closing
+    #   quote blocks their ``[:=]``); this form must not regress that.
+    # - unquoted form — ``AWS_SECRET_ACCESS_KEY=`` / ``aws_session_token =``
+    #   (env output, ~/.aws/credentials INI): same shape and FP profile as
+    #   the generic label rule above.
+    #
+    # The AKIA/ASIA rule below catches the key *IDs*; this one catches the
+    # *material* those IDs unlock. STM-origin: this rule is ahead of LTM's
+    # mirrored set until the forward-sync lands (the inverse of the
+    # #1488→#1491 reverse-sync direction; see the count-pin note in
+    # tests/test_privacy.py).
+    r"(?i)(?:[\"'](?:secret_?access_?key|session_?token)[\"']\s*:\s*[\"']"
+    r"|(?:secret[_-]?access[_-]?key|session[_-]?token)\s*[:=])",
     # Provider-prefixed token formats. Anchored by prefix so false positives
     # on arbitrary high-entropy strings are rare.
     r"(?i)(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[0-9A-Za-z-]+)",

--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -53,8 +53,17 @@ CREDENTIAL_PATTERNS = [
     #   pre-existing label rules never fire on bare JSON keys (the closing
     #   quote blocks their ``[:=]``); this form must not regress that.
     # - unquoted form — ``AWS_SECRET_ACCESS_KEY=`` / ``aws_session_token =``
-    #   (env output, ~/.aws/credentials INI): same shape and FP profile as
-    #   the generic label rule above.
+    #   (env output, ~/.aws/credentials INI). Unlike the generic label rule
+    #   above, this branch carries a LEFT boundary: the label must start a
+    #   token (``SESSION_TOKEN=``, namespaced ``TF_VAR_aws_secret_access_key=``)
+    #   or directly follow an ``aws`` separator (``aws.secret_access_key =``,
+    #   TOML dotted key). Without it, identifiers that merely EMBED the label
+    #   fire the rule — ``get_session_token: unhealthy`` (method name),
+    #   ``supports_session_token: true`` (capability flag),
+    #   ``rotateSecretAccessKey: done`` — and the scanning consumers mask
+    #   benign tools/records. A plain optional ``(?:aws[_-])?`` prefix
+    #   instead of the lookbehind pair would drop the namespaced env-var
+    #   forms above, so don't "simplify" it that way.
     #
     # The AKIA/ASIA rule below catches the key *IDs*; this one catches the
     # *material* those IDs unlock. STM-origin: this rule is ahead of LTM's
@@ -62,7 +71,8 @@ CREDENTIAL_PATTERNS = [
     # #1488→#1491 reverse-sync direction; see the count-pin note in
     # tests/test_privacy.py).
     r"(?i)(?:[\"'](?:secret[_-]?access[_-]?key|session[_-]?token)[\"']\s*:\s*[\"']"
-    r"|(?:secret[_-]?access[_-]?key|session[_-]?token)\s*[:=])",
+    r"|(?:(?<![A-Za-z0-9_.-])|(?<=aws[._-]))"
+    r"(?:secret[_-]?access[_-]?key|session[_-]?token)\s*[:=])",
     # Provider-prefixed token formats. Anchored by prefix so false positives
     # on arbitrary high-entropy strings are rare.
     r"(?i)(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[0-9A-Za-z-]+)",

--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -41,8 +41,11 @@ CREDENTIAL_PATTERNS = [
     # neither). Two alternatives in one rule:
     #
     # - quoted form — ``"SessionToken": "…"`` / ``"SecretAccessKey": "…"``
-    #   (STS JSON, python-dict repr). The quote must sit DIRECTLY on both
-    #   sides of the label and the value must open as a string: a JSON-Schema
+    #   (STS JSON, python-dict repr) plus kebab-case quoted keys
+    #   (``"session-token": "…"`` — serialized header dicts), so both
+    #   branches share the same ``[_-]?`` separator charset. The quote must
+    #   sit DIRECTLY on both sides of the label and the value must open as
+    #   a string: a JSON-Schema
     #   property (``"session_token": {"type"…`` — object value) and a
     #   prefixed key (``"aws.get_session_token": "unhealthy"`` — telemetry
     #   dicts keyed by tool name) must NOT fire, or the eligibility scanner
@@ -58,7 +61,7 @@ CREDENTIAL_PATTERNS = [
     # mirrored set until the forward-sync lands (the inverse of the
     # #1488→#1491 reverse-sync direction; see the count-pin note in
     # tests/test_privacy.py).
-    r"(?i)(?:[\"'](?:secret_?access_?key|session_?token)[\"']\s*:\s*[\"']"
+    r"(?i)(?:[\"'](?:secret[_-]?access[_-]?key|session[_-]?token)[\"']\s*:\s*[\"']"
     r"|(?:secret[_-]?access[_-]?key|session[_-]?token)\s*[:=])",
     # Provider-prefixed token formats. Anchored by prefix so false positives
     # on arbitrary high-entropy strings are rare.

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -155,6 +155,12 @@ class TestDefaultPatternCoverage:
             "npm_" + "E" * 32,
             "AKIAIOSFODNN7EXAMPLE",  # AWS IAM user
             "ASIAIOSFODNN7EXAMPLE",  # AWS temporary
+            # AWS secret *material* labels (values are FAKE): the generic
+            # api_key/secret_key/access_token rule misses all these spellings.
+            "AWS_SECRET_ACCESS_KEY=FAKEwJalrXUtnFEMIFAKE",  # env-var form
+            "aws_session_token = FAKEFwoGZXIvYXdzFAKE",  # ~/.aws/credentials form
+            '"SessionToken": "FAKEFwoGZXIvYXdzFAKE"',  # STS JSON form
+            '"SecretAccessKey": "FAKEwJalrXUtnFEMIFAKE"',  # STS JSON form (other branch)
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",  # JWT
             "-----BEGIN RSA PRIVATE KEY-----",
             "-----BEGIN DSA PRIVATE KEY-----",
@@ -187,6 +193,18 @@ class TestDefaultPatternCoverage:
             "abc.def.ghi",
             # Short alphanumerics that could trip the AWS prefix if unanchored
             "AKIAshort",  # missing the 16-char IAM suffix
+            # AWS-label false-positive guards. The quoted form requires the
+            # quote DIRECTLY on both sides of the label and a string value —
+            # a bare JSON key must never fire (the pre-existing label rules
+            # don't either; their [:=] is blocked by the closing quote):
+            # scanning consumers walk JSON-serialized structures whose keys
+            # are ordinary identifiers (tool schemas in tool_eligibility,
+            # tool-name-keyed dicts in selection_log).
+            "botocore.exceptions.SessionTokenError: expired",  # label runs into "Error"
+            "SecretAccessKeyRotation: done",  # other branch runs into "Rotation"
+            "we rotated the session tokens yesterday",  # prose, no separator
+            '"session_token": {"type": "string"}',  # JSON-Schema property (object value)
+            '"aws.get_session_token": "unhealthy"',  # prefixed key (telemetry by tool name)
             "github_pat_",  # just the prefix, no body
             "npm_",  # prefix only
             # --- #1488 mirror false-positive guards: prose / kebab slugs that
@@ -232,12 +250,15 @@ class TestCredentialPiiSplit:
 
     def test_credential_set_count_pinned(self):
         # 9 original secret-class patterns + 7 mirrored from memtomem LTM
-        # (#1488 / reverse sync #1491). Bump deliberately when adding a
-        # pattern so a silent add/drop surfaces here and stays coherent with
-        # LTM's matching pin (memtomem DEFAULT_PATTERNS == 16).
-        assert len(privacy.CREDENTIAL_PATTERNS) == 16
+        # (#1488 / reverse sync #1491) + 1 STM-origin AWS secret-material
+        # label rule awaiting its forward-sync into LTM. Bump deliberately
+        # when adding a pattern so a silent add/drop surfaces here. LTM's
+        # matching pin (memtomem DEFAULT_PATTERNS == 16) stays one behind
+        # until the AWS rule is mirrored forward — at which point both pins
+        # move to 17 together.
+        assert len(privacy.CREDENTIAL_PATTERNS) == 17
         assert len(privacy.PII_PATTERNS) == 1
-        assert len(privacy.DEFAULT_PATTERNS) == 17
+        assert len(privacy.DEFAULT_PATTERNS) == 18
 
     @pytest.mark.parametrize(
         "sample",
@@ -256,6 +277,9 @@ class TestCredentialPiiSplit:
             "ghp_" + "A" * 36,
             "api_key=sk-" + "a" * 48,
             "psql password=hunter2",
+            "AWS_SECRET_ACCESS_KEY=FAKEwJalrXUtnFEMIFAKE",
+            '"SessionToken": "FAKEFwoGZXIvYXdzFAKE"',
+            '"SecretAccessKey": "FAKEwJalrXUtnFEMIFAKE"',
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",
             "-----BEGIN RSA PRIVATE KEY-----",
             # #1488 mirror: each must classify as a credential (not PII) so the

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -161,6 +161,9 @@ class TestDefaultPatternCoverage:
             "aws_session_token = FAKEFwoGZXIvYXdzFAKE",  # ~/.aws/credentials form
             '"SessionToken": "FAKEFwoGZXIvYXdzFAKE"',  # STS JSON form
             '"SecretAccessKey": "FAKEwJalrXUtnFEMIFAKE"',  # STS JSON form (other branch)
+            "aws_session_token: FAKEFwoGZXIvYXdzFAKE",  # YAML form (unquoted ':' separator)
+            "{'SessionToken': 'FAKEFwoGZXIvYXdzFAKE'}",  # python-dict repr (single quotes)
+            '"session-token": "FAKEAQoDYXdzEPTFAKE"',  # kebab quoted key (serialized headers)
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",  # JWT
             "-----BEGIN RSA PRIVATE KEY-----",
             "-----BEGIN DSA PRIVATE KEY-----",

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -164,6 +164,9 @@ class TestDefaultPatternCoverage:
             "aws_session_token: FAKEFwoGZXIvYXdzFAKE",  # YAML form (unquoted ':' separator)
             "{'SessionToken': 'FAKEFwoGZXIvYXdzFAKE'}",  # python-dict repr (single quotes)
             '"session-token": "FAKEAQoDYXdzEPTFAKE"',  # kebab quoted key (serialized headers)
+            "TF_VAR_aws_secret_access_key=FAKEwJalrXUtnFEMIFAKE",  # namespaced env (Terraform)
+            "SESSION_TOKEN=FAKEFwoGZXIvYXdzFAKE",  # bare env var, no aws prefix
+            'aws.secret_access_key = "FAKEwJalrXUtnFEMIFAKE"',  # TOML dotted key
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",  # JWT
             "-----BEGIN RSA PRIVATE KEY-----",
             "-----BEGIN DSA PRIVATE KEY-----",
@@ -208,6 +211,14 @@ class TestDefaultPatternCoverage:
             "we rotated the session tokens yesterday",  # prose, no separator
             '"session_token": {"type": "string"}',  # JSON-Schema property (object value)
             '"aws.get_session_token": "unhealthy"',  # prefixed key (telemetry by tool name)
+            # Left-boundary guards: identifiers that merely EMBED the label
+            # must not fire the unquoted branch (method names, capability
+            # flags, attribute chains — realistic tool metadata / status text).
+            "aws.get_session_token: unhealthy",  # unquoted telemetry-ish status line
+            "get_session_token: unhealthy",  # method name embeds the label
+            "supports_session_token: true",  # capability flag
+            "rotateSecretAccessKey: done",  # camelCase method, label as suffix
+            "boto3.session_token: expired",  # attribute chain, non-aws head
             "github_pat_",  # just the prefix, no body
             "npm_",  # prefix only
             # --- #1488 mirror false-positive guards: prose / kebab slugs that


### PR DESCRIPTION
## Summary

The credential scan catches the AWS key **IDs** (`AKIA`/`ASIA` prefixes) but not the secret **material** those IDs unlock. Verified empirically on main:

```
False <- AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/b...
False <- AWS_SESSION_TOKEN=FwoGZXIvYXdzEBEa...
False <- aws_secret_access_key = wJalrXUtnFEMI/K7MDENG...
True  <- AKIAIOSFODNN7EXAMPLE
```

The generic label rule misses both spellings the AWS toolchain emits: `secret[_-]?key` needs its two words adjacent (`secret_access_key` splits them), and `access[_-]?token` needs the literal `access` (`session_token` has neither). A tool response echoing an `env | grep AWS` block or an STS AssumeRole JSON therefore scanned clean and could be routed to an external-LLM compressor or stored in the response cache.

## Change

One rule with two alternatives:

- **quoted form** — `"SessionToken": "…"` / `"SecretAccessKey": "…"` (STS JSON, dict repr). The quote must sit **directly on both sides of the label** and the value must **open as a string**. This is load-bearing: scanning consumers walk JSON-serialized structures whose keys are ordinary identifiers — a tool schema declaring a `session_token` property (`tool_eligibility` would hide the tool from `tools/list`) or a telemetry dict keyed by a tool name like `aws.get_session_token` (`selection_log` would drop the whole record). The pre-existing label rules never fire on bare JSON keys (the closing quote blocks their `[:=]`); both non-regressions are pinned as negative samples. (An earlier draft with a loose optional-quote branch had exactly this false-positive; caught in the pre-PR adversarial review pass and redesigned.)
- **unquoted form** — `AWS_SECRET_ACCESS_KEY=`, `aws_session_token = ` (env output, `~/.aws/credentials` INI): same shape and FP profile as the existing generic label rule.

Positive pins cover all four spellings (env-var, INI, both STS JSON keys); negative pins cover label-runs-into-identifier (`SessionTokenError:`, `SecretAccessKeyRotation:`), prose, the JSON-Schema property, and the prefixed telemetry key.

## LTM sync note

This rule is **STM-origin**: `CREDENTIAL_PATTERNS` moves to 17 while LTM's mirrored set stays at 16 until the forward-sync lands (the inverse of the #1488 → #1491 reverse-sync that produced #549). The count-pin comment in `test_privacy.py` documents the divergence window.

## Follow-ups (post-merge)

- **Changelog sync PR** (per the #551 pattern): add a Security entry for this rule, and qualify the existing Unreleased #549 entry — its "byte-identical, 16 patterns on both sides" claim becomes stale once this merges.
- **LTM forward-sync**: mirror the rule into `memtomem/privacy.py` (+ JS-translation SHA regeneration), then move both count pins to 17 together.

## Behavior change

Responses carrying these labels now route away from external-LLM compression strategies and are excluded from the response cache — the same (fail-safe) treatment every other credential label already gets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
