### PR TITLE
fix(cache): complete ttl<=0 invalidation for raised failures (#548/#550 follow-up)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -210,6 +210,21 @@ def _mark_recorded(exc: BaseException) -> None:
         pass
 
 
+def _mark_cache_invalidated(exc: BaseException) -> None:
+    """Tag *exc* as having already run the disabled-cache invalidation.
+
+    The ``isError`` branch in ``_call_tool_inner`` invalidates a stale row
+    (#541) and then raises; the raised-failure backstop in
+    ``_call_tool_guarded`` invalidates on any OTHER raise. This marker keeps
+    the two from issuing a second DELETE for the same call (same idiom as
+    ``_mark_recorded``).
+    """
+    try:
+        exc._stm_cache_invalidated = True  # type: ignore[attr-defined]
+    except (AttributeError, TypeError):
+        pass
+
+
 class ProxyManager:
     def __init__(
         self,
@@ -2115,7 +2130,27 @@ class ProxyManager:
         # tool exactly as the global ttl<=0 does (per-row TTL is frozen at write).
         cache_ttl = self._resolve_cache_ttl(server, tool, cfg_snap=self._config)
         if self._cache is None or (cache_ttl is not None and cache_ttl <= 0):
-            return await self._call_tool_inner(server, tool, arguments, trace_id=trace_id), False
+            try:
+                return (
+                    await self._call_tool_inner(server, tool, arguments, trace_id=trace_id),
+                    False,
+                )
+            except Exception as exc:
+                # A raise (upstream fetch failure or a pipeline-stage error)
+                # exits ``_call_tool_inner`` BEFORE any Stage-5 store, so under
+                # a disabled (``ttl<=0``) cache a row frozen at an earlier
+                # positive TTL would survive the call and resurface once the
+                # TTL is raised back within its window — the same hole #548/
+                # #550 closed for every *returned* response shape. Invalidate
+                # (best-effort, gated on ttl<=0 inside the helper) so raised
+                # failures behave like returned ones. The ``isError`` branch
+                # already invalidated and marked its ToolError; skip its
+                # second DELETE.
+                if not getattr(exc, "_stm_cache_invalidated", False):
+                    self._invalidate_disabled_cache(
+                        server, tool, upstream_args, cfg_snap=self._config
+                    )
+                raise
 
         # Cache-eligibility gate (MCP annotations / per-tool|server ``cache``
         # override): a tool the policy deems non-cacheable — e.g. a self-declared
@@ -3277,8 +3312,11 @@ class ProxyManager:
             # (text-only or mixed) under a disabled cache (ttl<=0) would otherwise
             # leave a prior cached text row for this key live. A non-text-ONLY
             # error has no text and is invalidated by the passthrough branch above
-            # instead; here we cover the text-bearing shapes (#541).
+            # instead; here we cover the text-bearing shapes (#541). Mark the
+            # exception so the raised-failure backstop in ``_call_tool_guarded``
+            # does not repeat the DELETE.
             self._invalidate_disabled_cache(server, tool, cache_args, cfg_snap=cfg_snap)
+            _mark_cache_invalidated(tool_err)
             raise tool_err
 
         # Resolve effective settings (using config snapshot)

--- a/tests/test_cache_eligibility.py
+++ b/tests/test_cache_eligibility.py
@@ -677,3 +677,118 @@ class TestTtlZeroTextStoreSkipInvalidation:
         await mgr.call_tool("srv", "t", {"q": "a"})
 
         assert cache.get("srv", "t", {"q": "a"}) is None  # stale row invalidated
+
+
+@pytest.mark.asyncio
+class TestTtlZeroRaisedFailureInvalidation:
+    """#541 follow-through (#548/#550 completed every *returned* response shape):
+    an exception RAISED out of ``_call_tool_inner`` — an upstream fetch failure or
+    a pipeline-stage error — also exits before the Stage-5 store, so under a
+    disabled (``ttl<=0``) cache a prior text row frozen at a positive TTL would
+    survive the failed call and resurface once the TTL is raised back within its
+    window. The ``ttl<=0`` dispatch in ``_call_tool_guarded`` now backstops every
+    raise with the same best-effort invalidation."""
+
+    async def test_upstream_raise_invalidates_prior_text_row(self, build):
+        mgr, _, cache = build(tools=[_tool("reader", _ann(read_only=True))])
+        session = mgr._connections["srv"].session
+
+        session.call_tool.return_value = _text_result("payload")
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+        assert cache.get("srv", "reader", {"q": "a"}) is not None
+
+        mgr._config.cache.default_ttl_seconds = 0
+        session.call_tool.side_effect = RuntimeError("upstream died")
+        with pytest.raises(RuntimeError, match="upstream died"):
+            await mgr.call_tool("srv", "reader", {"q": "a"})
+
+        assert cache.get("srv", "reader", {"q": "a"}) is None  # stale text row gone
+
+    async def test_upstream_raise_under_positive_ttl_leaves_row(self, build):
+        # Under an ENABLED cache a failure must NOT delete the live row — the
+        # TTL governs freshness there, and a transient upstream blip serving
+        # the cached copy on the next call is the configured behavior.
+        mgr, _, cache = build(tools=[_tool("reader", _ann(read_only=True))])
+        session = mgr._connections["srv"].session
+
+        session.call_tool.return_value = _text_result("payload")
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+        assert cache.get("srv", "reader", {"q": "a"}) is not None
+
+        session.call_tool.side_effect = RuntimeError("blip")
+        # The enabled-cache path serves the live row without hitting upstream,
+        # so drive the raise through a DIFFERENT key (same tool) and then check
+        # the original row survived.
+        with pytest.raises(RuntimeError, match="blip"):
+            await mgr.call_tool("srv", "reader", {"q": "other"})
+
+        assert cache.get("srv", "reader", {"q": "a"}) is not None
+
+    async def test_raise_window_does_not_resurface_stale_row(self, build):
+        # Full #541 sequence with a raised failure in the disabled window:
+        # cache under positive TTL → lower to 0 → the identical call RAISES
+        # (invalidates) → raise the TTL back within the original window. The
+        # stale row must not be served (await_count keeps climbing).
+        mgr, _, cache = build(global_ttl=3600.0, tools=[_tool("reader", _ann(read_only=True))])
+        session = mgr._connections["srv"].session
+
+        session.call_tool.return_value = _text_result("stale-text")
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+        assert session.call_tool.await_count == 1
+
+        mgr._config.cache.default_ttl_seconds = 0
+        session.call_tool.side_effect = RuntimeError("net down")
+        with pytest.raises(RuntimeError, match="net down"):
+            await mgr.call_tool("srv", "reader", {"q": "a"})
+        assert session.call_tool.await_count == 2
+
+        mgr._config.cache.default_ttl_seconds = 3600.0
+        session.call_tool.side_effect = None
+        session.call_tool.return_value = _text_result("fresh-text")
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+        assert session.call_tool.await_count == 3  # not served from the stale row
+        assert cache.get("srv", "reader", {"q": "a"}) is not None  # fresh row cached
+
+    async def test_is_error_raise_invalidates_exactly_once(self, build):
+        # The isError branch invalidates inside ``_call_tool_inner`` and marks
+        # its ToolError (``_mark_cache_invalidated``); the raised-failure
+        # backstop must not issue a second DELETE for the same call.
+        from unittest.mock import patch as mock_patch
+
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        mgr, _, cache = build(tools=[_tool("reader", _ann(read_only=True))])
+        session = mgr._connections["srv"].session
+
+        session.call_tool.return_value = _text_result("payload")
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+        assert cache.get("srv", "reader", {"q": "a"}) is not None
+
+        mgr._config.cache.default_ttl_seconds = 0
+        session.call_tool.return_value = _error_result("boom")
+        with mock_patch.object(cache, "invalidate", wraps=cache.invalidate) as spy:
+            with pytest.raises(ToolError):
+                await mgr.call_tool("srv", "reader", {"q": "a"})
+
+        assert spy.call_count == 1  # isError site only; backstop skipped via marker
+        assert cache.get("srv", "reader", {"q": "a"}) is None
+
+    async def test_unmarked_raise_invalidates_via_backstop_once(self, build):
+        # Complement of the exactly-once test: a plain raise carries no marker,
+        # so the backstop is the ONE site that runs — also exactly one DELETE.
+        from unittest.mock import patch as mock_patch
+
+        mgr, _, cache = build(tools=[_tool("reader", _ann(read_only=True))])
+        session = mgr._connections["srv"].session
+
+        session.call_tool.return_value = _text_result("payload")
+        await mgr.call_tool("srv", "reader", {"q": "a"})
+
+        mgr._config.cache.default_ttl_seconds = 0
+        session.call_tool.side_effect = RuntimeError("upstream died")
+        with mock_patch.object(cache, "invalidate", wraps=cache.invalidate) as spy:
+            with pytest.raises(RuntimeError):
+                await mgr.call_tool("srv", "reader", {"q": "a"})
+
+        assert spy.call_count == 1
+        assert cache.get("srv", "reader", {"q": "a"}) is None


### PR DESCRIPTION
## Summary

#548/#550 made every **returned** response shape drop a stale frozen-TTL row while the cache is disabled (resolved `ttl<=0`): non-text, empty, mixed, text store-skips, and text-bearing `isError` responses. An exception **raised** out of `_call_tool_inner` — an upstream fetch failure (timeout/transport/protocol) or a pipeline-stage error — still exited before all of those sites, so the row survived the failed call:

1. tool cached under `cache_ttl_seconds: 3600` → operator overrides to `0` (lookups bypass; row stays on disk under its frozen TTL)
2. the tool times out for a few calls — **raises, no invalidation**
3. operator raises the TTL back within the frozen window → the pre-failure row serves again

## Change

- The `ttl<=0` dispatch in `_call_tool_guarded` backstops the inner call with `try/except Exception` → best-effort `_invalidate_disabled_cache` → re-raise. The helper is internally gated on the resolved TTL, so this adds zero I/O to any enabled-cache path.
- The `isError` branch already invalidates inside the pipeline; it now stamps its `ToolError` via a new `_mark_cache_invalidated` helper (same idiom as `_mark_recorded`) so the backstop never issues a second DELETE for the same call.

## Tests

`TestTtlZeroRaisedFailureInvalidation` (5 tests): the 3 raise-path tests fail on unfixed main (verified by stashing the src change); the other 2 pin the guardrails in both directions — an **enabled**-cache row must survive a transient raise (TTL governs freshness there), and DELETE happens exactly once whether the raise is marked (isError) or unmarked (upstream failure), via `cache.invalidate` spy counts.

## Behavior change

Under a disabled (`ttl<=0`) cache, a call that fails by raising now also drops any stale row for its key — previously only completed calls did. Enabled-cache (`ttl>0`) behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
