### PR TITLE
fix(hook): guard `mms hook install/uninstall --apply` against lost updates

### DIFF
--- a/src/memtomem_stm/cli/_write_lock.py
+++ b/src/memtomem_stm/cli/_write_lock.py
@@ -10,7 +10,8 @@ that pair, and this is CLI glue around
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -69,6 +70,57 @@ def with_write_lock(f: F) -> F:
             raise click.ClickException(str(exc)) from exc
 
     return wrapper  # type: ignore[return-value]
+
+
+def hook_hosts_lock_path() -> Path:
+    """Cross-process write lock for the hook-host config domain.
+
+    Guards the ``mms hook install``/``uninstall --apply`` read-modify-write of
+    a HOST application's hook config (``~/.claude/settings.json``,
+    ``~/.codex/config.toml``, …). One fixed path for the whole domain rather
+    than a per-host sidecar: the span is milliseconds, contention is
+    operator-initiated, and a sidecar next to the host file would litter
+    foreign config directories with mms lock files. Resolved at call time so
+    monkeypatched ``HOME`` works in tests (mirrors ``stm_config_lock_path``).
+    """
+    return Path.home() / ".memtomem" / ".hook_hosts.lock"
+
+
+_HOOK_HOSTS_LOCK_HOLDER_HINT = (
+    "another `mms hook install/uninstall --apply` appears to be rewriting a host hook config"
+)
+
+
+@contextmanager
+def hook_hosts_write_lock(*, enabled: bool) -> Iterator[None]:
+    """Hold the hook-host write lock for an install/uninstall plan+apply span.
+
+    Same role as :func:`with_write_lock`, over :func:`hook_hosts_lock_path`:
+    the locked span covers plan (the config read) AND apply (backup + atomic
+    replace), so two concurrent ``--apply`` runs cannot both plan from the
+    same base and have the loser's write clobber the winner's (lost update).
+    Pass ``enabled=False`` for dry-run invocations — they never write.
+
+    A context manager rather than a ``with_*`` decorator ON PURPOSE:
+    ``hook_cmd`` is imported on the per-tool-call hook hot path, and a
+    module-top decorator import would drag ``mms.state`` (pydantic) into
+    every hook invocation (~+190ms measured); the command callbacks import
+    this lazily instead.
+
+    The lock only serializes *mms* processes. The host application itself
+    rewrites its own config without taking it — that direction is handled by
+    the staleness guard inside ``hook_hosts.apply_change``, which refuses to
+    overwrite contents the plan never saw.
+    """
+    try:
+        with state.write_lock(
+            enabled=enabled,
+            lock_path=hook_hosts_lock_path(),
+            holder_hint=_HOOK_HOSTS_LOCK_HOLDER_HINT,
+        ):
+            yield
+    except state.WriteLockTimeout as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def with_config_write_lock(

--- a/src/memtomem_stm/cli/hook_cmd.py
+++ b/src/memtomem_stm/cli/hook_cmd.py
@@ -918,16 +918,23 @@ def hook_install_command(host: str, apply_: bool) -> None:
     ``~/.cursor/hooks.json``, ``~/.kimi/config.toml``, or ``~/.codex/config.toml``)
     so the host fires ``mms hook --host <name>`` after each built-in tool call.
     Re-running updates STM's existing block in place rather than duplicating it.
-    Default is a dry-run preview; ``--apply`` writes (backing up any prior file)."""
+    Default is a dry-run preview; ``--apply`` writes (backing up any prior file)
+    under the hook-host write lock, with plan and apply in one locked span so
+    concurrent mms runs cannot interleave (the host app's own concurrent writes
+    are caught by ``apply_change``'s staleness guard instead)."""
+    # Lazy import: the lock machinery pulls in ``mms.state`` (pydantic), and
+    # this module is imported on the per-tool-call hook hot path.
     from memtomem_stm.cli import hook_hosts
+    from memtomem_stm.cli._write_lock import hook_hosts_write_lock
 
     command = shlex.join(_hook_install_command_argv(host))
-    try:
-        change = hook_hosts.plan_install(host, command)
-    except hook_hosts.HookInstallError as exc:
-        raise click.ClickException(str(exc)) from exc
-    backup = hook_hosts.apply_change(change) if apply_ else None
-    _emit_hook_change(change, apply_=apply_, backup=backup)
+    with hook_hosts_write_lock(enabled=apply_):
+        try:
+            change = hook_hosts.plan_install(host, command)
+            backup = hook_hosts.apply_change(change) if apply_ else None
+        except hook_hosts.HookInstallError as exc:
+            raise click.ClickException(str(exc)) from exc
+        _emit_hook_change(change, apply_=apply_, backup=backup)
 
 
 @hook_command.command(name="uninstall")
@@ -951,12 +958,16 @@ def hook_uninstall_command(host: str, apply_: bool) -> None:
     Removes exactly the block ``install`` would add (recognized by command
     shape), leaving any hand-written hooks untouched. A no-op when the config is
     absent or holds no STM block. Default is a dry-run preview; ``--apply`` writes
-    (backing up the prior file)."""
+    (backing up the prior file) under the same locked plan+apply span as
+    ``install``."""
+    # Lazy import: see hook_install_command.
     from memtomem_stm.cli import hook_hosts
+    from memtomem_stm.cli._write_lock import hook_hosts_write_lock
 
-    try:
-        change = hook_hosts.plan_uninstall(host)
-    except hook_hosts.HookInstallError as exc:
-        raise click.ClickException(str(exc)) from exc
-    backup = hook_hosts.apply_change(change) if apply_ else None
-    _emit_hook_change(change, apply_=apply_, backup=backup)
+    with hook_hosts_write_lock(enabled=apply_):
+        try:
+            change = hook_hosts.plan_uninstall(host)
+            backup = hook_hosts.apply_change(change) if apply_ else None
+        except hook_hosts.HookInstallError as exc:
+            raise click.ClickException(str(exc)) from exc
+        _emit_hook_change(change, apply_=apply_, backup=backup)

--- a/src/memtomem_stm/cli/hook_hosts.py
+++ b/src/memtomem_stm/cli/hook_hosts.py
@@ -626,10 +626,32 @@ def apply_change(change: HookChange) -> Path | None:
     (:func:`_write_backup`) *before* the new config is atomically written; returns
     the backup path (``None`` when there was nothing to back up). The new file
     inherits the prior file's permission bits, or ``0o600`` for a freshly-created
-    one (host configs can carry secrets)."""
+    one (host configs can carry secrets).
+
+    Staleness guard: ``change.new_text`` was merged from the config as read at
+    PLAN time, and the atomic replace writes that merge back wholesale — so if
+    the file changed in between (the host application persisting its own
+    settings; mms' advisory lock only serializes mms processes), applying would
+    silently revert the other writer's edit. The guard re-reads the file and
+    raises :class:`HookInstallError` on any divergence from what the plan saw
+    (including created-since-planned and deleted-since-planned), BEFORE the
+    backup, so an aborted apply has no side effect. Re-running re-plans from
+    the fresh contents."""
     if not change.changed:
         return None
     path = change.path
+    try:
+        on_disk = path.read_text(encoding="utf-8") if path.exists() else None
+    except OSError as exc:
+        raise HookInstallError(
+            f"cannot re-read {path} before writing ({exc}); nothing was written."
+        ) from exc
+    if on_disk != change.current_text:
+        raise HookInstallError(
+            f"{path} changed after this change was planned (a concurrent writer, "
+            "possibly the host application itself); nothing was written. Re-run "
+            "the command to re-plan against the current contents."
+        )
     try:
         mode = path.stat().st_mode & 0o777
     except OSError:

--- a/tests/cli/test_hook_install.py
+++ b/tests/cli/test_hook_install.py
@@ -548,6 +548,10 @@ def test_apply_change_refuses_when_file_deleted_after_plan(redirect) -> None:
     assert not path.exists()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="flock is POSIX-only; write_lock is documented as a no-op on Windows",
+)
 def test_cli_install_apply_under_held_lock_exits_cleanly(redirect, monkeypatch) -> None:
     # Two concurrent --apply runs must serialize on the hook-host write lock;
     # the loser times out with a clean, attributed error instead of planning
@@ -566,8 +570,14 @@ def test_cli_install_apply_under_held_lock_exits_cleanly(redirect, monkeypatch) 
     assert not path.exists()  # the loser wrote nothing
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="flock is POSIX-only; write_lock is documented as a no-op on Windows",
+)
 def test_cli_install_dry_run_ignores_held_lock(redirect, monkeypatch) -> None:
     # Dry-run never writes, so it must not queue behind (or fail on) the lock.
+    # (Vacuous on Windows — the no-op lock can't block anything — so skipped
+    # alongside the held-lock test rather than passing without meaning.)
     from memtomem_stm.cli._write_lock import hook_hosts_lock_path
     from memtomem_stm.mms import state
 

--- a/tests/cli/test_hook_install.py
+++ b/tests/cli/test_hook_install.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from helpers import set_home
 
 from memtomem_stm.cli.hook_adapter import READLIKE_SURFACE_TOOLS, known_hosts
 from memtomem_stm.cli.hook_cmd import _DEFAULT_SURFACE_TOOLS
@@ -54,6 +55,16 @@ def redirect(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         return path
 
     return _redirect
+
+
+@pytest.fixture(autouse=True)
+def _sandbox_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """The ``--apply`` span takes the hook-host write lock under
+    ``~/.memtomem/`` (see ``hook_hosts_lock_path``); pin HOME so no test in
+    this module touches the real one."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    return home
 
 
 # ── _is_stm_hook_command ─────────────────────────────────────────────────────
@@ -482,6 +493,92 @@ def test_cli_bare_hook_runtime_path_intact() -> None:
     result = CliRunner().invoke(cli, ["hook"], input="not json")
     assert result.exit_code == 0
     assert result.output.strip() == "{}"
+
+
+# ── staleness guard + write lock (lost-update protection) ───────────────────
+
+
+def test_apply_change_refuses_when_file_changed_after_plan(redirect) -> None:
+    # The host application rewriting its own config between plan and apply is
+    # the one writer mms' advisory lock cannot serialize; without the guard the
+    # atomic replace writes the plan-time merge back wholesale and silently
+    # reverts the app's edit (e.g. a permission Claude Code just persisted).
+    path = redirect("claude")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"hooks": {}}\n', encoding="utf-8")
+
+    change = plan_install("claude", _CMD.format(host="claude"))
+    concurrent = '{"permissions": {"allow": ["Bash(ls:*)"]}}\n'
+    path.write_text(concurrent, encoding="utf-8")  # app writes concurrently
+
+    with pytest.raises(HookInstallError, match="changed after this change was planned"):
+        apply_change(change)
+
+    assert path.read_text(encoding="utf-8") == concurrent  # not clobbered
+    # Aborted BEFORE the backup — a refused apply leaves no side effect.
+    assert not (path.parent / (path.name + ".bak")).exists()
+
+
+def test_apply_change_refuses_when_file_created_after_plan(redirect) -> None:
+    # Planned as "create" (file absent), but something wrote the file since —
+    # blind-applying would overwrite content the plan never saw.
+    path = redirect("claude")
+    change = plan_install("claude", _CMD.format(host="claude"))
+    assert change.status == "create"
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(HookInstallError, match="changed after this change was planned"):
+        apply_change(change)
+    assert path.read_text(encoding="utf-8") == "{}\n"
+
+
+def test_apply_change_refuses_when_file_deleted_after_plan(redirect) -> None:
+    # Deleted since plan: applying would resurrect the (merged) old contents.
+    path = redirect("claude")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"hooks": {}}\n', encoding="utf-8")
+    change = plan_install("claude", _CMD.format(host="claude"))
+
+    path.unlink()
+
+    with pytest.raises(HookInstallError, match="changed after this change was planned"):
+        apply_change(change)
+    assert not path.exists()
+
+
+def test_cli_install_apply_under_held_lock_exits_cleanly(redirect, monkeypatch) -> None:
+    # Two concurrent --apply runs must serialize on the hook-host write lock;
+    # the loser times out with a clean, attributed error instead of planning
+    # from a stale base and clobbering the winner's write (lost update).
+    from memtomem_stm.cli._write_lock import hook_hosts_lock_path
+    from memtomem_stm.mms import state
+
+    path = redirect("claude")
+    monkeypatch.setattr(state, "WRITE_LOCK_TIMEOUT_SECONDS", 0.2)
+
+    with state.write_lock(lock_path=hook_hosts_lock_path()):
+        result = CliRunner().invoke(cli, ["hook", "install", "--host", "claude", "--apply"])
+
+    assert result.exit_code == 1
+    assert "another `mms hook install/uninstall" in result.output
+    assert not path.exists()  # the loser wrote nothing
+
+
+def test_cli_install_dry_run_ignores_held_lock(redirect, monkeypatch) -> None:
+    # Dry-run never writes, so it must not queue behind (or fail on) the lock.
+    from memtomem_stm.cli._write_lock import hook_hosts_lock_path
+    from memtomem_stm.mms import state
+
+    redirect("claude")
+    monkeypatch.setattr(state, "WRITE_LOCK_TIMEOUT_SECONDS", 0.2)
+
+    with state.write_lock(lock_path=hook_hosts_lock_path()):
+        result = CliRunner().invoke(cli, ["hook", "install", "--host", "claude"])
+
+    assert result.exit_code == 0
+    assert "To apply" in result.output
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`mms hook install`/`uninstall --apply` read-modify-writes a **host application's** config (`~/.claude/settings.json`, `~/.codex/config.toml`, …) with nothing between plan (the read) and apply (the atomic whole-file replace). Two writers could interleave:

- **mms vs mms** — two concurrent `--apply` runs both plan from the same base; the loser's replace drops the winner's change.
- **mms vs the host app** — the app persists its own settings (e.g. Claude Code saving a permission) between our read and replace; applying the plan-time merge writes the pre-edit file back wholesale and silently reverts the app's edit. The `.bak` allows manual recovery, but the live file loses the other writer's data with no warning.

## Change — one guard per direction

- **Hook-host write lock** (`hook_hosts_write_lock` over `~/.memtomem/.hook_hosts.lock`, the same `state.write_lock` machinery as the registry and proxy-config domains) spans plan+apply, serializing mms processes; the loser times out with an attributed error. Dry-runs skip it. Exposed as a **lazily-imported context manager** rather than a `with_*` decorator: `hook_cmd` is imported on the per-tool-call hook hot path, and a module-top import of the lock machinery drags in pydantic via `mms.state` — measured at **+190ms per hook invocation** (113ms → 304ms module import).
- **Staleness guard** in `apply_change`: re-reads the file and refuses to write when it diverges from what the plan saw (changed / created / deleted since). The app takes no advisory lock, so this is the only protection in that direction. Checked **before** the backup — a refused apply has no side effect; re-running re-plans from fresh contents.

Also folds `apply_change` into the existing `HookInstallError` → `ClickException` conversion (it previously sat outside the `try`, so its errors surfaced as tracebacks).

## Tests

5 new tests (all fail on unfixed main, verified by stashing): three staleness-guard directions (changed/created/deleted after plan, each asserting the concurrent content survives and no `.bak` is written), held-lock `--apply` times out cleanly with the attributed hint, and dry-run ignores a held lock. The module gets an autouse HOME sandbox since `--apply` now touches `~/.memtomem`.

## Behavior change

- A concurrent-writer collision now aborts with an instructive error instead of silently losing one writer's data.
- `--apply` acquires a cross-process lock (attributed timeout after the standard `WRITE_LOCK_TIMEOUT_SECONDS` if another mms holds it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
