### PR TITLE
security(privacy): catch x-amz-security-token (header + presigned-URL query param)

### DIFF
--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -66,13 +66,39 @@ CREDENTIAL_PATTERNS = [
     #   forms above, so don't "simplify" it that way.
     #
     # The AKIA/ASIA rule below catches the key *IDs*; this one catches the
-    # *material* those IDs unlock. STM-origin: this rule is ahead of LTM's
-    # mirrored set until the forward-sync lands (the inverse of the
-    # #1488→#1491 reverse-sync direction; see the count-pin note in
+    # *material* those IDs unlock. STM-origin; forward-synced into LTM's
+    # mirrored set as memtomem#1533 (the inverse of the #1488→#1491
+    # reverse-sync direction; see the count-pin note in
     # tests/test_privacy.py).
     r"(?i)(?:[\"'](?:secret[_-]?access[_-]?key|session[_-]?token)[\"']\s*:\s*[\"']"
     r"|(?:(?<![A-Za-z0-9_.-])|(?<=aws[._-]))"
     r"(?:secret[_-]?access[_-]?key|session[_-]?token)\s*[:=])",
+    # The label AWS actually puts on the WIRE for that same session-token
+    # material: botocore DEBUG logs emit the ``x-amz-security-token`` request
+    # header verbatim, and every presigned URL generated with temporary
+    # credentials carries the ``X-Amz-Security-Token=…`` query parameter.
+    # No rule above reaches either: ``session[_-]?token`` cannot cross the
+    # ``security-token`` spelling, and the kebab header shape has no ``aws``
+    # separator directly before the label, so the left-boundary form above
+    # misses it too — catching these payloads otherwise relies on an
+    # ``ASIA…`` key ID co-occurring in the same text. Two alternatives,
+    # mirroring the rule above:
+    #
+    # - quoted form — ``"x-amz-security-token": "…"`` (serialized header
+    #   dicts, JSON or python repr). Quote directly on both sides of the
+    #   label and a string-opening value, so an OpenAPI/JSON-Schema header
+    #   *definition* (``"X-Amz-Security-Token": {"type"…`` — object value,
+    #   ubiquitous in AWS API specs) never fires.
+    # - unquoted form — the raw header line (``x-amz-security-token: FwoG…``)
+    #   and the presigned-URL query param (``…&X-Amz-Security-Token=FwoG…``).
+    #   No left boundary, unlike the rule above: the label is kebab-case, so
+    #   snake_case/camelCase identifiers cannot embed it, and its real left
+    #   neighbors (``?``, ``&``, quotes, line starts) are all non-word.
+    #   Prose that merely NAMES the header (``set the x-amz-security-token
+    #   header``, ``header: x-amz-security-token``) stays negative — the
+    #   separator must directly follow the label.
+    r"(?i)(?:[\"']x-amz-security-token[\"']\s*:\s*[\"']"
+    r"|x-amz-security-token\s*[:=])",
     # Provider-prefixed token formats. Anchored by prefix so false positives
     # on arbitrary high-entropy strings are rare.
     r"(?i)(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[0-9A-Za-z-]+)",

--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -91,14 +91,23 @@ CREDENTIAL_PATTERNS = [
     #   ubiquitous in AWS API specs) never fires.
     # - unquoted form — the raw header line (``x-amz-security-token: FwoG…``)
     #   and the presigned-URL query param (``…&X-Amz-Security-Token=FwoG…``).
-    #   No left boundary, unlike the rule above: the label is kebab-case, so
-    #   snake_case/camelCase identifiers cannot embed it, and its real left
-    #   neighbors (``?``, ``&``, quotes, line starts) are all non-word.
+    #   The left boundary rejects only a directly preceding SEPARATOR
+    #   (``[_.-]``), not alphanumerics — a narrower boundary than the rule
+    #   above, on purpose. Kebab/dotted compounds that merely NAME the
+    #   header must not fire — ``forward-x-amz-security-token: true``
+    #   (config knob about the header), ``proxy.headers.x-amz-security-token``
+    #   (flattened telemetry key — dotted heads are negative by design, as
+    #   in the rule above) — but a directly preceding alphanumeric must
+    #   stay a match: a bytes-repr header dump renders the newline before
+    #   the label as a LITERAL ``\r\n``, putting ``n`` right before the
+    #   ``x`` (``send: b'…\r\nx-amz-security-token: FwoG…'`` —
+    #   http.client debuglevel / botocore DEBUG wire dumps). Real left
+    #   neighbors (``?``, ``&``, quotes, line starts) pass either way.
     #   Prose that merely NAMES the header (``set the x-amz-security-token
     #   header``, ``header: x-amz-security-token``) stays negative — the
     #   separator must directly follow the label.
     r"(?i)(?:[\"']x-amz-security-token[\"']\s*:\s*[\"']"
-    r"|x-amz-security-token\s*[:=])",
+    r"|(?<![_.\-])x-amz-security-token\s*[:=])",
     # Provider-prefixed token formats. Anchored by prefix so false positives
     # on arbitrary high-entropy strings are rare.
     r"(?i)(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[0-9A-Za-z-]+)",

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -167,6 +167,14 @@ class TestDefaultPatternCoverage:
             "TF_VAR_aws_secret_access_key=FAKEwJalrXUtnFEMIFAKE",  # namespaced env (Terraform)
             "SESSION_TOKEN=FAKEFwoGZXIvYXdzFAKE",  # bare env var, no aws prefix
             'aws.secret_access_key = "FAKEwJalrXUtnFEMIFAKE"',  # TOML dotted key
+            # x-amz-security-token — the label AWS puts on the WIRE for the
+            # same session-token material (#561; values are FAKE): the header
+            # line botocore DEBUG logs emit verbatim, the presigned-URL query
+            # param, and serialized header dicts.
+            "x-amz-security-token: FAKEFwoGZXIvYXdzFAKE",  # raw header line
+            "https://b.s3.amazonaws.com/k?X-Amz-Security-Token=FAKEFwoG&X-Amz-Date=20260702",
+            '"x-amz-security-token": "FAKEFwoGZXIvYXdzFAKE"',  # serialized headers (JSON)
+            "{'x-amz-security-token': 'FAKEFwoGZXIvYXdzFAKE'}",  # python-repr headers
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",  # JWT
             "-----BEGIN RSA PRIVATE KEY-----",
             "-----BEGIN DSA PRIVATE KEY-----",
@@ -219,6 +227,13 @@ class TestDefaultPatternCoverage:
             "supports_session_token: true",  # capability flag
             "rotateSecretAccessKey: done",  # camelCase method, label as suffix
             "boto3.session_token: expired",  # attribute chain, non-aws head
+            # x-amz-security-token false-positive guards (#561): docs/prose
+            # that merely NAME the header carry no value — the separator must
+            # directly follow the label — and a spec's header *definition* has
+            # an object value, not a string.
+            "header: x-amz-security-token",  # docs prose, separator on the wrong side
+            "sign the x-amz-security-token header into the canonical request",  # prose
+            '"X-Amz-Security-Token": {"type": "string"}',  # OpenAPI header definition
             "github_pat_",  # just the prefix, no body
             "npm_",  # prefix only
             # --- #1488 mirror false-positive guards: prose / kebab slugs that
@@ -263,16 +278,17 @@ class TestCredentialPiiSplit:
         assert not set(privacy.CREDENTIAL_PATTERNS) & set(privacy.PII_PATTERNS)
 
     def test_credential_set_count_pinned(self):
-        # 9 original secret-class patterns + 7 mirrored from memtomem LTM
-        # (#1488 / reverse sync #1491) + 1 STM-origin AWS secret-material
-        # label rule awaiting its forward-sync into LTM. Bump deliberately
-        # when adding a pattern so a silent add/drop surfaces here. LTM's
-        # matching pin (memtomem DEFAULT_PATTERNS == 16) stays one behind
-        # until the AWS rule is mirrored forward — at which point both pins
-        # move to 17 together.
-        assert len(privacy.CREDENTIAL_PATTERNS) == 17
+        # 9 original secret-class patterns + 2 STM-origin AWS label rules
+        # (#553 secret-material labels, forward-synced into LTM as
+        # memtomem#1533; #561 x-amz-security-token, awaiting its forward
+        # sync) + 7 mirrored from memtomem LTM (#1488 / reverse sync #1491).
+        # Bump deliberately when adding a pattern so a silent add/drop
+        # surfaces here. LTM's matching pin sits at 17 until the #561 rule
+        # is mirrored forward — at which point both pins move to 18 together
+        # (the #559 content-hash pin tracks the shared subset).
+        assert len(privacy.CREDENTIAL_PATTERNS) == 18
         assert len(privacy.PII_PATTERNS) == 1
-        assert len(privacy.DEFAULT_PATTERNS) == 18
+        assert len(privacy.DEFAULT_PATTERNS) == 19
 
     @pytest.mark.parametrize(
         "sample",
@@ -294,6 +310,7 @@ class TestCredentialPiiSplit:
             "AWS_SECRET_ACCESS_KEY=FAKEwJalrXUtnFEMIFAKE",
             '"SessionToken": "FAKEFwoGZXIvYXdzFAKE"',
             '"SecretAccessKey": "FAKEwJalrXUtnFEMIFAKE"',
+            "x-amz-security-token: FAKEFwoGZXIvYXdzFAKE",
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",
             "-----BEGIN RSA PRIVATE KEY-----",
             # #1488 mirror: each must classify as a credential (not PII) so the

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -175,6 +175,10 @@ class TestDefaultPatternCoverage:
             "https://b.s3.amazonaws.com/k?X-Amz-Security-Token=FAKEFwoG&X-Amz-Date=20260702",
             '"x-amz-security-token": "FAKEFwoGZXIvYXdzFAKE"',  # serialized headers (JSON)
             "{'x-amz-security-token': 'FAKEFwoGZXIvYXdzFAKE'}",  # python-repr headers
+            # bytes-repr wire dump: the newline before the label is a LITERAL
+            # \r\n, so an alphanumeric (``n``) directly precedes the ``x`` —
+            # pins the boundary class ([_.-], NOT [A-Za-z0-9_.-]).
+            r"send: b'GET /k HTTP/1.1\r\nx-amz-security-token: FAKEFwoG\r\n'",
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",  # JWT
             "-----BEGIN RSA PRIVATE KEY-----",
             "-----BEGIN DSA PRIVATE KEY-----",
@@ -234,6 +238,8 @@ class TestDefaultPatternCoverage:
             "header: x-amz-security-token",  # docs prose, separator on the wrong side
             "sign the x-amz-security-token header into the canonical request",  # prose
             '"X-Amz-Security-Token": {"type": "string"}',  # OpenAPI header definition
+            "forward-x-amz-security-token: true",  # kebab config knob embeds the label
+            "proxy.headers.x-amz-security-token: passthrough",  # dotted telemetry head
             "github_pat_",  # just the prefix, no body
             "npm_",  # prefix only
             # --- #1488 mirror false-positive guards: prose / kebab slugs that


### PR DESCRIPTION
## Background

Closes #561.

#553 catches AWS secret material by config/JSON **label** (`SECRET_ACCESS_KEY` / `SESSION_TOKEN` spellings). The label AWS actually puts on the **wire** for the same material was covered by no pattern on either side:

- `x-amz-security-token: FwoGZXIvYXdz…` — the HTTP header carrying the session token, emitted **verbatim in botocore DEBUG logs** and in any HTTP-header dump a proxying/debugging tool returns;
- `X-Amz-Security-Token=FwoGZXIvYXdz…` — the presigned-URL query-parameter form, present in every presigned S3 URL generated with temporary credentials.

Catching these payloads previously relied entirely on an `ASIA…` key ID happening to co-occur in the same text.

## Why the existing rules don't reach it

`session[_-]?token` cannot cross the `security-token` spelling, and the kebab/header shape has no `aws` separator immediately before the label, so #553's left-boundary form doesn't reach it either (all four new positive samples verified to scan clean against the 17 patterns on main).

## The rule

One new `CREDENTIAL_PATTERNS` rule with two alternatives, mirroring #553's shape:

- **quoted form** — `"x-amz-security-token": "…"` (serialized header dicts, JSON or python repr). Quote directly on both sides of the label + a string-opening value, so an OpenAPI/JSON-Schema header *definition* (`"X-Amz-Security-Token": {"type"…` — object value, ubiquitous in AWS API specs) never fires and the scanning consumers (tool_eligibility, selection log) don't mask benign tools.
- **unquoted form** — the raw header line and the presigned-URL query param. The left boundary rejects only a directly preceding **separator** (`(?<![_.\-])`) — narrower than #553's boundary, on purpose (adjudicated with the codex cross-review; see the review comment below). Kebab/dotted compounds that merely name the header stay negative (`forward-x-amz-security-token: true` config knobs, `proxy.headers.x-amz-security-token` dotted telemetry heads — consistent with #553's dotted-heads-negative design), while a directly preceding *alphanumeric* stays a match: bytes-repr wire dumps render the newline before the header line as a literal `\r\n` (`send: b'…\r\nx-amz-security-token: FwoG…'` — `http.client` debuglevel / botocore DEBUG), putting `n` right before the `x`. Prose that merely NAMES the header stays negative — the separator must directly follow the label, which pins the issue's docs-prose case (`header: x-amz-security-token`) as a negative test, alongside a prose sentence and the OpenAPI object-value guard. A SigV4 canonical-request signed-headers *list* (`host;x-amz-security-token` with no value) also stays negative (verified; the header lines above it in a real canonical request carry the value and fire correctly).

Accepted fail-safe (same profile as every label rule): `x-amz-security-token=<placeholder>` in docs fires even with a placeholder value, matching how `password: <value>` behaves today.

## Sync bookkeeping

- `CREDENTIAL_PATTERNS` moves 17 → 18 (count pin bumped; the rule sits at index 3, directly after the #553 rule, so the LTM forward-sync should insert at the same index to keep the sets same-order).
- The #553 rule's "awaiting forward-sync" comments (privacy.py + the count-pin note) are updated in place to cite the landed memtomem#1533 — required anyway to rewrite the pin comment truthfully, and without it the file would claim two rules are awaiting sync when only this one is.
- The #559 content-hash pin should land together with (or after) this rule's forward-sync so the LTM mirror moves once — coordinated with #562, which widens the quoted-label vocabulary next.

## Behavior change

Responses carrying the `x-amz-security-token` label (botocore DEBUG output, presigned URLs, header dumps) now route away from external-LLM compression strategies and are excluded from the response cache — the same fail-safe treatment every other credential label already gets — and tool metadata carrying it is withheld from `tools/list` under the strict exposure profile.

## Testing

- 5 new positive pins (header line, presigned URL, JSON header dict, python-repr header dict, literal-`\r\n` bytes-repr wire dump) — each verified to scan clean without the new rule, so they pin it specifically.
- 5 new negative pins (docs-prose `header: x-amz-security-token`, prose sentence, OpenAPI header definition, kebab config knob, dotted telemetry head).
- 1 new credential-set-alone classification pin.
- `uv run pytest -m "not ollama"` and `uv run ruff check src` / `ruff format --check src` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
