### PR TITLE
security(privacy): generalize the quoted-JSON label rule beyond AWS labels

### DIFF
--- a/src/memtomem_stm/proxy/privacy.py
+++ b/src/memtomem_stm/proxy/privacy.py
@@ -34,6 +34,27 @@ logger = logging.getLogger(__name__)
 CREDENTIAL_PATTERNS = [
     r"(?i)(api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]",
     r"(?i)(password|passwd|pwd)\s*[:=]",
+    # Quoted-JSON / dict-repr forms of the generic labels above. The two
+    # label rules end in ``\s*[:=]``, and a quoted key's closing quote sits
+    # between the label and the colon — ``"password": "hunter2"``,
+    # ``"api_key": "sk-…"``, ``"accessToken": "ya29.…"``, ``{'password':
+    # 'hunter2'}`` match none of them — and JSON-serialized credentials are
+    # high-frequency tool output (``docker inspect``, ``kubectl get secret
+    # -o json``, DB connection configs). Same FP-guard shape as the AWS
+    # quoted branch below: the quote must sit DIRECTLY on both sides of the
+    # label and the value must open as a string, so a JSON-Schema property
+    # (``"access_token": {"type"…`` — object value; login/OAuth tool schemas
+    # carry these constantly), an identifier that merely embeds a label
+    # (``"my_api_key_name": …``), and a prefixed key (``"tools.api_key": …``
+    # — telemetry dicts keyed by tool name) never fire. The ``[_-]?``
+    # separator is optional, so camelCase JSON keys (``"apiKey"``,
+    # ``"accessToken"``) match under ``(?i)``. ``pwd`` is deliberately NOT
+    # in this vocabulary (unlike the unquoted rule above): shell/file tools
+    # legitimately return working-directory fields (``"pwd": "/home/user"``).
+    # The AWS spellings are listed so the vocabulary is self-contained,
+    # though the #553 rule below already covers their quoted forms.
+    r"(?i)[\"'](?:api[_-]?key|secret[_-]?(?:access[_-]?)?key"
+    r"|(?:access|session)[_-]?token|password|passwd)[\"']\s*:\s*[\"']",
     # AWS secret material by label. The generic label rule above misses both
     # spellings the AWS toolchain actually emits: ``secret[_-]?key`` needs its
     # two words adjacent (``secret_access_key`` splits them) and

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -179,6 +179,15 @@ class TestDefaultPatternCoverage:
             # \r\n, so an alphanumeric (``n``) directly precedes the ``x`` —
             # pins the boundary class ([_.-], NOT [A-Za-z0-9_.-]).
             r"send: b'GET /k HTTP/1.1\r\nx-amz-security-token: FAKEFwoG\r\n'",
+            # Quoted-JSON / dict-repr forms of the generic labels (#562; the
+            # closing quote blocks the unquoted rules' [:=]): docker/kubectl
+            # JSON output, DB connection configs, OAuth token responses.
+            '"password": "hunter2"',  # JSON config / secret dump
+            "{'password': 'hunter2'}",  # python-dict repr
+            '"api_key": "FAKE-abc123"',  # snake_case JSON key
+            '"apiKey": "FAKE-abc123"',  # camelCase (separator is optional)
+            '"accessToken": "ya29.FAKE"',  # OAuth token response
+            '"secret-key": "FAKEvalue"',  # kebab quoted key
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",  # JWT
             "-----BEGIN RSA PRIVATE KEY-----",
             "-----BEGIN DSA PRIVATE KEY-----",
@@ -240,6 +249,14 @@ class TestDefaultPatternCoverage:
             '"X-Amz-Security-Token": {"type": "string"}',  # OpenAPI header definition
             "forward-x-amz-security-token: true",  # kebab config knob embeds the label
             "proxy.headers.x-amz-security-token: passthrough",  # dotted telemetry head
+            # #562 quoted-label FP guards — same shape as the AWS quoted-
+            # branch guards above: excluded vocabulary, object values,
+            # embedded labels, prefixed keys.
+            '"pwd": "/home/user"',  # working-directory field — pwd is excluded
+            '"password": {"type": "string"}',  # login-form JSON-Schema property
+            '"access_token": {"type": "string"}',  # OAuth tool-schema property
+            '"my_api_key_name": "prod-key-1"',  # key NAME field embeds the label
+            '"tools.api_key": "configured"',  # prefixed key (telemetry-style)
             "github_pat_",  # just the prefix, no body
             "npm_",  # prefix only
             # --- #1488 mirror false-positive guards: prose / kebab slugs that
@@ -284,17 +301,18 @@ class TestCredentialPiiSplit:
         assert not set(privacy.CREDENTIAL_PATTERNS) & set(privacy.PII_PATTERNS)
 
     def test_credential_set_count_pinned(self):
-        # 9 original secret-class patterns + 2 STM-origin AWS label rules
-        # (#553 secret-material labels, forward-synced into LTM as
-        # memtomem#1533; #561 x-amz-security-token, awaiting its forward
-        # sync) + 7 mirrored from memtomem LTM (#1488 / reverse sync #1491).
-        # Bump deliberately when adding a pattern so a silent add/drop
-        # surfaces here. LTM's matching pin sits at 17 until the #561 rule
-        # is mirrored forward — at which point both pins move to 18 together
-        # (the #559 content-hash pin tracks the shared subset).
-        assert len(privacy.CREDENTIAL_PATTERNS) == 18
+        # 9 original secret-class patterns + 3 STM-origin label rules
+        # (#553 AWS secret-material labels, forward-synced into LTM as
+        # memtomem#1533; #561 x-amz-security-token and #562 the general
+        # quoted-label rule, both awaiting their forward sync) + 7 mirrored
+        # from memtomem LTM (#1488 / reverse sync #1491). Bump deliberately
+        # when adding a pattern so a silent add/drop surfaces here. LTM's
+        # matching pin sits at 17 until #561/#562 are mirrored forward — at
+        # which point both pins move to 19 together (the #559 content-hash
+        # pin tracks the shared subset).
+        assert len(privacy.CREDENTIAL_PATTERNS) == 19
         assert len(privacy.PII_PATTERNS) == 1
-        assert len(privacy.DEFAULT_PATTERNS) == 19
+        assert len(privacy.DEFAULT_PATTERNS) == 20
 
     @pytest.mark.parametrize(
         "sample",
@@ -317,6 +335,7 @@ class TestCredentialPiiSplit:
             '"SessionToken": "FAKEFwoGZXIvYXdzFAKE"',
             '"SecretAccessKey": "FAKEwJalrXUtnFEMIFAKE"',
             "x-amz-security-token: FAKEFwoGZXIvYXdzFAKE",
+            '"password": "hunter2"',
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF_-12345",
             "-----BEGIN RSA PRIVATE KEY-----",
             # #1488 mirror: each must classify as a credential (not PII) so the


### PR DESCRIPTION
## Background

Closes #562.

#553 added quoted-JSON-key detection for the two AWS secret-material labels, with the FP-guard design that makes the shape safe for the scanning consumers. The identical gap remained for the **rest of the label vocabulary**: `"password": "hunter2"`, `"api_key": "sk-abc"`, `"accessToken": "ya29.x"`, and dict-repr `{'password': 'hunter2'}` matched **zero** patterns (each new positive sample is verified to scan clean without the new rule). JSON-serialized credentials are high-frequency tool output — `docker inspect`, `kubectl get secret -o json`, DB connection configs, OAuth token responses.

## Why the existing rules don't reach it

The generic label rules end in `\s*[:=]`, and a quoted JSON key's closing quote sits between the label and the colon, so they never fire on any quoted-key form. This is exactly the gap #553 closed for the two AWS labels only.

## The rule

One general quoted-label rule reusing #553's FP-guard shape — quote directly on both sides of the label, value must open as a string:

```
(?i)["'](?:api[_-]?key|secret[_-]?(?:access[_-]?)?key|(?:access|session)[_-]?token|password|passwd)["']\s*:\s*["']
```

- The optional `[_-]?` separator means camelCase JSON keys (`"apiKey"`, `"accessToken"`, `"sessionToken"`) match under `(?i)`.
- **`pwd` is deliberately excluded** from the quoted vocabulary (unlike the unquoted rule): shell/file tools legitimately return working-directory fields (`"pwd": "/home/user"`), pinned as a negative.
- The FP guards hold: JSON-Schema/object values (`"password": {"type": "string"}`, `"access_token": {"type"…` — login/OAuth tool schemas carry these constantly), embedded labels (`"my_api_key_name": …`), and prefixed keys (`"tools.api_key": …`) all stay negative, as do the five pre-existing #553 guards.
- The AWS spellings are included so the vocabulary is self-contained, though #553's quoted branch (kept byte-identical for the LTM mirror) already covers them.
- `"password": ""` placeholders fire — the accepted fail-safe profile of the AWS branch (`"SessionToken": ""` fires too).

## Sync bookkeeping

- `CREDENTIAL_PATTERNS` moves 18 → 19 (count pin bumped; the rule sits at index 2, directly after the two generic label rules it generalizes — the LTM forward-sync should insert at the same index to keep the sets same-order).
- Sequenced after #564 (#561) — both add a pattern and move the same count pin, so this was rebased onto main once #564 merged (the rebased tree is byte-identical to the fully-tested pre-rebase tree). The LTM forward-sync should carry #561 + #562 in one LTM PR (inserting at LTM indices 4 and 2 respectively to keep the sets same-order), then the #559 content-hash pin lands — so the LTM mirror moves once, not twice.

## Behavior change

Responses carrying quoted credential labels (`"password": "…"`, `"api_key": "…"`, `"accessToken": "…"`, dict reprs) now route away from external-LLM compression strategies and are excluded from the response cache, and tool metadata carrying them is withheld from `tools/list` under the strict exposure profile — the same fail-safe treatment the unquoted spellings of these labels already get.

## Testing

- 6 new positive pins (JSON password, dict-repr, snake_case + camelCase api key, OAuth accessToken, kebab secret-key) — each verified to scan clean without the new rule.
- 5 new negative pins (`"pwd"` working directory, two object-value schema properties, embedded label, prefixed key); the five pre-existing #553 FP guards still pass unchanged.
- 1 new credential-set-alone classification pin.
- `uv run pytest -m "not ollama"` and `uv run ruff check src` / `ruff format --check src` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
