### PR TITLE
fix(metrics): reconcile cache-hit accounting in stm_proxy_stats (#558)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1986,7 +1986,7 @@ class ProxyManager:
         post-lock double-check so concurrent duplicate requests return
         through the same hit pipeline as a single call would.
         """
-        self.tracker.record_cache_hit()
+        self.tracker.record_cache_hit(chars=len(cached))
         context_query = arguments.get("_context_query") if arguments else None
         with traced("proxy_call_cache_hit", metadata={"server": server, "tool": tool}):
             return await self._apply_surfacing(
@@ -3250,6 +3250,28 @@ class ProxyManager:
                     exc_info=True,
                 )
 
+    def _record_unstorable_response(self, server: str, tool: str, *, cfg_snap: ProxyConfig) -> None:
+        """Count a recorded cache miss whose response shape refuses the store.
+
+        The gate mirrors the lookup path in ``_call_tool_guarded`` exactly
+        (cache wired, resolved TTL positive/None, tool cache-eligible): a miss
+        is recorded only behind that gate, so the counter must only move behind
+        the same gate — otherwise force-forwarded (ineligible / ttl<=0 / no-
+        cache) calls would report "unstorable" misses that were never counted
+        as misses in the first place. Direct ``_call_tool_inner`` callers
+        (tests) bypass the lookup AND this accounting stays consistent only
+        through production's guarded path; see the miss-accounting comment in
+        ``_call_tool_inner``.
+        """
+        if self._cache is None:
+            return
+        cache_ttl = self._resolve_cache_ttl(server, tool, cfg_snap=cfg_snap)
+        if cache_ttl is not None and cache_ttl <= 0:
+            return
+        if not self._tool_cache_eligible(server, tool, cfg_snap=cfg_snap):
+            return
+        self.tracker.record_cache_unstorable()
+
     def _store_cache(
         self,
         *,
@@ -3302,6 +3324,7 @@ class ProxyManager:
             # is disabled (resolved ttl<=0); the explicit ttl<=0 branch below does
             # the same for text responses. The non-text-ONLY response early-returns
             # in ``_call_tool_inner`` and invalidates there instead.
+            self._record_unstorable_response(server, tool, cfg_snap=cfg_snap)
             self._invalidate_disabled_cache(server, tool, cache_args, cfg_snap=cfg_snap)
             return
         cache_ttl = self._resolve_cache_ttl(server, tool, cfg_snap=cfg_snap)
@@ -3323,6 +3346,7 @@ class ProxyManager:
                 tool,
             )
         elif comp.progressive_passthrough_on_error:
+            self.tracker.record_cache_unstorable()
             logger.debug(
                 "Skipping cache store for %s/%s: progressive passthrough "
                 "degradation (transient store failure)",
@@ -3330,6 +3354,7 @@ class ProxyManager:
                 tool,
             )
         elif response_carries_transient_key(comp.compressed):
+            self.tracker.record_cache_unstorable()
             logger.debug(
                 "Skipping cache store for %s/%s: response carries a transient "
                 "retrieval key (progressive/selective TOC)",
@@ -3431,11 +3456,15 @@ class ProxyManager:
                 )
                 # Non-text-only response is never stored; mirror the mixed-branch
                 # invalidation in ``_store_cache`` so a stale prior text row for
-                # this key is dropped while caching is disabled (#541).
+                # this key is dropped while caching is disabled (#541), and count
+                # the store refusal against the miss already recorded (#558).
+                self._record_unstorable_response(server, tool, cfg_snap=cfg_snap)
                 self._invalidate_disabled_cache(server, tool, cache_args, cfg_snap=cfg_snap)
                 return non_text_content
             # A truly-empty upstream response is never stored either; invalidate a
-            # stale prior text row for this key while caching is disabled (#541).
+            # stale prior text row for this key while caching is disabled (#541)
+            # and count the store refusal against the recorded miss (#558).
+            self._record_unstorable_response(server, tool, cfg_snap=cfg_snap)
             self._invalidate_disabled_cache(server, tool, cache_args, cfg_snap=cfg_snap)
             return "[empty response]"
         original_text = shaped.original_text

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -2519,8 +2519,8 @@ class ProxyManager:
 
         Records no metrics and performs no early return: when no text remains it
         returns a ``ShapedResponse`` whose ``passthrough`` tells the caller to
-        record the non-text passthrough metric (and return the non-text list) or
-        return the ``"[empty response]"`` sentinel. The caller stays the single
+        record the 0/0 passthrough metric and return either the non-text list or
+        the ``"[empty response]"`` sentinel (#558). The caller stays the single
         owner of metric writes and return shapes (R8).
         """
         max_upstream = cfg_snap.max_upstream_chars
@@ -3444,28 +3444,28 @@ class ProxyManager:
         shaped = self._shape_response(result, server, tool, cfg_snap=cfg_snap)
         non_text_content = shaped.non_text_content
         if shaped.passthrough is not None:
-            if shaped.passthrough.has_non_text:
-                self.tracker.record(
-                    CallMetrics(
-                        server=server,
-                        tool=tool,
-                        original_chars=0,
-                        compressed_chars=0,
-                        trace_id=trace_id,
-                    )
+            # Both passthrough shapes are live upstream calls, so both record the
+            # 0/0 metric — otherwise an eligible empty response would carry a
+            # recorded miss + unstorable count with no matching call, breaking
+            # the ``total_invocations = total_calls + cache_hits`` reconciliation
+            # (#558; deliberately supersedes the R8 "empty records nothing" pin).
+            self.tracker.record(
+                CallMetrics(
+                    server=server,
+                    tool=tool,
+                    original_chars=0,
+                    compressed_chars=0,
+                    trace_id=trace_id,
                 )
-                # Non-text-only response is never stored; mirror the mixed-branch
-                # invalidation in ``_store_cache`` so a stale prior text row for
-                # this key is dropped while caching is disabled (#541), and count
-                # the store refusal against the miss already recorded (#558).
-                self._record_unstorable_response(server, tool, cfg_snap=cfg_snap)
-                self._invalidate_disabled_cache(server, tool, cache_args, cfg_snap=cfg_snap)
-                return non_text_content
-            # A truly-empty upstream response is never stored either; invalidate a
-            # stale prior text row for this key while caching is disabled (#541)
-            # and count the store refusal against the recorded miss (#558).
+            )
+            # Neither shape is ever stored; count the store refusal against the
+            # miss already recorded (#558) and mirror the mixed-branch
+            # invalidation in ``_store_cache`` so a stale prior text row for
+            # this key is dropped while caching is disabled (#541).
             self._record_unstorable_response(server, tool, cfg_snap=cfg_snap)
             self._invalidate_disabled_cache(server, tool, cache_args, cfg_snap=cfg_snap)
+            if shaped.passthrough.has_non_text:
+                return non_text_content
             return "[empty response]"
         original_text = shaped.original_text
 

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -3447,8 +3447,9 @@ class ProxyManager:
             # Both passthrough shapes are live upstream calls, so both record the
             # 0/0 metric — otherwise an eligible empty response would carry a
             # recorded miss + unstorable count with no matching call, breaking
-            # the ``total_invocations = total_calls + cache_hits`` reconciliation
-            # (#558; deliberately supersedes the R8 "empty records nothing" pin).
+            # the ``total_invocations = total_calls + cache_hits + total_errors``
+            # reconciliation (#558; deliberately supersedes the R8 "empty
+            # records nothing" pin).
             self.tracker.record(
                 CallMetrics(
                     server=server,

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -249,7 +249,9 @@ class TokenTracker:
         self._total_compress_ms = 0.0
         self._total_surface_ms = 0.0
         self._cache_hits = 0
+        self._cache_hit_chars = 0
         self._cache_misses = 0
+        self._cache_unstorable = 0
         self._reconnects = 0
         self._metrics_store = metrics_store
         self._by_server = _BoundedCounterDict(
@@ -326,11 +328,36 @@ class TokenTracker:
             except Exception:
                 logger.warning("Failed to persist metrics", exc_info=True)
 
-    def record_cache_hit(self) -> None:
+    def record_cache_hit(self, chars: int = 0) -> None:
+        """Record a response served from the cache.
+
+        Cache hits are deliberately NOT folded into ``record()``: ``_total_calls``
+        is the denominator for the per-stage latency averages and the unit of the
+        per-server/per-tool char counters, and a hit runs none of that pipeline.
+        ``chars`` is the size of the served (stored, compressed) text so the
+        cache's benefit is visible next to the compression savings it would
+        otherwise be structurally excluded from (#558); ``get_summary`` exposes
+        the reconciliation as ``total_invocations = total_calls + cache_hits``.
+        """
         self._cache_hits += 1
+        self._cache_hit_chars += chars
 
     def record_cache_miss(self) -> None:
         self._cache_misses += 1
+
+    def record_cache_unstorable(self) -> None:
+        """Record a counted cache miss whose response the cache refused to store.
+
+        Without this, a tool whose responses are never storable (mixed/non-text
+        content, transient retrieval keys, …) re-misses forever: ``cache_misses``
+        grows unbounded while its hit-rate contribution stays 0%, and the
+        diagnostics point at a tool the cache can never help (#558). Callers only
+        invoke this when the lookup path actually recorded a miss, so
+        ``cache_misses - cache_unstorable`` is the demand the cache can convert
+        to hits. Best-effort: store-side failures after an accepted response
+        (sqlite errors, the privacy write gate) are not counted.
+        """
+        self._cache_unstorable += 1
 
     def record_reconnect(self) -> None:
         self._reconnects += 1
@@ -397,6 +424,10 @@ class TokenTracker:
         n = self._total_calls or 1
         return {
             "total_calls": self._total_calls,
+            # ``total_calls`` counts live pipeline calls only; cache hits never
+            # reach ``record()``. Expose the reconciled total so an operator can
+            # match "Total calls / Cache hits" to actual tool invocations (#558).
+            "total_invocations": self._total_calls + self._cache_hits,
             "total_original_chars": self._total_original,
             "total_compressed_chars": self._total_compressed,
             "total_surfaced_chars": self._total_surfaced,
@@ -412,7 +443,9 @@ class TokenTracker:
             "avg_compress_ms": round(self._total_compress_ms / n, 2),
             "avg_surface_ms": round(self._total_surface_ms / n, 2),
             "cache_hits": self._cache_hits,
+            "cache_hit_chars": self._cache_hit_chars,
             "cache_misses": self._cache_misses,
+            "cache_unstorable": self._cache_unstorable,
             "reconnects": self._reconnects,
             "latency_percentiles": {
                 "clean_ms": self._percentiles(self._clean_latencies),

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -337,7 +337,8 @@ class TokenTracker:
         ``chars`` is the size of the served (stored, compressed) text so the
         cache's benefit is visible next to the compression savings it would
         otherwise be structurally excluded from (#558); ``get_summary`` exposes
-        the reconciliation as ``total_invocations = total_calls + cache_hits``.
+        the reconciliation as ``total_invocations = total_calls + cache_hits +
+        total_errors``.
         """
         self._cache_hits += 1
         self._cache_hit_chars += chars

--- a/src/memtomem_stm/proxy/metrics.py
+++ b/src/memtomem_stm/proxy/metrics.py
@@ -424,10 +424,13 @@ class TokenTracker:
         n = self._total_calls or 1
         return {
             "total_calls": self._total_calls,
-            # ``total_calls`` counts live pipeline calls only; cache hits never
-            # reach ``record()``. Expose the reconciled total so an operator can
-            # match "Total calls / Cache hits" to actual tool invocations (#558).
-            "total_invocations": self._total_calls + self._cache_hits,
+            # ``total_calls`` counts successful live pipeline calls only: cache
+            # hits never reach ``record()``, and a failed call only reaches
+            # ``record_error()`` (every pre-``record()`` stage failure raises,
+            # and the hit path swallows surfacing errors), so the three counters
+            # are mutually exclusive per call and their sum reconciles with
+            # actual tool invocations (#558).
+            "total_invocations": self._total_calls + self._cache_hits + self._total_errors,
             "total_original_chars": self._total_original,
             "total_compressed_chars": self._total_compressed,
             "total_surfaced_chars": self._total_surfaced,

--- a/src/memtomem_stm/proxy/pipeline_stages.py
+++ b/src/memtomem_stm/proxy/pipeline_stages.py
@@ -24,11 +24,13 @@ if TYPE_CHECKING:
 class ShapePassthrough:
     """The stage-3 early-exit verdict — the text/non-text split produced no text.
 
-    ``has_non_text`` True → the caller records the non-text passthrough metric and
-    returns the non-text content list; False → the caller returns the
-    ``"[empty response]"`` sentinel and records nothing. The shaping helper never
-    records metrics or returns itself, so the orchestrator stays the single owner
-    of metric writes and return shapes.
+    ``has_non_text`` True → the caller records the 0/0 passthrough metric and
+    returns the non-text content list; False → the caller records the same 0/0
+    metric (#558 — an empty response is still a live call, so it must appear in
+    ``total_calls`` for the invocation reconciliation) and returns the
+    ``"[empty response]"`` sentinel. The shaping helper never records metrics or
+    returns itself, so the orchestrator stays the single owner of metric writes
+    and return shapes.
     """
 
     has_non_text: bool

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -486,11 +486,17 @@ async def stm_proxy_stats(
     cache_lookups = cache_hits + cache_misses
     cache_hit_rate = (cache_hits / cache_lookups * 100) if cache_lookups else 0.0
 
-    # Every rendered number reconciles (#558): ``Total calls`` counts live
-    # pipeline calls only (the denominator of the savings/latency figures),
-    # cache hits never enter it, and the ``Total calls`` line states the sum
-    # explicitly so "calls + hits = invocations" needs no operator arithmetic.
-    total_invocations = summary.get("total_invocations", summary["total_calls"] + cache_hits)
+    # Every rendered number reconciles (#558): ``Total calls`` counts
+    # successful live pipeline calls only (the denominator of the savings/
+    # latency figures) — cache hits and failed calls never enter it — and the
+    # ``Total calls`` line states the sum explicitly so "live + failed +
+    # cache-served = invocations" needs no operator arithmetic. The failed
+    # component is rendered only when non-zero, matching the Errors section.
+    total_errors = summary.get("total_errors", 0)
+    total_invocations = summary.get(
+        "total_invocations", summary["total_calls"] + cache_hits + total_errors
+    )
+    failed_component = f" + {total_errors} failed" if total_errors else ""
     hits_suffix = (
         f"  ({summary.get('cache_hit_chars', 0):,} chars served from cache, no upstream I/O)"
         if cache_hits
@@ -500,7 +506,7 @@ async def stm_proxy_stats(
     lines = [
         "STM Proxy Stats",
         "===============",
-        f"Total calls:     {summary['total_calls']} live"
+        f"Total calls:     {summary['total_calls']} live{failed_component}"
         f" + {cache_hits} cache-served = {total_invocations} invocations",
         f"Original chars:  {summary['total_original_chars']}",
         f"Compressed:      {summary['total_compressed_chars']}",
@@ -548,7 +554,6 @@ async def stm_proxy_stats(
         )
 
     # Error summary
-    total_errors = summary.get("total_errors", 0)
     if total_errors > 0:
         lines.append(f"\nErrors: {total_errors} ({summary.get('error_rate', 0):.1f}%)")
         errors_by_cat = summary.get("errors_by_category", {})

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -512,15 +512,25 @@ async def stm_proxy_stats(
 
     # Misses the cache can never convert to hits (mixed/non-text/empty
     # responses, transient retrieval keys). Quiet when zero so the common
-    # all-text deployment keeps its familiar output.
+    # all-text deployment keeps its familiar output. When present, the hit-rate
+    # line also shows the rate over STORABLE lookups — otherwise a workload
+    # heavy in never-cacheable responses reads as a depressed hit rate, which
+    # is exactly the operator confusion the counter exists to resolve (#558).
     cache_unstorable = summary.get("cache_unstorable", 0)
+    hit_rate_line = f"Cache hit rate:  {cache_hit_rate:.1f}%"
     if cache_unstorable > 0:
         lines.append(
             f"Unstorable:      {cache_unstorable}  (of misses; response shape is never cacheable)"
         )
+        storable_lookups = cache_hits + max(cache_misses - cache_unstorable, 0)
+        if storable_lookups > 0:
+            effective_rate = cache_hits / storable_lookups * 100
+            hit_rate_line += f"  ({effective_rate:.1f}% of storable lookups)"
+        else:
+            hit_rate_line += "  (no storable lookups)"
 
     lines += [
-        f"Cache hit rate:  {cache_hit_rate:.1f}%",
+        hit_rate_line,
         f"Reconnects:      {summary.get('reconnects', 0)}",
     ]
 

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -553,9 +553,14 @@ async def stm_proxy_stats(
             f"(expired {cstats['expired_entries']}, evicted {cstats['evictions']})"
         )
 
-    # Error summary
+    # Error summary. ``error_rate``'s denominator is live upstream attempts
+    # (successful + failed calls) — cache hits can't error, so folding them in
+    # would only dilute the diagnostic. Label it so the percentage doesn't read
+    # as inconsistent next to the hits-inclusive invocation total (#558).
     if total_errors > 0:
-        lines.append(f"\nErrors: {total_errors} ({summary.get('error_rate', 0):.1f}%)")
+        lines.append(
+            f"\nErrors: {total_errors} ({summary.get('error_rate', 0):.1f}% of live attempts)"
+        )
         errors_by_cat = summary.get("errors_by_category", {})
         for cat, count in sorted(errors_by_cat.items()):
             lines.append(f"  {cat}: {count}")

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -486,16 +486,40 @@ async def stm_proxy_stats(
     cache_lookups = cache_hits + cache_misses
     cache_hit_rate = (cache_hits / cache_lookups * 100) if cache_lookups else 0.0
 
+    # Every rendered number reconciles (#558): ``Total calls`` counts live
+    # pipeline calls only (the denominator of the savings/latency figures),
+    # cache hits never enter it, and the ``Total calls`` line states the sum
+    # explicitly so "calls + hits = invocations" needs no operator arithmetic.
+    total_invocations = summary.get("total_invocations", summary["total_calls"] + cache_hits)
+    hits_suffix = (
+        f"  ({summary.get('cache_hit_chars', 0):,} chars served from cache, no upstream I/O)"
+        if cache_hits
+        else ""
+    )
+
     lines = [
         "STM Proxy Stats",
         "===============",
-        f"Total calls:     {summary['total_calls']}",
+        f"Total calls:     {summary['total_calls']} live"
+        f" + {cache_hits} cache-served = {total_invocations} invocations",
         f"Original chars:  {summary['total_original_chars']}",
         f"Compressed:      {summary['total_compressed_chars']}",
-        f"Savings:         {summary['total_savings_pct']:.1f}%",
+        f"Savings:         {summary['total_savings_pct']:.1f}%  (compression of live calls)",
         f"Token savings:   {summary.get('total_token_savings_pct', 0):.1f}%",
-        f"Cache hits:      {cache_hits}",
+        f"Cache hits:      {cache_hits}{hits_suffix}",
         f"Cache misses:    {cache_misses}",
+    ]
+
+    # Misses the cache can never convert to hits (mixed/non-text/empty
+    # responses, transient retrieval keys). Quiet when zero so the common
+    # all-text deployment keeps its familiar output.
+    cache_unstorable = summary.get("cache_unstorable", 0)
+    if cache_unstorable > 0:
+        lines.append(
+            f"Unstorable:      {cache_unstorable}  (of misses; response shape is never cacheable)"
+        )
+
+    lines += [
         f"Cache hit rate:  {cache_hit_rate:.1f}%",
         f"Reconnects:      {summary.get('reconnects', 0)}",
     ]

--- a/tests/test_cache_eligibility.py
+++ b/tests/test_cache_eligibility.py
@@ -342,6 +342,101 @@ class TestMissAccountingHonoursEligibility:
 
 
 @pytest.mark.asyncio
+class TestUnstorableAccounting:
+    """#558: a recorded miss whose response the cache refuses to store is counted
+    as ``cache_unstorable``, so a tool that can never register a hit (mixed /
+    non-text / empty responses) is diagnosable instead of presenting as an
+    ever-growing 0%-hit-rate miss pile. The counter mirrors the lookup gate:
+    no recorded miss → no unstorable count."""
+
+    async def test_mixed_response_counts_unstorable_every_call(self, build):
+        mgr, _, cache = build(tools=[_tool("mixed", _ann(read_only=True))])
+        mgr._connections["srv"].session.call_tool.return_value = _mixed_result()
+
+        await mgr.call_tool("srv", "mixed", {"q": "a"})
+        await mgr.call_tool("srv", "mixed", {"q": "a"})  # never stored → re-miss
+
+        summary = mgr.tracker.get_summary()
+        assert summary["cache_misses"] == 2
+        assert summary["cache_unstorable"] == 2
+        assert summary["cache_hits"] == 0
+        assert cache.get("srv", "mixed", {"q": "a"}) is None
+
+    async def test_nontext_only_response_counts_unstorable(self, build):
+        mgr, _, _ = build(tools=[_tool("img", _ann(read_only=True))])
+        mgr._connections["srv"].session.call_tool.return_value = _nontext_result()
+
+        await mgr.call_tool("srv", "img", {})
+
+        summary = mgr.tracker.get_summary()
+        assert summary["cache_misses"] == 1
+        assert summary["cache_unstorable"] == 1
+
+    async def test_empty_response_counts_unstorable(self, build):
+        mgr, _, _ = build(tools=[_tool("empty", _ann(read_only=True))])
+        mgr._connections["srv"].session.call_tool.return_value = _empty_result()
+
+        await mgr.call_tool("srv", "empty", {})
+
+        summary = mgr.tracker.get_summary()
+        assert summary["cache_misses"] == 1
+        assert summary["cache_unstorable"] == 1
+
+    async def test_ineligible_writer_mixed_response_not_counted(self, build):
+        """No lookup was attempted (force-forwarded writer), so neither a miss
+        nor an unstorable count may move — they must stay reconciled."""
+        mgr, _, _ = build(tools=[_tool("writer", _ann(read_only=False))])
+        mgr._connections["srv"].session.call_tool.return_value = _mixed_result()
+
+        await mgr.call_tool("srv", "writer", {})
+
+        summary = mgr.tracker.get_summary()
+        assert summary["cache_misses"] == 0
+        assert summary["cache_unstorable"] == 0
+
+    async def test_ttl_zero_mixed_response_not_counted(self, build):
+        """Caching disabled (resolved ttl<=0) bypasses the lookup entirely, so
+        the store refusal must not be counted as an unstorable miss."""
+        mgr, _, _ = build(
+            tools=[_tool("mixed", _ann(read_only=True))],
+            tool_overrides={"mixed": ToolOverrideConfig(cache_ttl_seconds=0.0)},
+        )
+        mgr._connections["srv"].session.call_tool.return_value = _mixed_result()
+
+        await mgr.call_tool("srv", "mixed", {})
+
+        summary = mgr.tracker.get_summary()
+        assert summary["cache_misses"] == 0
+        assert summary["cache_unstorable"] == 0
+
+    async def test_storable_response_not_counted(self, build):
+        mgr, _, _ = build(tools=[_tool("reader", _ann(read_only=True))])
+        mgr._connections["srv"].session.call_tool.return_value = _text_result("payload")
+
+        await mgr.call_tool("srv", "reader", {})
+
+        summary = mgr.tracker.get_summary()
+        assert summary["cache_misses"] == 1
+        assert summary["cache_unstorable"] == 0
+
+    async def test_hit_records_served_chars(self, build):
+        """A cache hit records the size of the served (stored) text so the
+        cache's benefit is visible next to the compression savings (#558)."""
+        mgr, _, cache = build(tools=[_tool("reader", _ann(read_only=True))])
+        mgr._connections["srv"].session.call_tool.return_value = _text_result("payload")
+
+        await mgr.call_tool("srv", "reader", {"q": "a"})  # miss → stored
+        await mgr.call_tool("srv", "reader", {"q": "a"})  # hit
+
+        stored = cache.get("srv", "reader", {"q": "a"})
+        assert stored is not None
+        summary = mgr.tracker.get_summary()
+        assert summary["cache_hits"] == 1
+        assert summary["cache_hit_chars"] == len(stored)
+        assert summary["total_invocations"] == summary["total_calls"] + 1
+
+
+@pytest.mark.asyncio
 class TestTtlZeroDisablesServing:
     """Lowering cache.default_ttl_seconds to 0 must stop serving rows cached under
     a prior positive TTL — per-row TTL is frozen at write time, so the lookup path

--- a/tests/test_cache_eligibility.py
+++ b/tests/test_cache_eligibility.py
@@ -372,7 +372,10 @@ class TestUnstorableAccounting:
         assert summary["cache_misses"] == 1
         assert summary["cache_unstorable"] == 1
 
-    async def test_empty_response_counts_unstorable(self, build):
+    async def test_empty_response_counts_unstorable_and_reconciles(self, build):
+        """An empty response records the 0/0 call metric too (#558 codex round
+        1): without it the recorded miss/unstorable would have no matching call
+        and ``total_invocations`` would understate actual invocations."""
         mgr, _, _ = build(tools=[_tool("empty", _ann(read_only=True))])
         mgr._connections["srv"].session.call_tool.return_value = _empty_result()
 
@@ -381,6 +384,8 @@ class TestUnstorableAccounting:
         summary = mgr.tracker.get_summary()
         assert summary["cache_misses"] == 1
         assert summary["cache_unstorable"] == 1
+        assert summary["total_calls"] == 1
+        assert summary["total_invocations"] == 1
 
     async def test_ineligible_writer_mixed_response_not_counted(self, build):
         """No lookup was attempted (force-forwarded writer), so neither a miss

--- a/tests/test_call_tool_inner_characterization.py
+++ b/tests/test_call_tool_inner_characterization.py
@@ -16,8 +16,9 @@ exercise end-to-end:
 - **R8**  a non-text-only response records a ``0/0`` metric and returns the list;
   an empty response records the same ``0/0`` metric and returns the sentinel
   string. (Amended by #558 — through the A1 refactor the empty branch recorded
-  NOTHING; it now records so ``total_invocations = total_calls + cache_hits``
-  reconciles for eligible empty responses whose miss/unstorable were counted.)
+  NOTHING; it now records so ``total_invocations = total_calls + cache_hits +
+  total_errors`` reconciles for eligible empty responses whose miss/unstorable
+  were counted.)
 - **R10** every downstream consumer (upstream, surfacing, auto-index, extract)
   receives the mutated ``upstream_args`` (with ``_trace_id``); only ``cache.set``
   receives the unmutated ``cache_args``.

--- a/tests/test_call_tool_inner_characterization.py
+++ b/tests/test_call_tool_inner_characterization.py
@@ -14,7 +14,10 @@ exercise end-to-end:
   non-progressive paths use ``_apply_surfacing`` — and the recorded
   ``surfacing_on_progressive_ok`` / ``surface_error`` match the engine outcome.
 - **R8**  a non-text-only response records a ``0/0`` metric and returns the list;
-  an empty response records NOTHING and returns the sentinel string.
+  an empty response records the same ``0/0`` metric and returns the sentinel
+  string. (Amended by #558 — through the A1 refactor the empty branch recorded
+  NOTHING; it now records so ``total_invocations = total_calls + cache_hits``
+  reconciles for eligible empty responses whose miss/unstorable were counted.)
 - **R10** every downstream consumer (upstream, surfacing, auto-index, extract)
   receives the mutated ``upstream_args`` (with ``_trace_id``); only ``cache.set``
   receives the unmutated ``cache_args``.
@@ -445,14 +448,21 @@ class TestEarlyReturnMetrics:
         assert row["original_chars"] == 0
         assert row["compressed_chars"] == 0
 
-    async def test_empty_response_records_nothing(self, make_mgr):
+    async def test_empty_response_records_zero_metric(self, make_mgr):
+        # Amended by #558 (was: records NOTHING): an empty response is a live
+        # upstream call, so it records the same 0/0 metric as the non-text
+        # branch — otherwise its recorded miss/unstorable would have no
+        # matching call and the invocation reconciliation would be false.
         mgr, store, _ = make_mgr()
         mgr._connections["srv"].session.call_tool.return_value = SimpleNamespace(
             content=[], isError=False
         )
         result = await mgr.call_tool("srv", "tool", {})
         assert result == "[empty response]"
-        assert _row_count(store) == 0
+        assert _row_count(store) == 1
+        row = _latest(store, "original_chars", "compressed_chars")
+        assert row["original_chars"] == 0
+        assert row["compressed_chars"] == 0
 
 
 # ── scorer_fallback recorded around the compression call ─────────────────

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -160,6 +160,22 @@ class TestProxyStats:
         result = await stm_proxy_stats(ctx=ctx)
         assert "Total calls:     1 live + 2 cache-served = 3 invocations" in result
 
+    async def test_total_calls_line_includes_failed_calls(self):
+        """#558 codex round 2: failed calls are a third mutually-exclusive
+        component of the invocation total; the component renders only when
+        non-zero (matching the Errors section)."""
+        from memtomem_stm.proxy.metrics import CallMetrics
+
+        tracker = TokenTracker()
+        tracker.record(CallMetrics(server="s", tool="t", original_chars=10, compressed_chars=5))
+        tracker.record_cache_hit(chars=5)
+        tracker.record_error(
+            CallMetrics(server="s", tool="t", original_chars=0, compressed_chars=0, is_error=True)
+        )
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "Total calls:     1 live + 1 failed + 1 cache-served = 3 invocations" in result
+
     async def test_cache_hits_line_shows_served_chars(self):
         """#558: the cache's benefit (chars served with zero upstream I/O) is
         rendered on the hits line; quiet suffix when there are no hits."""

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -147,6 +147,44 @@ class TestProxyStats:
         result = await stm_proxy_stats(ctx=ctx)
         assert "Cache hit rate:  75.0%" in result
 
+    async def test_total_calls_line_reconciles_invocations(self):
+        """#558: the Total calls line states live + cache-served = invocations
+        explicitly, so hits are no longer invisible in the call count."""
+        from memtomem_stm.proxy.metrics import CallMetrics
+
+        tracker = TokenTracker()
+        tracker.record(CallMetrics(server="s", tool="t", original_chars=10, compressed_chars=5))
+        tracker.record_cache_hit(chars=5)
+        tracker.record_cache_hit(chars=5)
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "Total calls:     1 live + 2 cache-served = 3 invocations" in result
+
+    async def test_cache_hits_line_shows_served_chars(self):
+        """#558: the cache's benefit (chars served with zero upstream I/O) is
+        rendered on the hits line; quiet suffix when there are no hits."""
+        tracker = TokenTracker()
+        tracker.record_cache_hit(chars=1234)
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "Cache hits:      1  (1,234 chars served from cache, no upstream I/O)" in result
+
+        result_no_hits = await stm_proxy_stats(ctx=_make_ctx(tracker=TokenTracker()))
+        assert "chars served from cache" not in result_no_hits
+
+    async def test_unstorable_line_only_when_nonzero(self):
+        """#558: unstorable misses get their own line so a permanently
+        re-missing tool is diagnosable; hidden in the common all-text case."""
+        tracker = TokenTracker()
+        tracker.record_cache_miss()
+        tracker.record_cache_unstorable()
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "Unstorable:      1" in result
+
+        result_zero = await stm_proxy_stats(ctx=_make_ctx(tracker=TokenTracker()))
+        assert "Unstorable:" not in result_zero
+
     async def test_cache_entries_line_when_cache_wired(self, tmp_path):
         """When the response cache is wired, occupancy/eviction is surfaced."""
         from memtomem_stm.proxy.cache import ProxyCache

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -185,6 +185,39 @@ class TestProxyStats:
         result_zero = await stm_proxy_stats(ctx=_make_ctx(tracker=TokenTracker()))
         assert "Unstorable:" not in result_zero
 
+    async def test_effective_hit_rate_over_storable_lookups(self):
+        """#558 codex round 1: with unstorable misses present, the hit-rate
+        line also shows the rate over storable lookups, so a never-cacheable-
+        heavy workload doesn't read as a depressed hit rate."""
+        tracker = TokenTracker()
+        tracker.record_cache_hit()  # 1 hit
+        for _ in range(3):
+            tracker.record_cache_miss()  # 3 misses, 2 unstorable
+        tracker.record_cache_unstorable()
+        tracker.record_cache_unstorable()
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        # raw: 1/4 = 25.0%; storable: 1 hit + (3-2) convertible miss → 1/2
+        assert "Cache hit rate:  25.0%  (50.0% of storable lookups)" in result
+
+    async def test_effective_hit_rate_no_storable_lookups(self):
+        """Every lookup was an unstorable miss → no percentage is fabricated."""
+        tracker = TokenTracker()
+        tracker.record_cache_miss()
+        tracker.record_cache_unstorable()
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "Cache hit rate:  0.0%  (no storable lookups)" in result
+
+    async def test_hit_rate_line_unchanged_without_unstorable(self):
+        """Zero unstorable → the pinned plain hit-rate line stays as-is."""
+        tracker = TokenTracker()
+        tracker.record_cache_hit()
+        tracker.record_cache_miss()
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        assert "Cache hit rate:  50.0%\n" in result
+
     async def test_cache_entries_line_when_cache_wired(self, tmp_path):
         """When the response cache is wired, occupancy/eviction is surfaced."""
         from memtomem_stm.proxy.cache import ProxyCache

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -176,6 +176,24 @@ class TestProxyStats:
         result = await stm_proxy_stats(ctx=ctx)
         assert "Total calls:     1 live + 1 failed + 1 cache-served = 3 invocations" in result
 
+    async def test_error_rate_labeled_as_live_attempts(self):
+        """#558 codex round 3: error_rate's denominator is live attempts
+        (successful + failed calls, no cache hits), so the rendered percentage
+        must say so or it reads inconsistent next to the invocation total."""
+        from memtomem_stm.proxy.metrics import CallMetrics
+
+        tracker = TokenTracker()
+        tracker.record(CallMetrics(server="s", tool="t", original_chars=10, compressed_chars=5))
+        tracker.record_error(
+            CallMetrics(server="s", tool="t", original_chars=0, compressed_chars=0, is_error=True)
+        )
+        for _ in range(2):
+            tracker.record_cache_hit(chars=5)
+        ctx = _make_ctx(tracker=tracker)
+        result = await stm_proxy_stats(ctx=ctx)
+        # 1 error / (1 live + 1 failed) = 50.0% — NOT 1/4 over the invocations.
+        assert "Errors: 1 (50.0% of live attempts)" in result
+
     async def test_cache_hits_line_shows_served_chars(self):
         """#558: the cache's benefit (chars served with zero upstream I/O) is
         rendered on the hits line; quiet suffix when there are no hits."""

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -408,6 +408,32 @@ class TestTokenTracker:
         assert s["cache_hits"] == 2
         assert s["cache_misses"] == 1
 
+    def test_total_invocations_reconciles_calls_and_hits(self, token_tracker: TokenTracker) -> None:
+        """#558: hits never enter ``total_calls``; the summary exposes the
+        reconciled ``total_invocations = total_calls + cache_hits`` instead."""
+        token_tracker.record(
+            CallMetrics(server="s", tool="t", original_chars=100, compressed_chars=50)
+        )
+        token_tracker.record_cache_hit(chars=50)
+        token_tracker.record_cache_hit(chars=30)
+        s = token_tracker.get_summary()
+        assert s["total_calls"] == 1
+        assert s["cache_hits"] == 2
+        assert s["total_invocations"] == 3
+        assert s["cache_hit_chars"] == 80
+
+    def test_cache_hit_default_chars_zero(self, token_tracker: TokenTracker) -> None:
+        token_tracker.record_cache_hit()
+        s = token_tracker.get_summary()
+        assert s["cache_hits"] == 1
+        assert s["cache_hit_chars"] == 0
+
+    def test_cache_unstorable_counter(self, token_tracker: TokenTracker) -> None:
+        s = token_tracker.get_summary()
+        assert s["cache_unstorable"] == 0
+        token_tracker.record_cache_unstorable()
+        assert token_tracker.get_summary()["cache_unstorable"] == 1
+
     def test_reconnect_counter(self, token_tracker: TokenTracker) -> None:
         token_tracker.record_reconnect()
         assert token_tracker.get_summary()["reconnects"] == 1

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -410,7 +410,9 @@ class TestTokenTracker:
 
     def test_total_invocations_reconciles_calls_and_hits(self, token_tracker: TokenTracker) -> None:
         """#558: hits never enter ``total_calls``; the summary exposes the
-        reconciled ``total_invocations = total_calls + cache_hits`` instead."""
+        reconciled ``total_invocations = total_calls + cache_hits +
+        total_errors`` instead (this test is the no-error case; the failed
+        component is pinned by test_total_invocations_includes_failed_calls)."""
         token_tracker.record(
             CallMetrics(server="s", tool="t", original_chars=100, compressed_chars=50)
         )

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -422,6 +422,23 @@ class TestTokenTracker:
         assert s["total_invocations"] == 3
         assert s["cache_hit_chars"] == 80
 
+    def test_total_invocations_includes_failed_calls(self, token_tracker: TokenTracker) -> None:
+        """#558 codex round 2: a failed call only reaches ``record_error()``,
+        never ``record()``, so the invocation total must include errors or a
+        failing workload renders "0 live + 0 cache-served = 0 invocations"
+        next to a non-zero error count."""
+        token_tracker.record(
+            CallMetrics(server="s", tool="t", original_chars=100, compressed_chars=50)
+        )
+        token_tracker.record_cache_hit(chars=50)
+        token_tracker.record_error(
+            CallMetrics(server="s", tool="t", original_chars=0, compressed_chars=0, is_error=True)
+        )
+        s = token_tracker.get_summary()
+        assert s["total_calls"] == 1
+        assert s["total_errors"] == 1
+        assert s["total_invocations"] == 3
+
     def test_cache_hit_default_chars_zero(self, token_tracker: TokenTracker) -> None:
         token_tracker.record_cache_hit()
         s = token_tracker.get_summary()


### PR DESCRIPTION
Closes #558.

## Background

#536 added cache hit-rate/occupancy counters to `stm_proxy_stats`, but the three accounting exclusions in #558 left the rendered numbers irreconcilable: hits are invisible in `total_calls`, the cache's benefit is excluded from the savings figure it sits next to, and a tool whose responses can never be stored re-misses forever with a permanent 0% hit-rate contribution.

## Design

Of the two options in #558, this takes the **additive/reconcilable** one — expose `total_invocations` plus an `unstorable` counter — rather than folding hits into `total_calls`/savings:

- `total_calls` is the denominator of the per-stage latency averages (`avg_clean_ms` etc.) and the unit of the per-server/per-tool char counters; a cache hit runs none of that pipeline, so folding hits in would skew every derived figure and require synthesizing a fake `CallMetrics` per hit.
- A true hits-inclusive savings % needs the original (pre-compression) size at hit time, which the cache row does not retain — that would be a schema migration. Instead the hits line reports the honest figure available: chars served from the cache with zero upstream I/O.

## Changes

- **`total_invocations = total_calls + cache_hits + total_errors`** in `get_summary()`; the stats line reads `Total calls: N live [+ K failed] + M cache-served = T invocations` — no operator arithmetic needed (gap 1). The three counters are mutually exclusive per call (every pre-`record()` stage failure raises so a failed call only reaches `record_error()`; the hit path swallows surfacing errors), so the sum is exact.
- **`record_cache_hit(chars=len(cached))`** → `cache_hit_chars` in the summary, rendered as `Cache hits: M (X chars served from cache, no upstream I/O)`; the savings line is labeled `(compression of live calls)` and the Errors line labels its denominator `(% of live attempts)` (gap 2).
- **`cache_unstorable`** counter incremented on every store refusal of a *counted* miss: mixed non-text in `_store_cache`, the progressive-passthrough and transient-key skips, and the non-text-only / empty early returns in `_call_tool_inner`. The increment mirrors the lookup gate exactly (cache wired ∧ resolved TTL positive ∧ tool cache-eligible), so force-forwarded calls that recorded no miss count nothing and `cache_misses − cache_unstorable` = demand the cache can convert to hits (gap 3). Rendered as an `Unstorable` line only when non-zero, and the hit-rate line then also shows the **effective rate over storable lookups** so a never-cacheable-heavy workload doesn't read as a depressed hit rate.

Best-effort boundary (documented in the counter docstring): store-side failures after an accepted response (sqlite errors, the privacy write gate in `ProxyCache.set`) are not counted.

## Behavior change

Observability-focused; one recording-path change:

- **An empty upstream response now records a 0/0 `CallMetrics` row** (in-memory + `proxy_metrics.db`), mirroring the non-text branch — previously it recorded nothing (the R8 characterization pin from the completed A1 refactor, amended deliberately with a #558 note). Without this, an eligible empty response carried a recorded miss + unstorable count with no matching call and the invocation reconciliation was false.
- `stm_proxy_stats` output changes shape: reconciliation suffix on `Total calls`, `(compression of live calls)` qualifier on `Savings`, served-chars suffix on `Cache hits` when non-zero, conditional `Unstorable` line + storable-lookups effective hit rate, `(% of live attempts)` label on `Errors`. `get_summary()` gains three keys (`total_invocations`, `cache_hit_chars`, `cache_unstorable`); no existing key changes meaning.

## Review

Four dev-trio codex rounds: NEEDS-FIX(2 Major) → NEEDS-FIX(1 Major) → NEEDS-FIX(1 Major + 1 Minor) → **SHIP** (nit-only, fixed). Round findings, in order: empty responses broke the invocation reconciliation (fixed by the 0/0 record above); hit rate still counted unstorable misses (fixed by the effective-rate suffix); failed calls were omitted from the invocation total (fixed by the three-term sum); error-rate denominator needed an explicit label (fixed).

## Tests

- `TestUnstorableAccounting` (integration): mixed response re-misses count unstorable every call; non-text-only and empty responses count **and reconcile**; ineligible writers and `cache_ttl_seconds: 0` overrides count **nothing** (gate mirror); a hit records `cache_hit_chars == len(stored row)`.
- `TokenTracker` unit tests: three-term `total_invocations` reconciliation (with and without errors), `chars` default, `cache_unstorable` default/increment.
- `stm_proxy_stats` rendering: reconciliation line verbatim (with/without failed component), hits-chars suffix, `Unstorable` + effective-rate lines only when non-zero (incl. the no-storable-lookups fallback), `of live attempts` label with hits+errors present.
- R8 characterization test amended deliberately: `test_empty_response_records_zero_metric` (was `records_nothing`).

Existing #536 counter-snapshot pins pass unchanged — miss/hit semantics are untouched. Full suite: 4068 passed, 3 skipped; `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)