### PR TITLE
fix(surfacing): default result_format to structured for full-precision scores (#560)

### DIFF
--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -65,7 +65,7 @@ _surfacing_id: abc123def456_
 
 Each result line shows a relevance bucket (`[weak]`, `[related]`, or `[strong]`) instead of the raw search score. Buckets are computed across the active `[min_score, 1.0]` range, so changing `min_score` also shifts the bucket boundaries. Exact raw-score distributions remain available through `stm_surfacing_stats`.
 
-Each bullet also carries its memory's id as a backticked token (e.g. `` `a1b2c3d4e5f6a7b8` ``). Pass it as a `memory_id` in the batched `stm_surfacing_feedback(ratings=[...])` call to rate individual memories — `not_relevant` / `already_known` then invalidate exactly those memories on the next cache hit. Under the default `result_format="compact"` this id is a content-derived surrogate (`sha256(content)[:16]`): it drives STM-side cache invalidation but not the LTM `increment_access` boost, and two memories with identical content collide on one id. Set `result_format="structured"` to carry the real `chunk_id` end to end.
+Each bullet also carries its memory's id as a backticked token (e.g. `` `a1b2c3d4e5f6a7b8` ``). Pass it as a `memory_id` in the batched `stm_surfacing_feedback(ratings=[...])` call to rate individual memories — `not_relevant` / `already_known` then invalidate exactly those memories on the next cache hit. Under the default `result_format="structured"` this id is the real LTM `chunk_id`, carried end to end, so `helpful` boosts reach the underlying chunk. Under `result_format="compact"` (legacy fallback, auto-selected when the core doesn't advertise structured support) the id is a content-derived surrogate (`sha256(content)[:16]`): it drives STM-side cache invalidation but not the LTM `increment_access` boost, and two memories with identical content collide on one id. Compact also renders scores rounded to two decimals, which collapses the RRF score distribution to a single value above `min_score` — the reason structured is the default (#560).
 
 The injection mode is configurable: `append` (default), `prepend`, or `section`. `prepend` is skipped on the progressive-delivery path because it would shift character offsets and break `stm_proxy_read_more` — the skip is counted as `progressive_mode_conflict` in `stm_surfacing_stats`.
 
@@ -95,6 +95,7 @@ The injection mode is configurable: `append` (default), `prepend`, or `section`.
 | `result_content_max_chars` | `500` | Max chars retained per LTM result before the formatter sees it |
 | `preview_max_chars` | `300` | Max chars per result preview in the injected memory block |
 | `consumer_model` | `""` | Model name for auto-scaling `max_results` and `max_injection_chars` |
+| `result_format` | `structured` | `mem_search` output format. `structured` carries full-precision scores and real chunk ids; auto-downgrades to `compact` when the core doesn't advertise structured support. Pin `compact` only for cores that predate the structured format (its 2-decimal score rendering collapses the score distribution, #560). |
 | `feedback_db_path` | `~/.memtomem/stm_feedback.db` | SQLite store for events, feedback, and cross-session dedup |
 | `ltm_mcp_transport` | `stdio` | LTM MCP transport: `stdio`, `sse`, or `streamable_http` |
 | `ltm_mcp_command` | `memtomem-server` | Command used when `ltm_mcp_transport=stdio` |

--- a/src/memtomem_stm/surfacing/config.py
+++ b/src/memtomem_stm/surfacing/config.py
@@ -127,11 +127,22 @@ class SurfacingConfig(BaseModel):
     out raw text on a TTL for operators who keep the default and want
     bounded retention rather than full opt-out."""
     consumer_model: str = ""
-    result_format: Literal["compact", "structured"] = "compact"
-    """Parser format for mem_search output. ``compact`` is the legacy
-    core format (``[rank] score | source``). ``structured`` selects the
-    machine-parseable JSON format (``{"results": [...]}``) with automatic
-    version negotiation — falls back to compact if core is too old.
+    result_format: Literal["compact", "structured"] = "structured"
+    """Parser format for mem_search output. ``structured`` (default)
+    selects the machine-parseable JSON format (``{"results": [...]}``)
+    with automatic version negotiation — the client silently downgrades
+    to ``compact`` when the core doesn't advertise ``structured`` in
+    ``capabilities.search_formats`` (older cores). ``compact`` is the
+    legacy core text format (``[rank] score | source``).
+
+    Score fidelity (#560): the compact format renders scores rounded to
+    two decimals, and RRF fusion scores live in ``(0, ~0.033]`` — so
+    under ``compact`` every score that survives the default ``min_score``
+    filter (0.03) parses back as exactly ``0.03``. The degenerate
+    distribution blinds ``min_score`` calibration and the auto-tuner
+    (both were benchmarked against full-precision scores, #329) and is
+    why ``structured`` is the default. Only pin ``compact`` for cores
+    that predate the structured format.
 
     Per-memory feedback fidelity (EN-2/3): the formatter renders each
     memory's ``chunk.id`` so the agent can rate memories individually via
@@ -142,9 +153,8 @@ class SurfacingConfig(BaseModel):
     the underlying chunk (``increment_access`` no-ops), and two memories
     with identical content collide on one id. STM-side cache invalidation
     (``not_relevant`` / ``already_known``) still works because it keys on
-    the same surrogate within the process. Select ``structured`` when
-    reliable per-memory boost / dedup matters — it carries the real
-    ``chunk_id`` end to end."""
+    the same surrogate within the process. ``structured`` carries the real
+    ``chunk_id`` end to end, so per-memory boost / dedup stay reliable."""
 
     @model_validator(mode="after")
     def _validate_auto_tune_bounds(self) -> SurfacingConfig:

--- a/tests/_fake_memtomem_server.py
+++ b/tests/_fake_memtomem_server.py
@@ -4,9 +4,13 @@ Stands in for `memtomem-server` so that STM's McpClientSearchAdapter can be
 exercised end-to-end without depending on a real memtomem installation. It
 exposes the two tools the adapter actually calls — ``mem_search`` and the
 ``mem_do`` meta-tool routing the ``scratch_get`` and ``increment_access``
-actions — both returning canned text in **core's real compact format**
-(``[rank] score | source > hierarchy``) so that integration tests validate
-the same parsing path used in production.
+actions. ``mem_search`` honors the ``output_format`` argument like real
+core: ``"structured"`` returns the JSON format (``{"results": [...]}``,
+the adapter default since #560) and the default returns **core's real
+compact format** (``[rank] score | source > hierarchy``) — so integration
+tests validate the same parsing paths used in production. The ``mem_do``
+``version`` action advertises both formats, matching what the fake
+actually serves.
 
 **Default mode — content must vary per call.** STM's cross-session dedup
 keys on ``sha256(content)[:16]`` (see
@@ -75,33 +79,82 @@ def _emit_seeds(seeds: list[dict]) -> str:
     return "\n".join(blocks).rstrip() + "\n"
 
 
+def _emit_structured(items: list[dict]) -> str:
+    """Format *items* as core's structured ``mem_search`` output.
+
+    Mirrors ``memtomem.server.formatters``' structured JSON shape. No
+    ``chunk_id`` key is emitted unless the seed carries one, so the
+    adapter falls back to its ``sha256(content)[:16]`` surrogate and
+    bench_qa's pre-computed IDs keep lining up across both formats.
+    """
+    results = []
+    for item in items:
+        entry = {
+            "rank": item["rank"],
+            "score": item["score"],
+            "source": item["source"],
+            "hierarchy": item.get("hierarchy", "Memory"),
+            "namespace": item.get("namespace", "default"),
+            "content": str(item["content"]),
+        }
+        if "chunk_id" in item:
+            entry["chunk_id"] = item["chunk_id"]
+        results.append(entry)
+    return json.dumps({"results": results})
+
+
 @mcp.tool()
 async def mem_search(
     query: str,
     top_k: int | None = None,
     namespace: str | list[str] | None = None,
     context_window: int = 0,
+    output_format: str = "compact",
 ) -> str:
     """Return canned search hits, or fixture seeds if ``--seeds`` was given.
 
-    Matches the output of ``memtomem.server.formatters._format_compact_result``
-    so integration tests validate the real parsing path. In the default
+    Honors ``output_format`` the way real core does: ``"structured"``
+    returns the JSON format, anything else the compact text format —
+    both built from the same result set, so integration tests validate
+    whichever real parsing path the adapter negotiated. In the default
     (no-seeds) mode each call embeds a fresh UUID in both the source path
     and the body text so ``sha256(content)`` dedup never collapses repeated
     calls. See the module docstring for the full rationale.
     """
     if _SEEDS is not None:
+        if output_format == "structured":
+            return _emit_structured(_SEEDS)
         return _emit_seeds(_SEEDS)
 
     auth_tag = uuid.uuid4().hex[:8]
     api_tag = uuid.uuid4().hex[:8]
-    return (
-        "Found 2 results:\n\n"
-        f"[1] 0.92 | auth-{auth_tag}.md > Authentication\n"
-        f"JWT authentication uses HS256 with rotating secrets every 24 hours. [run={auth_tag}]\n\n"
-        f"[2] 0.87 | api-{api_tag}.md > Rate Limiting\n"
-        f"All API responses include rate limit headers (X-RateLimit-*). [run={api_tag}]"
-    )
+    hits = [
+        {
+            "rank": 1,
+            "score": 0.92,
+            "source": f"auth-{auth_tag}.md",
+            "hierarchy": "Authentication",
+            "content": (
+                f"JWT authentication uses HS256 with rotating secrets every 24 hours. "
+                f"[run={auth_tag}]"
+            ),
+        },
+        {
+            "rank": 2,
+            "score": 0.87,
+            "source": f"api-{api_tag}.md",
+            "hierarchy": "Rate Limiting",
+            "content": f"All API responses include rate limit headers (X-RateLimit-*). [run={api_tag}]",
+        },
+    ]
+    if output_format == "structured":
+        return _emit_structured(hits)
+    blocks = [f"Found {len(hits)} results:", ""]
+    for hit in hits:
+        blocks.append(f"[{hit['rank']}] {hit['score']} | {hit['source']} > {hit['hierarchy']}")
+        blocks.append(str(hit["content"]))
+        blocks.append("")
+    return "\n".join(blocks).rstrip()
 
 
 @mcp.tool()

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -296,6 +296,14 @@ class TestSurfacingNumericConstraints:
         SurfacingConfig(result_format="compact")
         SurfacingConfig(result_format="structured")
 
+    def test_surfacing_result_format_default_is_structured(self) -> None:
+        """#560: compact's 2-decimal score rendering collapses the RRF
+        score distribution to a single value above ``min_score``, blinding
+        the filter and the auto-tuner. ``structured`` carries full-precision
+        scores (and real chunk ids) and auto-downgrades to compact for
+        cores that don't advertise it."""
+        assert SurfacingConfig().result_format == "structured"
+
 
 class TestLangfuseInterdepValidator:
     def test_enabled_requires_both_keys(self) -> None:

--- a/tests/test_mcp_client_reconnect.py
+++ b/tests/test_mcp_client_reconnect.py
@@ -232,7 +232,11 @@ class TestReconnectRetrySuccess:
 
     @pytest.mark.asyncio
     async def test_transient_failure_then_retry_returns_results(self):
-        adapter = McpClientSearchAdapter(SurfacingConfig())
+        # The session is injected directly (no start() → no format
+        # negotiation), so pin the legacy compact format to match the
+        # compact fixture text below. Same pattern in the other
+        # injected-session tests in this module that parse results.
+        adapter = McpClientSearchAdapter(SurfacingConfig(result_format="compact"))
 
         compact_output = "[1] 0.95 | [default] src/app.py\nThe retry worked.\n"
         good_result = _result_with_text(compact_output)
@@ -352,8 +356,14 @@ class TestNetworkTransportErrorsReconnect:
 
     @staticmethod
     def _network_adapter(transport: str = "sse") -> McpClientSearchAdapter:
+        # result_format pinned to match the compact fixture text (injected
+        # session, no negotiation).
         return McpClientSearchAdapter(
-            SurfacingConfig(ltm_mcp_transport=transport, ltm_mcp_url="http://127.0.0.1:9/mcp")
+            SurfacingConfig(
+                ltm_mcp_transport=transport,
+                ltm_mcp_url="http://127.0.0.1:9/mcp",
+                result_format="compact",
+            )
         )
 
     @pytest.mark.parametrize("transport", ["sse", "streamable_http"])
@@ -620,7 +630,9 @@ class TestTextNoneTolerance:
 
     @pytest.mark.asyncio
     async def test_search_tolerates_none_text(self):
-        adapter = McpClientSearchAdapter(SurfacingConfig())
+        # result_format pinned to match the compact fixture text (injected
+        # session, no negotiation).
+        adapter = McpClientSearchAdapter(SurfacingConfig(result_format="compact"))
         mock_session = AsyncMock()
 
         none_content = MagicMock()
@@ -698,7 +710,9 @@ class TestOuterCancellationLazyReconnect:
 
     @pytest.mark.asyncio
     async def test_next_call_lazy_reconnects_after_cancellation(self):
-        adapter = McpClientSearchAdapter(SurfacingConfig())
+        # result_format pinned to match the compact fixture text (injected
+        # session, no negotiation).
+        adapter = McpClientSearchAdapter(SurfacingConfig(result_format="compact"))
         adapter._needs_reconnect = True  # simulate prior cancellation
 
         compact_output = "[1] 0.90 | [default] note.md\nhealed result\n"
@@ -797,7 +811,9 @@ class TestLazyStart:
         """No prior ``start()`` — search() must bootstrap the session itself
         and deliver real results, not the silent ``no_session`` of the old
         eager-start contract."""
-        adapter = McpClientSearchAdapter(SurfacingConfig())
+        # result_format pinned to match the compact fixture text (start()
+        # is mocked, so no negotiation runs).
+        adapter = McpClientSearchAdapter(SurfacingConfig(result_format="compact"))
 
         compact_output = "[1] 0.9 | [default] src/a.py\nfrom lazy start.\n"
         good_result = _result_with_text(compact_output)

--- a/tests/test_stm_remaining.py
+++ b/tests/test_stm_remaining.py
@@ -552,13 +552,25 @@ class TestMcpClientSearchAdapter:
 
     @pytest.mark.asyncio
     async def test_search_calls_mem_search(self) -> None:
+        """Default-config adapter requests the structured format (#560).
+
+        The ``output_format`` arg in the asserted call is the wire-level
+        pin for the structured default — compact's 2-decimal score
+        rendering collapses the RRF score distribution to a single value
+        above ``min_score``, so full-precision scores must be the default
+        request.
+        """
         from memtomem_stm.surfacing.config import SurfacingConfig
 
         adapter = McpClientSearchAdapter(SurfacingConfig())
 
         mock_content = MagicMock()
         mock_content.type = "text"
-        mock_content.text = "Found 1 results:\n\n[1] 0.9 | notes.md\nRelevant memory"
+        mock_content.text = (
+            '{"results": [{"rank": 1, "score": 0.0325, "source": "notes.md",'
+            ' "hierarchy": "Notes", "namespace": "default",'
+            ' "content": "Relevant memory"}]}'
+        )
 
         mock_result = MagicMock()
         mock_result.content = [mock_content]
@@ -569,10 +581,10 @@ class TestMcpClientSearchAdapter:
 
         results, _, outcome = await adapter.search("what is X", top_k=5)
         mock_session.call_tool.assert_awaited_once_with(
-            "mem_search", {"query": "what is X", "top_k": 5}
+            "mem_search", {"query": "what is X", "top_k": 5, "output_format": "structured"}
         )
         assert len(results) == 1
-        assert results[0].score == 0.9
+        assert results[0].score == 0.0325
         assert outcome == "ok"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Background

#560 reported that every surfacing event in `stm_feedback.db` records scores of exactly `0.03` — zero variance across queries, tools, and weeks — leaving `min_score` and the auto-tuner with no signal to act on.

## Reproduction (step 1 of #560)

The premise "LTM relevance scores arrive flat" turned out to be wrong. A direct `mem_search` against the same LTM instance with `output_format="structured"` returns varied four-decimal scores (`0.0325, 0.0164, 0.0159, 0.0156, 0.0154`). The flatness is an STM-side rendering artifact:

1. STM surfacing defaulted to the **compact** result format (`surfacing/config.py`).
2. Core's compact formatter renders scores with two decimals (`f"[{r.rank}] {r.score:.2f} | ..."`, core `server/formatters.py`).
3. RRF fusion scores live in `(0, ~0.033]` (k=60 → theoretical max `2/61 ≈ 0.0328`), so 2-dp rounding collapses the whole distribution to `{0.02, 0.03}`.
4. The `min_score` filter (default `0.03`) passes only the `0.03` bucket → every recorded score is exactly `0.03`.

Notably, the `0.03` default was calibrated in #329 against a **raw-float** score sweep (fixture `s11`), so under compact rounding the deployed filter never operated in the regime that calibration assumed. Rounding also happens *before* the filter, so true scores down to ~`0.025` render as `"0.03"` and pass a floor they are actually below.

## Fix

Flip the `result_format` default from `"compact"` to `"structured"`. The flip is backward-compatible: `McpClientSearchAdapter._negotiate_format()` already downgrades to compact when the core doesn't advertise `"structured"` in `capabilities.search_formats` (older cores). Structured also carries the real `chunk_id` end to end, so per-memory `helpful` boosts now reach the underlying chunk by default (EN-2/3 notes in the config docstring).

The fake memtomem test server advertised structured in its `version` capabilities but only ever emitted compact text — latent while the default was compact. It now honors `output_format` like real core, in both canned and `--seeds` modes. Seeds emit no `chunk_id`, so the adapter keeps its `sha256(content)[:16]` surrogate and bench_qa's pre-computed IDs (and the drift baseline, unchanged in this PR) stay valid across both formats.

## Behavior change

- **Surfacing scores recorded in `surfacing_events` become full-precision and varied** instead of a constant `0.03`; `stm_surfacing_stats` distributions become meaningful, and the auto-tune band (floor/ceiling around `min_score`) finally has a gradient to move along.
- **Effective selectivity tightens slightly**: under compact, true scores in `[~0.025, 0.03)` rounded up past the `0.03` floor; under structured they are now (correctly) filtered. Fewer, more relevant memories may be surfaced per call — this is the regime the #329 calibration chose (`F1` peaks at `0.030` on the sweep).
- Memories surfaced under the default now carry real LTM chunk ids, so `helpful` feedback boosts (`increment_access`) take effect instead of silently no-oping.
- Cores that don't support the structured format are unaffected (automatic downgrade to compact).

## Tests

- New: `test_surfacing_result_format_default_is_structured` (config-level pin) and a wire-level pin in `test_search_calls_mem_search` (default adapter must request `output_format="structured"`).
- Injected-session unit tests that feed compact fixture text now pin `result_format="compact"` explicitly (no `start()` → no negotiation runs there).
- Verified end-to-end against a real `memtomem-server`: default-config adapter negotiates and keeps `StructuredResultParser`, returns 5 distinct full-precision scores with real chunk-id UUIDs.
- `uv run pytest -m "not ollama"`: 4069 passed, 3 skipped. `ruff check` clean; `ruff format` clean on the files this PR touches.

Closes #560 steps 1–2. Step 3 (zero-variance score warning in `stm_surfacing_stats`) remains a separate observability follow-up — still useful as a regression tripwire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
