### PR TITLE
feat(surfacing): warn on zero-variance score distributions in stm_surfacing_stats (#560)

### DIFF
--- a/docs/surfacing.md
+++ b/docs/surfacing.md
@@ -446,7 +446,15 @@ Cache (since process start): hits 9, misses 14, hit ratio 39.1%
 ```
 
 The first block (totals + ratings + helpfulness) is read from
-`stm_feedback.db` and persists across restarts. The lower
+`stm_feedback.db` and persists across restarts. When every
+recorded score in the reported window is identical (10+ samples),
+this block also emits a `WARNING: zero score variance` line: a
+flat score distribution means the upstream relevance score
+carries no ranking information, so `min_score` degenerates to a
+step function and auto-tune has no gradient to move along —
+check the LTM search path and `result_format` (#560, where
+compact's 2-decimal rounding produced months of a constant
+`0.03`). The lower
 sections — `Healthy skips`, `Fault skips`, `Outcomes`, `Cache` —
 are in-memory counters from `SurfacingObservability` and reset
 whenever the proxy process restarts. They are suppressed

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -42,6 +42,15 @@ user-typed checksum search) would be 80-char-clipped by the store but
 still carry the literal prefix; matching the full 23-char digest shape
 keeps the legend from misfiring on those rows."""
 
+_FLAT_SCORE_WARNING_MIN_SAMPLES = 10
+"""Minimum recorded scores before ``stm_surfacing_stats`` warns about a
+zero-variance score distribution (#560 step 3). A handful of identical
+scores is expected noise (a single query surfaced twice, a tiny window);
+ten identical values with zero spread is not — the compact-format
+rounding artifact this tripwire exists to catch produced *months* of a
+single constant. Deliberately a constant, not config: the warning is
+advisory text, and a knob would imply operators should tune it."""
+
 
 @dataclass
 class STMContext:
@@ -1011,6 +1020,28 @@ async def stm_surfacing_stats(
             first_iso = datetime.fromtimestamp(dr["first"]).isoformat(timespec="seconds")
             last_iso = datetime.fromtimestamp(dr["last"]).isoformat(timespec="seconds")
             lines.append(f"Date range:      {first_iso} — {last_iso}")
+
+        # #560 step 3: zero-variance tripwire. A flat score distribution
+        # means the upstream score channel carries no ranking information
+        # (e.g. the compact-format 2-decimal rounding artifact) — the
+        # min_score filter degenerates to a step function and the
+        # auto-tuner moves along a gradient that doesn't exist. Rendered
+        # from the same filtered event set as the counts above, so a
+        # ``tool=`` / ``since=`` window warns about exactly the rows it
+        # shows. ``.get`` guards older/mocked stats dicts without the key.
+        sd = stats.get("score_distribution") or {}
+        if (
+            sd.get("count", 0) >= _FLAT_SCORE_WARNING_MIN_SAMPLES
+            and sd.get("min") is not None
+            and sd["min"] == sd["max"]
+        ):
+            lines.append(
+                f"\nWARNING: zero score variance — all {sd['count']} recorded "
+                f"scores in this window equal {sd['min']:.4f}. The upstream "
+                "relevance score carries no ranking information here, so "
+                "min_score filtering and auto-tune have no signal to act on. "
+                "Check the LTM search path / result_format (#560)."
+            )
 
         # Min score block — show the default, whether auto-tune is on, and any
         # per-tool adjustments AutoTuner has made this process. Surfaced before

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -472,6 +472,7 @@ class FeedbackStore:
             "rating_distribution": {},
             "total_feedback": 0,
             "recent": [],
+            "score_distribution": {"count": 0, "min": None, "max": None},
         }
         if self._db is None:
             return empty
@@ -508,11 +509,19 @@ class FeedbackStore:
         # Per-tool: events + average memory_ids length. Average is computed
         # in Python because memory_ids is JSON-encoded and SQLite's JSON1
         # extension isn't universally guaranteed on the shipping wheels.
+        # The same pass aggregates the score distribution (count/min/max)
+        # for the flat-score tripwire (#560): min == max over a large
+        # enough sample means the upstream score channel carries no
+        # ranking information. min/max is O(1) memory and is exactly the
+        # "all scores equal" predicate — no need to hold the value set.
         rows = self._db.execute(
-            f"SELECT tool, memory_ids FROM surfacing_events{where_sql}", event_params
+            f"SELECT tool, memory_ids, scores FROM surfacing_events{where_sql}", event_params
         ).fetchall()
         per_tool: dict[str, dict[str, float]] = {}
-        for tool_name, memory_ids_json in rows:
+        score_count = 0
+        score_min: float | None = None
+        score_max: float | None = None
+        for tool_name, memory_ids_json, scores_json in rows:
             try:
                 ids = json.loads(memory_ids_json)
                 n = len(ids) if isinstance(ids, list) else 0
@@ -521,6 +530,18 @@ class FeedbackStore:
             bucket = per_tool.setdefault(tool_name, {"events": 0, "sum_memory_count": 0})
             bucket["events"] += 1
             bucket["sum_memory_count"] += n
+            try:
+                scores = json.loads(scores_json)
+            except (json.JSONDecodeError, TypeError):
+                scores = []
+            if isinstance(scores, list):
+                for s in scores:
+                    # bool is an int subclass — a corrupt ``true`` in the
+                    # JSON must not masquerade as score 1.0.
+                    if isinstance(s, (int, float)) and not isinstance(s, bool):
+                        score_count += 1
+                        score_min = s if score_min is None else min(score_min, s)
+                        score_max = s if score_max is None else max(score_max, s)
 
         # Per-tool feedback counts (total + negative) within the same
         # event filter. Powers the AutoTuner readiness signal: with these
@@ -630,6 +651,7 @@ class FeedbackStore:
             "rating_distribution": rating_distribution,
             "total_feedback": total_feedback,
             "recent": recent,
+            "score_distribution": {"count": score_count, "min": score_min, "max": score_max},
         }
 
     # ── Cross-session dedup ────────────────────────────────────────────

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -127,6 +127,7 @@ class TestFeedbackStore:
         assert stats["rating_distribution"] == {}
         assert stats["total_feedback"] == 0
         assert stats["recent"] == []
+        assert stats["score_distribution"] == {"count": 0, "min": None, "max": None}
 
     def test_get_stats_multi_tool_breakdown(self, feedback_store: FeedbackStore):
         # tool_a: 2 events (2 + 3 memories) → avg 2.5
@@ -169,6 +170,45 @@ class TestFeedbackStore:
         assert stats["total_feedback"] == 3
         assert stats["date_range"]["first"] is not None
         assert stats["date_range"]["last"] is not None
+
+    def test_get_stats_score_distribution_aggregates(self, feedback_store: FeedbackStore):
+        """#560 step 3 — count/min/max span every score of every event in
+        the filter window, and the tool filter narrows the aggregate to
+        that tool's events only."""
+        feedback_store.record_surfacing("s1", "srv", "tool_a", "q1", ["m1", "m2"], [0.03, 0.03])
+        feedback_store.record_surfacing("s2", "srv", "tool_a", "q2", ["m3"], [0.03])
+        feedback_store.record_surfacing("s3", "srv", "tool_b", "q3", ["m4", "m5"], [0.0164, 0.0325])
+
+        stats = feedback_store.get_stats()
+        assert stats["score_distribution"] == {"count": 5, "min": 0.0164, "max": 0.0325}
+
+        # tool_a alone is flat: min == max is the zero-variance predicate.
+        stats_a = feedback_store.get_stats(tool="tool_a")
+        assert stats_a["score_distribution"] == {"count": 3, "min": 0.03, "max": 0.03}
+
+    def test_get_stats_score_distribution_skips_malformed_scores(
+        self, feedback_store: FeedbackStore
+    ):
+        """Corrupt scores JSON (or non-numeric entries) must not crash the
+        aggregate or skew min/max — the row's memory counts still count."""
+        feedback_store.record_surfacing("s1", "srv", "tool_a", "q1", ["m1"], [0.02])
+        feedback_store._db.execute(  # type: ignore[union-attr]
+            "UPDATE surfacing_events SET scores = ? WHERE id = ?",
+            ("not-json", "s1"),
+        )
+        feedback_store._db.commit()  # type: ignore[union-attr]
+        feedback_store.record_surfacing("s2", "srv", "tool_a", "q2", ["m2"], [0.03])
+        # A JSON ``true`` must not sneak in as score 1.0 (bool is an int
+        # subclass in Python).
+        feedback_store._db.execute(  # type: ignore[union-attr]
+            "UPDATE surfacing_events SET scores = ? WHERE id = ?",
+            ("[true, 0.03]", "s2"),
+        )
+        feedback_store._db.commit()  # type: ignore[union-attr]
+
+        stats = feedback_store.get_stats()
+        assert stats["events_total"] == 2
+        assert stats["score_distribution"] == {"count": 1, "min": 0.03, "max": 0.03}
 
     def test_get_stats_since_filter(self, feedback_store: FeedbackStore):
         feedback_store.record_surfacing("s_old", "srv", "tool_a", "q_old", ["m1"], [0.9])

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -712,6 +712,63 @@ class TestSurfacingStats:
         assert "Recent:" in result
         assert "hello world" in result
         assert "(filtered by tool: t)" in result
+        # No score_distribution key in this legacy-shaped dict — the
+        # zero-variance tripwire must degrade to silence, not crash.
+        assert "zero score variance" not in result
+
+    @staticmethod
+    def _stats_with_scores(score_distribution: dict) -> dict:
+        """Minimal stats shape for exercising the flat-score tripwire."""
+        return {
+            "events_total": 21,
+            "distinct_tools": 1,
+            "date_range": {"first": 1_700_000_000.0, "last": 1_700_000_999.0},
+            "per_tool_breakdown": [],
+            "rating_distribution": {},
+            "total_feedback": 0,
+            "recent": [],
+            "score_distribution": score_distribution,
+        }
+
+    async def test_flat_score_warning_renders_when_zero_variance(self):
+        """#560 step 3: n>=threshold identical scores → explicit warning,
+        with the sample count and the constant value in the text."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = self._stats_with_scores(
+            {"count": 37, "min": 0.03, "max": 0.03}
+        )
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=None)
+        result = await stm_surfacing_stats(ctx=ctx)
+        assert "WARNING: zero score variance" in result
+        assert "all 37 recorded scores" in result
+        assert "equal 0.0300" in result
+
+    async def test_flat_score_warning_absent_when_scores_vary(self):
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = self._stats_with_scores(
+            {"count": 37, "min": 0.0164, "max": 0.0325}
+        )
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=None)
+        result = await stm_surfacing_stats(ctx=ctx)
+        assert "zero score variance" not in result
+
+    async def test_flat_score_warning_absent_below_sample_threshold(self):
+        """A handful of identical scores is expected noise — the tripwire
+        stays quiet until _FLAT_SCORE_WARNING_MIN_SAMPLES."""
+        mock_tracker = MagicMock()
+        mock_tracker.get_stats.return_value = self._stats_with_scores(
+            {"count": 9, "min": 0.03, "max": 0.03}
+        )
+        ctx = _make_ctx(feedback_tracker=mock_tracker, surfacing_engine=None)
+        result = await stm_surfacing_stats(ctx=ctx)
+        assert "zero score variance" not in result
+
+        # Boundary: exactly at the threshold the warning fires (>=).
+        mock_tracker.get_stats.return_value = self._stats_with_scores(
+            {"count": 10, "min": 0.03, "max": 0.03}
+        )
+        result = await stm_surfacing_stats(ctx=ctx)
+        assert "WARNING: zero score variance" in result
 
     async def test_min_score_block_when_engine_present(self):
         """With a surfacing engine, output includes the min_score snapshot


### PR DESCRIPTION
## Background

#560 step 3. The flat-score state that motivated the issue — every surfacing score recorded as exactly `0.03` for weeks — was only discoverable by querying `stm_feedback.db` by hand. `stm_surfacing_stats` reported the degenerate scores without flagging that they carry no ranking information: in that state the `min_score` filter is a step function at the single observed value and the auto-tuner walks a gradient that doesn't exist, so tuning knobs are silently inert.

The root cause of the original incident (compact-format 2-decimal rounding) is fixed by #572 (structured `result_format` default). This PR is the regression tripwire: whatever the *next* cause of a degenerate score channel is, the stats output itself now says so.

## Change

- `FeedbackStore.get_stats()` gains a `score_distribution` aggregate (`count` / `min` / `max`), computed in the same pass — and against the same `tool=` / `since=` filter — as the per-tool breakdown, so the warning always describes exactly the window being rendered. `min == max` is the zero-variance predicate (O(1) memory, no value set retained). Booleans are excluded explicitly: a corrupt JSON `true` would otherwise masquerade as score `1.0` (`bool` is an `int` subclass).
- `stm_surfacing_stats` renders a `WARNING: zero score variance` line when **10+** recorded scores are all identical (`_FLAT_SCORE_WARNING_MIN_SAMPLES` — below that, identical scores are expected small-sample noise; a constant, not config, since the warning is advisory text).
- `docs/surfacing.md` documents the warning next to the stats-output walkthrough.

## Invariants preserved

- Zero-traffic output is byte-for-byte unchanged (`count` 0 never warns; the empty-DB stats shape gains the key with zeros).
- Stats dicts without the new key (older callers / mocks) degrade to silence rather than crashing (`stats.get(...)`).

## Tests

- Store level: aggregate correctness across events, `tool=` filter narrowing (flat subset vs varied whole), malformed-`scores`-JSON and boolean-entry tolerance, empty-DB shape.
- Server level: warning renders with count and constant value at ≥ threshold (including the exact-10 boundary), absent when scores vary, absent below threshold, absent when the key is missing.
- Verified against a copy of the real `stm_feedback.db` that motivated #560: 11 recorded scores, all `0.03` → the warning renders through the real tool path.
- `uv run pytest -m "not ollama"`: 4073 passed, 3 skipped. `ruff check` clean; `ruff format` clean on this PR's files (the one remaining reformat hint in `tests/test_feedback.py` is pre-existing local-ruff-version churn on an untouched line).

Independent of #572 (different files; branched from `main`). Together they close out #560: root cause fixed there, observability tripwire here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)