### PR TITLE
fix(server): degrade to disabled when metrics/cache store init fails (#575)

### DIFF
--- a/src/memtomem_stm/proxy/metrics_store.py
+++ b/src/memtomem_stm/proxy/metrics_store.py
@@ -239,8 +239,17 @@ class MetricsStore:
         ``extract_ok``, ``surfacing_on_progressive_ok``) are nullable
         ``INTEGER DEFAULT NULL`` — ``NULL`` means "stage did not run", which
         readers must distinguish from ``0`` (stage ran and failed).
+
+        The ``table_info`` snapshot makes each ALTER conditional, but the
+        check and the ALTER are not one atomic step across processes: two
+        ``mms`` sessions starting right after a column-adding upgrade can
+        both read the pre-migration schema before either ALTERs, and the
+        loser's ALTER then raises ``duplicate column name``. That race is
+        tolerated per-column below (the column exists afterwards either way,
+        which is the desired end state); any other ``OperationalError`` is a
+        real failure and propagates.
         """
-        existing = {row[1] for row in db.execute("PRAGMA table_info(proxy_metrics)")}
+        existing = self._existing_columns(db)
         migrations = {
             "is_error": "ALTER TABLE proxy_metrics ADD COLUMN is_error INTEGER NOT NULL DEFAULT 0",
             "error_category": "ALTER TABLE proxy_metrics ADD COLUMN error_category TEXT DEFAULT NULL",
@@ -281,8 +290,24 @@ class MetricsStore:
         }
         for col, ddl in migrations.items():
             if col not in existing:
-                db.execute(ddl)
+                try:
+                    db.execute(ddl)
+                except sqlite3.OperationalError as exc:
+                    # A concurrent process won the race and added this column
+                    # between our ``_existing_columns`` read and this ALTER —
+                    # the column now exists, so treat the duplicate as a no-op.
+                    if "duplicate column name" not in str(exc).lower():
+                        raise
         db.commit()
+
+    def _existing_columns(self, db: sqlite3.Connection) -> set[str]:
+        """Current ``proxy_metrics`` column names — the migration snapshot.
+
+        Its own method so the concurrent-migration race (a stale snapshot
+        that misses a column another process just added) can be reproduced
+        deterministically in tests.
+        """
+        return {row[1] for row in db.execute("PRAGMA table_info(proxy_metrics)")}
 
     def close(self) -> None:
         if self._db:

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -136,11 +136,23 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
         if config.proxy.enabled:
             # Metrics store
             if config.proxy.metrics.enabled:
-                metrics_store = MetricsStore(
-                    config.proxy.metrics.db_path.expanduser().resolve(),
-                    max_history=config.proxy.metrics.max_history,
-                )
-                metrics_store.initialize()
+                try:
+                    metrics_store = MetricsStore(
+                        config.proxy.metrics.db_path.expanduser().resolve(),
+                        max_history=config.proxy.metrics.max_history,
+                    )
+                    metrics_store.initialize()
+                except Exception:
+                    # A corrupt/locked metrics DB (or a lost migration race)
+                    # must not take down every proxied tool — telemetry is
+                    # optional. Degrade to no metrics, like the sibling
+                    # trackers below. ``initialize`` closes its own handle on
+                    # failure, so dropping the object leaks nothing.
+                    logger.warning(
+                        "Metrics store init failed — proxy metrics disabled",
+                        exc_info=True,
+                    )
+                    metrics_store = None
             tracker = TokenTracker(metrics_store=metrics_store)
 
             # Compression feedback tracker — learning loop for agent-reported
@@ -260,11 +272,23 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
 
             # Response cache
             if config.proxy.cache.enabled:
-                proxy_cache = ProxyCache(
-                    config.proxy.cache.db_path.expanduser().resolve(),
-                    max_entries=config.proxy.cache.max_entries,
-                )
-                proxy_cache.initialize()
+                try:
+                    proxy_cache = ProxyCache(
+                        config.proxy.cache.db_path.expanduser().resolve(),
+                        max_entries=config.proxy.cache.max_entries,
+                    )
+                    proxy_cache.initialize()
+                except Exception:
+                    # A corrupt/locked cache DB must not take down every
+                    # proxied call — the cache is an optional optimization.
+                    # Degrade to cache-disabled (ProxyManager already handles
+                    # cache=None). ``initialize`` closes its own handle on
+                    # failure, so dropping the object leaks nothing.
+                    logger.warning(
+                        "Response cache init failed — proxy cache disabled",
+                        exc_info=True,
+                    )
+                    proxy_cache = None
 
             # Langfuse (optional)
             try:

--- a/tests/test_metrics_store.py
+++ b/tests/test_metrics_store.py
@@ -130,6 +130,64 @@ class TestMigrationIdempotency:
         finally:
             store.close()
 
+    def test_migrate_tolerates_lost_race_duplicate_column(self, tmp_path, monkeypatch):
+        """A migration whose ``_existing_columns`` snapshot is stale (another
+        process added the columns after the read) must not raise.
+
+        Reproduces the cross-process race: two ``mms`` sessions start right
+        after a column-adding upgrade, both read the pre-migration schema,
+        and the loser's ALTER hits ``duplicate column name``. The loser must
+        treat that as benign and initialize cleanly instead of crashing
+        startup. Forcing the snapshot to ``set()`` makes EVERY new-column
+        ALTER duplicate, so the tolerance is exercised for all of them.
+        """
+        db_path = tmp_path / "metrics.db"
+        # Winner fully migrates the DB.
+        winner = MetricsStore(db_path)
+        winner.initialize()
+        winner.close()
+
+        # Loser reads a stale (empty) snapshot → every ALTER targets an
+        # already-present column and raises "duplicate column name".
+        monkeypatch.setattr(MetricsStore, "_existing_columns", lambda self, db: set())
+        loser = MetricsStore(db_path)
+        try:
+            loser.initialize()  # must not raise
+            assert NEW_COLUMNS.issubset(_column_names(loser._db))
+        finally:
+            loser.close()
+
+    def test_migrate_reraises_non_duplicate_operational_error(self, tmp_path, monkeypatch):
+        """The duplicate-column tolerance must not swallow real ALTER
+        failures — any other ``OperationalError`` still propagates so a
+        genuinely broken migration is not silently skipped."""
+        db_path = tmp_path / "metrics.db"
+
+        class _AlterFailsConnection:
+            """Wraps a real connection; makes only the ADD COLUMN ALTERs
+            fail with a non-duplicate error, delegating everything else."""
+
+            def __init__(self, real: sqlite3.Connection) -> None:
+                self._real = real
+
+            def execute(self, sql: str, *args):  # noqa: ANN002, ANN202
+                if sql.startswith("ALTER TABLE proxy_metrics ADD COLUMN"):
+                    raise sqlite3.OperationalError("database is locked")
+                return self._real.execute(sql, *args)
+
+            def __getattr__(self, name: str):  # noqa: ANN202
+                return getattr(self._real, name)
+
+        real_connect = sqlite3.connect
+        monkeypatch.setattr(
+            "memtomem_stm.proxy.metrics_store.sqlite3.connect",
+            lambda *a, **k: _AlterFailsConnection(real_connect(*a, **k)),
+        )
+
+        store = MetricsStore(db_path)
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            store.initialize()
+
 
 class TestRecordPersistsNewFields:
     """``CallMetrics`` → SQLite round-trip for the F2 observability fields."""

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1620,6 +1621,88 @@ class TestLifespan:
             async with app_lifespan(mcp) as ctx:
                 assert ctx.feedback_tracker is None
                 assert captured_engine_kwargs.get("feedback_tracker") is None
+
+    async def test_metrics_store_init_failure_degrades_gracefully(self):
+        """A corrupt/locked metrics DB (or a lost migration race) raising at
+        init must log and fall back to no metrics rather than crashing the
+        server — every proxied tool would otherwise go down for an optional
+        telemetry DB. Mirrors the sibling-tracker guard pattern."""
+        from memtomem_stm.server import app_lifespan, mcp
+
+        mock_pm_instance = MagicMock()
+        mock_pm_instance.start = AsyncMock()
+        mock_pm_instance.stop = AsyncMock()
+        mock_pm_instance.get_proxy_tools.return_value = []
+
+        with (
+            patch("memtomem_stm.server.STMConfig") as MockConfig,
+            patch("memtomem_stm.server.ProxyManager", return_value=mock_pm_instance),
+            patch(
+                "memtomem_stm.proxy.metrics_store.MetricsStore",
+                side_effect=sqlite3.DatabaseError("file is not a database"),
+            ),
+        ):
+            mock_cfg = MockConfig.return_value
+            mock_cfg.proxy = MagicMock()
+            mock_cfg.proxy.enabled = True
+            mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
+            mock_cfg.proxy.metrics.enabled = True
+            mock_cfg.proxy.compression_feedback.enabled = False
+            mock_cfg.proxy.progressive_reads.enabled = False
+            mock_cfg.proxy.selection_telemetry.enabled = False
+            mock_cfg.proxy.cache.enabled = False
+            mock_cfg.surfacing = MagicMock()
+            mock_cfg.surfacing.enabled = False
+            mock_cfg.langfuse = MagicMock()
+            mock_cfg.langfuse.enabled = False
+
+            async with app_lifespan(mcp) as ctx:
+                # Server came up; the tracker just has no backing store.
+                assert ctx.tracker._metrics_store is None
+                mock_pm_instance.start.assert_awaited_once()
+
+    async def test_cache_init_failure_degrades_gracefully(self):
+        """A corrupt/locked cache DB raising at init must degrade to
+        cache-disabled (ProxyManager receives cache=None) instead of failing
+        startup — the response cache is an optional optimization."""
+        from memtomem_stm.server import app_lifespan, mcp
+
+        mock_pm_instance = MagicMock()
+        mock_pm_instance.start = AsyncMock()
+        mock_pm_instance.stop = AsyncMock()
+        mock_pm_instance.get_proxy_tools.return_value = []
+
+        captured_pm_kwargs: dict = {}
+
+        def _capture_pm(*_args, **kwargs):
+            captured_pm_kwargs.update(kwargs)
+            return mock_pm_instance
+
+        with (
+            patch("memtomem_stm.server.STMConfig") as MockConfig,
+            patch("memtomem_stm.server.ProxyManager", side_effect=_capture_pm),
+            patch(
+                "memtomem_stm.proxy.cache.ProxyCache",
+                side_effect=sqlite3.DatabaseError("file is not a database"),
+            ),
+        ):
+            mock_cfg = MockConfig.return_value
+            mock_cfg.proxy = MagicMock()
+            mock_cfg.proxy.enabled = True
+            mock_cfg.proxy.config_path = Path("/tmp/proxy.json")
+            mock_cfg.proxy.metrics.enabled = False
+            mock_cfg.proxy.compression_feedback.enabled = False
+            mock_cfg.proxy.progressive_reads.enabled = False
+            mock_cfg.proxy.selection_telemetry.enabled = False
+            mock_cfg.proxy.cache.enabled = True
+            mock_cfg.surfacing = MagicMock()
+            mock_cfg.surfacing.enabled = False
+            mock_cfg.langfuse = MagicMock()
+            mock_cfg.langfuse.enabled = False
+
+            async with app_lifespan(mcp) as _ctx:
+                assert captured_pm_kwargs.get("cache") is None
+                mock_pm_instance.start.assert_awaited_once()
 
     async def test_init_failure_after_mcp_adapter_runs_cleanup(self):
         """If a post-mcp_adapter init step raises (e.g. proxy_manager.start()),


### PR DESCRIPTION
## Summary

Closes #575. The lifespan wraps most store inits in a degrade-to-disabled `try/except`; `metrics_store.initialize()` (`server.py`) and `proxy_cache.initialize()` were the only two unwrapped. A failure in either raised out of `app_lifespan`, so **the MCP server never started — every proxied tool went down because an optional telemetry/cache DB was unhealthy.**

Two reachable triggers:
- **Corrupt DB file** (non-SQLite bytes): the first PRAGMA in `tune_connection` raises `DatabaseError: file is not a database`. (Zero-byte files are safe — SQLite reinitializes them.)
- **Concurrent-migration race**: metrics `_migrate` did check-then-ALTER (`PRAGMA table_info` → `ALTER TABLE ADD COLUMN`) with no cross-process guard. Two `mms` sessions starting right after a column-adding upgrade (the normal multi-session Claude Code shape) can both read the pre-migration schema before either ALTERs; the loser's ALTER raises `duplicate column name` → startup crash.

## Changes

- **`server.py`** — wrap both inits like their siblings (compression-feedback / progressive-reads / selection-telemetry): log a WARNING and fall back to `None`. `TokenTracker(metrics_store=None)` and `ProxyManager(cache=None)` already tolerate the degraded state (the latter is the same path as `cache.enabled=false`), and each `initialize()` already closes its own handle on failure, so the discarded object leaks nothing. This also narrows the migration race's blast radius from "server down" to "metrics disabled for one session".
- **`metrics_store.py`** — `_migrate` now tolerates the lost-race `duplicate column name` per-column (the column exists afterwards either way — the desired end state); any other `OperationalError` still propagates. The column snapshot is extracted to `_existing_columns` so the race is reproducible deterministically in a test.

## Behavior change

On a corrupt/locked metrics or cache DB, `mms` now starts with that feature disabled (one WARNING per feature) instead of failing to start. No change on a healthy DB.

## Tests

- `test_metrics_store.py`: lost-race duplicate-column tolerance (stale snapshot forces every ALTER to duplicate) + a re-raise guard that a non-duplicate `OperationalError` still propagates.
- `test_server_tools.py::TestLifespan`: metrics-init failure degrades to `tracker._metrics_store is None`; cache-init failure degrades to `ProxyManager(cache=None)`. Both assert the server still comes up.
- Full suite: 4078 passed, 3 skipped.

## Scope note

The request-path `ProxyCache.get()` guard is a separate fix site tracked in #576; the SELECTIVE/HYBRID store-write discard is #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
