### PR TITLE
fix(cache): degrade ProxyCache.get() to a MISS on a SQLite fault (#576)

### DIFF
--- a/src/memtomem_stm/proxy/cache.py
+++ b/src/memtomem_stm/proxy/cache.py
@@ -174,11 +174,25 @@ class ProxyCache:
         if self._db is None:
             return None
         key = _make_key(server, tool, args)
-        with self._lock:
-            row = self._db.execute(
-                "SELECT result, created_at, ttl_seconds FROM proxy_cache WHERE cache_key = ?",
-                (key,),
-            ).fetchone()
+        try:
+            with self._lock:
+                row = self._db.execute(
+                    "SELECT result, created_at, ttl_seconds FROM proxy_cache WHERE cache_key = ?",
+                    (key,),
+                ).fetchone()
+        except sqlite3.Error:
+            # A lookup fault (disk I/O error, page-level corruption surfacing
+            # mid-session, an external writer holding the file past the busy
+            # timeout) must degrade to a plain MISS — the cache is an optional
+            # optimization and a read fault must never fail the proxied call.
+            # Mirrors the privacy-eviction guard below and GraphConsultCache.get.
+            logger.warning(
+                "Cache lookup failed for %s/%s — serving a miss",
+                server,
+                tool,
+                exc_info=True,
+            )
+            return None
         if row is None:
             return None
         entry = CacheEntry(result=row[0], created_at=row[1], ttl_seconds=row[2])

--- a/tests/test_proxy_cache.py
+++ b/tests/test_proxy_cache.py
@@ -43,6 +43,33 @@ class TestProxyCacheBasic:
         assert proxy_cache.get("s", "t", {"a": 1}) == "new"
 
 
+class TestProxyCacheDegradation:
+    def test_get_degrades_to_miss_on_sqlite_error(self, tmp_path, caplog):
+        """A lookup fault (disk I/O error, page corruption mid-session, a
+        writer holding the file past the busy timeout) must degrade to a
+        plain MISS instead of raising out of the request path — the cache
+        is optional and must never fail an otherwise-healthy proxied call."""
+        cache = ProxyCache(tmp_path / "c.db", max_entries=10)
+        cache.initialize()
+        cache.set("s", "t", {"a": 1}, "result", ttl_seconds=60.0)
+        assert cache.get("s", "t", {"a": 1}) == "result"  # sanity
+
+        real_db = cache._db
+
+        class _BoomDB:
+            def execute(self, *args, **kwargs):
+                raise sqlite3.OperationalError("disk I/O error")
+
+        cache._db = _BoomDB()
+        try:
+            with caplog.at_level("WARNING", logger="memtomem_stm.proxy.cache"):
+                assert cache.get("s", "t", {"a": 1}) is None
+            assert any("Cache lookup failed" in r.getMessage() for r in caplog.records)
+        finally:
+            cache._db = real_db
+            cache.close()
+
+
 class TestProxyCacheTTL:
     def test_expired_entry_returns_none(self, proxy_cache: ProxyCache):
         proxy_cache.set("s", "t", {"a": 1}, "result", ttl_seconds=0.001)


### PR DESCRIPTION
## Summary

Closes #576. The response cache is best-effort **on the write side** — `_store_cache` wraps `set()` ("response unaffected") and degraded responses skip the cache (#496) — but the read side was not. `ProxyCache.get()`'s SELECT ran unguarded (only the privacy-eviction DELETE inside it was already wrapped), and the two call sites in `ProxyManager` (`manager.py:2307`/`:2317`) are bare.

A runtime `sqlite3.Error` on the lookup (disk I/O error, page-level corruption surfacing mid-session, or an external process holding the file past the busy timeout) therefore propagated out of the call pipeline and **failed the proxied tool call with INTERNAL_ERROR even though the upstream was healthy and the cache is only an optimization.** A persistently broken cache DB took down every cache-eligible call until restart.

## Change

Wrap the SELECT in the same degrade-to-MISS pattern the sibling privacy-eviction guard (`cache.py:202-212`) and `GraphConsultCache.get()` ("must degrade to a plain MISS, never raise") already use: log a WARNING and return `None` so the call falls through to the upstream. Fixing it inside `get()` covers both bare call sites at once. `contains_sensitive_content` (pure regex) and `is_expired` (pure) can't raise `sqlite3.Error`, and the eviction DELETE is already guarded — so `get()` is now fully fault-tolerant against a broken DB.

## Behavior change

A lookup fault now degrades to a cache MISS (one WARNING) and the call proceeds to the upstream, instead of failing the tool call. No change on a healthy DB.

## Tests

`test_proxy_cache.py::TestProxyCacheDegradation` — a `_db` whose `execute` raises `sqlite3.OperationalError` makes `get()` return `None` (MISS) and log `Cache lookup failed`, asserting no exception escapes. Full cache-adjacent suite: 99 passed.

## Series

Second of the ops-stability audit fixes (2026-07-03). #575 (unwrapped store `initialize()`) merged as #587; the SELECTIVE/HYBRID store-write discard is #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
