### PR TITLE
fix(surfacing): record a circuit-breaker failure on surfacing timeout (#579)

### DIFF
--- a/src/memtomem_stm/surfacing/engine.py
+++ b/src/memtomem_stm/surfacing/engine.py
@@ -324,6 +324,12 @@ class SurfacingEngine:
                 tool,
                 self._config.timeout_seconds,
             )
+            # A hung LTM must open the breaker like an erroring one (#579): a
+            # timeout is a degraded dependency, and it also cancels the adapter
+            # mid-RPC, forcing a stdio child respawn on the next call (#290/#296).
+            # Without counting it, every eligible call pays the full timeout
+            # indefinitely and the breaker never opens.
+            self._circuit_breaker.record_failure()
             return response_text
         except Exception:
             self._observability.record_outcome(tool, "error_other")

--- a/tests/test_surfacing_engine.py
+++ b/tests/test_surfacing_engine.py
@@ -291,6 +291,56 @@ class TestSurfacingTimeout:
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert output == LONG_RESPONSE
 
+    async def test_timeout_records_circuit_breaker_failure(self):
+        # A hung LTM times out (not errors); it must still count as a breaker
+        # failure, otherwise the breaker never opens and every call pays the
+        # full timeout indefinitely (#579).
+        async def slow_search(*args, **kwargs):
+            await asyncio.sleep(10)
+            return [], [], "empty_results"
+
+        adapter = AsyncMock()
+        adapter.search = slow_search
+
+        engine = SurfacingEngine(
+            config=_make_config(timeout_seconds=0.05),
+            mcp_adapter=adapter,
+        )
+        await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+        assert engine._circuit_breaker.failure_count == 1
+
+    async def test_circuit_breaker_opens_after_repeated_timeouts(self):
+        # Mirror TestSurfacingCircuitBreaker for a *hung* dependency: repeated
+        # timeouts must open the breaker so surfacing is skipped rather than
+        # taxed forever (#579).
+        call_count = 0
+
+        async def slow_search(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(10)
+            return [], [], "empty_results"
+
+        adapter = AsyncMock()
+        adapter.search = slow_search
+
+        engine = SurfacingEngine(
+            config=_make_config(
+                circuit_max_failures=2, circuit_reset_seconds=60, timeout_seconds=0.05
+            ),
+            mcp_adapter=adapter,
+        )
+
+        # First 2 timeouts still return original (caught by except) and open the breaker.
+        await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+        await engine.surface("gh", "read_file", {"path": "y"}, LONG_RESPONSE)
+        assert call_count == 2
+
+        # Circuit now open — the third call skips surfacing without touching the adapter.
+        output = await engine.surface("gh", "read_file", {"path": "z"}, LONG_RESPONSE)
+        assert output == LONG_RESPONSE
+        assert call_count == 2
+
 
 class TestSessionDedup:
     """Verify same memory isn't surfaced twice in one session."""


### PR DESCRIPTION
Closes #579.

## Problem

The surfacing circuit breaker exists to stop paying for a degraded LTM, but `SurfacingEngine.surface()` (`src/memtomem_stm/surfacing/engine.py`) recorded a breaker failure only in the generic `except Exception:` branch. The `except asyncio.TimeoutError:` branch recorded the `error_timeout` observability outcome and returned **without** `record_failure()`.

So a *hung* (not erroring) LTM — a lock, disk stall, or wedged child — times out on every call, the breaker never opens, and every surfacing-eligible proxied call pays the full `timeout_seconds` (default 3.0s) latency indefinitely. Compounding: the timeout cancels the adapter mid-RPC, which sets `_needs_reconnect` (`surfacing/mcp_client.py`, the #290/#296 fix), so each subsequent call also tears down and respawns the LTM stdio child — a per-call subprocess-respawn churn loop with no breaker to stop it. Meanwhile `stm_proxy_health` reports the breaker closed (healthy).

A hung dependency is the most realistic degraded mode and exactly what a breaker is for. No test pinned the asymmetry as deliberate.

## Fix

Call `self._circuit_breaker.record_failure()` in the `TimeoutError` branch too, keeping the distinct `error_timeout` outcome for observability (its label and the `error_timeout` vs `error_other` split in `stm_surfacing_stats` are unchanged). No breaker-class or config changes.

## Behavior change

Repeated surfacing timeouts now count toward the circuit breaker. After `circuit_max_failures` (default 3) consecutive timeouts the breaker opens and surfacing is skipped for `circuit_reset_seconds` (default 60s) instead of taxing every proxied call with the full timeout and respawning the LTM child each call. On reset the half-open probe re-opens the breaker if it still times out. The existing `stm_proxy_health` line flips from `closed (healthy)` to `open (failing)` — resolving the issue's "consider surfacing repeated timeouts in health" note without a new field. Non-timeout errors are unaffected (already counted).

## Tests

`tests/test_surfacing_engine.py` (`TestSurfacingTimeout`):
- `test_timeout_records_circuit_breaker_failure` — a single timed-out `surface()` increments `failure_count` to 1.
- `test_circuit_breaker_opens_after_repeated_timeouts` — mirrors the existing erroring-adapter breaker test with a *hanging* adapter (`asyncio.sleep(10)`, `timeout_seconds=0.05`, `circuit_max_failures=2`); after two timeouts the third call skips surfacing without touching the adapter.

Both fail on `main` (breaker stays closed) and pass with the fix. Full suite: 4085 passed, 3 skipped; ruff check + format clean.

## Changelog

No CHANGELOG entry here — matching current convention where fix PRs (#587–#589) ship without one and entries are batched into a separate `docs(changelog)` PR (e.g. #574).

🤖 Generated with [Claude Code](https://claude.com/claude-code)