### PR TITLE
fix(proxy): gate timeout-retry on tool idempotency to stop replaying writes (#578)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -2338,6 +2338,7 @@ class ProxyManager:
         upstream_args: dict[str, Any],
         *,
         trace_id: str | None,
+        cfg_snap: ProxyConfig | None = None,
     ) -> "CallToolResult":
         """Stage 1: fetch the upstream tool result with bounded retry + reconnect.
 
@@ -2348,6 +2349,10 @@ class ProxyManager:
         ``call_tool`` does not double-record), best-effort reconnects, and re-raises.
         ``upstream_args`` must already carry ``_trace_id`` — the caller injects it
         before this call so the cache-key snapshot stays trace-free.
+
+        ``cfg_snap`` is the caller's per-request config snapshot, used by the
+        timeout-replay guard (#578); ``None`` (direct test callers) falls back
+        to the live config.
         """
         conn = self._connections[server]
         cfg = conn.config
@@ -2450,7 +2455,27 @@ class ProxyManager:
                         logger.debug("Post-protocol-error reconnect failed", exc_info=True)
                     raise
 
-                if attempt >= cfg.max_retries:
+                # Timeout-replay guard (#578): a per-attempt timeout cancels OUR
+                # wait — the request may already have executed upstream, so
+                # re-invoking a non-read-only tool would manufacture duplicate
+                # writes. Connection-level failures (refused / reset / EOF) stay
+                # retryable for every tool: they overwhelmingly mean the request
+                # never completed, and gating them would disable most useful
+                # retries. MCP-error retries (err_code path) also re-execute but
+                # are out of scope here — tracked as a follow-up on #578.
+                replay_unsafe = isinstance(
+                    exc, asyncio.TimeoutError
+                ) and not self._tool_idempotent_for_retry(
+                    server, tool, cfg_snap=cfg_snap if cfg_snap is not None else self._config
+                )
+                if attempt >= cfg.max_retries or replay_unsafe:
+                    if replay_unsafe and attempt < cfg.max_retries:
+                        logger.warning(
+                            "Timeout on non-read-only tool %s/%s — not retrying "
+                            "(replay guard); reconnecting for the next call",
+                            server,
+                            tool,
+                        )
                     cat = (
                         ErrorCategory.TIMEOUT
                         if isinstance(exc, asyncio.TimeoutError)
@@ -3269,6 +3294,55 @@ class ProxyManager:
         # ``cache: true``. Pinned by test_destructive_wins_over_read_only_claim.
         return not (read_only is False or destructive is True)
 
+    def _tool_idempotent_for_retry(self, server: str, tool: str, *, cfg_snap: ProxyConfig) -> bool:
+        """Whether a timed-out call to ``(server, tool)`` may be re-invoked (#578).
+
+        A per-attempt timeout cancels OUR wait, not the upstream execution — the
+        request may already have committed its side effect, so re-invoking a
+        non-read-only tool manufactures duplicate writes the client never asked
+        for. This gate is deliberately NOT ``_tool_cache_eligible``:
+
+        - An explicit ``cache: true`` override still counts as the operator's
+          "effectively read-only" assertion (a coherent replay-safety claim),
+          but ``cache: false`` — documented for *volatile read* tools — says
+          nothing about replay safety and falls through to the annotations
+          instead of needlessly killing their timeout-retry.
+        - Under BOTH ``strict`` and ``conservative`` annotation policies only an
+          explicit ``readOnlyHint=True`` (without a contradicting
+          ``destructiveHint=True``) qualifies. ``conservative`` is
+          strict-shaped here on purpose: a conservative *cache* verdict serves
+          a stored response (no re-execution), while a conservative *retry*
+          verdict would RE-EXECUTE an unknown tool's side effect — the failure
+          directions are not symmetric, so unknown means don't replay.
+        - ``policy == "ignore"`` returns True: the operator declared the
+          annotations untrustworthy, and deriving a new safety gate from data
+          they opted out of would silently change behavior on known-bad input.
+          They keep the pre-#578 replay-on-timeout semantics.
+
+        An unknown server (direct dispatch / tests with no registered
+        connection) is treated as idempotent, mirroring ``_tool_cache_eligible``.
+        """
+        conn = self._connections.get(server)
+        if conn is None:
+            return True
+        override = conn.config.tool_overrides.get(tool)
+        if override is not None and override.cache is not None:
+            if override.cache is True:
+                return True
+            # ``cache: false`` set per-tool: fall through to annotations, and
+            # skip the per-server override (the per-tool setting shadows it,
+            # mirroring the cache-eligibility precedence).
+        elif conn.config.cache is True:
+            return True
+
+        policy = cfg_snap.cache.tool_annotation_policy
+        if policy == "ignore":
+            return True
+        ann = self._tool_annotations(conn, tool)
+        read_only = getattr(ann, "readOnlyHint", None)
+        destructive = getattr(ann, "destructiveHint", None)
+        return read_only is True and destructive is not True
+
     def _invalidate_disabled_cache(
         self, server: str, tool: str, cache_args: dict[str, Any], *, cfg_snap: ProxyConfig
     ) -> None:
@@ -3495,7 +3569,9 @@ class ProxyManager:
         # metric (and ``_mark_recorded``-ing the exception so the outer
         # ``call_tool`` does not double-record). ``conn``/``cfg``/``delay`` are
         # owned entirely by the helper — nothing after the fetch reads them.
-        result = await self._fetch_upstream(server, tool, upstream_args, trace_id=trace_id)
+        result = await self._fetch_upstream(
+            server, tool, upstream_args, trace_id=trace_id, cfg_snap=cfg_snap
+        )
 
         # ── Stage 3: SHAPE (text/non-text split + max_upstream_chars guard) ──
         # The helper records no metrics and performs no return; when no text

--- a/tests/test_proxy_error_paths.py
+++ b/tests/test_proxy_error_paths.py
@@ -11,9 +11,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from memtomem_stm.proxy.config import (
+    CacheConfig,
     CompressionStrategy,
     ProgressiveConfig,
     ProxyConfig,
+    ToolOverrideConfig,
     UpstreamServerConfig,
 )
 from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
@@ -33,6 +35,23 @@ def _make_result(text: str, is_error: bool = False):
     return SimpleNamespace(content=[_text_content(text)], isError=is_error)
 
 
+def _ann(*, read_only=None, destructive=None):
+    """A stand-in for MCP ``ToolAnnotations`` (``getattr``-based consumers, so a
+    SimpleNamespace matches the real model). Mirrors test_cache_eligibility."""
+    return SimpleNamespace(readOnlyHint=read_only, destructiveHint=destructive)
+
+
+def _tool(name, ann=None):
+    return SimpleNamespace(name=name, annotations=ann)
+
+
+def _read_only_tools(name: str = "tool"):
+    """Connection tool snapshot declaring ``name`` read-only, so the #578
+    timeout-replay guard keeps retrying it — for tests that exercise the retry
+    MECHANICS (backoff, deadlines, reconnect ordering) rather than the guard."""
+    return [_tool(name, _ann(read_only=True, destructive=False))]
+
+
 def _make_manager(
     max_retries: int = 3,
     reconnect_delay: float = 0.0,
@@ -43,6 +62,9 @@ def _make_manager(
     call_timeout: float = 90.0,
     overall_deadline: float = 180.0,
     progressive: ProgressiveConfig | None = None,
+    tools: list | None = None,
+    tool_overrides: dict[str, ToolOverrideConfig] | None = None,
+    annotation_policy: str = "conservative",
 ) -> ProxyManager:
     """Create a ProxyManager with a mocked upstream connection."""
     server_cfg = UpstreamServerConfig(
@@ -55,11 +77,13 @@ def _make_manager(
         call_timeout_seconds=call_timeout,
         overall_deadline_seconds=overall_deadline,
         progressive=progressive,
+        tool_overrides=tool_overrides or {},
     )
     config_path = (tmp_path / "proxy.json") if tmp_path else Path("/tmp/proxy.json")
     proxy_cfg = ProxyConfig(
         config_path=config_path,
         upstream_servers={"srv": server_cfg},
+        cache=CacheConfig(tool_annotation_policy=annotation_policy),
     )
     tracker = TokenTracker()
     mgr = ProxyManager(proxy_cfg, tracker)
@@ -70,7 +94,7 @@ def _make_manager(
         name="srv",
         config=server_cfg,
         session=session,
-        tools=[],
+        tools=tools if tools is not None else [],
     )
     mgr._connections["srv"] = conn
     return mgr
@@ -92,7 +116,10 @@ class TestTransportFailureRetry:
         ids=["OSError", "ConnectionError", "TimeoutError", "EOFError"],
     )
     async def test_retryable_error_succeeds_on_second_attempt(self, exc_type):
-        mgr = _make_manager(max_retries=3)
+        # Read-only annotations so the TimeoutError case stays retryable under
+        # the #578 replay guard (the guard itself is covered by
+        # TestTimeoutReplayGuard).
+        mgr = _make_manager(max_retries=3, tools=_read_only_tools())
         session = _get_session(mgr)
         session.call_tool.side_effect = [exc_type("fail"), _make_result("ok")]
 
@@ -884,6 +911,7 @@ class TestCallTimeout:
             max_reconnect_delay=0.0,
             call_timeout=0.05,
             overall_deadline=1.0,
+            tools=_read_only_tools(),
         )
         session = _get_session(mgr)
 
@@ -939,6 +967,7 @@ class TestCallTimeout:
             max_reconnect_delay=0.0,
             call_timeout=0.05,
             overall_deadline=1.0,
+            tools=_read_only_tools(),
         )
         session = _get_session(mgr)
 
@@ -979,6 +1008,7 @@ class TestCallTimeout:
             max_reconnect_delay=0.0,
             call_timeout=0.02,
             overall_deadline=0.05,
+            tools=_read_only_tools(),
         )
         session = _get_session(mgr)
 
@@ -1009,6 +1039,7 @@ class TestCallTimeout:
             max_reconnect_delay=0.0,
             call_timeout=0.1,
             overall_deadline=0.12,
+            tools=_read_only_tools(),
         )
         session = _get_session(mgr)
 
@@ -1044,6 +1075,209 @@ class TestCallTimeout:
             f"second attempt used {captured_timeouts[1]:.4f}s but remaining "
             "deadline was smaller; shrink logic not applied"
         )
+
+
+class TestTimeoutReplayGuard:
+    """#578: a per-attempt timeout cancels our wait, not the upstream execution,
+    so a non-read-only tool must NOT be re-invoked (that would replay its side
+    effect). The connection is still refreshed for the next call, and the
+    original ``TimeoutError`` propagates. Connection-level failures stay
+    retryable for every tool."""
+
+    async def test_writer_timeout_not_retried(self):
+        """A tool annotated ``readOnlyHint=False`` that times out is invoked
+        exactly once, reconnected for the next call, and raises."""
+        mgr = _make_manager(
+            max_retries=3,
+            call_timeout=0.05,
+            overall_deadline=1.0,
+            tools=[_tool("tool", _ann(read_only=False))],
+        )
+        session = _get_session(mgr)
+
+        async def hang(*_a, **_kw):
+            await asyncio.sleep(10)
+
+        session.call_tool.side_effect = hang
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock) as mock_reconnect:
+            with pytest.raises(asyncio.TimeoutError):
+                await mgr.call_tool("srv", "tool", {})
+
+        assert session.call_tool.call_count == 1, "writer tool must not be re-invoked on timeout"
+        mock_reconnect.assert_awaited_once_with("srv")
+
+    async def test_unannotated_timeout_not_retried(self):
+        """The core case: a tool with NO annotations (may-mutate per spec) is
+        treated as a writer under the default ``conservative`` policy."""
+        mgr = _make_manager(
+            max_retries=3,
+            call_timeout=0.05,
+            overall_deadline=1.0,
+            tools=[],  # no annotations at all
+        )
+        session = _get_session(mgr)
+
+        async def hang(*_a, **_kw):
+            await asyncio.sleep(10)
+
+        session.call_tool.side_effect = hang
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock) as mock_reconnect:
+            with pytest.raises(asyncio.TimeoutError):
+                await mgr.call_tool("srv", "tool", {})
+
+        assert session.call_tool.call_count == 1
+        mock_reconnect.assert_awaited_once_with("srv")
+
+    async def test_readonly_timeout_is_retried(self):
+        """A declared read-only tool is replay-safe: timeout still retries."""
+        mgr = _make_manager(
+            max_retries=1,
+            call_timeout=0.05,
+            overall_deadline=1.0,
+            tools=_read_only_tools(),
+        )
+        session = _get_session(mgr)
+
+        attempts = 0
+
+        async def hang_once_then_ok(*_a, **_kw):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                await asyncio.sleep(10)
+            return _make_result("ok")
+
+        session.call_tool.side_effect = hang_once_then_ok
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            result = await mgr.call_tool("srv", "tool", {})
+
+        assert result == "ok"
+        assert attempts == 2
+
+    async def test_writer_connection_refused_is_retried(self):
+        """A non-timeout connection failure (refused) provably never executed,
+        so it stays retryable even for a writer tool."""
+        mgr = _make_manager(
+            max_retries=3,
+            tools=[_tool("tool", _ann(read_only=False))],
+        )
+        session = _get_session(mgr)
+        session.call_tool.side_effect = [ConnectionRefusedError("refused"), _make_result("ok")]
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock) as mock_reconnect:
+            result = await mgr.call_tool("srv", "tool", {})
+
+        assert result == "ok"
+        assert session.call_tool.call_count == 2
+        mock_reconnect.assert_awaited_once_with("srv")
+
+    async def test_ignore_policy_keeps_replay(self):
+        """``tool_annotation_policy=ignore`` opts out of annotation trust, so a
+        writer timeout retries as it did pre-#578."""
+        mgr = _make_manager(
+            max_retries=1,
+            call_timeout=0.05,
+            overall_deadline=1.0,
+            tools=[_tool("tool", _ann(read_only=False))],
+            annotation_policy="ignore",
+        )
+        session = _get_session(mgr)
+
+        attempts = 0
+
+        async def hang_once_then_ok(*_a, **_kw):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                await asyncio.sleep(10)
+            return _make_result("ok")
+
+        session.call_tool.side_effect = hang_once_then_ok
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            result = await mgr.call_tool("srv", "tool", {})
+
+        assert result == "ok"
+        assert attempts == 2
+
+    async def test_per_tool_cache_true_override_keeps_replay(self):
+        """An explicit per-tool ``cache: true`` is the operator's 'effectively
+        read-only' assertion, so timeout-retry is preserved for an otherwise
+        unannotated tool."""
+        mgr = _make_manager(
+            max_retries=1,
+            call_timeout=0.05,
+            overall_deadline=1.0,
+            tools=[],
+            tool_overrides={"tool": ToolOverrideConfig(cache=True)},
+        )
+        session = _get_session(mgr)
+
+        attempts = 0
+
+        async def hang_once_then_ok(*_a, **_kw):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                await asyncio.sleep(10)
+            return _make_result("ok")
+
+        session.call_tool.side_effect = hang_once_then_ok
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            result = await mgr.call_tool("srv", "tool", {})
+
+        assert result == "ok"
+        assert attempts == 2
+
+    async def test_contradictory_annotation_treated_as_writer(self):
+        """``readOnlyHint=True`` AND ``destructiveHint=True`` is a mis-annotation;
+        the guard treats it as a writer (unknown → don't replay)."""
+        mgr = _make_manager(
+            max_retries=3,
+            call_timeout=0.05,
+            overall_deadline=1.0,
+            tools=[_tool("tool", _ann(read_only=True, destructive=True))],
+        )
+        session = _get_session(mgr)
+
+        async def hang(*_a, **_kw):
+            await asyncio.sleep(10)
+
+        session.call_tool.side_effect = hang
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            with pytest.raises(asyncio.TimeoutError):
+                await mgr.call_tool("srv", "tool", {})
+
+        assert session.call_tool.call_count == 1
+
+    async def test_gated_path_records_exactly_one_timeout_metric(self):
+        """The replay-gated terminal path records exactly one TIMEOUT error, not
+        one per would-be attempt, and the outer call_tool does not double-record."""
+        mgr = _make_manager(
+            max_retries=3,
+            call_timeout=0.05,
+            overall_deadline=1.0,
+            tools=[_tool("tool", _ann(read_only=False))],
+        )
+        session = _get_session(mgr)
+
+        async def hang(*_a, **_kw):
+            await asyncio.sleep(10)
+
+        session.call_tool.side_effect = hang
+
+        with patch.object(mgr, "_reconnect_server", new_callable=AsyncMock):
+            with pytest.raises(asyncio.TimeoutError):
+                await mgr.call_tool("srv", "tool", {})
+
+        summary = mgr.tracker.get_summary()
+        assert summary["total_errors"] == 1
+        assert summary["errors_by_category"].get("timeout") == 1
 
 
 class TestTransientKeyResponsesNotCached:


### PR DESCRIPTION
## Summary

Closes #578. The upstream retry loop (`_fetch_upstream`) retries on `asyncio.TimeoutError` by reconnecting and **re-invoking the same tool** up to `max_retries` times. A per-attempt timeout only cancels *our* `asyncio.wait_for` — the upstream request may already have committed its side effect — so for a non-idempotent tool the proxy manufactures duplicate writes the client never asked for. With `max_retries=3`, one slow write can be applied up to 4 times. A transparent proxy retrying blind is a semantic change relative to the client calling the upstream directly (the client would see one timeout, not N replayed writes).

## Change

A new gate, `_tool_idempotent_for_retry(server, tool, *, cfg_snap)`, decides whether a **timed-out** call may be re-invoked. When it says no, the loop takes the existing terminal branch: record the TIMEOUT metric, `_mark_recorded`, best-effort `_reconnect_server` ("reconnect for the next call"), and re-raise the original `TimeoutError` — no re-invocation.

- **Only `asyncio.TimeoutError` is gated.** Connection-level failures (refused / reset / EOF) stay retryable for every tool — they overwhelmingly mean the request never completed, and gating them would disable most useful retries. MCP-error retries (the `err_code` path) also re-execute an already-delivered call but are left as a follow-up.
- **The gate is deliberately not `_tool_cache_eligible`.** An explicit `cache: true` override still counts as the operator's "effectively read-only" assertion (a coherent replay-safety claim), but `cache: false` — documented for *volatile read* tools — says nothing about replay safety and falls through to the annotations instead of needlessly killing their timeout-retry.
- **Idempotency = `readOnlyHint is True and destructiveHint is not True`** under both `strict` and `conservative` policies. `conservative` is strict-shaped here on purpose: a conservative *cache* verdict serves a stored response (no re-execution), while a conservative *retry* verdict would RE-EXECUTE an unknown tool's side effect — the failure directions are asymmetric, so unknown means don't replay.
- **`tool_annotation_policy: ignore`** returns idempotent=True: the operator declared the annotations untrustworthy, so we keep the pre-#578 replay-on-timeout behavior rather than derive a new safety gate from data they opted out of.

`_fetch_upstream` gains a `cfg_snap` kwarg (passed by the single caller `_call_tool_inner`; `None` for direct test callers falls back to the live config).

## Behavior change

Under the default `tool_annotation_policy: conservative`, a tool **without** `readOnlyHint: true` no longer gets its call *retried* on a per-attempt timeout — the connection is still refreshed and the timeout propagates, instead of the tool being re-invoked. Transport-error retries are unchanged. Escape hatches to keep the old replay behavior: a per-tool/server `cache: true` override, or `tool_annotation_policy: ignore`.

## Follow-ups (out of scope)

- `EOFError` / `ConnectionResetError` are ambiguous post-send but stay retryable (they overwhelmingly signal a dead server); tightening these would disable most useful retries.
- MCP-error retries (`err_code` outside `_NO_RETRY_CODES`) re-execute a call that reached the app layer — arguably a worse replay — but are a separate concern.

## Tests

`tests/test_proxy_error_paths.py`:
- `_make_manager` gains `tools=` / `tool_overrides=` / `annotation_policy=`; the existing timeout-retry mechanics tests now pass a read-only-annotated tool so they still exercise backoff/deadline/reconnect ordering.
- New `TestTimeoutReplayGuard`: writer + timeout → 1 invocation + reconnect + raise; unannotated + timeout → same (the core case); read-only + timeout → retried; writer + `ConnectionRefusedError` → retried; `policy=ignore` → retried; per-tool `cache: true` → retried; contradictory `readOnly+destructive` → gated; gated path records exactly one TIMEOUT metric (no double-record).

Full suite: 4093 passed, 3 skipped. `ruff check` + `format` clean.

## Series

Part of the 2026-07-03 ops-stability audit. #575–#577 / #579 merged (#587–#590); this is #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
