### PR TITLE
fix(proxy): surface startup-failed upstreams in stm_proxy_health (#580)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -306,6 +306,13 @@ class ProxyManager:
         self._toolgraph_cache: GraphConsultCache | None = None
         self._toolgraph_from_cache: bool = False
         self._connections: dict[str, UpstreamConnection] = {}
+        # Configured servers whose startup connect FAILED (#580). Entries never
+        # land in ``_connections`` (created only on a successful connect), so
+        # without this map a startup-failed upstream is invisible in
+        # ``stm_proxy_health`` — an operator sees only healthy servers and no
+        # anomaly. name → short error summary; an entry is cleared if the
+        # server later connects (e.g. via reconnect).
+        self._failed_servers: dict[str, str] = {}
         self._stack: AsyncExitStack | None = None
         self._selective_compressor: SelectiveCompressor | None = None
         self._selective_compressor_cfg: SelectiveConfig | None = None
@@ -453,8 +460,14 @@ class ProxyManager:
         for name, cfg in servers.items():
             try:
                 await self._connect_server(name, cfg)
-            except Exception:
+            except Exception as exc:
                 logger.exception("Failed to connect to upstream server '%s'", name)
+                # Record the failure so ``get_upstream_health`` can report the
+                # configured-but-dead server (#580) — otherwise it is absent
+                # from ``stm_proxy_health`` entirely (no ``_connections`` entry
+                # is created on a failed connect) and the degradation is
+                # undiagnosable from inside the session.
+                self._failed_servers[name] = format_error_message_from_exc(exc)
 
         # #465: evaluate per-tool health once per session, before the first
         # advertisement. get_proxy_tools() applies this cached snapshot so
@@ -893,6 +906,8 @@ class ProxyManager:
         self._connections[name] = UpstreamConnection(
             name=name, config=cfg, session=session, tools=list(result.tools), stack=conn_stack
         )
+        # A successful connect clears any prior startup-failure record (#580).
+        self._failed_servers.pop(name, None)
         logger.info("Connected to '%s' (%s tools discovered)", name, len(result.tools))
 
     async def _reconnect_server(self, name: str) -> None:
@@ -2186,6 +2201,12 @@ class ProxyManager:
         withheld tool from a missing one. ``advertised_tools`` reflects
         the most recent ``get_proxy_tools()`` pass — in the server it runs
         at startup registration, before any health probe can observe it.
+
+        A configured server that FAILED to connect at startup (#580) has no
+        ``_connections`` entry, so it is reported here from ``_failed_servers``
+        with ``connected: False`` and an ``error`` summary — making the
+        existing ``DISCONNECTED`` rendering reachable instead of the server
+        vanishing from health entirely.
         """
         health: dict[str, dict] = {}
         for name, conn in self._connections.items():
@@ -2195,6 +2216,17 @@ class ProxyManager:
                 "advertised_tools": sum(
                     1 for info in self._advertised_infos if info.server == name
                 ),
+            }
+        for name, error in self._failed_servers.items():
+            # A server can't be both connected and in the failed map (the
+            # success path pops it), but guard against a stale entry anyway.
+            if name in health:
+                continue
+            health[name] = {
+                "connected": False,
+                "tools": 0,
+                "advertised_tools": 0,
+                "error": error,
             }
         return health
 

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -468,22 +468,27 @@ class ProxyManager:
             try:
                 await self._connect_server(name, cfg)
             except Exception as exc:
-                logger.exception("Failed to connect to upstream server '%s'", name)
-                # Record the failure so ``get_upstream_health`` can report the
-                # configured-but-dead server (#580) — otherwise it is absent
-                # from ``stm_proxy_health`` entirely (no ``_connections`` entry
-                # is created on a failed connect) and the degradation is
-                # undiagnosable from inside the session. Redact first: httpx
-                # transport exceptions embed the full request URL — userinfo
-                # included — so a credentialed upstream
-                # (``https://user:token@host/mcp``) would otherwise leak its
-                # token through ``stm_proxy_health`` to the MCP client/model.
-                # Redact the FULL message, THEN cap: capping first (as
+                # Redact the full exception text ONCE, then reuse it for both the
+                # operator log and the health record (#580). httpx transport
+                # exceptions embed the credentialed request URL
+                # (``https://user:token@host/mcp``), so an unredacted path would
+                # leak the token — via ``stm_proxy_health`` to the MCP
+                # client/model, or via the log. Do NOT use ``logger.exception``
+                # here: its traceback tail repeats the raw, unredacted exception
+                # string. Redact the FULL message, THEN cap: capping first (as
                 # format_error_message_from_exc does) can truncate a long
-                # credential mid-token so redact_exception_text no longer
-                # matches the configured URL, leaving a partial token exposed.
-                redacted = redact_exception_text(f"{type(exc).__name__}: {exc}", cfg.url)
-                self._failed_servers[name] = redacted[:MAX_ERROR_MESSAGE_CHARS]
+                # credential mid-token so redact_exception_text no longer matches
+                # the configured URL, leaving a partial token exposed.
+                redacted = redact_exception_text(f"{type(exc).__name__}: {exc}", cfg.url)[
+                    :MAX_ERROR_MESSAGE_CHARS
+                ]
+                logger.error("Failed to connect to upstream server '%s': %s", name, redacted)
+                # Record the failure so ``get_upstream_health`` can report the
+                # configured-but-dead server — otherwise it is absent from
+                # ``stm_proxy_health`` entirely (no ``_connections`` entry is
+                # created on a failed connect) and the degradation is
+                # undiagnosable from inside the session.
+                self._failed_servers[name] = redacted
 
         # #465: evaluate per-tool health once per session, before the first
         # advertisement. get_proxy_tools() applies this cached snapshot so

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -133,6 +133,7 @@ from memtomem_stm.proxy.metrics import (
     format_error_message_from_exc,
 )
 from memtomem_stm.observability.tracing import traced
+from memtomem_stm.utils.redact import redact_exception_text
 
 # JSON-RPC error codes that indicate bad input, not connection problems.
 # Retrying these wastes time and can damage the connection.
@@ -370,6 +371,12 @@ class ProxyManager:
             except Exception:
                 logger.debug("Failed to close previous stack in double-start guard", exc_info=True)
             self._connections.clear()
+            # Drop stale startup-failure records (#580): a manager reused across
+            # ``start()`` calls (new config, or a server removed) must not keep
+            # reporting a previous session's failed upstream in
+            # ``stm_proxy_health``. The next connect pass repopulates from the
+            # current config.
+            self._failed_servers.clear()
             # Reset the #557 refresh bookkeeping alongside the connections it
             # tracks (same rationale as in ``stop()``): a ``running`` entry
             # orphaned by a never-started drain task would silently drop every
@@ -466,8 +473,14 @@ class ProxyManager:
                 # configured-but-dead server (#580) — otherwise it is absent
                 # from ``stm_proxy_health`` entirely (no ``_connections`` entry
                 # is created on a failed connect) and the degradation is
-                # undiagnosable from inside the session.
-                self._failed_servers[name] = format_error_message_from_exc(exc)
+                # undiagnosable from inside the session. Redact first: httpx
+                # transport exceptions embed the full request URL — userinfo
+                # included — so a credentialed upstream
+                # (``https://user:token@host/mcp``) would otherwise leak its
+                # token through ``stm_proxy_health`` to the MCP client/model.
+                self._failed_servers[name] = redact_exception_text(
+                    format_error_message_from_exc(exc), cfg.url
+                )
 
         # #465: evaluate per-tool health once per session, before the first
         # advertisement. get_proxy_tools() applies this cached snapshot so
@@ -854,6 +867,15 @@ class ProxyManager:
 
         if cfg.transport != TransportType.STDIO and not cfg.url:
             logger.warning("Skipping server '%s': transport=%s requires url", name, cfg.transport)
+            # Record the misconfiguration (#580) instead of returning silently:
+            # this early return raises nothing, so ``start()``'s except never
+            # fires and the configured-but-unconnected server would otherwise
+            # stay invisible in ``stm_proxy_health`` — the exact false-green
+            # this surfacing is meant to close. Static message (no url), so
+            # nothing to redact.
+            self._failed_servers[name] = (
+                f"configuration error: transport={cfg.transport.value} requires a url"
+            )
             return
 
         conn_stack = AsyncExitStack()
@@ -1191,6 +1213,9 @@ class ProxyManager:
                 logger.debug("Failed to close progressive store on stop", exc_info=True)
             self._progressive_store = None
             self._progressive_store_cfg = None
+        # Clear startup-failure records too (#580) so a stopped manager reports
+        # no upstreams — mirrors the double-start reset in ``start()``.
+        self._failed_servers.clear()
 
     @property
     def _config(self) -> ProxyConfig:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -468,20 +468,13 @@ class ProxyManager:
             try:
                 await self._connect_server(name, cfg)
             except Exception as exc:
-                # Redact the full exception text ONCE, then reuse it for both the
+                # Redact the exception text ONCE, then reuse it for both the
                 # operator log and the health record (#580). httpx transport
-                # exceptions embed the credentialed request URL
-                # (``https://user:token@host/mcp``), so an unredacted path would
-                # leak the token — via ``stm_proxy_health`` to the MCP
-                # client/model, or via the log. Do NOT use ``logger.exception``
-                # here: its traceback tail repeats the raw, unredacted exception
-                # string. Redact the FULL message, THEN cap: capping first (as
-                # format_error_message_from_exc does) can truncate a long
-                # credential mid-token so redact_exception_text no longer matches
-                # the configured URL, leaving a partial token exposed.
-                redacted = redact_exception_text(f"{type(exc).__name__}: {exc}", cfg.url)[
-                    :MAX_ERROR_MESSAGE_CHARS
-                ]
+                # exceptions embed the credentialed request URL, so an unredacted
+                # path would leak the token — via ``stm_proxy_health`` to the MCP
+                # client/model, or via the log. Do NOT use ``logger.exception``:
+                # its traceback tail repeats the raw, unredacted exception string.
+                redacted = self._redacted_error(exc, cfg.url)
                 logger.error("Failed to connect to upstream server '%s': %s", name, redacted)
                 # Record the failure so ``get_upstream_health`` can report the
                 # configured-but-dead server — otherwise it is absent from
@@ -869,6 +862,17 @@ class ProxyManager:
                     StdioServerParameters(command=cfg.command, args=cfg.args, env=cfg.env)
                 )
 
+    @staticmethod
+    def _redacted_error(exc: BaseException, url: str) -> str:
+        """Exception text with *url* userinfo scrubbed, capped for storage/logs
+        (#580). One choke point for every credential-safe rendering of a
+        connect/cleanup exception: httpx transport errors embed the credentialed
+        request URL, so any log or health field built from them must go through
+        here. Redacts the FULL message BEFORE the cap so a long credential can't
+        be truncated past ``redact_exception_text``'s reach.
+        """
+        return redact_exception_text(f"{type(exc).__name__}: {exc}", url)[:MAX_ERROR_MESSAGE_CHARS]
+
     async def _connect_server(self, name: str, cfg: UpstreamServerConfig) -> None:
         if self._stack is None:
             raise RuntimeError("ProxyManager.start() not called")
@@ -901,9 +905,14 @@ class ProxyManager:
             # visible to stop()/reconnect cleanup.
             try:
                 await conn_stack.aclose()
-            except Exception:
+            except Exception as cleanup_exc:
+                # Redact + no exc_info (#580): a network transport was opened
+                # with the credentialed ``cfg.url``, so a cleanup failure's
+                # traceback tail could otherwise leak the token even at DEBUG.
                 logger.debug(
-                    "Error during initial connection cleanup for '%s'", name, exc_info=True
+                    "Error during initial connection cleanup for '%s': %s",
+                    name,
+                    self._redacted_error(cleanup_exc, cfg.url),
                 )
             raise
 

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -478,9 +478,12 @@ class ProxyManager:
                 # included — so a credentialed upstream
                 # (``https://user:token@host/mcp``) would otherwise leak its
                 # token through ``stm_proxy_health`` to the MCP client/model.
-                self._failed_servers[name] = redact_exception_text(
-                    format_error_message_from_exc(exc), cfg.url
-                )
+                # Redact the FULL message, THEN cap: capping first (as
+                # format_error_message_from_exc does) can truncate a long
+                # credential mid-token so redact_exception_text no longer
+                # matches the configured URL, leaving a partial token exposed.
+                redacted = redact_exception_text(f"{type(exc).__name__}: {exc}", cfg.url)
+                self._failed_servers[name] = redacted[:MAX_ERROR_MESSAGE_CHARS]
 
         # #465: evaluate per-tool health once per session, before the first
         # advertisement. get_proxy_tools() applies this cached snapshot so

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -780,6 +780,11 @@ async def stm_proxy_health(
             f"  {name}: {status} "
             f"({info['tools']} tools discovered, {info['advertised_tools']} advertised)"
         )
+        # A startup-failed upstream (#580) carries the connect error so the
+        # DISCONNECTED status is actionable, not just visible.
+        error = info.get("error")
+        if error:
+            lines.append(f"      startup connect failed: {error}")
 
     surfacing = app.surfacing_engine
     if surfacing is not None:

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -94,6 +94,52 @@ class TestStart:
             await mgr.start()
 
         assert "Failed to connect to upstream server 'bad'" in caplog.text
+        # #580: the failed server is recorded so it stays visible in health,
+        # instead of vanishing (no _connections entry is created on failure).
+        assert "bad" in mgr._failed_servers
+        assert "unreachable" in mgr._failed_servers["bad"]
+
+    async def test_startup_failed_server_appears_in_health(self):
+        """#580: a configured-but-unconnected server surfaces in
+        get_upstream_health with connected=False and its connect error,
+        making the DISCONNECTED rendering reachable."""
+        mgr = _make_manager(
+            servers={
+                "ok": UpstreamServerConfig(prefix="ok"),
+                "bad": UpstreamServerConfig(prefix="bad"),
+            }
+        )
+
+        async def _conditional_connect(name, cfg):
+            if name == "bad":
+                raise ConnectionError("unreachable")
+            # The 'ok' server: register a live connection so it reports healthy.
+            mgr._connections[name] = UpstreamConnection(
+                name=name, config=cfg, session=AsyncMock(), tools=[]
+            )
+
+        with patch.object(mgr, "_connect_server", side_effect=_conditional_connect):
+            await mgr.start()
+
+        health = mgr.get_upstream_health()
+        assert health["bad"]["connected"] is False
+        assert "unreachable" in health["bad"]["error"]
+        assert health["ok"]["connected"] is True
+        assert "error" not in health["ok"]
+
+    async def test_health_prefers_live_connection_over_stale_failed_entry(self):
+        """If a name is somehow in both maps (a live connection and a stale
+        failed record), get_upstream_health reports it connected — the live
+        connection wins and no error line leaks (#580 guard)."""
+        mgr = _make_manager(servers={"srv": UpstreamServerConfig(prefix="srv")})
+        mgr._connections["srv"] = UpstreamConnection(
+            name="srv", config=UpstreamServerConfig(prefix="srv"), session=AsyncMock(), tools=[]
+        )
+        mgr._failed_servers["srv"] = "stale error"
+
+        health = mgr.get_upstream_health()
+        assert health["srv"]["connected"] is True
+        assert "error" not in health["srv"]
 
     async def test_double_start_closes_previous(self):
         """Calling start() twice closes the previous AsyncExitStack."""

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -199,6 +199,33 @@ class TestStart:
             assert "t" * 100 not in blob
             assert "***@ltm.example.com" in blob
 
+    async def test_startup_failure_log_line_redacts_credential(self, caplog):
+        """#580: the operator LOG for a failed credentialed connect must also be
+        scrubbed. The failure is logged as a redacted message, not via
+        logger.exception whose traceback tail repeats the raw exception string
+        (URL included)."""
+        url = "https://alice:s3cr3t-token@ltm.example.com/mcp"
+        mgr = _make_manager(
+            servers={
+                "web": UpstreamServerConfig(prefix="web", transport=TransportType.SSE, url=url),
+            }
+        )
+
+        async def _leaky_connect(name, cfg):
+            raise ConnectionError(f"All connection attempts failed for {url}")
+
+        with caplog.at_level("ERROR"):
+            with patch.object(mgr, "_connect_server", side_effect=_leaky_connect):
+                await mgr.start()
+
+        # caplog.text includes any exc_info traceback, so this also fails if the
+        # code regresses to logger.exception.
+        assert "s3cr3t-token" not in caplog.text
+        assert "alice:s3cr3t-token" not in caplog.text
+        # The failure is still logged, redacted.
+        assert "Failed to connect to upstream server 'web'" in caplog.text
+        assert "***@ltm.example.com" in caplog.text
+
     async def test_url_less_network_upstream_recorded_in_health(self):
         """#580: a non-stdio upstream configured without a url is skipped by
         _connect_server with a warning + early return (no exception), so it

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -458,6 +458,46 @@ class TestConnectServerCleanup:
         mock_session.__aexit__.assert_awaited_once()
         mock_transport.__aexit__.assert_awaited_once()
 
+    async def test_cleanup_failure_log_redacts_credential(self, caplog):
+        """#580: if the rollback aclose() ALSO raises for a credentialed network
+        upstream, the DEBUG cleanup log must not leak the token — the message is
+        redacted and no exc_info traceback (whose tail repeats the raw exception
+        string) is emitted."""
+        import pytest as _pt
+
+        url = "https://alice:s3cr3t-token@ltm.example.com/mcp"
+        cfg = UpstreamServerConfig(prefix="bad", transport=TransportType.SSE, url=url)
+        mgr = _make_manager(servers={"bad": cfg})
+
+        with patch.object(mgr, "_connect_server", new_callable=AsyncMock):
+            await mgr.start()
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(side_effect=RuntimeError("catalog failed"))
+
+        mock_transport = AsyncMock()
+        mock_transport.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+        # The rollback close itself raises an httpx-style error embedding the URL.
+        mock_transport.__aexit__ = AsyncMock(
+            side_effect=ConnectionError(f"cleanup failed for {url}")
+        )
+
+        with caplog.at_level("DEBUG"):
+            with (
+                patch.object(mgr, "_open_transport", return_value=mock_transport),
+                patch("memtomem_stm.proxy.manager.ClientSession", return_value=mock_session),
+            ):
+                with _pt.raises(RuntimeError, match="catalog failed"):
+                    await mgr._connect_server("bad", cfg)
+
+        assert "Error during initial connection cleanup for 'bad'" in caplog.text
+        assert "s3cr3t-token" not in caplog.text
+        assert "alice:s3cr3t-token" not in caplog.text
+        assert "***@ltm.example.com" in caplog.text
+
 
 class TestConcurrentReconnect:
     """#586 — two concurrent _reconnect_server calls for one server must

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -169,6 +169,36 @@ class TestStart:
             assert "alice:s3cr3t-token" not in blob
             assert "***@ltm.example.com" in blob
 
+    async def test_startup_failure_redacts_long_credential_past_cap(self):
+        """#580: redaction runs on the FULL message before the 500-char cap, so
+        a credential long enough that ``@host`` falls past the cap is still
+        scrubbed. Capping first (as format_error_message_from_exc does) would
+        truncate the token mid-string, leaving a partial that redact can no
+        longer match against the configured URL."""
+        from memtomem_stm.proxy.metrics import MAX_ERROR_MESSAGE_CHARS
+
+        token = "t" * (MAX_ERROR_MESSAGE_CHARS + 300)  # pushes @host past the cap
+        url = f"https://user:{token}@ltm.example.com/mcp"
+        mgr = _make_manager(
+            servers={
+                "web": UpstreamServerConfig(prefix="web", transport=TransportType.SSE, url=url),
+            }
+        )
+
+        async def _leaky_connect(name, cfg):
+            raise ConnectionError(f"All connection attempts failed for {url}")
+
+        with patch.object(mgr, "_connect_server", side_effect=_leaky_connect):
+            await mgr.start()
+
+        recorded = mgr._failed_servers["web"]
+        health_error = mgr.get_upstream_health()["web"]["error"]
+        for blob in (recorded, health_error):
+            # Not even a long partial run of the token may survive the cap.
+            assert token not in blob
+            assert "t" * 100 not in blob
+            assert "***@ltm.example.com" in blob
+
     async def test_url_less_network_upstream_recorded_in_health(self):
         """#580: a non-stdio upstream configured without a url is skipped by
         _connect_server with a warning + early return (no exception), so it

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 from memtomem_stm.proxy.config import (
     ProxyConfig,
+    TransportType,
     UpstreamServerConfig,
 )
 from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
@@ -141,6 +142,67 @@ class TestStart:
         assert health["srv"]["connected"] is True
         assert "error" not in health["srv"]
 
+    async def test_startup_failure_redacts_credentialed_url(self):
+        """#580: a startup connect error whose message embeds a credentialed
+        URL (as httpx exceptions do) must be scrubbed before it lands in
+        _failed_servers / stm_proxy_health — otherwise the token leaks to the
+        MCP client/model through the health tool."""
+        url = "https://alice:s3cr3t-token@ltm.example.com/mcp"
+        mgr = _make_manager(
+            servers={
+                "web": UpstreamServerConfig(prefix="web", transport=TransportType.SSE, url=url),
+            }
+        )
+
+        async def _leaky_connect(name, cfg):
+            # httpx-style message that embeds the full request URL, userinfo
+            # included.
+            raise ConnectionError(f"All connection attempts failed for {url}")
+
+        with patch.object(mgr, "_connect_server", side_effect=_leaky_connect):
+            await mgr.start()
+
+        recorded = mgr._failed_servers["web"]
+        health_error = mgr.get_upstream_health()["web"]["error"]
+        for blob in (recorded, health_error):
+            assert "s3cr3t-token" not in blob
+            assert "alice:s3cr3t-token" not in blob
+            assert "***@ltm.example.com" in blob
+
+    async def test_url_less_network_upstream_recorded_in_health(self):
+        """#580: a non-stdio upstream configured without a url is skipped by
+        _connect_server with a warning + early return (no exception), so it
+        must be recorded in _failed_servers itself — otherwise start()'s except
+        never fires and the misconfigured server stays false-green in health."""
+        mgr = _make_manager(
+            servers={
+                "web": UpstreamServerConfig(prefix="web", transport=TransportType.SSE, url=""),
+            }
+        )
+
+        await mgr.start()
+
+        assert "web" in mgr._failed_servers
+        assert "configuration error" in mgr._failed_servers["web"]
+        health = mgr.get_upstream_health()
+        assert health["web"]["connected"] is False
+        assert "configuration error" in health["web"]["error"]
+
+    async def test_double_start_clears_stale_failed_servers(self):
+        """#580: a manager reused across start() calls must not keep reporting
+        a previous session's failed upstream — the double-start reset clears
+        _failed_servers alongside _connections."""
+        mgr = _make_manager(servers={})
+        with patch.object(ProxyConfig, "load_from_file", return_value=None):
+            await mgr.start()
+        mgr._failed_servers["gone"] = "stale connect error"
+
+        with patch.object(ProxyConfig, "load_from_file", return_value=None):
+            await mgr.start()
+
+        assert mgr._failed_servers == {}
+        assert "gone" not in mgr.get_upstream_health()
+
     async def test_double_start_closes_previous(self):
         """Calling start() twice closes the previous AsyncExitStack."""
         mgr = _make_manager(servers={})
@@ -209,6 +271,16 @@ class TestStop:
         await mgr.stop()
 
         mock_ext.close.assert_awaited_once()
+
+    async def test_stop_clears_failed_servers(self):
+        """#580: stop() clears startup-failure records so a stopped manager
+        reports no upstreams — mirrors the double-start reset."""
+        mgr = _make_manager(servers={})
+        mgr._failed_servers["bad"] = "connect error"
+
+        await mgr.stop()
+
+        assert mgr._failed_servers == {}
 
     async def test_stop_nulls_extractor_so_restart_rebuilds(self):
         """stop() nulls _extractor (like _llm_compressor) — _get_extractor()

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -430,6 +430,23 @@ class TestHealth:
         result = await stm_proxy_health(ctx=ctx)
         assert "srv: connected (2 tools discovered, 0 advertised)" in result
 
+    async def test_startup_failed_server_rendered_disconnected(self):
+        """#580: a server that failed to connect at startup is rendered
+        DISCONNECTED with its connect error, instead of being absent."""
+        pm = _make_proxy_manager()
+        pm._connections["ok"] = UpstreamConnection(
+            name="ok",
+            config=UpstreamServerConfig(prefix="ok"),
+            session=AsyncMock(),
+            tools=[MagicMock()],
+        )
+        pm._failed_servers["bad"] = "ConnectionError: host unreachable"
+        ctx = _make_ctx(proxy_manager=pm)
+        result = await stm_proxy_health(ctx=ctx)
+        assert "ok: connected (1 tools discovered, 0 advertised)" in result
+        assert "bad: DISCONNECTED" in result
+        assert "startup connect failed: ConnectionError: host unreachable" in result
+
     @staticmethod
     def _proxy_enabled_config() -> STMConfig:
         cfg = STMConfig()


### PR DESCRIPTION
## Summary

Closes #580 (the health-visibility gap). Startup degrade for a failing upstream is already correct — `_connect_server` failure is caught and logged, other upstreams proceed — but the degradation was **invisible from inside the session**: `self._connections` entries are created only on a successful connect, and `get_upstream_health` iterates `self._connections` only, so a startup-failed server did not appear in `stm_proxy_health` at all. An operator checking health saw only the healthy servers and no anomaly; the one `logger.exception` at startup was the sole trace. (The `DISCONNECTED` branch rendered at `server.py` was effectively dead code, since an entry that exists always has a live session.)

## Change

- **`manager.py`** — a new `self._failed_servers: dict[str, str]` (name → connect-error summary) is recorded in the startup connect `except`. `get_upstream_health` now merges these in with `connected: False`, `tools: 0`, and an `error` field — so the failed server is reported instead of vanishing. A successful `_connect_server` pops the name (so a later reconnect clears the record), and the merge skips any name already present as a live connection (a live connection wins over a stale failed entry).
- **`server.py`** — `stm_proxy_health` renders the failed server as `DISCONNECTED` (the existing branch, now reachable) and adds a `startup connect failed: <error>` line so the status is actionable, not just visible.

## Scope

**Part 1 (health visibility) only.** The retry/re-registration half of #580 is deliberately left open: there is no plumbing today to re-register an upstream's tools with FastMCP after startup (registration is one-shot in `app_lifespan`, and the #557 `list_changed` refresh only re-lists an *already-connected* server's tools). Adding a background re-connect + downstream `tools/list_changed` is a separate, design-heavier change. I'll comment this scoping on the issue and leave it open.

## Behavior change

`stm_proxy_health` now lists configured-but-unconnected upstreams as `DISCONNECTED` with their startup connect error, where previously they were absent from the output entirely. No change for healthy servers.

## Tests

- `tests/test_proxy_manager_lifecycle.py` — `test_start_server_failure_logged` now also asserts the failed server is recorded; new `test_startup_failed_server_appears_in_health` (failed server reports `connected: False` + error, healthy server unaffected) and `test_health_prefers_live_connection_over_stale_failed_entry` (the live-wins guard).
- `tests/test_server_tools.py::TestHealth::test_startup_failed_server_rendered_disconnected` — the rendered output shows `DISCONNECTED` + the `startup connect failed:` line.

Full suite: 4088 passed, 3 skipped. `ruff check` + `format` clean.

## Series

Part of the 2026-07-03 ops-stability audit. #575–#579 merged (#587–#590), #578 in flight (#592); this is #580 part 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
