### PR TITLE
fix(daemon): log the traceback on a detached startup crash (#581)

### DIFF
--- a/src/memtomem_stm/daemon/server.py
+++ b/src/memtomem_stm/daemon/server.py
@@ -453,6 +453,30 @@ class DaemonServer:
 
 
 def run(config: STMConfig | None = None) -> int:
-    """Synchronous entry point used by ``mms daemon run``."""
+    """Synchronous entry point used by ``mms daemon run``.
+
+    Exception barrier (mirrors the MCP server's #209 barrier): a detached
+    daemon runs with ``stderr=DEVNULL``, so an uncaught crash during startup
+    — e.g. ``_build_engine`` (SurfacingEngine ctor) or ``asyncio.start_server``
+    raising inside ``serve()`` — would otherwise leave *no* trace: the
+    traceback goes to the devnulled stderr, never through the file logger, so
+    ``stm-daemon.log`` (which ``mms daemon start`` points the operator at)
+    stays empty. ``_configure_logging`` has already installed the file handler
+    by the time ``run()`` is called (``daemon_cmd.run_cmd``), so logging here
+    lands in that file. Re-raise after logging so the exit code still reflects
+    the failure — this only adds observability.
+    """
     cfg = config if config is not None else STMConfig()
-    return asyncio.run(DaemonServer(cfg).serve())
+    try:
+        return asyncio.run(DaemonServer(cfg).serve())
+    except (RuntimeError, ExceptionGroup) as e:
+        # A clean anyio cancel-scope teardown on shutdown is not a crash — the
+        # main server's barrier ignores the same shape (#410 follow-up).
+        if is_clean_cancel_scope_shutdown(e):
+            logger.warning("daemon shut down with an AnyIO cancel scope warning (ignored): %s", e)
+            return 0
+        logger.exception("daemon terminated with an unhandled exception")
+        raise
+    except Exception:
+        logger.exception("daemon terminated with an unhandled exception")
+        raise

--- a/tests/daemon/test_server.py
+++ b/tests/daemon/test_server.py
@@ -759,3 +759,46 @@ async def test_lifetime_lock_retry_acquires_after_incumbent_releases(
         await _await_handshake(cfg)  # proves it acquired → built → published
     finally:
         await _stop(cfg, task)
+
+
+# ── run() top-level exception barrier (#581) ─────────────────────────────
+
+
+def test_run_logs_traceback_on_startup_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A crash inside serve() (e.g. _build_engine / start_server) must reach the
+    logger — for a detached daemon its stderr is DEVNULL, so without the barrier
+    the traceback would be lost and stm-daemon.log (the log the start hint points
+    at) would stay empty."""
+    cfg = _config(tmp_path)
+
+    async def _boom(self):
+        raise ValueError("engine build blew up")
+
+    monkeypatch.setattr(DaemonServer, "serve", _boom)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match="engine build blew up"):
+            daemon_server.run(cfg)
+
+    assert "daemon terminated with an unhandled exception" in caplog.text
+    # The original traceback is attached (exc_info), not just the message.
+    assert any(r.exc_info for r in caplog.records if r.levelno >= logging.ERROR)
+
+
+def test_run_ignores_clean_cancel_scope_shutdown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clean anyio cancel-scope teardown is not a crash: the barrier swallows
+    it, returns 0, and does not re-raise."""
+    cfg = _config(tmp_path)
+
+    async def _clean_teardown(self):
+        raise RuntimeError("Attempted to exit cancel scope in a different task")
+
+    monkeypatch.setattr(DaemonServer, "serve", _clean_teardown)
+    monkeypatch.setattr(daemon_server, "is_clean_cancel_scope_shutdown", lambda _e: True)
+
+    rc = daemon_server.run(cfg)
+    assert rc == 0


### PR DESCRIPTION
## Summary

Closes #581. A detached daemon crash during startup left **no diagnosable trace anywhere**:

- The detached child runs with `stderr=DEVNULL` (`spawn.py`).
- `serve()`'s `try/except` guards only `open_lock_fd`; an exception in `_build_engine()` (e.g. the `SurfacingEngine` ctor) or `asyncio.start_server` propagates uncaught through `asyncio.run` → `run()` → an interpreter traceback on the devnulled stderr. It never passes through a logger, so `stm-daemon.log` stays empty.
- `mms daemon start` then tells the user *"daemon did not become ready in time — check the daemon log under data_dir (stm-daemon.log)"* — pointing at a log with none of the actual cause. The `_START_MAX_SPAWNS = 3` comment explicitly anticipates a "crash-looping config", yet that config's crash reason was undebuggable.

## Change

Wrap `run()`'s `asyncio.run(DaemonServer(cfg).serve())` in a top-level exception barrier that mirrors the MCP server's #209 barrier: a clean anyio cancel-scope teardown (`is_clean_cancel_scope_shutdown`, already imported and used by the daemon's teardown path) is logged at WARNING and returns 0; any other exception is `logger.exception(...)`-ed and re-raised so the exit code still reflects the failure. `_configure_logging` has already installed the `stm-daemon.log` FileHandler by the time `run()` is called (`daemon_cmd.run_cmd` → `_configure_logging` → `run_daemon`), so the traceback lands in that file — the start-command hint becomes truthful.

Pure observability: no behavior change on a healthy start, and the process still exits non-zero on a real crash.

## Verification

Drove a real startup crash end-to-end (detached-logging setup via `_configure_logging(detached=True)`, `serve()` forced to raise): `run()` re-raised as expected and `stm-daemon.log` contained `ERROR ... daemon terminated with an unhandled exception` followed by the full traceback down to the raising line — previously empty.

## Tests

`tests/daemon/test_server.py`:
- `test_run_logs_traceback_on_startup_crash` — `serve()` patched to raise; `run()` re-raises and the ERROR log carries the message + `exc_info`.
- `test_run_ignores_clean_cancel_scope_shutdown` — a clean cancel-scope teardown is swallowed, returns 0, no re-raise.

Full suite: 4087 passed, 3 skipped. `ruff check` + `format` clean.

## Series

Part of the 2026-07-03 ops-stability audit. #575–#579 merged (#587–#590); #578 (#592) and #580 (#593) in flight; this is #581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
