### PR TITLE
fix(cli): write-lock the mms project mutators against lost updates (#582)

### DIFF
--- a/src/memtomem_stm/cli/mms_project.py
+++ b/src/memtomem_stm/cli/mms_project.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import click
 
+from memtomem_stm.cli._write_lock import with_write_lock
 from memtomem_stm.mms import state
 from memtomem_stm.mms.detect import Project, Source, detect_project
 
@@ -142,6 +143,7 @@ def _refresh_index(name: str, root: Path) -> None:
     "--name", "name_opt", default=None, help="Override project name (default: dir basename)."
 )
 @click.option("--force", is_flag=True, help="Overwrite an existing .mms/project.toml.")
+@with_write_lock
 def init_cmd(path: Path | None, name_opt: str | None, force: bool) -> None:
     """Create ``<path>/.mms/project.toml`` (default path = cwd) and add to index."""
     target_root = (path or Path.cwd()).expanduser().resolve()
@@ -247,21 +249,30 @@ def _emit_show(proj: Project, json_output: bool, *, cwd: Path) -> None:
 @click.option("--json", "json_output", is_flag=True, help="Machine-readable output.")
 def list_cmd(prune: bool, json_output: bool) -> None:
     """List known projects from the index. Mark current cwd's project with ``*``."""
-    idx = state.load_projects_index()
     cwd = Path.cwd().resolve()
 
+    # ``--prune`` does a read-modify-write of the shared ~/.mms/projects.toml,
+    # so it must hold the same cross-process write lock every other registry
+    # mutator uses (#582) — otherwise two concurrent prunes interleave and the
+    # loser's save drops the winner's kept entries. A plain ``list`` (no prune)
+    # is read-only and stays unlocked, mirroring the ``--plan`` skip convention.
     pruned: list[state.ProjectIndexEntry] = []
-    if prune:
-        kept: list[state.ProjectIndexEntry] = []
-        for entry in idx.projects:
-            if Path(entry.path).is_dir():
-                kept.append(entry)
-            else:
-                pruned.append(entry)
-        if pruned:
-            new_idx = state.ProjectsIndex(schema_version=idx.schema_version, projects=kept)
-            state.save_projects_index(new_idx)
-            idx = new_idx
+    try:
+        with state.write_lock(enabled=prune):
+            idx = state.load_projects_index()
+            if prune:
+                kept: list[state.ProjectIndexEntry] = []
+                for entry in idx.projects:
+                    if Path(entry.path).is_dir():
+                        kept.append(entry)
+                    else:
+                        pruned.append(entry)
+                if pruned:
+                    new_idx = state.ProjectsIndex(schema_version=idx.schema_version, projects=kept)
+                    state.save_projects_index(new_idx)
+                    idx = new_idx
+    except state.WriteLockTimeout as exc:
+        raise click.ClickException(str(exc)) from exc
 
     def _is_current(entry: state.ProjectIndexEntry) -> bool:
         return Path(entry.path).resolve() == cwd
@@ -304,6 +315,7 @@ def list_cmd(prune: bool, json_output: bool) -> None:
 @click.option(
     "--project", "project_name", default=None, help="Target project (default: detect from cwd)."
 )
+@with_write_lock
 def enable_cmd(mcps: tuple[str, ...], project_name: str | None) -> None:
     """Add MCP names to the project's enabled list (RFC §7.1)."""
     proj = _resolve_project_for_mutation(project_name)
@@ -355,6 +367,7 @@ def enable_cmd(mcps: tuple[str, ...], project_name: str | None) -> None:
 @click.option(
     "--project", "project_name", default=None, help="Target project (default: detect from cwd)."
 )
+@with_write_lock
 def disable_cmd(mcps: tuple[str, ...], project_name: str | None) -> None:
     """Remove MCP names from the project's enabled list.
 

--- a/tests/cli/test_mms_project.py
+++ b/tests/cli/test_mms_project.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -383,3 +384,56 @@ def test_enable_project_flag_missing_marker_complains(runner, sandbox):
     assert res.exit_code != 0
     assert "marker file is missing" in res.output
     assert "list --prune" in res.output
+
+
+# ---------------------------------------------------------------------------
+# write lock (#582) — the shared ~/.mms registry lock serializes the mutators
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="flock is POSIX-only; write_lock is documented as a no-op on Windows",
+)
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["init"], id="init"),
+        pytest.param(["enable", "filesystem"], id="enable"),
+        pytest.param(["disable", "filesystem"], id="disable"),
+        pytest.param(["list", "--prune"], id="list-prune"),
+    ],
+)
+def test_project_mutator_under_held_lock_exits_cleanly(runner, sandbox, monkeypatch, argv):
+    # Every project mutator must serialize on the shared ~/.mms registry write
+    # lock; a concurrent run that can't acquire it times out with a clean,
+    # attributed error instead of doing an unlocked read-modify-write of the
+    # shared projects.toml and dropping the other run's rows (lost update).
+    if argv[0] in {"enable", "disable"}:
+        runner.invoke(project_group, ["init"])
+        _seed_registry("filesystem")
+    monkeypatch.setattr(state, "WRITE_LOCK_TIMEOUT_SECONDS", 0.2)
+
+    with state.write_lock():  # hold the default registry lock like a sibling run
+        res = runner.invoke(project_group, argv)
+
+    assert res.exit_code == 1
+    # WriteLockTimeout is surfaced as a Click error, not a traceback.
+    assert "Error" in res.output
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="flock is POSIX-only; write_lock is documented as a no-op on Windows",
+)
+def test_list_without_prune_ignores_held_lock(runner, sandbox, monkeypatch):
+    # A plain list is read-only, so it must not queue behind (or fail on) the
+    # write lock — mirroring the --plan skip convention.
+    runner.invoke(project_group, ["init"])
+    monkeypatch.setattr(state, "WRITE_LOCK_TIMEOUT_SECONDS", 0.2)
+
+    with state.write_lock():
+        res = runner.invoke(project_group, ["list"])
+
+    assert res.exit_code == 0, res.output
+    assert "proj" in res.output


### PR DESCRIPTION
## Summary

Closes #582. Every registry-domain CLI mutator runs under the cross-process write lock — `mms import`, `mms host sync`, and all five `stm_proxy.json` mutators — **except** `mms project`, which did not import `_write_lock` at all. Its mutators (`init`, `enable`, `disable`, `list --prune`) each do an unlocked read-modify-write of the **shared** `~/.mms/projects.toml`:

```python
idx = state.load_projects_index()
idx = state.upsert_project_in_index(idx, name=name, path=str(root))
state.save_projects_index(idx)
```

Two concurrent runs (plausible with parallel agent sessions) interleave: both load the same base index, and the loser's `save_projects_index` silently drops the winner's row. No file corruption (writes are atomic), only a lost update — but a dropped row means that project stops resolving by name until re-registered.

## Change

- `init` / `enable` / `disable` get the existing `@with_write_lock` decorator (placed closest to `def`, below the option stack — same as `mms import` / `mms host sync`). They always write, so the lock is always on; they have no `--plan`/`is_plan` parameter, so the decorator's `is_plan` skip never fires.
- `list --prune` needs conditional locking (a plain `list` is read-only). The bare decorator can't express "lock only when `--prune`", so its load→prune→save span is wrapped inline in `with state.write_lock(enabled=prune)`, with `WriteLockTimeout` surfaced as a `ClickException` — the same shape the decorator produces. A plain `list` stays unlocked, mirroring the `--plan` skip convention.

All four use the default registry lock (`write_lock_path()`, `~/.mms`), the correct domain for `projects.toml` — no new lock path. `show` and `list` (no `--prune`) are read-only and stay unlocked.

## Behavior change

Concurrent `mms project init/enable/disable/list --prune` now serialize on the shared registry lock; a run that can't acquire it within the timeout fails with a clean attributed `Error:` (exit 1) instead of racing. No change to single-process usage, and read-only `show` / `list` are unaffected.

## Tests

`tests/cli/test_mms_project.py`:
- `test_project_mutator_under_held_lock_exits_cleanly` (parametrized over `init`, `enable`, `disable`, `list --prune`) — with the registry lock held by a sibling, each mutator times out with exit 1 and a clean `Error:` (POSIX-only; `write_lock` is a documented no-op on Windows).
- `test_list_without_prune_ignores_held_lock` — a plain `list` succeeds under a held lock (read-only path stays unlocked).

Full suite: 4090 passed, 3 skipped. `ruff check` + `format` clean.

## Series

Part of the 2026-07-03 ops-stability audit. #575–#579 merged (#587–#590); #578 (#592), #580 (#593), #581 (#594) in flight; this is #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
