### PR TITLE
fix(proxy): reach the SQLite pending store after a restart (#583)

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -990,6 +990,18 @@ class SelectiveCompressor:
 
         return "\n\n".join(selected_parts)
 
+    def close(self) -> None:
+        """Release the underlying pending store's OS resources.
+
+        The SQLite backend holds a connection; the in-memory backend has
+        nothing to release. Called by ``ProxyManager`` on stop and before it
+        rebuilds a compressor for a changed config (#583), so a cached
+        SQLite-backed compressor does not leak its connection.
+        """
+        close = getattr(self._store, "close", None)
+        if callable(close):
+            close()
+
     def _detect_and_parse(self, text: str) -> tuple[str, dict[str, str]]:
         try:
             data = _mm_json_loads(text)

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1132,6 +1132,24 @@ class ProxyManager:
             await self._stack.aclose()
             self._stack = None
         self._connections.clear()
+        # Close the lazily-built selective/progressive stores (#583): a restart
+        # recovery or a SELECTIVE/HYBRID/progressive call may have opened a
+        # SQLite-backed store that ``_connections`` cleanup never touches, so
+        # without this the connection leaks across stop()/reuse.
+        if self._selective_compressor is not None:
+            try:
+                self._selective_compressor.close()
+            except Exception:
+                logger.debug("Failed to close selective compressor on stop", exc_info=True)
+            self._selective_compressor = None
+            self._selective_compressor_cfg = None
+        if self._progressive_store is not None:
+            try:
+                self._progressive_store.close()
+            except Exception:
+                logger.debug("Failed to close progressive store on stop", exc_info=True)
+            self._progressive_store = None
+            self._progressive_store_cfg = None
 
     @property
     def _config(self) -> ProxyConfig:
@@ -1314,31 +1332,18 @@ class ProxyManager:
             timeout=sc.embedding_timeout,
         )
 
-    def _fallback_selective_cfg(self) -> SelectiveConfig | None:
-        """Resolve a SelectiveConfig to reach a persisted pending store when no
-        compressor/store has been lazily built yet (#583).
+    def _distinct_sqlite_selective_cfgs(self) -> list[SelectiveConfig]:
+        """All configured SQLite ``SelectiveConfig`` s, deduped by resolved
+        path, in deterministic order (#583).
 
         ``SelectiveConfig`` is nested per-server (``UpstreamServerConfig.selective``)
         and per-tool (``ToolOverrideConfig.selective``); there is no global one.
-        After a restart, ``stm_proxy_select_chunks`` / ``stm_proxy_read_more`` can
-        receive a key whose row still lives in a configured SQLite pending store,
-        but the compressor/progressive store that would read it is built lazily
-        (only inside a compress call), so the retrieval endpoint defaults to a
-        fresh in-memory store and reports "not found" while the row persists on
-        disk. This scans the configured servers (sorted for determinism) —
-        server-level ``selective`` first, then that server's tool overrides — and
-        returns the first that opts into the SQLite backend, so the endpoint can
-        build the configured store on first use. Returns ``None`` when nothing
-        configures SQLite (the in-memory default has nothing to recover).
-
-        Common case is a single shared SQLite path (the default
-        ``~/.memtomem/pending_selections.db``). If distinct paths are configured
-        across tools, this returns the first and warns; a key that lives in a
-        different path stays unreachable until that tool's next compression
-        rebuilds its compressor — probing every configured path on a miss is a
-        possible follow-up.
+        Scans servers (sorted), server-level ``selective`` first then each
+        server's tool overrides (sorted), keeping the first config seen for each
+        distinct on-disk path. The in-memory default contributes nothing — it
+        has no persisted rows to recover.
         """
-        chosen: SelectiveConfig | None = None
+        out: list[SelectiveConfig] = []
         seen_paths: set[str] = set()
         for _srv_name, srv_cfg in sorted(self._config.upstream_servers.items()):
             candidates: list[SelectiveConfig | None] = [srv_cfg.selective]
@@ -1347,18 +1352,74 @@ class ProxyManager:
             )
             for sel in candidates:
                 if sel is not None and sel.pending_store == "sqlite":
-                    seen_paths.add(str(sel.pending_store_path.expanduser()))
-                    if chosen is None:
-                        chosen = sel
-        if len(seen_paths) > 1:
-            logger.warning(
-                "Multiple distinct SQLite pending_store paths configured (%s); "
-                "restart-recovery for pending selections uses %s — keys written to "
-                "the others stay unreachable until their tool's next compression",
-                sorted(seen_paths),
-                chosen.pending_store_path.expanduser() if chosen else None,
-            )
-        return chosen
+                    path = str(sel.pending_store_path.expanduser())
+                    if path not in seen_paths:
+                        seen_paths.add(path)
+                        out.append(sel)
+        return out
+
+    def _recover_cfg_for_key(self, key: str) -> SelectiveConfig | None:
+        """Resolve the configured SelectiveConfig whose SQLite store actually
+        holds *key*, for restart recovery when no compressor/store has been
+        lazily built yet (#583).
+
+        After a restart, ``stm_proxy_select_chunks`` / ``stm_proxy_read_more``
+        can receive a key whose row still lives in a configured SQLite pending
+        store, but the compressor/progressive store that would read it is built
+        lazily (only inside a compress call), so the retrieval endpoint defaults
+        to a fresh in-memory store and reports "not found" while the row
+        persists on disk.
+
+        ``pending_store_path`` is configurable per server and per tool, so
+        several distinct stores may exist. Probe each distinct store read-only
+        (a cheap ``get`` that opens then closes its own connection) and return
+        the config whose store holds the key, so a key in *any* configured path
+        is reachable — not just the first. When no store holds it, fall back to
+        the first configured store so a genuinely-absent key still degrades
+        through the normal not-found path; this also keeps the common
+        single-store case a straight passthrough with no extra open. Returns
+        ``None`` when nothing configures SQLite.
+        """
+        cfgs = self._distinct_sqlite_selective_cfgs()
+        if len(cfgs) <= 1:
+            return cfgs[0] if cfgs else None
+
+        from memtomem_stm.proxy.pending_store import SQLitePendingStore
+
+        for sel_cfg in cfgs:
+            try:
+                probe = SQLitePendingStore(sel_cfg.pending_store_path.expanduser())
+                probe.initialize()
+            except Exception:
+                logger.warning(
+                    "Could not open configured SQLite pending store %s while probing "
+                    "for a persisted key",
+                    sel_cfg.pending_store_path,
+                    exc_info=True,
+                )
+                continue
+            try:
+                if probe.get(key) is not None:
+                    return sel_cfg
+            finally:
+                probe.close()
+        return cfgs[0]
+
+    def _rebuild_selective_compressor(self, sel_cfg: SelectiveConfig | None) -> SelectiveCompressor:
+        """Replace the cached selective compressor, closing the superseded one
+        first so a SQLite-backed store from a changed config does not leak its
+        connection (#583). Returns the new compressor. Only called when the cfg
+        changed or nothing is cached; the recovery path in ``select_chunks``
+        builds inline because it needs its own degrade-on-open-failure handling.
+        """
+        if self._selective_compressor is not None:
+            try:
+                self._selective_compressor.close()
+            except Exception:
+                logger.debug("Failed to close superseded selective compressor", exc_info=True)
+        self._selective_compressor = self._create_selective(sel_cfg)
+        self._selective_compressor_cfg = sel_cfg
+        return self._selective_compressor
 
     def _create_selective(self, sel_cfg: SelectiveConfig | None) -> SelectiveCompressor:
         """Create a SelectiveCompressor with the appropriate PendingStore backend."""
@@ -1534,12 +1595,11 @@ class ProxyManager:
                 name="selective_lock",
             ):
                 if self._selective_compressor is None or self._selective_compressor_cfg != sel_cfg:
-                    self._selective_compressor = self._create_selective(sel_cfg)
-                    self._selective_compressor_cfg = sel_cfg
+                    sel_compressor = self._rebuild_selective_compressor(sel_cfg)
+                else:
+                    sel_compressor = self._selective_compressor
             return (
-                self._selective_compressor.compress(
-                    text, max_chars=max_chars, context_query=context_query
-                ),
+                sel_compressor.compress(text, max_chars=max_chars, context_query=context_query),
                 None,
             )
 
@@ -1754,8 +1814,7 @@ class ProxyManager:
             name="selective_lock",
         ):
             if self._selective_compressor is None or self._selective_compressor_cfg != sel_cfg:
-                self._selective_compressor = self._create_selective(sel_cfg)
-                self._selective_compressor_cfg = sel_cfg
+                self._rebuild_selective_compressor(sel_cfg)
 
         compressor = HybridCompressor(
             head_chars=cfg.head_chars,
@@ -1845,7 +1904,7 @@ class ProxyManager:
             # bad state). No await runs between the check and the assignment, and
             # neither do the lock-holding compress paths, so this can't interleave
             # with them on the event loop — no _selective_lock needed here.
-            sel_cfg = self._fallback_selective_cfg()
+            sel_cfg = self._recover_cfg_for_key(key)
             if sel_cfg is None:
                 return "Selective compression not active — no pending TOC selections."
             try:
@@ -1877,6 +1936,13 @@ class ProxyManager:
                 from memtomem_stm.proxy.pending_store import InMemoryPendingStore
 
                 store = InMemoryPendingStore()
+            # Close the superseded adapter first so a SQLite-backed store from a
+            # changed config does not leak its connection (#583).
+            if self._progressive_store is not None:
+                try:
+                    self._progressive_store.close()
+                except Exception:
+                    logger.debug("Failed to close superseded progressive store", exc_info=True)
             self._progressive_store = ProgressiveStoreAdapter(store)
             self._progressive_store_cfg = sel_cfg
         return self._progressive_store
@@ -1956,7 +2022,7 @@ class ProxyManager:
         # sentinel; _get_progressive_store caches only after initialize()
         # succeeds, so nothing bad is pinned and the next call retries.
         if self._progressive_store is None:
-            fallback = self._fallback_selective_cfg()
+            fallback = self._recover_cfg_for_key(key)
             if fallback is not None:
                 try:
                     store = self._get_progressive_store(fallback)

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1358,31 +1358,25 @@ class ProxyManager:
                         out.append(sel)
         return out
 
-    def _recover_cfg_for_key(self, key: str) -> SelectiveConfig | None:
-        """Resolve the configured SelectiveConfig whose SQLite store actually
-        holds *key*, for restart recovery when no compressor/store has been
-        lazily built yet (#583).
-
-        After a restart, ``stm_proxy_select_chunks`` / ``stm_proxy_read_more``
-        can receive a key whose row still lives in a configured SQLite pending
-        store, but the compressor/progressive store that would read it is built
-        lazily (only inside a compress call), so the retrieval endpoint defaults
-        to a fresh in-memory store and reports "not found" while the row
-        persists on disk.
+    def _sqlite_cfg_holding_key(self, key: str) -> SelectiveConfig | None:
+        """The distinct configured SQLite ``SelectiveConfig`` whose store
+        currently holds *key*, or ``None`` if none does (#583).
 
         ``pending_store_path`` is configurable per server and per tool, so
-        several distinct stores may exist. Probe each distinct store read-only
-        (a cheap ``get`` that opens then closes its own connection) and return
-        the config whose store holds the key, so a key in *any* configured path
-        is reachable — not just the first. When no store holds it, fall back to
-        the first configured store so a genuinely-absent key still degrades
-        through the normal not-found path; this also keeps the common
-        single-store case a straight passthrough with no extra open. Returns
-        ``None`` when nothing configures SQLite.
+        several distinct stores may exist. After a restart the retrieval
+        endpoints (``stm_proxy_select_chunks`` / ``stm_proxy_read_more``) can
+        receive a key whose row still lives in one of them while the lazily
+        built compressor/store points at a different one. Probe each distinct
+        store read-only (a cheap ``get`` that opens then closes its own
+        connection) and return the config whose store holds the key.
+
+        Single-store / no-store configs return ``None`` **without probing** —
+        callers fall back to the sole (or first) configured store, so the common
+        case pays no extra open and only genuinely multi-store configs probe.
         """
         cfgs = self._distinct_sqlite_selective_cfgs()
         if len(cfgs) <= 1:
-            return cfgs[0] if cfgs else None
+            return None
 
         from memtomem_stm.proxy.pending_store import SQLitePendingStore
 
@@ -1403,23 +1397,30 @@ class ProxyManager:
                     return sel_cfg
             finally:
                 probe.close()
-        return cfgs[0]
+        return None
 
     def _rebuild_selective_compressor(self, sel_cfg: SelectiveConfig | None) -> SelectiveCompressor:
         """Replace the cached selective compressor, closing the superseded one
-        first so a SQLite-backed store from a changed config does not leak its
+        so a SQLite-backed store from a changed config does not leak its
         connection (#583). Returns the new compressor. Only called when the cfg
         changed or nothing is cached; the recovery path in ``select_chunks``
         builds inline because it needs its own degrade-on-open-failure handling.
+
+        Build the replacement BEFORE closing the old one: if ``_create_selective``
+        fails to open the new SQLite store it raises here, leaving the still-open
+        old compressor cached and usable rather than a closed store behind the
+        cfg-equality fast path.
         """
-        if self._selective_compressor is not None:
+        new = self._create_selective(sel_cfg)
+        old = self._selective_compressor
+        self._selective_compressor = new
+        self._selective_compressor_cfg = sel_cfg
+        if old is not None:
             try:
-                self._selective_compressor.close()
+                old.close()
             except Exception:
                 logger.debug("Failed to close superseded selective compressor", exc_info=True)
-        self._selective_compressor = self._create_selective(sel_cfg)
-        self._selective_compressor_cfg = sel_cfg
-        return self._selective_compressor
+        return new
 
     def _create_selective(self, sel_cfg: SelectiveConfig | None) -> SelectiveCompressor:
         """Create a SelectiveCompressor with the appropriate PendingStore backend."""
@@ -1891,20 +1892,31 @@ class ProxyManager:
     # Backward-compatible delegate
     _format_fact_md = staticmethod(format_fact_md)
 
+    @staticmethod
+    def _is_recovery_miss(text: str) -> bool:
+        """Whether a select/read_more result is a store MISS (key absent) as
+        opposed to a hit or a section-mismatch. Both endpoints render the miss
+        with this stable suffix; used to decide whether to re-probe other
+        configured SQLite stores for the key (#583)."""
+        return "not found or expired" in text
+
     def select_chunks(self, key: str, sections: list[str]) -> str:
+        cfgs = self._distinct_sqlite_selective_cfgs()
         if self._selective_compressor is None:
             # Restart recovery (#583): no compress call has run yet this process,
             # so the compressor (and its store handle) hasn't been built — but a
             # configured SQLite pending store may hold a selection persisted
             # before the restart. Build the configured compressor on first use so
-            # the key becomes reachable; a later SELECTIVE/HYBRID compress with
-            # the same cfg reuses it via the cfg-equality check. If nothing
-            # configures SQLite, or the store can't be opened, degrade to the
-            # existing sentinel and cache NOTHING (a failed open must not pin a
-            # bad state). No await runs between the check and the assignment, and
-            # neither do the lock-holding compress paths, so this can't interleave
-            # with them on the event loop — no _selective_lock needed here.
-            sel_cfg = self._recover_cfg_for_key(key)
+            # the key becomes reachable — from the store that actually holds it
+            # (multi-store) or the first configured store otherwise. A later
+            # SELECTIVE/HYBRID compress with the same cfg reuses it via the
+            # cfg-equality check. If nothing configures SQLite, or the store
+            # can't be opened, degrade to the existing sentinel and cache NOTHING
+            # (a failed open must not pin a bad state). No await runs between the
+            # check and the assignment, and neither do the lock-holding compress
+            # paths, so this can't interleave with them on the event loop — no
+            # _selective_lock needed here.
+            sel_cfg = self._sqlite_cfg_holding_key(key) or (cfgs[0] if cfgs else None)
             if sel_cfg is None:
                 return "Selective compression not active — no pending TOC selections."
             try:
@@ -1917,7 +1929,46 @@ class ProxyManager:
                 return "Selective compression not active — no pending TOC selections."
             self._selective_compressor = compressor
             self._selective_compressor_cfg = sel_cfg
-        return self._selective_compressor.select(key, sections)
+        result = self._selective_compressor.select(key, sections)
+        if len(cfgs) > 1 and self._is_recovery_miss(result):
+            # The cached compressor's store did not hold the key, but with
+            # multiple distinct stores configured an earlier call may have
+            # cached a *different* store (#583). Probe the others; if one holds
+            # the key, serve it from a temporary compressor without disturbing
+            # the cache or this session's in-memory selections.
+            alt = self._sqlite_cfg_holding_key(key)
+            if alt is not None and alt != self._selective_compressor_cfg:
+                try:
+                    tmp = self._create_selective(alt)
+                except Exception:
+                    logger.warning(
+                        "Could not open alternate SQLite pending store for select_chunks recovery",
+                        exc_info=True,
+                    )
+                    return result
+                try:
+                    return tmp.select(key, sections)
+                finally:
+                    tmp.close()
+        return result
+
+    def _open_progressive_adapter(self, sel_cfg: SelectiveConfig | None) -> ProgressiveStoreAdapter:
+        """Build (do NOT cache) a ProgressiveStoreAdapter for *sel_cfg* —
+        SQLite-backed when configured, else in-memory. ``_get_progressive_store``
+        uses it for the cached adapter; ``read_more``'s multi-store recovery uses
+        it for a throwaway adapter it closes after the call (#583)."""
+        store: PendingStore
+        if sel_cfg is not None and sel_cfg.pending_store == "sqlite":
+            from memtomem_stm.proxy.pending_store import SQLitePendingStore
+
+            sqlite_store = SQLitePendingStore(sel_cfg.pending_store_path.expanduser())
+            sqlite_store.initialize()
+            store = sqlite_store
+        else:
+            from memtomem_stm.proxy.pending_store import InMemoryPendingStore
+
+            store = InMemoryPendingStore()
+        return ProgressiveStoreAdapter(store)
 
     def _get_progressive_store(
         self, sel_cfg: SelectiveConfig | None = None
@@ -1925,25 +1976,16 @@ class ProxyManager:
         if self._progressive_store is None or (
             sel_cfg is not None and sel_cfg != self._progressive_store_cfg
         ):
-            store: PendingStore
-            if sel_cfg is not None and sel_cfg.pending_store == "sqlite":
-                from memtomem_stm.proxy.pending_store import SQLitePendingStore
-
-                sqlite_store = SQLitePendingStore(sel_cfg.pending_store_path.expanduser())
-                sqlite_store.initialize()
-                store = sqlite_store
-            else:
-                from memtomem_stm.proxy.pending_store import InMemoryPendingStore
-
-                store = InMemoryPendingStore()
-            # Close the superseded adapter first so a SQLite-backed store from a
-            # changed config does not leak its connection (#583).
+            # Build the replacement BEFORE closing the old one (#583): if the new
+            # SQLite store fails to open this raises with the old adapter still
+            # cached and usable rather than a closed store behind the cfg check.
+            new = self._open_progressive_adapter(sel_cfg)
             if self._progressive_store is not None:
                 try:
                     self._progressive_store.close()
                 except Exception:
                     logger.debug("Failed to close superseded progressive store", exc_info=True)
-            self._progressive_store = ProgressiveStoreAdapter(store)
+            self._progressive_store = new
             self._progressive_store_cfg = sel_cfg
         return self._progressive_store
 
@@ -2021,8 +2063,10 @@ class ProxyManager:
         # keys written since startup. On a SQLite open failure, degrade to the
         # sentinel; _get_progressive_store caches only after initialize()
         # succeeds, so nothing bad is pinned and the next call retries.
+        cfgs = self._distinct_sqlite_selective_cfgs()
+        temp_store: ProgressiveStoreAdapter | None = None
         if self._progressive_store is None:
-            fallback = self._recover_cfg_for_key(key)
+            fallback = self._sqlite_cfg_holding_key(key) or (cfgs[0] if cfgs else None)
             if fallback is not None:
                 try:
                     store = self._get_progressive_store(fallback)
@@ -2037,47 +2081,74 @@ class ProxyManager:
         else:
             store = self._get_progressive_store()
         resp = store.get(key)
-        if resp is None:
-            return f"Progressive delivery key '{key}' not found or expired."
-        with traced(
-            "proxy_call_read_more",
-            metadata={
-                "server": resp.server,
-                "tool": resp.tool,
-                "trace_id": resp.trace_id,
-                "key": key,
-            },
-        ):
-            store.touch(key)
-            # Continue with the chunking the first chunk used (persisted on
-            # the ProgressiveResponse) — an explicit ``limit`` from the agent
-            # still wins. Hardcoding ``4000`` here made follow-ups diverge
-            # from a tuned ``progressive.chunk_size`` / hint preference.
-            chunk_size = limit or resp.chunk_size
-            chunker = ProgressiveChunker(
-                chunk_size=chunk_size, include_hint=resp.include_structure_hint
-            )
-            output = chunker.read_chunk(
-                resp.content, offset, limit, key=key, ttl_seconds=resp.ttl_seconds
-            )
-            # Skip telemetry when ``read_chunk`` short-circuits with the
-            # ``(no more content)`` sentinel (offset >= len(content)) —
-            # that response carries no footer and no payload, so logging
-            # it would inflate ``follow_up_rate`` with calls that served
-            # zero new bytes and push ``avg_chars_served`` above
-            # ``total_chars``.
-            if self._progressive_reads_tracker is not None and PROGRESSIVE_FOOTER_TOKEN in output:
-                chunk_chars = len(output.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
-                self._progressive_reads_tracker.record_follow_up(
-                    key=key,
-                    trace_id=resp.trace_id,
-                    server=resp.server,
-                    tool=resp.tool,
-                    offset=offset,
-                    chars=chunk_chars,
-                    total_chars=resp.total_chars,
+        if resp is None and len(cfgs) > 1:
+            # The cached store did not hold the key, but with multiple distinct
+            # stores configured an earlier call may have cached a *different*
+            # one (#583). Probe the others and, if one holds the key, serve it
+            # from a temporary adapter (closed below) without disturbing the
+            # cache or this session's in-memory progressive responses.
+            alt = self._sqlite_cfg_holding_key(key)
+            if alt is not None and alt != self._progressive_store_cfg:
+                try:
+                    temp_store = self._open_progressive_adapter(alt)
+                except Exception:
+                    logger.warning(
+                        "Could not open alternate SQLite pending store for read_more recovery",
+                        exc_info=True,
+                    )
+                    temp_store = None
+                if temp_store is not None:
+                    alt_resp = temp_store.get(key)
+                    if alt_resp is not None:
+                        store, resp = temp_store, alt_resp
+        try:
+            if resp is None:
+                return f"Progressive delivery key '{key}' not found or expired."
+            with traced(
+                "proxy_call_read_more",
+                metadata={
+                    "server": resp.server,
+                    "tool": resp.tool,
+                    "trace_id": resp.trace_id,
+                    "key": key,
+                },
+            ):
+                store.touch(key)
+                # Continue with the chunking the first chunk used (persisted on
+                # the ProgressiveResponse) — an explicit ``limit`` from the agent
+                # still wins. Hardcoding ``4000`` here made follow-ups diverge
+                # from a tuned ``progressive.chunk_size`` / hint preference.
+                chunk_size = limit or resp.chunk_size
+                chunker = ProgressiveChunker(
+                    chunk_size=chunk_size, include_hint=resp.include_structure_hint
                 )
-            return output
+                output = chunker.read_chunk(
+                    resp.content, offset, limit, key=key, ttl_seconds=resp.ttl_seconds
+                )
+                # Skip telemetry when ``read_chunk`` short-circuits with the
+                # ``(no more content)`` sentinel (offset >= len(content)) —
+                # that response carries no footer and no payload, so logging
+                # it would inflate ``follow_up_rate`` with calls that served
+                # zero new bytes and push ``avg_chars_served`` above
+                # ``total_chars``.
+                if (
+                    self._progressive_reads_tracker is not None
+                    and PROGRESSIVE_FOOTER_TOKEN in output
+                ):
+                    chunk_chars = len(output.split(PROGRESSIVE_FOOTER_TOKEN, 1)[0])
+                    self._progressive_reads_tracker.record_follow_up(
+                        key=key,
+                        trace_id=resp.trace_id,
+                        server=resp.server,
+                        tool=resp.tool,
+                        offset=offset,
+                        chars=chunk_chars,
+                        total_chars=resp.total_chars,
+                    )
+                return output
+        finally:
+            if temp_store is not None:
+                temp_store.close()
 
     def get_upstream_health(self) -> dict[str, dict]:
         """Return per-server health: connection status, tool counts.

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1314,6 +1314,52 @@ class ProxyManager:
             timeout=sc.embedding_timeout,
         )
 
+    def _fallback_selective_cfg(self) -> SelectiveConfig | None:
+        """Resolve a SelectiveConfig to reach a persisted pending store when no
+        compressor/store has been lazily built yet (#583).
+
+        ``SelectiveConfig`` is nested per-server (``UpstreamServerConfig.selective``)
+        and per-tool (``ToolOverrideConfig.selective``); there is no global one.
+        After a restart, ``stm_proxy_select_chunks`` / ``stm_proxy_read_more`` can
+        receive a key whose row still lives in a configured SQLite pending store,
+        but the compressor/progressive store that would read it is built lazily
+        (only inside a compress call), so the retrieval endpoint defaults to a
+        fresh in-memory store and reports "not found" while the row persists on
+        disk. This scans the configured servers (sorted for determinism) —
+        server-level ``selective`` first, then that server's tool overrides — and
+        returns the first that opts into the SQLite backend, so the endpoint can
+        build the configured store on first use. Returns ``None`` when nothing
+        configures SQLite (the in-memory default has nothing to recover).
+
+        Common case is a single shared SQLite path (the default
+        ``~/.memtomem/pending_selections.db``). If distinct paths are configured
+        across tools, this returns the first and warns; a key that lives in a
+        different path stays unreachable until that tool's next compression
+        rebuilds its compressor — probing every configured path on a miss is a
+        possible follow-up.
+        """
+        chosen: SelectiveConfig | None = None
+        seen_paths: set[str] = set()
+        for _srv_name, srv_cfg in sorted(self._config.upstream_servers.items()):
+            candidates: list[SelectiveConfig | None] = [srv_cfg.selective]
+            candidates.extend(
+                srv_cfg.tool_overrides[t].selective for t in sorted(srv_cfg.tool_overrides)
+            )
+            for sel in candidates:
+                if sel is not None and sel.pending_store == "sqlite":
+                    seen_paths.add(str(sel.pending_store_path.expanduser()))
+                    if chosen is None:
+                        chosen = sel
+        if len(seen_paths) > 1:
+            logger.warning(
+                "Multiple distinct SQLite pending_store paths configured (%s); "
+                "restart-recovery for pending selections uses %s — keys written to "
+                "the others stay unreachable until their tool's next compression",
+                sorted(seen_paths),
+                chosen.pending_store_path.expanduser() if chosen else None,
+            )
+        return chosen
+
     def _create_selective(self, sel_cfg: SelectiveConfig | None) -> SelectiveCompressor:
         """Create a SelectiveCompressor with the appropriate PendingStore backend."""
         kwargs: dict[str, Any] = {}
@@ -1788,7 +1834,30 @@ class ProxyManager:
 
     def select_chunks(self, key: str, sections: list[str]) -> str:
         if self._selective_compressor is None:
-            return "Selective compression not active — no pending TOC selections."
+            # Restart recovery (#583): no compress call has run yet this process,
+            # so the compressor (and its store handle) hasn't been built — but a
+            # configured SQLite pending store may hold a selection persisted
+            # before the restart. Build the configured compressor on first use so
+            # the key becomes reachable; a later SELECTIVE/HYBRID compress with
+            # the same cfg reuses it via the cfg-equality check. If nothing
+            # configures SQLite, or the store can't be opened, degrade to the
+            # existing sentinel and cache NOTHING (a failed open must not pin a
+            # bad state). No await runs between the check and the assignment, and
+            # neither do the lock-holding compress paths, so this can't interleave
+            # with them on the event loop — no _selective_lock needed here.
+            sel_cfg = self._fallback_selective_cfg()
+            if sel_cfg is None:
+                return "Selective compression not active — no pending TOC selections."
+            try:
+                compressor = self._create_selective(sel_cfg)
+            except Exception:
+                logger.warning(
+                    "Could not open the configured SQLite pending store for select_chunks recovery",
+                    exc_info=True,
+                )
+                return "Selective compression not active — no pending TOC selections."
+            self._selective_compressor = compressor
+            self._selective_compressor_cfg = sel_cfg
         return self._selective_compressor.select(key, sections)
 
     def _get_progressive_store(
@@ -1877,7 +1946,30 @@ class ProxyManager:
         upstream call and otherwise loses its link to the originating
         trace_id.
         """
-        store = self._get_progressive_store()
+        # Restart recovery (#583): if no progressive store has been built yet
+        # this process, a configured SQLite backend may hold the key from before
+        # the restart — but a bare _get_progressive_store() defaults to a fresh
+        # in-memory store and reports "not found". Pass the fallback cfg ONLY
+        # when nothing is cached: passing it once a store exists would trip the
+        # cfg-mismatch rebuild and discard a live in-memory store still holding
+        # keys written since startup. On a SQLite open failure, degrade to the
+        # sentinel; _get_progressive_store caches only after initialize()
+        # succeeds, so nothing bad is pinned and the next call retries.
+        if self._progressive_store is None:
+            fallback = self._fallback_selective_cfg()
+            if fallback is not None:
+                try:
+                    store = self._get_progressive_store(fallback)
+                except Exception:
+                    logger.warning(
+                        "Could not open the configured SQLite pending store for read_more recovery",
+                        exc_info=True,
+                    )
+                    return f"Progressive delivery key '{key}' not found or expired."
+            else:
+                store = self._get_progressive_store()
+        else:
+            store = self._get_progressive_store()
         resp = store.get(key)
         if resp is None:
             return f"Progressive delivery key '{key}' not found or expired."

--- a/src/memtomem_stm/proxy/progressive.py
+++ b/src/memtomem_stm/proxy/progressive.py
@@ -127,6 +127,17 @@ class ProgressiveStoreAdapter:
         self._store.evict_expired(ttl)
         self._store.evict_oldest(max_size)
 
+    def close(self) -> None:
+        """Release the underlying store's OS resources (SQLite connection).
+
+        The in-memory backend has nothing to release. ``ProxyManager`` calls
+        this on stop and before rebuilding the adapter for a changed config
+        (#583) so a cached SQLite-backed adapter does not leak its connection.
+        """
+        close = getattr(self._store, "close", None)
+        if callable(close):
+            close()
+
 
 class ProgressiveChunker:
     """Splits content into cursor-based chunks with metadata footers."""

--- a/tests/test_pending_store.py
+++ b/tests/test_pending_store.py
@@ -315,3 +315,164 @@ class TestSelectiveCompressorWithStore:
         result = comp.compress(text, max_chars=50)
         assert "selection_key" in result
         store.close()
+
+
+# ── Restart reachability of the SQLite pending store (#583) ───────────────
+
+
+def _sqlite_manager(tmp_path, *, override: bool = False):
+    """A ProxyManager configured with a SQLite selective pending store, either
+    at the server level or (``override=True``) only in a per-tool override."""
+    from memtomem_stm.proxy.config import (
+        ProxyConfig,
+        SelectiveConfig,
+        ToolOverrideConfig,
+        UpstreamServerConfig,
+    )
+    from memtomem_stm.proxy.manager import ProxyManager
+    from memtomem_stm.proxy.metrics import TokenTracker
+
+    sel = SelectiveConfig(pending_store="sqlite", pending_store_path=tmp_path / "pending.db")
+    if override:
+        srv = UpstreamServerConfig(
+            prefix="t", tool_overrides={"some_tool": ToolOverrideConfig(selective=sel)}
+        )
+    else:
+        srv = UpstreamServerConfig(prefix="t", selective=sel)
+    cfg = ProxyConfig(config_path=tmp_path / "proxy.json", upstream_servers={"srv": srv})
+    return ProxyManager(cfg, TokenTracker()), sel
+
+
+class TestSelectChunksRestartRecovery:
+    def test_finds_key_persisted_before_restart(self, tmp_path):
+        """A selection written by a prior process is reachable via select_chunks
+        on a fresh manager, before any compress call rebuilds the compressor."""
+        # Pre-restart: seed a selection directly into the SQLite store.
+        store = SQLitePendingStore(tmp_path / "pending.db")
+        store.initialize()
+        store.put("k1", _make_selection({"A": "recovered content"}))
+        store.close()
+
+        # Post-restart: a brand-new manager, no compress call has run.
+        mgr, sel = _sqlite_manager(tmp_path)
+        assert mgr._selective_compressor is None
+        result = mgr.select_chunks("k1", ["A"])
+        assert result == "recovered content"
+        assert mgr._selective_compressor_cfg == sel
+
+    def test_override_only_sqlite_is_found(self, tmp_path):
+        """The fallback scan reaches a SQLite store configured only in a per-tool
+        override (server-level compression is memory/unset)."""
+        store = SQLitePendingStore(tmp_path / "pending.db")
+        store.initialize()
+        store.put("k1", _make_selection({"A": "from override"}))
+        store.close()
+
+        mgr, _sel = _sqlite_manager(tmp_path, override=True)
+        assert mgr.select_chunks("k1", ["A"]) == "from override"
+
+    def test_no_sqlite_configured_returns_sentinel(self, tmp_path):
+        """With no SQLite backend anywhere, the endpoint keeps the sentinel."""
+        from memtomem_stm.proxy.config import ProxyConfig, UpstreamServerConfig
+        from memtomem_stm.proxy.manager import ProxyManager
+        from memtomem_stm.proxy.metrics import TokenTracker
+
+        cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={"srv": UpstreamServerConfig(prefix="t")},
+        )
+        mgr = ProxyManager(cfg, TokenTracker())
+        assert "not active" in mgr.select_chunks("k1", ["A"])
+
+    def test_unopenable_path_degrades_without_caching(self, tmp_path):
+        """A store that can't be opened degrades to the sentinel and pins no
+        compressor (a failed open must not cache a bad state)."""
+        from memtomem_stm.proxy.config import (
+            ProxyConfig,
+            SelectiveConfig,
+            UpstreamServerConfig,
+        )
+        from memtomem_stm.proxy.manager import ProxyManager
+        from memtomem_stm.proxy.metrics import TokenTracker
+
+        # Point the DB path at a directory → sqlite open fails.
+        bad_dir = tmp_path / "as_dir"
+        bad_dir.mkdir()
+        sel = SelectiveConfig(pending_store="sqlite", pending_store_path=bad_dir)
+        cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={"srv": UpstreamServerConfig(prefix="t", selective=sel)},
+        )
+        mgr = ProxyManager(cfg, TokenTracker())
+        assert "not active" in mgr.select_chunks("k1", ["A"])
+        assert mgr._selective_compressor is None
+
+
+class TestReadMoreRestartRecovery:
+    def test_finds_progressive_key_persisted_before_restart(self, tmp_path):
+        """A progressive response written by a prior process is reachable via
+        read_more on a fresh manager (SQLite backend), rather than reporting
+        'not found' from a fresh in-memory store."""
+        from memtomem_stm.proxy.config import ProgressiveConfig
+
+        # Pre-restart: write a progressive response through mgr1's SQLite store.
+        mgr1, sel = _sqlite_manager(tmp_path)
+        prog_cfg = ProgressiveConfig(chunk_size=40)
+        text = "First chunk content. " * 20
+        first = mgr1._apply_progressive(text, prog_cfg, "srv", "some_tool", sel)
+        # Recover the key from the footer.
+        import re
+
+        m = re.search(r'key="([0-9a-f]{16})"', first)
+        assert m is not None, first
+        key = m.group(1)
+
+        # Post-restart: a fresh manager over the same config finds the key.
+        mgr2, _sel2 = _sqlite_manager(tmp_path)
+        assert mgr2._progressive_store is None
+        out = mgr2.read_more(key, len(text) // 4)
+        assert "not found or expired" not in out
+
+    def test_open_failure_degrades_to_sentinel(self, tmp_path):
+        """A SQLite open failure in read_more recovery degrades to the sentinel
+        and caches no store."""
+        from memtomem_stm.proxy.config import (
+            ProxyConfig,
+            SelectiveConfig,
+            UpstreamServerConfig,
+        )
+        from memtomem_stm.proxy.manager import ProxyManager
+        from memtomem_stm.proxy.metrics import TokenTracker
+
+        bad_dir = tmp_path / "as_dir"
+        bad_dir.mkdir()
+        sel = SelectiveConfig(pending_store="sqlite", pending_store_path=bad_dir)
+        cfg = ProxyConfig(
+            config_path=tmp_path / "proxy.json",
+            upstream_servers={"srv": UpstreamServerConfig(prefix="t", selective=sel)},
+        )
+        mgr = ProxyManager(cfg, TokenTracker())
+        assert "not found or expired" in mgr.read_more("k1", 0)
+        assert mgr._progressive_store is None
+
+    def test_no_clobber_of_live_inmemory_store(self, tmp_path):
+        """A key written to a live in-memory store (no sel_cfg) stays readable;
+        read_more must not rebuild the store from the fallback cfg and lose it."""
+        from memtomem_stm.proxy.config import ProgressiveConfig
+
+        mgr, _sel = _sqlite_manager(tmp_path)
+        prog_cfg = ProgressiveConfig(chunk_size=40)
+        text = "In memory chunk. " * 20
+        # Write WITHOUT sel_cfg → builds/caches an in-memory store.
+        first = mgr._apply_progressive(text, prog_cfg, "srv", "some_tool", None)
+        import re
+
+        m = re.search(r'key="([0-9a-f]{16})"', first)
+        assert m is not None, first
+        key = m.group(1)
+
+        store_before = mgr._progressive_store
+        out = mgr.read_more(key, len(text) // 4)
+        assert "not found or expired" not in out
+        # The live in-memory store was not rebuilt from the fallback cfg.
+        assert mgr._progressive_store is store_before

--- a/tests/test_pending_store.py
+++ b/tests/test_pending_store.py
@@ -476,3 +476,140 @@ class TestReadMoreRestartRecovery:
         assert "not found or expired" not in out
         # The live in-memory store was not rebuilt from the fallback cfg.
         assert mgr._progressive_store is store_before
+
+
+# ── Multi-path recovery + store lifecycle (#583 follow-up) ────────────────
+
+
+def _two_store_manager(tmp_path):
+    """A ProxyManager with two servers, each configured to a DISTINCT SQLite
+    pending store, so restart recovery must probe both to reach a key."""
+    from memtomem_stm.proxy.config import (
+        ProxyConfig,
+        SelectiveConfig,
+        UpstreamServerConfig,
+    )
+    from memtomem_stm.proxy.manager import ProxyManager
+    from memtomem_stm.proxy.metrics import TokenTracker
+
+    sel_a = SelectiveConfig(pending_store="sqlite", pending_store_path=tmp_path / "a.db")
+    sel_b = SelectiveConfig(pending_store="sqlite", pending_store_path=tmp_path / "b.db")
+    cfg = ProxyConfig(
+        config_path=tmp_path / "proxy.json",
+        upstream_servers={
+            "a": UpstreamServerConfig(prefix="a", selective=sel_a),
+            "b": UpstreamServerConfig(prefix="b", selective=sel_b),
+        },
+    )
+    return ProxyManager(cfg, TokenTracker()), sel_a, sel_b
+
+
+class TestMultiPathRecovery:
+    def test_select_chunks_probes_all_stores(self, tmp_path):
+        """A key persisted in the SECOND of two distinct SQLite stores is
+        reachable — recovery probes every configured path, not just the first."""
+        store_b = SQLitePendingStore(tmp_path / "b.db")
+        store_b.initialize()
+        store_b.put("kB", _make_selection({"A": "in store B"}))
+        store_b.close()
+
+        mgr, _sel_a, sel_b = _two_store_manager(tmp_path)
+        assert mgr.select_chunks("kB", ["A"]) == "in store B"
+        # It bound the store that actually held the key, not merely the first.
+        assert mgr._selective_compressor_cfg == sel_b
+
+    def test_select_chunks_absent_key_falls_back_to_first(self, tmp_path):
+        """When no configured store holds the key, recovery falls back to the
+        first store so the key still degrades through the normal not-found
+        path (and the common single-store case stays a straight passthrough)."""
+        for name in ("a.db", "b.db"):
+            s = SQLitePendingStore(tmp_path / name)
+            s.initialize()
+            s.close()
+
+        mgr, sel_a, _sel_b = _two_store_manager(tmp_path)
+        assert "not found" in mgr.select_chunks("missing", ["A"])
+        assert mgr._selective_compressor_cfg == sel_a
+
+    def test_read_more_probes_all_stores(self, tmp_path):
+        """A progressive key persisted in the second store is reachable via
+        read_more on a fresh manager."""
+        import re
+
+        from memtomem_stm.proxy.config import ProgressiveConfig
+
+        mgr1, _sel_a, sel_b = _two_store_manager(tmp_path)
+        text = "Second store chunk. " * 20
+        first = mgr1._apply_progressive(text, ProgressiveConfig(chunk_size=40), "b", "tool", sel_b)
+        m = re.search(r'key="([0-9a-f]{16})"', first)
+        assert m is not None, first
+        key = m.group(1)
+        mgr1._progressive_store.close()  # release b.db before reopening
+
+        mgr2, *_ = _two_store_manager(tmp_path)
+        assert mgr2._progressive_store is None
+        assert "not found or expired" not in mgr2.read_more(key, len(text) // 4)
+
+
+class TestStoreLifecycleCleanup:
+    async def test_stop_closes_recovered_stores(self, tmp_path):
+        """stop() closes the lazily-built selective and progressive stores and
+        nulls them, so a recovery-opened SQLite connection does not leak."""
+        from unittest.mock import patch
+
+        from memtomem_stm.proxy.config import ProgressiveConfig
+
+        store = SQLitePendingStore(tmp_path / "pending.db")
+        store.initialize()
+        store.put("k1", _make_selection({"A": "x"}))
+        store.close()
+
+        mgr, sel = _sqlite_manager(tmp_path)
+        mgr.select_chunks("k1", ["A"])  # opens a SQLite-backed selective compressor
+        mgr._apply_progressive("y " * 50, ProgressiveConfig(chunk_size=40), "srv", "t", sel)
+        sel_comp = mgr._selective_compressor
+        prog = mgr._progressive_store
+        assert sel_comp is not None and prog is not None
+
+        with (
+            patch.object(sel_comp, "close", wraps=sel_comp.close) as sel_spy,
+            patch.object(prog, "close", wraps=prog.close) as prog_spy,
+        ):
+            await mgr.stop()
+
+        sel_spy.assert_called_once()
+        prog_spy.assert_called_once()
+        assert mgr._selective_compressor is None
+        assert mgr._selective_compressor_cfg is None
+        assert mgr._progressive_store is None
+        assert mgr._progressive_store_cfg is None
+
+    def test_rebuild_selective_closes_superseded(self, tmp_path):
+        """Rebuilding the selective compressor for a changed config closes the
+        superseded one first, so its SQLite store does not leak."""
+        from unittest.mock import patch
+
+        mgr, sel = _sqlite_manager(tmp_path)
+        mgr._rebuild_selective_compressor(sel)
+        first = mgr._selective_compressor
+        assert first is not None
+
+        with patch.object(first, "close", wraps=first.close) as spy:
+            mgr._rebuild_selective_compressor(sel)
+
+        spy.assert_called_once()
+        assert mgr._selective_compressor is not first
+
+    def test_progressive_rebuild_closes_superseded(self, tmp_path):
+        """A progressive-store rebuild for a changed cfg closes the old adapter."""
+        from unittest.mock import patch
+
+        mgr, sel_a, sel_b = _two_store_manager(tmp_path)
+        first = mgr._get_progressive_store(sel_a)
+        assert first is not None
+
+        with patch.object(first, "close", wraps=first.close) as spy:
+            mgr._get_progressive_store(sel_b)  # different path → rebuild
+
+        spy.assert_called_once()
+        assert mgr._progressive_store is not first

--- a/tests/test_pending_store.py
+++ b/tests/test_pending_store.py
@@ -7,6 +7,7 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
 
 from memtomem_stm.proxy.compression import PendingSelection, SelectiveCompressor
 from memtomem_stm.proxy.pending_store import InMemoryPendingStore, SQLitePendingStore
@@ -550,6 +551,51 @@ class TestMultiPathRecovery:
         assert mgr2._progressive_store is None
         assert "not found or expired" not in mgr2.read_more(key, len(text) // 4)
 
+    def test_select_chunks_reprobes_after_caching_other_store(self, tmp_path):
+        """Even once a compressor is cached for the FIRST store (e.g. an earlier
+        absent-key call), a later key that lives in the SECOND store is still
+        reached — select_chunks re-probes on a miss instead of trusting the
+        cached store's not-found."""
+        store_b = SQLitePendingStore(tmp_path / "b.db")
+        store_b.initialize()
+        store_b.put("kB", _make_selection({"A": "in store B"}))
+        store_b.close()
+
+        mgr, sel_a, sel_b = _two_store_manager(tmp_path)
+        # First call is for an absent key → caches the first store (a.db).
+        assert "not found" in mgr.select_chunks("absent", ["A"])
+        assert mgr._selective_compressor_cfg == sel_a
+        # A later key that lives in b.db is still served, via the miss re-probe.
+        assert mgr.select_chunks("kB", ["A"]) == "in store B"
+        # The cache was NOT disturbed — the temp store served it.
+        assert mgr._selective_compressor_cfg == sel_a
+
+    def test_read_more_reprobes_after_caching_other_store(self, tmp_path):
+        """read_more re-probes the other configured stores on a miss even after
+        a progressive store is already cached for a different path."""
+        import re
+
+        from memtomem_stm.proxy.config import ProgressiveConfig
+
+        # Persist a progressive key into b.db via a manager pointed at it.
+        writer, _sa, sel_b = _two_store_manager(tmp_path)
+        text = "Second store progressive. " * 20
+        first = writer._apply_progressive(
+            text, ProgressiveConfig(chunk_size=40), "b", "tool", sel_b
+        )
+        key = re.search(r'key="([0-9a-f]{16})"', first).group(1)
+        writer._progressive_store.close()
+
+        mgr, _sa2, _sb2 = _two_store_manager(tmp_path)
+        # Force a cached progressive store for a.db via a miss on an absent key.
+        assert "not found or expired" in mgr.read_more("absent", 0)
+        cached = mgr._progressive_store
+        assert cached is not None
+        # The b.db key is still reachable through the miss re-probe...
+        assert "not found or expired" not in mgr.read_more(key, len(text) // 4)
+        # ...without disturbing the cached a.db adapter.
+        assert mgr._progressive_store is cached
+
 
 class TestStoreLifecycleCleanup:
     async def test_stop_closes_recovered_stores(self, tmp_path):
@@ -613,3 +659,44 @@ class TestStoreLifecycleCleanup:
 
         spy.assert_called_once()
         assert mgr._progressive_store is not first
+
+    def test_rebuild_selective_failure_leaves_old_usable(self, tmp_path):
+        """If building the replacement compressor fails (bad SQLite path), the
+        old compressor stays cached and usable instead of a closed store behind
+        the cfg-equality fast path."""
+        from memtomem_stm.proxy.config import SelectiveConfig
+
+        mgr, sel = _sqlite_manager(tmp_path)
+        mgr._rebuild_selective_compressor(sel)
+        first = mgr._selective_compressor
+        assert first is not None
+
+        bad_dir = tmp_path / "as_dir"
+        bad_dir.mkdir()
+        bad = SelectiveConfig(pending_store="sqlite", pending_store_path=bad_dir)
+        with pytest.raises(Exception):
+            mgr._rebuild_selective_compressor(bad)
+
+        # Old compressor untouched: still cached, same cfg, and NOT closed —
+        # a select on it still works (its store connection is live).
+        assert mgr._selective_compressor is first
+        assert mgr._selective_compressor_cfg == sel
+        assert "not found or expired" in first.select("missing", ["A"])
+
+    def test_progressive_rebuild_failure_leaves_old_usable(self, tmp_path):
+        """A failed progressive-store rebuild leaves the old adapter cached and
+        usable rather than closing it before the replacement is built."""
+        from memtomem_stm.proxy.config import SelectiveConfig
+
+        mgr, sel_a, _sel_b = _two_store_manager(tmp_path)
+        first = mgr._get_progressive_store(sel_a)
+        assert first is not None
+
+        bad_dir = tmp_path / "as_dir"
+        bad_dir.mkdir()
+        bad = SelectiveConfig(pending_store="sqlite", pending_store_path=bad_dir)
+        with pytest.raises(Exception):
+            mgr._get_progressive_store(bad)
+
+        assert mgr._progressive_store is first
+        assert first.get("missing") is None  # still live, not closed


### PR DESCRIPTION
## Summary

Closes #583. The opt-in `pending_store: "sqlite"` backend exists so pending TOC/progressive entries survive restarts and can be shared across instances. After a restart, both retrieval endpoints failed to reach it:

- `stm_proxy_select_chunks` → `select_chunks`: early-returned "Selective compression not active" when `self._selective_compressor is None`. The compressor (and its SQLite store handle) is built **lazily**, only inside a compress call — so a key replayed from the previous process got the sentinel even though the row sits live in the SQLite store.
- `stm_proxy_read_more` → `read_more`: called `_get_progressive_store()` with **no `sel_cfg`**, which constructs a fresh `InMemoryPendingStore` and reports "not found or expired" while the entry persists on disk. Only the next progressive *write* (which passes `sel_cfg`) built the SQLite adapter.

## Change

A new `_fallback_selective_cfg()` resolves a `SelectiveConfig` to reach a persisted store when nothing has been built yet. There is no global `SelectiveConfig` — it nests per-server (`UpstreamServerConfig.selective`) and per-tool (`ToolOverrideConfig.selective`) — so it scans the configured servers (sorted for determinism; server-level first, then tool overrides) and returns the first that opts into the SQLite backend.

- `select_chunks`: when `_selective_compressor is None`, resolve the fallback cfg and build the configured compressor via `_create_selective` (so a later compress with the same cfg reuses it). Stays synchronous with no `_selective_lock`: the check→build→assign has no `await`, and neither do the lock-holding compress paths, so they can't interleave on the event loop.
- `read_more`: pass the fallback cfg to `_get_progressive_store()` **only when `self._progressive_store is None`**. Passing it unconditionally would trip the cfg-mismatch rebuild and discard a live in-memory store still holding keys written since startup.

Both degrade to their existing sentinel strings (with a WARNING) on a SQLite open failure and cache nothing — `_get_progressive_store` / `_create_selective` only cache after a successful `initialize()`, so a failed open pins no bad state and the next call retries. No changes to `pending_store.py` (its `put()` stores wall-clock `created_at`, so restart-crossing TTLs are already correct).

## Residual edges (documented, not fixed)

- **Multiple distinct SQLite paths** across tools: the fallback returns the first and logs a WARNING naming all of them; a key in a non-first path stays unreachable until that tool's next compression rebuilds its compressor. Probing every configured path on a miss is a possible follow-up.
- If the first post-restart progressive event is a **write from a no-cfg tool**, an in-memory store gets cached and shadows SQLite for later reads — left as-is to avoid a write-path behavior change.

## Behavior change

Under `pending_store: "sqlite"`, `stm_proxy_select_chunks` / `stm_proxy_read_more` now recover keys persisted before a restart instead of reporting "not active"/"not found". No change for the default `pending_store: "memory"` backend, and the retrieval endpoints never raise on a store fault.

## Tests

`tests/test_pending_store.py` — `TestSelectChunksRestartRecovery` (key persisted pre-restart is found on a fresh manager; override-only SQLite is found by the scan; no-SQLite keeps the sentinel; unopenable path degrades and pins no compressor) and `TestReadMoreRestartRecovery` (progressive key recovered across a fresh manager; open failure degrades to the sentinel with no cached store; a live in-memory store is not clobbered).

Full suite: 4092 passed, 3 skipped. `ruff check` + `format` clean.

## Series

Part of the 2026-07-03 ops-stability audit. #575–#579 merged (#587–#590); #578 (#592), #580 (#593), #581 (#594), #582 (#595) in flight; this is #583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
