### PR TITLE
fix(fileio): add opt-in fsync durability to atomic_write_text (#585)

### DIFF
--- a/src/memtomem_stm/cli/hook_hosts.py
+++ b/src/memtomem_stm/cli/hook_hosts.py
@@ -659,5 +659,5 @@ def apply_change(change: HookChange) -> Path | None:
     backup: Path | None = None
     if change.current_text is not None:
         backup = _write_backup(path, change.current_text, mode)
-    atomic_write_text(path, change.new_text, mode=mode)
+    atomic_write_text(path, change.new_text, mode=mode, durable=True)
     return backup

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -153,7 +153,7 @@ def _save(config_path: Path, data: dict[str, Any]) -> None:
     even if the parent directory is shared.
     """
     payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
-    atomic_write_text(config_path, payload, mode=0o600)
+    atomic_write_text(config_path, payload, mode=0o600, durable=True)
 
 
 # ── MCP client registration helpers ─────────────────────────────────────
@@ -356,7 +356,7 @@ def _write_mcp_json_for_stm(target_dir: Path, server_cmd: str, server_args: list
         file_mode = mcp_path.stat().st_mode & 0o777
     except OSError:
         file_mode = 0o644
-    atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n", mode=file_mode)
+    atomic_write_text(mcp_path, json.dumps(existing, indent=2) + "\n", mode=file_mode, durable=True)
     return mcp_path
 
 
@@ -1510,7 +1510,7 @@ def _desktop_json_remove_entry(name: str) -> tuple[bool, str | None]:
         return (False, f"'{name}' not registered in {path}")
     del servers[name]
     try:
-        atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n", durable=True)
     except OSError as exc:
         return (False, f"write error: {exc}")
     return (True, None)
@@ -1587,7 +1587,9 @@ def _append_pruned_backup(
     # 0600 like ``stm_proxy.json`` (``_save``): ``original`` carries verbatim
     # host env/headers, secrets included.
     try:
-        atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False) + "\n", mode=0o600)
+        atomic_write_text(
+            path, json.dumps(data, indent=2, ensure_ascii=False) + "\n", mode=0o600, durable=True
+        )
     except OSError as exc:
         return (False, f"backup log write failed: {exc}")
     return (True, None)
@@ -2979,6 +2981,7 @@ def _json_config_set_entry(
             path,
             json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
             mode=default_mode,
+            durable=True,
         )
     except OSError as exc:
         return (False, f"write error: {exc}")

--- a/src/memtomem_stm/mms/state.py
+++ b/src/memtomem_stm/mms/state.py
@@ -426,24 +426,26 @@ def load_import_state(path: Path | None = None) -> ImportState:
 def save_registry(config: RegistryConfig, path: Path | None = None) -> None:
     """Atomically write ``registry.toml`` with mode 0o600 (contains secrets)."""
     p = path or registry_path()
-    atomic_write_text(p, tomli_w.dumps(config.model_dump()), mode=_REGISTRY_MODE)
+    atomic_write_text(p, tomli_w.dumps(config.model_dump()), mode=_REGISTRY_MODE, durable=True)
 
 
 def save_projects_index(index: ProjectsIndex, path: Path | None = None) -> None:
     """Atomically write ``projects.toml`` with mode 0o600 (paths are private)."""
     p = path or projects_index_path()
-    atomic_write_text(p, tomli_w.dumps(index.model_dump()), mode=_PROJECTS_INDEX_MODE)
+    atomic_write_text(p, tomli_w.dumps(index.model_dump()), mode=_PROJECTS_INDEX_MODE, durable=True)
 
 
 def save_project_config(config: ProjectConfig, path: Path) -> None:
     """Atomically write a per-project ``project.toml`` (committed file, default mode)."""
-    atomic_write_text(path, tomli_w.dumps(config.model_dump()), mode=_PROJECT_FILE_MODE)
+    atomic_write_text(
+        path, tomli_w.dumps(config.model_dump()), mode=_PROJECT_FILE_MODE, durable=True
+    )
 
 
 def save_import_state(state: ImportState, path: Path | None = None) -> None:
     """Atomically write ``import_state.toml`` with mode 0o600."""
     p = path or import_state_path()
-    atomic_write_text(p, tomli_w.dumps(state.model_dump()), mode=_IMPORT_STATE_MODE)
+    atomic_write_text(p, tomli_w.dumps(state.model_dump()), mode=_IMPORT_STATE_MODE, durable=True)
 
 
 # ---------------------------------------------------------------------------

--- a/src/memtomem_stm/utils/fileio.py
+++ b/src/memtomem_stm/utils/fileio.py
@@ -30,6 +30,7 @@ def atomic_write_text(
     mode: int | None = None,
     ensure_parent: bool = True,
     parent_mode: int = 0o700,
+    durable: bool = False,
 ) -> None:
     """Atomically write ``content`` to ``path``.
 
@@ -56,6 +57,15 @@ def atomic_write_text(
         already prepared the parent and does not want its mode rewritten.
     :param parent_mode: Mode for created parent directories. Only used
         when ``ensure_parent`` is True.
+    :param durable: When True, ``fsync`` the temp file before the rename
+        and ``fsync`` the parent directory after it (POSIX), so the write
+        survives power loss / kernel panic — not just a process crash. The
+        default ``os.replace`` guards against process crash already; the
+        rename can otherwise become durable before the data blocks, leaving
+        a truncated file after an unclean shutdown. Costs a disk flush per
+        write, so it is opt-in: pass ``durable=True`` from config/state
+        writers (single sources of truth that ``mms init`` refuses to
+        recreate), leave it off for high-frequency hot-path writers.
     """
     resolved = path.expanduser().resolve()
     if ensure_parent:
@@ -69,15 +79,43 @@ def atomic_write_text(
     try:
         with os.fdopen(fd, "w", encoding=encoding) as f:
             f.write(content)
+            if durable:
+                # Flush Python + libc buffers, then force the data blocks to
+                # disk BEFORE the rename, so os.replace can't make the new
+                # name durable ahead of the content it points at.
+                f.flush()
+                os.fsync(f.fileno())
         if mode is not None:
             try:
                 tmp.chmod(mode)
             except OSError:
                 pass
         _replace_with_windows_retry(tmp, resolved)
+        if durable:
+            _fsync_dir(resolved.parent)
     except Exception:
         tmp.unlink(missing_ok=True)
         raise
+
+
+def _fsync_dir(directory: Path) -> None:
+    """Best-effort fsync of ``directory`` so a rename into it is durable
+    (POSIX). No-op on platforms without directory fds (Windows) or when the
+    open/fsync fails — durability is a best-effort hardening, not a hard
+    guarantee, and a failure here must not fail the write that already
+    landed via ``os.replace``."""
+    if sys.platform == "win32":
+        return
+    try:
+        dir_fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
 
 
 def _replace_with_windows_retry(src: Path, dst: Path) -> None:

--- a/tests/test_utils_fileio.py
+++ b/tests/test_utils_fileio.py
@@ -47,6 +47,60 @@ class TestAtomicWriteText:
         # Bottom 9 bits = permission bits.
         assert (target.stat().st_mode & 0o777) == 0o600
 
+    def test_durable_false_does_not_fsync(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """#585 — the default (durable=False) never calls os.fsync (no extra
+        disk flush on the hot path)."""
+        calls: list[int] = []
+        monkeypatch.setattr("memtomem_stm.utils.fileio.os.fsync", lambda fd: calls.append(fd))
+        atomic_write_text(tmp_path / "out.txt", "hello")
+        assert calls == []
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="directory fsync is POSIX-only",
+    )
+    def test_durable_true_fsyncs_file_and_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """#585 — durable=True fsyncs the temp file (before rename) and the
+        parent directory (after), so the write survives power loss."""
+        fsynced: list[int] = []
+        real_fsync = os.fsync
+        monkeypatch.setattr(
+            "memtomem_stm.utils.fileio.os.fsync",
+            lambda fd: (fsynced.append(fd), real_fsync(fd))[0],
+        )
+        target = tmp_path / "cfg.json"
+        atomic_write_text(target, "{}", durable=True)
+        assert target.read_text() == "{}"
+        # At least two fsyncs: the temp file fd and the parent-dir fd.
+        assert len(fsynced) >= 2
+
+    def test_durable_true_dir_fsync_failure_does_not_break_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A directory fsync failure is best-effort — the write that already
+        landed via os.replace must still succeed."""
+        real_fsync = os.fsync
+
+        def flaky_fsync(fd: int):
+            # Fail only the directory fsync (a dir fd isn't the temp file's).
+            try:
+                os.fstat(fd)
+            except OSError:
+                raise
+            # Distinguish dir from file by checking if it's a directory fd.
+            import stat as _stat
+
+            if _stat.S_ISDIR(os.fstat(fd).st_mode):
+                raise OSError("simulated dir fsync failure")
+            return real_fsync(fd)
+
+        monkeypatch.setattr("memtomem_stm.utils.fileio.os.fsync", flaky_fsync)
+        target = tmp_path / "cfg.json"
+        atomic_write_text(target, "payload", durable=True)
+        assert target.read_text() == "payload"
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="NTFS doesn't expose POSIX mode bits; ACL is the right primitive",


### PR DESCRIPTION
## Summary

Closes #585. `atomic_write_text` is the single funnel for every config/state file write (`stm_proxy.json`, `registry.toml`, `projects.toml`, host `.mcp.json`, prune backup log, daemon handshake, markdown facts). The temp-in-same-dir + `os.replace` pattern is correct against a **process crash**, but there is no `fsync` before the rename (nor a directory fsync after): against **power loss / kernel panic** the rename can become durable before the data blocks, leaving a zero-length or partial file after reboot. Because these files are single sources of truth and `mms init` refuses to recreate an existing config, a truncated `stm_proxy.json` needs manual recovery.

## Change

Add an opt-in `durable: bool = False` parameter to `atomic_write_text`:

- when `True`, `f.flush()` + `os.fsync(f.fileno())` before the rename (so `os.replace` can't make the new name durable ahead of its content), and a best-effort parent-directory fsync after the rename on POSIX (new `_fsync_dir` helper — a dir-fsync failure never fails the write that already landed).
- default `False` keeps the current behavior (no extra disk flush) for high-frequency hot-path writers.

**Opted in** (config/state/registry — single sources of truth, low frequency): all five `cli/proxy.py` writers (config save, host `.mcp.json`, registry-remove, prune backup log, host client entry), `cli/hook_hosts.py` host-config apply, and the four `mms/state.py` savers (registry / projects index / project marker / import state).

**Left non-durable**: `proxy/memory_ops.py` auto-index + per-fact markdown writers (the hot path — one flush per fact would be a real cost, and a lost fact file is re-derivable), and the daemon handshake (ephemeral runtime state, rewritten every start).

## Behavior change

Config/state/registry writes now fsync before returning (one disk flush per write). No API change for existing callers — `durable` defaults off, so hot-path writers are unaffected. On a healthy filesystem the only observable difference is a slightly slower config save; the payoff is that an unclean shutdown can no longer truncate a config file to zero bytes.

## Scope note

The related stale-`.tmp` sweep noted in the issue (a SIGKILL between `mkstemp` and `os.replace` strands a `<name>.<rand>.tmp` sibling) is left out as cosmetic — those temps are already cleaned on the normal error path, and a swept-in foreign-dir cleanup carries its own risk.

## Tests

`tests/test_utils_fileio.py`: `durable=False` calls `os.fsync` zero times; `durable=True` fsyncs both the temp-file fd and the parent-dir fd (POSIX) and the content lands; a simulated directory-fsync failure does not fail a write that already replaced. Existing atomicity/cleanup/Windows-retry tests unchanged.

Full suite: 4088 passed, 3 skipped. `ruff check` + `format` clean.

## Series

Part of the 2026-07-03 ops-stability audit. #575–#579 merged (#587–#590); #578 (#592), #580 (#593), #581 (#594), #582 (#595), #583 (#596), #584 (#597) in flight; this is #585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
