### PR TITLE
fix(proxy): serialize _reconnect_server to stop orphaning AsyncExitStacks (#586)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -10,7 +10,7 @@ import time as _time
 import uuid
 from collections import Counter
 from contextlib import AsyncExitStack
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -197,6 +197,15 @@ class UpstreamConnection:
     session: ClientSession
     tools: list[Any]
     stack: AsyncExitStack | None = None
+    # Serialize concurrent ``_reconnect_server`` calls for this server (#586).
+    # Four unserialized retry-loop sites can reconnect the same connection at
+    # once; without this, two interleaving reconnects each build a fresh
+    # ``AsyncExitStack`` and the last writer wins — orphaning the loser's stack
+    # (a leaked stdio child + fds per race). The generation counter lets a
+    # waiter that wakes after another reconnect already completed skip its own,
+    # collapsing a reconnect storm into one transport spawn.
+    reconnect_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    reconnect_generation: int = 0
 
 
 def _mark_recorded(exc: BaseException) -> None:
@@ -890,36 +899,53 @@ class ProxyManager:
         conn = self._connections[name]
         cfg = conn.config
 
-        if conn.stack is not None:
-            try:
-                await conn.stack.aclose()
-            except Exception:
-                logger.debug("Failed to close previous stack for '%s'", name, exc_info=True)
+        # Serialize concurrent reconnects for this server (#586). Capture the
+        # generation BEFORE acquiring: if it advanced while we waited, another
+        # caller already reconnected this connection, so we skip — no redundant
+        # transport spawn, and no stack to orphan. The lock lives on ``conn``,
+        # which is mutated in place (never replaced), so its identity is stable.
+        generation_at_entry = conn.reconnect_generation
+        async with conn.reconnect_lock:
+            if conn.reconnect_generation != generation_at_entry:
+                logger.debug(
+                    "Skipping reconnect for '%s' — another reconnect already completed", name
+                )
+                return
 
-        conn_stack = AsyncExitStack()
-        try:
-            transport_ctx = self._open_transport(cfg)
-            streams = await conn_stack.enter_async_context(transport_ctx)
-            read, write = streams[0], streams[1]
-            session = await conn_stack.enter_async_context(
-                ClientSession(read, write, message_handler=self._make_message_handler(name))
-            )
-            await asyncio.wait_for(session.initialize(), timeout=cfg.connect_timeout_seconds)
-            result = await session.list_tools()
-        except BaseException:
-            # Roll back any contexts we entered (transport subprocess, session
-            # streams). Without this, a failed reconnect leaks file descriptors
-            # and child processes across retry storms.
-            try:
-                await conn_stack.aclose()
-            except Exception:
-                logger.debug("Error during reconnect cleanup for '%s'", name, exc_info=True)
-            raise
+            if conn.stack is not None:
+                try:
+                    await conn.stack.aclose()
+                except Exception:
+                    logger.debug("Failed to close previous stack for '%s'", name, exc_info=True)
 
-        conn.session = session
-        conn.stack = conn_stack
-        conn.tools = list(result.tools)
-        logger.info("Reconnected to '%s' (%s tools discovered)", name, len(conn.tools))
+            conn_stack = AsyncExitStack()
+            try:
+                transport_ctx = self._open_transport(cfg)
+                streams = await conn_stack.enter_async_context(transport_ctx)
+                read, write = streams[0], streams[1]
+                session = await conn_stack.enter_async_context(
+                    ClientSession(read, write, message_handler=self._make_message_handler(name))
+                )
+                await asyncio.wait_for(session.initialize(), timeout=cfg.connect_timeout_seconds)
+                result = await session.list_tools()
+            except BaseException:
+                # Roll back any contexts we entered (transport subprocess, session
+                # streams). Without this, a failed reconnect leaks file descriptors
+                # and child processes across retry storms.
+                try:
+                    await conn_stack.aclose()
+                except Exception:
+                    logger.debug("Error during reconnect cleanup for '%s'", name, exc_info=True)
+                raise
+
+            conn.session = session
+            conn.stack = conn_stack
+            conn.tools = list(result.tools)
+            # Bump the generation only on a successful reconnect so a waiter
+            # skips its own; a failed attempt leaves it unchanged so the next
+            # caller retries rather than silently skipping.
+            conn.reconnect_generation += 1
+            logger.info("Reconnected to '%s' (%s tools discovered)", name, len(conn.tools))
 
     def _make_message_handler(self, name: str) -> Any:
         """Per-upstream MCP message handler wired into ``ClientSession``.

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from memtomem_stm.proxy.config import (
@@ -281,6 +282,65 @@ class TestConnectServerCleanup:
         assert "bad" not in mgr._connections
         mock_session.__aexit__.assert_awaited_once()
         mock_transport.__aexit__.assert_awaited_once()
+
+
+class TestConcurrentReconnect:
+    """#586 — two concurrent _reconnect_server calls for one server must
+    collapse into a single transport spawn; the loser skips (generation
+    advanced) instead of building a second AsyncExitStack that gets orphaned."""
+
+    async def test_concurrent_reconnect_spawns_one_transport(self):
+        cfg = UpstreamServerConfig(prefix="srv", connect_timeout_seconds=5.0)
+        mgr = _make_manager(servers={"srv": cfg})
+
+        # Seed a live connection with an existing (closeable) stack.
+        old_stack = AsyncMock()
+        mgr._connections["srv"] = UpstreamConnection(
+            name="srv",
+            config=cfg,
+            session=AsyncMock(),
+            tools=[],
+            stack=old_stack,
+        )
+
+        transport_opens = 0
+
+        def _open_transport(_cfg):
+            nonlocal transport_opens
+            transport_opens += 1
+            t = AsyncMock()
+
+            async def _delayed_streams(*_args):
+                # Yield control so the second reconnect reaches the lock while
+                # the first is mid-setup — the interleaving the guard defends.
+                await asyncio.sleep(0.01)
+                return (AsyncMock(), AsyncMock())
+
+            t.__aenter__ = AsyncMock(side_effect=_delayed_streams)
+            t.__aexit__ = AsyncMock(return_value=False)
+            return t
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+
+        with (
+            patch.object(mgr, "_open_transport", side_effect=_open_transport),
+            patch("memtomem_stm.proxy.manager.ClientSession", return_value=mock_session),
+        ):
+            await asyncio.gather(
+                mgr._reconnect_server("srv"),
+                mgr._reconnect_server("srv"),
+            )
+
+        # Exactly one reconnect actually ran: one transport spawn, one
+        # generation bump, and the old stack closed once (not twice).
+        assert transport_opens == 1
+        assert mgr._connections["srv"].reconnect_generation == 1
+        old_stack.aclose.assert_awaited_once()
+        assert mgr._connections["srv"].session is mock_session
 
 
 # ── tool name overflow (#261 → exposure-time enforcement via #465) ──────


### PR DESCRIPTION
## Summary

Closes #586. `_reconnect_server` is called from four unserialized retry-loop sites. Its per-attempt rollback is solid, but **concurrent** invocations for the same server race:

```python
if conn.stack is not None:
    await conn.stack.aclose()      # A and B can both pass this
conn_stack = AsyncExitStack()
...                                # awaits: transport spawn, initialize, list_tools
conn.session = session             # last writer wins
conn.stack = conn_stack            # loser's stack is orphaned
```

Two concurrent calls fail against the same dead upstream, both enter their retry loops, both call `_reconnect_server`. Interleaving across the awaits: A closes the old stack and starts opening a transport; B (still seeing the old state) proceeds too and assigns its session/stack; A then overwrites with its own — **B's `AsyncExitStack` is never closed**, leaking a stdio child process + fds per race. Under a retry storm against a flapping upstream this repeats. `_refresh_server_tools` already defends against the session-replaced-mid-operation race, so the hazard class is known in-repo; the reconnect path itself was unguarded.

## Change

Add a per-server `asyncio.Lock` and a reconnect generation counter to `UpstreamConnection` (the object is mutated in place, never replaced, so the lock's identity is stable). `_reconnect_server` captures the generation **before** acquiring the lock; inside the lock, if the generation advanced while it waited, another caller already reconnected → it returns without reconnecting. The generation is bumped only on a **successful** reconnect (a failed attempt leaves it unchanged so the next caller retries rather than silently skipping).

This both removes the orphaned-stack leak (only one reconnect builds a stack) and collapses N concurrent reconnect attempts against a flapping upstream into a single transport spawn.

## Behavior change

None user-visible. Concurrent reconnects for one server now serialize and deduplicate instead of racing; a single reconnect is unchanged.

## Tests

`tests/test_proxy_manager_lifecycle.py::TestConcurrentReconnect` — two `_reconnect_server` calls fired via `asyncio.gather` against one seeded connection (the transport `__aenter__` sleeps to force the interleaving the guard defends). Asserts exactly one transport spawn, the generation bumped by exactly one, the old stack closed once (not twice), and the session set — proving the loser skipped rather than building a second, orphaned stack. Without the guard the transport spawns twice.

Full suite: 4086 passed, 3 skipped. `ruff check` + `format` clean.

## Series

Final item of the 2026-07-03 ops-stability audit. #575–#579 merged (#587–#590); #578 (#592), #580 (#593), #581 (#594), #582 (#595), #583 (#596), #584 (#597), #585 (#598) in flight; this is #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
