### PR TITLE
fix(circuit-breaker): make is_open/state/time_until_reset pure reads (#600)

### DIFF
--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -782,7 +782,16 @@ async def stm_proxy_health(
     surfacing = app.surfacing_engine
     if surfacing is not None:
         cb = surfacing._circuit_breaker
-        cb_state = "open (failing)" if cb.is_open else "closed (healthy)"
+        # Render all three states from the pure ``cb.state`` (#600), not just
+        # the open/closed split off ``is_open``: once the reset window elapses
+        # an open breaker reads as ``half-open`` with ``is_open == False``, so
+        # an ``is_open``-only check would report ``closed (healthy)`` before any
+        # probe has actually succeeded — hiding a still-degraded dependency.
+        cb_state = {
+            "open": "open (failing)",
+            "half-open": "half-open (probe eligible)",
+            "closed": "closed (healthy)",
+        }.get(cb.state, cb.state)
         lines.append(f"\nSurfacing circuit breaker: {cb_state}")
 
     lines.extend(_toolgraph_health_lines(pm.get_toolgraph_status()))

--- a/src/memtomem_stm/utils/circuit_breaker.py
+++ b/src/memtomem_stm/utils/circuit_breaker.py
@@ -12,8 +12,19 @@ class CircuitBreaker:
     """Three-state circuit breaker: closed → open → half-open.
 
     - **closed**: all calls pass through.
-    - **open**: all calls blocked; transitions to half-open after ``reset_timeout``.
-    - **half-open**: one probe call allowed; success closes, failure re-opens.
+    - **open**: all calls blocked; becomes eligible to probe (half-open) after
+      ``reset_timeout``.
+    - **half-open**: the reset window has elapsed; the next call is allowed
+      through as a probe — success closes, failure re-opens.
+
+    The half-open transition is **computed, not committed on read** (#600):
+    ``is_open`` / ``state`` / ``time_until_reset`` are pure — reading them
+    never mutates the breaker, so an observer (e.g. ``stm_proxy_health``)
+    cannot perturb or misreport its state. The commit happens on the probe's
+    outcome via ``record_success`` / ``record_failure``. (Half-open is not
+    single-probe-gated: a failing dependency behind a serialized single MCP
+    client is probed once per elapsed window in practice; concurrent
+    single-probe enforcement is out of scope — see #600.)
     """
 
     def __init__(
@@ -29,22 +40,29 @@ class CircuitBreaker:
         self._state = "closed"
         self._opened_at = 0.0
 
+    def _effective_state(self) -> str:
+        """Effective state without mutating (#600): an open breaker whose
+        ``reset_timeout`` has elapsed reads as ``half-open`` (probe eligible)
+        but ``self._state`` stays ``open`` until ``record_*`` commits the
+        outcome. Only ``record_success`` / ``record_failure`` write state."""
+        if self._state == "open" and time.monotonic() - self._opened_at >= self._reset_timeout:
+            return "half-open"
+        return self._state
+
     @property
     def is_open(self) -> bool:
-        if self._state == "closed":
-            return False
-        if self._state == "open" and time.monotonic() - self._opened_at >= self._reset_timeout:
-            self._state = "half-open"
-            return False  # allow one probe
-        return self._state == "open"
+        """Whether calls should currently be blocked. PURE — reading this never
+        mutates the breaker (#600), so an observer like ``stm_proxy_health`` can
+        read it without perturbing state. Returns ``False`` once the reset
+        window has elapsed (effectively half-open — the next call probes)."""
+        return self._effective_state() == "open"
 
     @property
     def state(self) -> str:
-        """Current state: 'closed', 'open', or 'half-open'."""
-        # Trigger half-open transition if timeout elapsed
-        if self._state == "open" and time.monotonic() - self._opened_at >= self._reset_timeout:
-            self._state = "half-open"
-        return self._state
+        """Current effective state: 'closed', 'open', or 'half-open'. PURE —
+        computes the open→half-open transition from elapsed time without
+        committing it (#600)."""
+        return self._effective_state()
 
     @property
     def failure_count(self) -> int:
@@ -66,12 +84,13 @@ class CircuitBreaker:
         The value is a real ``time.monotonic()`` reading — typically in
         the ~1e5 to 1e9 second range on long-running processes.
         ``time_until_reset`` computes ``reset_timeout - (now - opened_at)``
-        from this; ``(opened_at + 10.0) - opened_at`` loses a few low
-        bits at those magnitudes and the result is ``~1e-14`` rather
-        than bit-exact ``0.0``. Callers subtracting two
-        ``opened_at``-derived values must tolerate a few ULPs of float
-        residue (the test at ``test_time_until_reset_at_boundary``
-        pins an absolute-tolerance check).
+        from this; at those magnitudes ``now - opened_at`` loses a few low
+        bits, so a value just under the reset window can return a tiny
+        positive residue rather than a bit-exact figure. Callers must
+        tolerate a few ULPs of float residue (the test at
+        ``test_time_until_reset_near_boundary`` pins an absolute-tolerance
+        check). At or past the window the breaker reads effectively
+        half-open and ``time_until_reset`` is ``None``.
 
         The backing field uses ``0.0`` as a "never opened" sentinel.
         ``time.monotonic()`` is implementation-defined and could in
@@ -82,8 +101,11 @@ class CircuitBreaker:
 
     @property
     def time_until_reset(self) -> float | None:
-        """Seconds until open breaker transitions to half-open. None if not open."""
-        if self._state != "open":
+        """Seconds until an open breaker becomes probe-eligible (half-open).
+        ``None`` once the window has elapsed (effectively half-open) or closed.
+        PURE — uses the effective state, so a read never commits the transition
+        (#600)."""
+        if self._effective_state() != "open":
             return None
         remaining = self._reset_timeout - (time.monotonic() - self._opened_at)
         return max(0.0, remaining)
@@ -94,9 +116,13 @@ class CircuitBreaker:
 
     def record_failure(self) -> None:
         self._failures += 1
-        if self._state == "half-open" or (
-            self._failures >= self._max_failures and self._state == "closed"
-        ):
+        # Re-open on a failed probe (effectively half-open once the reset window
+        # elapsed) or when a closed breaker crosses the failure threshold. Since
+        # reads no longer commit the half-open transition (#600), the effective
+        # state is recomputed here; a probe that fails in the elapsed window
+        # restarts the window with a fresh ``_opened_at``.
+        eff = self._effective_state()
+        if eff == "half-open" or (self._failures >= self._max_failures and eff == "closed"):
             self._state = "open"
             self._opened_at = time.monotonic()
             logger.warning(

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -59,9 +59,12 @@ class TestCircuitBreakerHalfOpen:
         # Simulate time passing beyond reset_timeout
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = cb.opened_at + 11.0
-            # Should transition to half-open and allow one probe
+            # Effectively half-open (probe eligible) — but reading it does NOT
+            # commit the transition (#600): the public state reads half-open
+            # while the raw internal state stays "open" until record_* runs.
             assert not cb.is_open
-            assert cb._state == "half-open"
+            assert cb.state == "half-open"
+            assert cb._state == "open"
 
     def test_half_open_success_closes_circuit(self):
         cb = CircuitBreaker(max_failures=1, reset_timeout=10.0)
@@ -79,13 +82,17 @@ class TestCircuitBreakerHalfOpen:
         cb = CircuitBreaker(max_failures=1, reset_timeout=10.0)
         cb.record_failure()
 
+        # The probe fails WITHIN the elapsed window (as it does in production:
+        # the gate reads is_open → admits → the call fails → record_failure, all
+        # at roughly the same, post-timeout instant). Since reads no longer
+        # commit the transition (#600), record_failure must see the elapsed
+        # time itself to re-open — so it runs inside the patched clock.
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = cb.opened_at + 11.0
-            assert not cb.is_open  # half-open
-
-        cb.record_failure()
-        assert cb._state == "open"
-        assert cb.is_open
+            assert not cb.is_open  # effectively half-open
+            cb.record_failure()
+            assert cb._state == "open"
+            assert cb.is_open  # re-opened with a fresh window
 
     def test_half_open_failure_resets_timeout(self):
         cb = CircuitBreaker(max_failures=1, reset_timeout=10.0)
@@ -94,12 +101,11 @@ class TestCircuitBreakerHalfOpen:
 
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = first_opened_at + 11.0
-            assert not cb.is_open  # half-open
-
-        cb.record_failure()
-        # opened_at should be refreshed
-        assert cb.opened_at > first_opened_at or cb.opened_at == first_opened_at
-        # If time.monotonic was called normally, opened_at >= first_opened_at
+            assert not cb.is_open  # effectively half-open
+            cb.record_failure()  # fails within the window → re-open
+            # opened_at refreshed to the (mocked) failure time, strictly later.
+            assert cb.opened_at == first_opened_at + 11.0
+            assert cb.opened_at > first_opened_at
 
     def test_repeated_open_close_cycles(self):
         cb = CircuitBreaker(max_failures=2, reset_timeout=5.0)
@@ -121,23 +127,23 @@ class TestCircuitBreakerHalfOpen:
         cb.record_failure()
         assert cb.is_open
 
-    def test_half_open_does_not_allow_multiple_probes(self):
-        """After transitioning to half-open, subsequent is_open calls should not
-        return False again (the probe was already allowed)."""
+    def test_reads_are_pure_and_idempotent(self):
+        """#600 — repeated is_open / state / time_until_reset reads in the
+        elapsed (effectively half-open) window never mutate the breaker: the
+        raw internal state stays "open" no matter how many times an observer
+        reads it. This is what lets stm_proxy_health read the breaker without
+        flipping it."""
         cb = CircuitBreaker(max_failures=1, reset_timeout=10.0)
         cb.record_failure()
 
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
             mock_time.monotonic.return_value = cb.opened_at + 11.0
-            # First call: transitions to half-open, returns False
-            assert not cb.is_open
-            assert cb._state == "half-open"
-
-        # Second call without success/failure: state is half-open,
-        # is_open returns False (half-open is not "open").
-        # This is acceptable because the consumer should call
-        # record_success/failure before the next is_open check.
-        # The important thing is the circuit reacts correctly to the result.
+            for _ in range(5):
+                assert not cb.is_open
+                assert cb.state == "half-open"
+                assert cb.time_until_reset is None
+                # The raw state is never committed by a read.
+                assert cb._state == "open"
 
 
 class TestCircuitBreakerProperties:
@@ -162,18 +168,26 @@ class TestCircuitBreakerProperties:
             # assertion inside the patch block — fix for timing concern
             assert cb.time_until_reset is None
 
-    def test_time_until_reset_at_boundary(self):
+    def test_time_until_reset_near_boundary(self):
         cb = CircuitBreaker(max_failures=1, reset_timeout=10.0)
         cb.record_failure()
+        opened = cb.opened_at
 
+        # Just BEFORE the window elapses: still open, a tiny positive remaining
+        # (the float-residue tolerance — see the ``opened_at`` docstring).
         with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
-            mock_time.monotonic.return_value = cb.opened_at + 10.0
+            mock_time.monotonic.return_value = opened + 9.999
             result = cb.time_until_reset
-            # The contract here is "not positive, effectively zero" — pick a
-            # tolerance several orders of magnitude below any observable reset
-            # window. See ``CircuitBreaker.opened_at`` docstring for the
-            # float-precision rationale (paragraph migrated there per #277).
-            assert result is not None and abs(result) < 1e-9
+            assert result is not None and 0.0 <= result < 0.01
+
+        # Past the window: effectively half-open → None (no time until reset,
+        # the reset has completed). Pure read — does not commit the transition.
+        # (Use a value clearly past reset_timeout so the float residue at
+        # ~1e5-1e9 magnitudes can't land it on the wrong side of the boundary.)
+        with patch("memtomem_stm.utils.circuit_breaker.time") as mock_time:
+            mock_time.monotonic.return_value = opened + 10.001
+            assert cb.time_until_reset is None
+            assert cb._state == "open"
 
     def test_opened_at_lifecycle_preserves_most_recent_open(self):
         """``opened_at`` is None initially, captures the open transition,

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -493,6 +493,44 @@ class TestHealth:
         result = await stm_proxy_health(ctx=ctx)
         assert "Surfacing Bootstrap" not in result
 
+    async def test_circuit_breaker_reports_three_states(self):
+        """#600: the breaker line renders all three states from the pure
+        cb.state. An elapsed open breaker reads half-open (is_open == False) and
+        must NOT be reported as 'closed (healthy)' before a probe succeeds."""
+        from memtomem_stm.utils.circuit_breaker import CircuitBreaker
+
+        def _ctx_with_breaker(cb):
+            # The breaker line only renders past the "no upstream servers"
+            # early-return, so give health a connected upstream to report.
+            pm = _make_proxy_manager()
+            pm._connections["srv"] = UpstreamConnection(
+                name="srv", config=UpstreamServerConfig(prefix="t"), session=AsyncMock(), tools=[]
+            )
+            engine = MagicMock()
+            engine._circuit_breaker = cb
+            return _make_ctx(proxy_manager=pm, surfacing_engine=engine)
+
+        # closed
+        cb_closed = CircuitBreaker(max_failures=1, reset_timeout=100.0)
+        result = await stm_proxy_health(ctx=_ctx_with_breaker(cb_closed))
+        assert "Surfacing circuit breaker: closed (healthy)" in result
+
+        # open — just tripped, window not elapsed
+        cb_open = CircuitBreaker(max_failures=1, reset_timeout=100.0)
+        cb_open.record_failure()
+        assert cb_open.state == "open"
+        result = await stm_proxy_health(ctx=_ctx_with_breaker(cb_open))
+        assert "Surfacing circuit breaker: open (failing)" in result
+
+        # half-open — reset window elapsed, is_open is False but no probe yet
+        cb_half = CircuitBreaker(max_failures=1, reset_timeout=0.0)
+        cb_half.record_failure()
+        assert cb_half.state == "half-open"
+        assert cb_half.is_open is False
+        result = await stm_proxy_health(ctx=_ctx_with_breaker(cb_half))
+        assert "Surfacing circuit breaker: half-open (probe eligible)" in result
+        assert "circuit breaker: closed (healthy)" not in result
+
 
 # ── stm_surfacing_feedback ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #600. `CircuitBreaker.is_open` / `state` performed the open→half-open transition as a **side effect of the property read**:

```python
@property
def is_open(self) -> bool:
    ...
    if self._state == "open" and now - self._opened_at >= self._reset_timeout:
        self._state = "half-open"   # mutated inside a read
        return False
```

`stm_proxy_health` renders the surfacing breaker by reading `is_open` (`server.py:785`), so once the breaker is open and `reset_timeout` has elapsed, **running a health check flips the breaker to half-open and then reports `closed (healthy)`** — a read that both mutates and misreports the state it claims to observe.

## Change

Make `is_open` / `state` / `time_until_reset` **pure** via a new `_effective_state()` helper that computes the effective state (open past its reset window → `half-open`) **without assigning** `self._state`. State is now committed only by `record_success` / `record_failure`.

Because reads no longer commit the half-open transition, `record_failure` recomputes the effective state: a probe that fails within the elapsed window (effectively half-open) re-opens the breaker with a fresh `_opened_at`, exactly as before — just driven by the outcome instead of by a prior read. The three admission-path gates (surfacing / compression / extraction) each already call `record_success` / `record_failure` after proceeding, so their behavior is unchanged; `is_open`'s external return values are identical, only the hidden mutation is gone.

`stm_proxy_health` (and any future observer) can now read the breaker without perturbing it.

## Scope

Single-probe enforcement in half-open (the docstring's "one probe" claim, never actually enforced) is deliberately **out of scope**: it is theoretical for STM's serialized single-MCP-client deployment, and the surfacing gate has intermediate non-recording skips between the `is_open` check and the call that would make an in-flight-probe flag unsafe without restructuring. The docstring is corrected to stop overclaiming it.

## Behavior change

None external — `is_open` returns the same values and the gate/probe lifecycle is preserved. The only observable difference is that reading `is_open` / `state` / `time_until_reset` no longer mutates the breaker, so `stm_proxy_health` reports the true state instead of flipping open→half-open on observation. `time_until_reset` now returns `None` at/after the reset window (effectively half-open) rather than `~0.0`.

## Tests

`tests/test_circuit_breaker.py`: the pins that asserted `cb._state == "half-open"` *after a read* are updated to the new contract — the public `state` reads `half-open` while the raw `_state` stays `open` until `record_*` commits. New `test_reads_are_pure_and_idempotent` (5 repeated reads in the elapsed window never mutate `_state`). The half-open failure/reset tests now call `record_failure` inside the elapsed (mocked) window, matching production timing. `test_time_until_reset_near_boundary` replaces the exact-boundary float pin with deterministic just-before (small positive) and just-past (`None`) cases.

Full suite: 4085 passed, 3 skipped. `ruff check` + `format` clean.

## Series

From the 2026-07-03 ops-stability low-severity triage (2nd pass). Filed as #600 (L4); the sibling #601 (L9, `stop()` pending-store leak) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
