### PR TITLE
fix(proxy): close the sqlite pending stores in ProxyManager.stop() (#601)

### DIFF
--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -853,6 +853,15 @@ class SelectiveCompressor:
 
             self._store = InMemoryPendingStore()
 
+    def close(self) -> None:
+        """Release the backing pending store (#601). A ``SQLitePendingStore``
+        holds a live sqlite connection; the in-memory store has no ``close``,
+        so this is a no-op there. Idempotent — safe to call from
+        ``ProxyManager.stop()`` and again on a subsequent stop."""
+        close = getattr(self._store, "close", None)
+        if callable(close):
+            close()
+
     def compress(self, text: str, *, max_chars: int, context_query: str | None = None) -> str:
         if not text or len(text) <= max_chars:
             return text

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -1122,6 +1122,27 @@ class ProxyManager:
             except Exception:
                 logger.debug("Failed to close tool-graph consult cache", exc_info=True)
             self._toolgraph_cache = None
+        # Close the pending stores (#601). Under ``pending_store: "sqlite"`` the
+        # selective compressor and the progressive store each hold a live sqlite
+        # connection; they were the lone long-lived resources ``stop()`` left
+        # open. Close and null them (with their cfg snapshots) so a stop->start —
+        # or a post-restart config change that rebuilds them — starts from a
+        # fresh store instead of reusing a closed connection, matching the
+        # close-and-null pattern used for the extractor / tool-graph cache above.
+        if self._selective_compressor is not None:
+            try:
+                self._selective_compressor.close()
+            except Exception:
+                logger.debug("Failed to close selective pending store", exc_info=True)
+            self._selective_compressor = None
+            self._selective_compressor_cfg = None
+        if self._progressive_store is not None:
+            try:
+                self._progressive_store.close()
+            except Exception:
+                logger.debug("Failed to close progressive pending store", exc_info=True)
+            self._progressive_store = None
+            self._progressive_store_cfg = None
         for conn in self._connections.values():
             if conn.stack is not None:
                 try:

--- a/src/memtomem_stm/proxy/progressive.py
+++ b/src/memtomem_stm/proxy/progressive.py
@@ -62,6 +62,14 @@ class ProgressiveStoreAdapter:
     def __init__(self, store: object) -> None:
         self._store = store
 
+    def close(self) -> None:
+        """Release the backing pending store (#601). A ``SQLitePendingStore``
+        holds a live sqlite connection; the in-memory store has no ``close``,
+        so this is a no-op there. Idempotent."""
+        close = getattr(self._store, "close", None)
+        if callable(close):
+            close()
+
     def put(self, key: str, resp: ProgressiveResponse) -> None:
         meta = json.dumps(
             {

--- a/tests/test_pending_store.py
+++ b/tests/test_pending_store.py
@@ -255,6 +255,19 @@ class TestSelectiveCompressorWithStore:
         assert "Data X" in selected
         store.close()
 
+    def test_compressor_close_closes_sqlite_store(self, tmp_path):
+        """#601 — SelectiveCompressor.close() releases the backing sqlite
+        connection; InMemory has no close() so it's a harmless no-op."""
+        store = SQLitePendingStore(tmp_path / "sel.db")
+        store.initialize()
+        comp = SelectiveCompressor(store=store)
+        assert store._db is not None
+        comp.close()
+        assert store._db is None  # connection released
+
+        # InMemory-backed compressor: close() is a no-op, no raise.
+        SelectiveCompressor().close()
+
     def test_multi_instance_shared_sqlite(self, tmp_path):
         """Two compressors sharing one SQLite DB can cross-select."""
         db_path = tmp_path / "shared.db"

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -193,6 +193,44 @@ class TestStop:
         mock_stack.aclose.assert_awaited_once()
         assert len(mgr._connections) == 0
 
+    async def test_stop_closes_and_nulls_pending_stores(self):
+        """#601 — stop() closes the selective compressor + progressive store
+        (their sqlite connections) and nulls both handles + cfg snapshots, so a
+        stop→start rebuilds cleanly instead of reusing a closed store."""
+        from unittest.mock import MagicMock
+
+        mgr = _make_manager(servers={})
+
+        selective = MagicMock()
+        progressive = MagicMock()
+        mgr._selective_compressor = selective
+        mgr._selective_compressor_cfg = object()
+        mgr._progressive_store = progressive
+        mgr._progressive_store_cfg = object()
+
+        await mgr.stop()
+
+        selective.close.assert_called_once()
+        progressive.close.assert_called_once()
+        assert mgr._selective_compressor is None
+        assert mgr._selective_compressor_cfg is None
+        assert mgr._progressive_store is None
+        assert mgr._progressive_store_cfg is None
+
+    async def test_stop_pending_store_close_failure_is_swallowed(self):
+        """A close() that raises must not break stop() — the handle is still
+        nulled so a restart rebuilds."""
+        from unittest.mock import MagicMock
+
+        mgr = _make_manager(servers={})
+        selective = MagicMock()
+        selective.close.side_effect = RuntimeError("db locked")
+        mgr._selective_compressor = selective
+
+        await mgr.stop()  # must not raise
+
+        assert mgr._selective_compressor is None
+
 
 # ── connect timeout ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #601. `ProxyManager.stop()` follows a consistent **close-and-null** pattern for every long-lived resource — background tasks, `_llm_compressor`, `_extractor`, `_toolgraph_cache`, the per-connection stacks, the main `_stack`. The pending stores were the lone exception: `_selective_compressor` and `_progressive_store` (and their underlying `SQLitePendingStore`, which holds a live `sqlite3.Connection`) were neither closed nor nulled.

Under the opt-in `pending_store: "sqlite"` backend, a post-restart config change rebuilds these (`_create_selective` / `_get_progressive_store` on a cfg mismatch call `SQLitePendingStore.initialize()` again), opening a fresh sqlite connection while the previous one is never closed — its fd / file-lock lingers until GC reclaims the `Connection`.

## Change

- New `close()` on `SelectiveCompressor` (`compression.py`) and `ProgressiveStoreAdapter` (`progressive.py`): each releases its backing store's sqlite connection via `getattr(store, "close", None)` — a no-op for `InMemoryPendingStore` (no `close`), idempotent for `SQLitePendingStore` (nulls `_db`).
- `stop()` now closes and nulls `_selective_compressor` / `_progressive_store` (and their `_cfg` snapshots), guarded so a failing `close()` can't break shutdown — mirroring the `_extractor` / `_toolgraph_cache` blocks. A stop→start (or a post-restart config-change rebuild) now starts from a fresh store instead of reusing a closed connection.

## Behavior change

None external. On the default `pending_store: "memory"` backend `close()` is a no-op. With the sqlite backend, the connection is now released deterministically at `stop()` instead of at GC.

## Tests

- `tests/test_proxy_manager_lifecycle.py`: `test_stop_closes_and_nulls_pending_stores` (both `close()` called, all four fields nulled) and `test_stop_pending_store_close_failure_is_swallowed` (a raising `close()` doesn't break `stop()`, handle still nulled).
- `tests/test_pending_store.py::test_compressor_close_closes_sqlite_store`: a real SQLite-backed `SelectiveCompressor.close()` releases the connection (`store._db is None`); the in-memory compressor's `close()` is a harmless no-op.

Full suite: 4088 passed, 3 skipped. `ruff check` + `format` clean.

## Series

From the 2026-07-03 ops-stability low-severity triage (2nd pass). Filed as #601 (L9); the sibling #600 (L4, circuit-breaker mutating reads) is PR #602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
