### PR TITLE
fix(cli): name the mms project mutators in the write-lock timeout hint (#582)

### DIFF
--- a/src/memtomem_stm/mms/state.py
+++ b/src/memtomem_stm/mms/state.py
@@ -135,13 +135,18 @@ class CorruptedConfig(MmsConfigError):
 
 
 _REGISTRY_LOCK_HOLDER_HINT = (
-    "another `mms host sync --apply` or `mms import --apply` appears to be "
-    "running (possibly waiting at its confirmation prompt)"
+    "another registry-mutating command (`mms host sync --apply`, "
+    "`mms import --apply`, or a `mms project` mutator such as "
+    "`init`/`enable`/`disable`/`list --prune`) appears to be running "
+    "(possibly waiting at its confirmation prompt)"
 )
-"""Default :class:`WriteLockTimeout` attribution — names the registry/sidecar
-mutators that hold the default ``~/.mms/.lock``. Locks over other domains
-(the proxy-config lock, #475 PR2) pass their own hint so the operator is
-pointed at the right family of commands."""
+"""Default :class:`WriteLockTimeout` attribution — names every command that
+holds the default ``~/.mms/.lock``: the registry/sidecar mutators
+(``mms host sync --apply``, ``mms import --apply``) and the ``mms project``
+mutators (``init``/``enable``/``disable`` and ``list --prune``), which share
+the same lock (#582). Locks over other domains (the proxy-config lock, #475
+PR2) pass their own hint so the operator is pointed at the right family of
+commands."""
 
 
 class WriteLockTimeout(MmsConfigError):

--- a/src/memtomem_stm/mms/state.py
+++ b/src/memtomem_stm/mms/state.py
@@ -135,8 +135,8 @@ class CorruptedConfig(MmsConfigError):
 
 
 _REGISTRY_LOCK_HOLDER_HINT = (
-    "another registry-mutating command (`mms host sync --apply`, "
-    "`mms import --apply`, or a `mms project` mutator such as "
+    "another `~/.mms` state-mutating command (`mms host sync --apply`, "
+    "`mms import --apply`, or a `mms project` mutator: "
     "`init`/`enable`/`disable`/`list --prune`) appears to be running "
     "(possibly waiting at its confirmation prompt)"
 )

--- a/tests/cli/test_mms_project.py
+++ b/tests/cli/test_mms_project.py
@@ -420,6 +420,10 @@ def test_project_mutator_under_held_lock_exits_cleanly(runner, sandbox, monkeypa
     assert res.exit_code == 1
     # WriteLockTimeout is surfaced as a Click error, not a traceback.
     assert "Error" in res.output
+    # #582 follow-up: the timeout attribution must name the `mms project`
+    # mutators too, not just host sync / import — they share this lock, so an
+    # operator whose project command timed out needs to see it in the hint.
+    assert "mms project" in res.output
 
 
 @pytest.mark.skipif(

--- a/tests/cli/test_mms_project.py
+++ b/tests/cli/test_mms_project.py
@@ -423,7 +423,11 @@ def test_project_mutator_under_held_lock_exits_cleanly(runner, sandbox, monkeypa
     # #582 follow-up: the timeout attribution must name the `mms project`
     # mutators too, not just host sync / import — they share this lock, so an
     # operator whose project command timed out needs to see it in the hint.
+    # Pin the specific subcommand tokens so the assertion fails if the hint
+    # stops enumerating them (not just the "mms project" prefix).
     assert "mms project" in res.output
+    for token in ("init", "enable", "disable", "list --prune"):
+        assert token in res.output, f"holder hint should name `{token}`: {res.output!r}"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Background
Codex review of #595 flagged a Minor: the `mms project` mutators (`init`/`enable`/`disable`, `list --prune`) share the default `~/.mms/.lock`, but the `WriteLockTimeout` attribution (`_REGISTRY_LOCK_HOLDER_HINT`) named only `mms host sync --apply` / `mms import --apply`. An operator whose `mms project` command timed out was pointed at the wrong family of commands.

## Change
- Broaden the default holder hint to name the `mms project` mutators alongside the registry/sidecar ones (they all hold the same lock).
- Update the hint docstring accordingly.
- Assert the `mms project` attribution in `test_project_mutator_under_held_lock_exits_cleanly`.

Custom-hint domains (the proxy-config lock, #475 PR2) still override the default, so their attribution is unchanged (`test_custom_holder_hint_lands_in_timeout_message` still passes).

## Tests
`tests/cli/test_mms_project.py` + `tests/mms/test_write_lock.py`: 48 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)