### PR TITLE
fix(proxy): redact credentialed cleanup logs on reconnect/stop paths (#605)

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -361,10 +361,15 @@ class ProxyManager:
                 if conn.stack is not None:
                     try:
                         await conn.stack.aclose()
-                    except Exception:
+                    except Exception as cleanup_exc:
+                        # Redact + no exc_info (#605): this stack wraps a transport
+                        # opened with the credentialed ``conn.config.url``, so a
+                        # close failure's traceback tail could leak the token even
+                        # at DEBUG. Route through the #593 choke point.
                         logger.debug(
-                            "Failed to close connection stack in double-start guard",
-                            exc_info=True,
+                            "Failed to close connection stack for '%s' in double-start guard: %s",
+                            conn.name,
+                            self._redacted_error(cleanup_exc, conn.config.url),
                         )
             try:
                 await self._stack.aclose()
@@ -969,8 +974,15 @@ class ProxyManager:
             if conn.stack is not None:
                 try:
                     await conn.stack.aclose()
-                except Exception:
-                    logger.debug("Failed to close previous stack for '%s'", name, exc_info=True)
+                except Exception as cleanup_exc:
+                    # Redact + no exc_info (#605): the previous stack wraps a
+                    # transport opened with the credentialed ``cfg.url``, so a
+                    # close failure's traceback tail could leak the token at DEBUG.
+                    logger.debug(
+                        "Failed to close previous stack for '%s': %s",
+                        name,
+                        self._redacted_error(cleanup_exc, cfg.url),
+                    )
 
             conn_stack = AsyncExitStack()
             try:
@@ -988,8 +1000,15 @@ class ProxyManager:
                 # and child processes across retry storms.
                 try:
                     await conn_stack.aclose()
-                except Exception:
-                    logger.debug("Error during reconnect cleanup for '%s'", name, exc_info=True)
+                except Exception as cleanup_exc:
+                    # Redact + no exc_info (#605): the rolled-back stack wraps a
+                    # transport just opened with the credentialed ``cfg.url``, so a
+                    # close failure's traceback tail could leak the token at DEBUG.
+                    logger.debug(
+                        "Error during reconnect cleanup for '%s': %s",
+                        name,
+                        self._redacted_error(cleanup_exc, cfg.url),
+                    )
                 raise
 
             conn.session = session
@@ -1206,8 +1225,15 @@ class ProxyManager:
             if conn.stack is not None:
                 try:
                     await conn.stack.aclose()
-                except Exception:
-                    logger.debug("Failed to close connection stack", exc_info=True)
+                except Exception as cleanup_exc:
+                    # Redact + no exc_info (#605): this stack wraps a transport
+                    # opened with the credentialed ``conn.config.url``, so a close
+                    # failure's traceback tail could leak the token at DEBUG.
+                    logger.debug(
+                        "Failed to close connection stack for '%s': %s",
+                        conn.name,
+                        self._redacted_error(cleanup_exc, conn.config.url),
+                    )
         if self._stack:
             await self._stack.aclose()
             self._stack = None
@@ -2721,8 +2747,15 @@ class ProxyManager:
                 _mark_recorded(deadline_exc)
                 try:
                     await self._reconnect_server(server)
-                except Exception:
-                    logger.debug("Post-deadline reconnect failed", exc_info=True)
+                except Exception as reconnect_exc:
+                    # Redact + no exc_info (#605): the reconnect reopens a transport
+                    # with the credentialed ``cfg.url``, so a failure's traceback
+                    # tail could leak the token at DEBUG.
+                    logger.debug(
+                        "Post-deadline reconnect failed for '%s': %s",
+                        server,
+                        self._redacted_error(reconnect_exc, cfg.url),
+                    )
                 raise deadline_exc
             per_attempt_timeout = min(cfg.call_timeout_seconds, remaining_deadline)
             try:
@@ -2776,12 +2809,18 @@ class ProxyManager:
                     _mark_recorded(exc)
                     try:
                         await self._reconnect_server(server)
-                    except Exception:
+                    except Exception as reconnect_exc:
                         # Expected fallback: the primary error is already being
                         # re-raised and carries the actionable trace. The
                         # reconnect attempt here is best-effort for the NEXT
                         # call — a failure is noise for current operators.
-                        logger.debug("Post-protocol-error reconnect failed", exc_info=True)
+                        # Redact + no exc_info (#605): the reconnect reopens a
+                        # transport with the credentialed ``cfg.url``.
+                        logger.debug(
+                            "Post-protocol-error reconnect failed for '%s': %s",
+                            server,
+                            self._redacted_error(reconnect_exc, cfg.url),
+                        )
                     raise
 
                 # Timeout-replay guard (#578): a per-attempt timeout cancels OUR
@@ -2826,11 +2865,17 @@ class ProxyManager:
                     # Reconnect before raising so the NEXT call starts fresh
                     try:
                         await self._reconnect_server(server)
-                    except Exception:
+                    except Exception as reconnect_exc:
                         # Same reasoning as the protocol-error path above:
                         # the primary failure is being re-raised, the
                         # reconnect attempt is just pre-emptive cleanup.
-                        logger.debug("Post-failure reconnect failed", exc_info=True)
+                        # Redact + no exc_info (#605): the reconnect reopens a
+                        # transport with the credentialed ``cfg.url``.
+                        logger.debug(
+                            "Post-failure reconnect failed for '%s': %s",
+                            server,
+                            self._redacted_error(reconnect_exc, cfg.url),
+                        )
                     raise
                 logger.warning(
                     "Tool call %s/%s failed (attempt %d/%d): %s",

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -680,3 +680,230 @@ class TestConnectServerOverflowSkip:
         assert mgr._advertised_reject_reasons == {}
         # No overflow guidance in the log — no overflow happened.
         assert "will not be advertised" not in caplog.text
+
+
+class TestCleanupLogCredentialRedaction:
+    """#605 (follow-up to #580/#593): the connection-lifecycle cleanup and
+    reconnect DEBUG logs close or reopen transports opened with the
+    credentialed ``cfg.url``. httpx transport exceptions embed the request
+    URL, so a close/reconnect failure routed through ``logger.debug(...,
+    exc_info=True)`` would repeat the token in the traceback tail. Every such
+    site must instead render the exception through ``_redacted_error`` with no
+    ``exc_info`` — the same guarantee #593 gave the startup connect path.
+
+    One regression per in-scope site: the two ``_reconnect_server`` closes, the
+    ``stop()`` and double-start-guard connection-stack closes, and the three
+    ``_fetch_upstream`` post-error reconnect logs.
+    """
+
+    URL = "https://alice:s3cr3t-token@ltm.example.com/mcp"
+
+    def _assert_redacted(self, caplog, expect_msg: str) -> None:
+        assert expect_msg in caplog.text
+        assert "s3cr3t-token" not in caplog.text
+        assert "alice:s3cr3t-token" not in caplog.text
+        # The redacted rendering still identifies the host for operators.
+        assert "***@ltm.example.com" in caplog.text
+
+    def _cfg(self, **overrides) -> UpstreamServerConfig:
+        return UpstreamServerConfig(
+            prefix="bad", transport=TransportType.SSE, url=self.URL, **overrides
+        )
+
+    async def test_double_start_guard_conn_stack_close_redacts(self, caplog):
+        """start() re-entry closes each live connection's stack; a close failure
+        for a credentialed upstream must not leak the token."""
+        from contextlib import AsyncExitStack
+
+        cfg = self._cfg()
+        mgr = _make_manager(servers={"bad": cfg})
+        failing_stack = AsyncMock()
+        failing_stack.aclose = AsyncMock(
+            side_effect=ConnectionError(f"close failed for {self.URL}")
+        )
+        mgr._connections["bad"] = UpstreamConnection(
+            name="bad", config=cfg, session=AsyncMock(), tools=[], stack=failing_stack
+        )
+        mgr._stack = AsyncExitStack()  # non-None → double-start branch runs
+
+        with caplog.at_level("DEBUG"):
+            with patch.object(mgr, "_connect_server", new_callable=AsyncMock):
+                await mgr.start()
+
+        self._assert_redacted(
+            caplog, "Failed to close connection stack for 'bad' in double-start guard"
+        )
+
+    async def test_stop_conn_stack_close_redacts(self, caplog):
+        """stop() closes every connection stack; a close failure for a
+        credentialed upstream must not leak the token."""
+        from contextlib import AsyncExitStack
+
+        cfg = self._cfg()
+        mgr = _make_manager(servers={"bad": cfg})
+        failing_stack = AsyncMock()
+        failing_stack.aclose = AsyncMock(
+            side_effect=ConnectionError(f"close failed for {self.URL}")
+        )
+        mgr._connections["bad"] = UpstreamConnection(
+            name="bad", config=cfg, session=AsyncMock(), tools=[], stack=failing_stack
+        )
+        mgr._stack = AsyncExitStack()
+
+        with caplog.at_level("DEBUG"):
+            await mgr.stop()
+
+        self._assert_redacted(caplog, "Failed to close connection stack for 'bad'")
+
+    async def test_reconnect_previous_stack_close_redacts(self, caplog):
+        """_reconnect_server closes the previous stack before reopening; a close
+        failure must not leak the credentialed URL."""
+        cfg = self._cfg(connect_timeout_seconds=5.0)
+        mgr = _make_manager(servers={"bad": cfg})
+        failing_stack = AsyncMock()
+        failing_stack.aclose = AsyncMock(
+            side_effect=ConnectionError(f"prev close failed for {self.URL}")
+        )
+        mgr._connections["bad"] = UpstreamConnection(
+            name="bad", config=cfg, session=AsyncMock(), tools=[], stack=failing_stack
+        )
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+        mock_transport = AsyncMock()
+        mock_transport.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+        mock_transport.__aexit__ = AsyncMock(return_value=False)
+
+        with caplog.at_level("DEBUG"):
+            with (
+                patch.object(mgr, "_open_transport", return_value=mock_transport),
+                patch("memtomem_stm.proxy.manager.ClientSession", return_value=mock_session),
+            ):
+                await mgr._reconnect_server("bad")
+
+        self._assert_redacted(caplog, "Failed to close previous stack for 'bad'")
+
+    async def test_reconnect_rollback_cleanup_redacts(self, caplog):
+        """When a reconnect's list_tools fails, the rollback aclose() of the new
+        stack may itself raise for a credentialed transport; the cleanup log
+        must not leak the token."""
+        import pytest as _pt
+
+        cfg = self._cfg(connect_timeout_seconds=5.0)
+        mgr = _make_manager(servers={"bad": cfg})
+        mgr._connections["bad"] = UpstreamConnection(
+            name="bad", config=cfg, session=AsyncMock(), tools=[], stack=None
+        )
+
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(side_effect=RuntimeError("catalog failed"))
+        mock_transport = AsyncMock()
+        mock_transport.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+        mock_transport.__aexit__ = AsyncMock(
+            side_effect=ConnectionError(f"rollback failed for {self.URL}")
+        )
+
+        with caplog.at_level("DEBUG"):
+            with (
+                patch.object(mgr, "_open_transport", return_value=mock_transport),
+                patch("memtomem_stm.proxy.manager.ClientSession", return_value=mock_session),
+            ):
+                with _pt.raises(RuntimeError, match="catalog failed"):
+                    await mgr._reconnect_server("bad")
+
+        self._assert_redacted(caplog, "Error during reconnect cleanup for 'bad'")
+
+    def _seed_fetch_conn(self, mgr, cfg):
+        """A connection whose session.call_tool is a controllable AsyncMock."""
+        session = AsyncMock()
+        mgr._connections["bad"] = UpstreamConnection(
+            name="bad", config=cfg, session=session, tools=[], stack=AsyncMock()
+        )
+        return session
+
+    async def test_fetch_post_deadline_reconnect_redacts(self, caplog):
+        """_fetch_upstream best-effort reconnect after the overall deadline is
+        blown; a reconnect failure must not leak the credentialed URL."""
+        import pytest as _pt
+
+        cfg = self._cfg(overall_deadline_seconds=1.0, call_timeout_seconds=1.0)
+        mgr = _make_manager(servers={"bad": cfg})
+        self._seed_fetch_conn(mgr, cfg)
+
+        with caplog.at_level("DEBUG"):
+            with (
+                # _call_started_at, then the in-loop deadline check reads a
+                # monotonic far in the future → remaining_deadline <= 0.
+                patch(
+                    "memtomem_stm.proxy.manager._time.monotonic",
+                    side_effect=[100.0, 200.0, 200.0, 200.0],
+                ),
+                patch.object(
+                    mgr,
+                    "_reconnect_server",
+                    new_callable=AsyncMock,
+                    side_effect=ConnectionError(f"reconnect boom for {self.URL}"),
+                ),
+            ):
+                with _pt.raises(asyncio.TimeoutError):
+                    await mgr._fetch_upstream("bad", "t", {"_trace_id": None}, trace_id=None)
+
+        self._assert_redacted(caplog, "Post-deadline reconnect failed for 'bad'")
+
+    async def test_fetch_post_protocol_error_reconnect_redacts(self, caplog):
+        """_fetch_upstream reconnects after a no-retry protocol error; a
+        reconnect failure must not leak the credentialed URL."""
+        import pytest as _pt
+
+        cfg = self._cfg()
+        mgr = _make_manager(servers={"bad": cfg})
+        session = self._seed_fetch_conn(mgr, cfg)
+
+        class _ProtocolError(Exception):
+            def __init__(self):
+                super().__init__("protocol boom")
+                self.error = SimpleNamespace(code=-32601)  # METHOD_NOT_FOUND
+
+        session.call_tool = AsyncMock(side_effect=_ProtocolError())
+
+        with caplog.at_level("DEBUG"):
+            with patch.object(
+                mgr,
+                "_reconnect_server",
+                new_callable=AsyncMock,
+                side_effect=ConnectionError(f"reconnect boom for {self.URL}"),
+            ):
+                with _pt.raises(_ProtocolError):
+                    await mgr._fetch_upstream("bad", "t", {"_trace_id": None}, trace_id=None)
+
+        self._assert_redacted(caplog, "Post-protocol-error reconnect failed for 'bad'")
+
+    async def test_fetch_post_failure_reconnect_redacts(self, caplog):
+        """_fetch_upstream reconnects after exhausting retries on a transport
+        error; a reconnect failure must not leak the credentialed URL."""
+        import pytest as _pt
+
+        cfg = self._cfg(max_retries=0)
+        mgr = _make_manager(servers={"bad": cfg})
+        session = self._seed_fetch_conn(mgr, cfg)
+        # URL-free upstream error so the ONLY token-bearing string is the
+        # reconnect failure we assert is redacted.
+        session.call_tool = AsyncMock(side_effect=ConnectionError("upstream boom"))
+
+        with caplog.at_level("DEBUG"):
+            with patch.object(
+                mgr,
+                "_reconnect_server",
+                new_callable=AsyncMock,
+                side_effect=ConnectionError(f"reconnect boom for {self.URL}"),
+            ):
+                with _pt.raises(ConnectionError, match="upstream boom"):
+                    await mgr._fetch_upstream("bad", "t", {"_trace_id": None}, trace_id=None)
+
+        self._assert_redacted(caplog, "Post-failure reconnect failed for 'bad'")


### PR DESCRIPTION
## Summary

Closes #605 — the deferred follow-up to #580/#593.

#593 closed a credential-leak class on the **startup** connect path: httpx transport exceptions embed the credentialed request URL, and `logger.debug(..., exc_info=True)` re-emits that string in the traceback tail. It introduced the single choke point `ProxyManager._redacted_error(exc, url)` and routed the startup failure log, the health record, and the initial-connection rollback log through it.

This PR applies the same treatment to the **sibling** connection-lifecycle cleanup logs on the reconnect / double-start / stop paths, which the #593 scope note deferred here. They close or reopen `AsyncExitStack`s wrapping transports opened with the same credentialed `cfg.url`, so a close/reconnect failure's traceback could leak the token the same way.

## In-scope sites (all `src/memtomem_stm/proxy/manager.py`)

Each now renders the exception via `_redacted_error(exc, url)` and drops `exc_info=True`:

| Site | URL source |
|------|-----------|
| `start()` double-start guard — per-connection stack close | `conn.config.url` |
| `stop()` — "Failed to close connection stack" | `conn.config.url` |
| `_reconnect_server` — "Failed to close previous stack" | `cfg.url` |
| `_reconnect_server` — "Error during reconnect cleanup" | `cfg.url` |
| `_fetch_upstream` — post-deadline / post-protocol-error / post-failure reconnect | `cfg.url` |

The three `_fetch_upstream` messages previously carried no server context — the server name is added while touching them.

## Behavior change

These are all DEBUG-level logs. They **lose the `exc_info` traceback**; in exchange the message now carries the redacted exception text (`_redacted_error` — URL userinfo scrubbed, then capped). This mirrors the #593 startup site exactly. The traceback is dropped only on these credentialed connection-lifecycle paths, where the traceback tail is the leak vector; every credential-free `exc_info` debug path is untouched.

## Explicitly out of scope (unchanged, `exc_info` retained)

- **`start()` double-start guard `self._stack.aclose()`** — nothing is ever entered onto `self._stack` (there is no `enter_async_context` call against it anywhere), so an empty `AsyncExitStack`'s `aclose` cannot raise a transport error embedding a URL, and no single `cfg.url` is attributable to it.
- Tool-graph cache closes, selective/progressive store closes, telemetry / ranking `exc_info` sites — no credentialed URL in the exception path. Per #605, `exc_info` is deliberately preserved here for non-credential debugging.

`redact_exception_text` already no-ops on a falsy url, so the stdio-transport `cfg.url is None` case needs no extra guard (same as the existing #593 call sites).

## Tests

`tests/test_proxy_manager_lifecycle.py::TestCleanupLogCredentialRedaction` — one `caplog` regression per in-scope site, mirroring the #593 test shape (`TestConnectServerCleanup::test_cleanup_failure_log_redacts_credential`): a cleanup or reconnect raises an error embedding `https://alice:s3cr3t-token@ltm.example.com/mcp`; each test asserts the site's message appears, the token does **not** appear in `caplog.text`, and the redacted `***@ltm.example.com` does.

## Verification

- `uv run pytest -m "not ollama"` → 4151 passed, 3 skipped
- `uv run ruff check src && uv run ruff format --check src` → clean
- `grep exc_info=True src/…/manager.py` → only the documented out-of-scope sites remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)