### PR TITLE
fix(proxy): redact the credentialed URL in the mid-loop reconnect log

### DIFF
--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -2974,7 +2974,15 @@ class ProxyManager:
                     await self._reconnect_server(server)
                     conn = self._connections[server]
                 except Exception as reconnect_exc:
-                    logger.error("Reconnect to '%s' failed: %s", server, reconnect_exc)
+                    # Redact (#622, #605/#606 family): the reconnect reopens a
+                    # transport with the credentialed ``cfg.url``, so an httpx
+                    # error here embeds the token — the three sibling
+                    # reconnect-failure sites in this loop already scrub it.
+                    logger.error(
+                        "Reconnect to '%s' failed: %s",
+                        server,
+                        self._redacted_error(reconnect_exc, cfg.url),
+                    )
                     # Third terminal exit (#608): a mid-loop reconnect failure
                     # means the upstream is unreachable — count it, or a dead
                     # stdio upstream whose respawns fail escapes the breaker.

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -907,3 +907,29 @@ class TestCleanupLogCredentialRedaction:
                     await mgr._fetch_upstream("bad", "t", {"_trace_id": None}, trace_id=None)
 
         self._assert_redacted(caplog, "Post-failure reconnect failed for 'bad'")
+
+    async def test_fetch_mid_loop_reconnect_failure_redacts(self, caplog):
+        """#622: the mid-loop reconnect on the retry-continue path (a retryable
+        transport error with attempts remaining) re-raises the reconnect error;
+        its ERROR log must not leak the credentialed URL. Sibling to the three
+        #605 post-error reconnect sites, which this sweep originally missed."""
+        import pytest as _pt
+
+        cfg = self._cfg(max_retries=1, reconnect_delay_seconds=0.0, max_reconnect_delay_seconds=0.0)
+        mgr = _make_manager(servers={"bad": cfg})
+        session = self._seed_fetch_conn(mgr, cfg)
+        # URL-free upstream error so the ONLY token-bearing string is the
+        # mid-loop reconnect failure we assert is redacted.
+        session.call_tool = AsyncMock(side_effect=ConnectionError("upstream boom"))
+
+        with caplog.at_level("DEBUG"):
+            with patch.object(
+                mgr,
+                "_reconnect_server",
+                new_callable=AsyncMock,
+                side_effect=ConnectionError(f"reconnect boom for {self.URL}"),
+            ):
+                with _pt.raises(ConnectionError, match="reconnect boom"):
+                    await mgr._fetch_upstream("bad", "t", {"_trace_id": None}, trace_id=None)
+
+        self._assert_redacted(caplog, "Reconnect to 'bad' failed")


### PR DESCRIPTION
Closes #622.

## Problem

The #605/#606 credential-redaction sweep scrubbed every reconnect/cleanup log site in `manager.py` except one — the **mid-loop reconnect failure** on `_fetch_upstream`'s retry-continue path (`manager.py:2977`):

```python
except Exception as reconnect_exc:
    logger.error("Reconnect to '%s' failed: %s", server, reconnect_exc)
```

`_reconnect_server` re-raises the underlying connect exception; for an HTTP/SSE upstream that httpx error embeds `cfg.url`, which can carry userinfo credentials. So a reconnect failure during a retry storm against a credentialed upstream leaked the token to the logs — and at `logger.error` (default level), broader than the `logger.debug` siblings.

## Fix

One line — route it through the existing `_redacted_error(exc, url)` choke point (`redact_url_userinfo` + `MAX_ERROR_MESSAGE_CHARS` cap), exactly like the three sibling reconnect-failure sites in the same loop (`:2819`, `:2899`, `:2959`).

## Test

`test_fetch_mid_loop_reconnect_failure_redacts` in the existing `TestCleanupLogCredentialRedaction` suite, targeting the mid-loop path specifically (`max_retries=1` + a retryable transport error so the retry-continue branch runs; asserts it re-raises the *reconnect* error, distinguishing it from the terminal exit). Mirrors the three `test_fetch_post_*_reconnect_redacts` siblings the original sweep shipped; this is the site those per-site tests missed.

## Scope

Behavior: none beyond the log string. Credential-safety hardening only. Found while implementing #620 (per-upstream breaker) on the same retry loop; filed separately as #622 and fixed here per the no-bundle rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)