### PR TITLE
feat(config): mms config validate, unknown-key warnings, and visible parse failure

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,6 +36,7 @@ Options:
 
 Commands:
   add        Add an upstream MCP server to the proxy configuration.
+  config     Inspect and validate the proxy config file.
   daemon     Manage the local surfacing daemon (warm LTM connection for...
   eject      Restore imported upstream(s) to their host MCP client, then...
   health     Check upstream server connectivity.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -398,6 +398,27 @@ Options:
 
 Shows the current proxy gateway configuration file path, enabled flag, and the list of configured upstream servers with their prefix, transport, command or URL, compression strategy, character budget, and surfacing toggle. In `--json` output, every server's `env` and `headers` values are masked (`<REDACTED>`, keys preserved); the human-readable table never prints those fields at all, so read the on-disk config directly when a value is genuinely needed.
 
+When the file is valid JSON but fails schema validation (the state a running server silently degrades to env/defaults on), `status` and `health` print a warning naming the first error — exit code unchanged. Use `mms config validate` for the strict check.
+
+### `config validate`
+
+```
+Usage: mms config validate [OPTIONS]
+
+Options:
+  --config TEXT  Path to the proxy config JSON.  [default: ~/.memtomem/stm_proxy.json]
+  --json         Output as JSON for scripting.
+```
+
+Strictly validates the config file *as written* — no `MEMTOMEM_STM_PROXY__*` env overlay, since this lints the artifact you edit and commit, not the runtime composite. Reports, with non-zero exit on any of them:
+
+- JSON parse errors and non-object roots,
+- schema validation errors (dotted location + message, one line each),
+- **unknown keys at every nesting level** (dotted paths like `upstream_servers.gh.tool_overides`). The runtime load deliberately keeps pydantic's `extra="ignore"` for forward compatibility, so a typo'd key silently vanishes there; this command is where typos fail loudly. The load path also logs one aggregated unknown-key warning per load,
+- a missing file (`status: "missing"` — a strict validator with nothing to validate fails, which is what a CI gate wants).
+
+Group/world-readable file permissions produce a warning line but exit 0 on their own. `--json` emits `{"config_path", "status": "ok"|"invalid"|"missing", "errors": [...], "unknown_keys": [...], "warnings": [...]}`.
+
 ### `stats`
 
 ```

--- a/src/memtomem_stm/cli/config_cmd.py
+++ b/src/memtomem_stm/cli/config_cmd.py
@@ -1,0 +1,134 @@
+"""``mms config`` Click subgroup — config-file linting (#611).
+
+``mms config validate`` checks the proxy config file *as written* — no env
+overlay — and reports everything the lenient runtime load silently drops or
+papers over: unknown keys at every nesting level (the models deliberately
+keep pydantic's ``extra="ignore"`` for forward compat, so a typo'd key just
+vanishes), schema validation errors (which a running server degrades to
+env/defaults on), and the permissive-file-mode warning. Strict by design:
+parse errors, validation errors, unknown keys, and a missing file all exit
+non-zero so the command can gate CI or a commit hook. The runtime load path
+stays lenient — strictness lives only here.
+
+Lives in its own file per the subgroup convention (``mms_project.py`` etc.)
+and must not import from ``cli/proxy.py`` — that module imports this group
+for registration, so the dependency only goes one way.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import click
+from pydantic import ValidationError
+
+from memtomem_stm.proxy.config import ProxyConfig, _permissive_mode, find_unknown_keys
+
+# Mirrors cli/proxy.py:_DEFAULT_CONFIG (not imported — see module docstring).
+_DEFAULT_CONFIG = Path("~/.memtomem/stm_proxy.json")
+
+
+def _color_on() -> bool:
+    return "NO_COLOR" not in os.environ
+
+
+def _err(s: str) -> str:
+    return click.style(s, fg="red", bold=True) if _color_on() else s
+
+
+def _warn(s: str) -> str:
+    return click.style(s, fg="yellow") if _color_on() else s
+
+
+def _ok(s: str) -> str:
+    return click.style(s, fg="green") if _color_on() else s
+
+
+@click.group(name="config")
+def config_group() -> None:
+    """Inspect and validate the proxy config file."""
+
+
+@config_group.command(name="validate")
+@click.option(
+    "--config",
+    "config_path",
+    default=str(_DEFAULT_CONFIG),
+    show_default=True,
+    help="Path to the proxy config JSON.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
+def validate_command(config_path: str, as_json: bool) -> None:
+    """Strictly validate the config file as written (no env overlay).
+
+    Exits non-zero on parse errors, schema validation errors, unknown keys
+    (silently ignored at runtime — usually typos), or a missing file.
+    Env vars (MEMTOMEM_STM_PROXY__*) are deliberately not merged: this
+    lints the artifact you edit and commit, not the runtime composite.
+    """
+    resolved = Path(config_path).expanduser().resolve()
+    errors: list[str] = []
+    unknown_keys: list[str] = []
+    warnings: list[str] = []
+    status = "ok"
+
+    if not resolved.exists():
+        status = "missing"
+        errors.append(f"config file not found: {resolved}")
+    else:
+        mode = _permissive_mode(resolved)
+        if mode is not None:
+            warnings.append(f"permissive mode {mode:o} — consider restricting to 0600")
+        data = None
+        try:
+            data = json.loads(resolved.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                errors.append(f"config root must be a JSON object, got {type(data).__name__}")
+                data = None
+        except json.JSONDecodeError as exc:
+            errors.append(f"invalid JSON: {exc}")
+        except OSError as exc:
+            errors.append(f"cannot read file: {exc}")
+        if data is not None:
+            unknown_keys = find_unknown_keys(ProxyConfig, data)
+            try:
+                ProxyConfig.model_validate(data)
+            except ValidationError as exc:
+                for err in exc.errors():
+                    loc = ".".join(str(part) for part in err["loc"])
+                    errors.append(f"{loc}: {err['msg']}" if loc else err["msg"])
+        if errors or unknown_keys:
+            status = "invalid"
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "config_path": str(resolved),
+                    "status": status,
+                    "errors": errors,
+                    "unknown_keys": unknown_keys,
+                    "warnings": warnings,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    else:
+        click.echo(f"Validating {resolved}")
+        for msg in errors:
+            click.echo(f"{_err('Error:')} {msg}")
+        for path in unknown_keys:
+            click.echo(f"{_err('Error:')} unknown key (silently ignored at runtime): {path}")
+        for msg in warnings:
+            click.echo(f"{_warn('Warning:')} {msg}")
+        if status == "ok":
+            click.echo(_ok("OK") + " — config is valid")
+        else:
+            click.echo(
+                f"{_err('Invalid:')} {len(errors)} error(s), {len(unknown_keys)} unknown key(s)"
+            )
+    if status != "ok":
+        raise SystemExit(1)

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -22,6 +22,7 @@ from typing import Any, TextIO
 import click
 
 from memtomem_stm.cli._write_lock import with_config_write_lock
+from memtomem_stm.cli.config_cmd import config_group as _config_group
 from memtomem_stm.cli.daemon_cmd import daemon_group as _daemon_group
 from memtomem_stm.cli.hook_cmd import hook_command as _hook_command
 from memtomem_stm.cli.mms_host import host_group as _mms_host_group
@@ -140,6 +141,33 @@ def _load(config_path: Path) -> dict[str, Any]:
         )
         raise SystemExit(1)
     return data
+
+
+def _schema_validation_error(data: dict[str, Any]) -> str | None:
+    """First schema-validation error for a raw config dict, or ``None``.
+
+    ``_load`` only guards JSON syntax and coarse shape; valid-JSON-but-
+    invalid-schema is exactly the case a running server silently degrades to
+    env/defaults on (#611). ``status`` / ``health`` warn on it — exit code
+    unchanged, since inspection commands stay lenient and strictness lives in
+    ``mms config validate``.
+    """
+    from pydantic import ValidationError
+
+    from memtomem_stm.proxy.config import ProxyConfig
+
+    try:
+        ProxyConfig.model_validate(data)
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        loc = ".".join(str(part) for part in first["loc"])
+        return f"{loc}: {first['msg']}" if loc else first["msg"]
+    return None
+
+
+_CONFIG_INVALID_WARNING = (
+    "config file present but fails validation — a running server falls back to env/defaults"
+)
 
 
 def _save(config_path: Path, data: dict[str, Any]) -> None:
@@ -654,6 +682,7 @@ def status(config_path: str, *, as_json: bool = False) -> None:
     data = _load(path)
     enabled = data.get("enabled", False)
     servers: dict[str, Any] = data.get("upstream_servers", {})
+    config_error = _schema_validation_error(data)
 
     if as_json:
         click.echo(
@@ -661,6 +690,8 @@ def status(config_path: str, *, as_json: bool = False) -> None:
                 {
                     "config_path": str(resolved),
                     "enabled": enabled,
+                    "config_valid": config_error is None,
+                    "config_error": config_error,
                     "servers": _redacted_servers_json(servers),
                 },
                 indent=2,
@@ -669,6 +700,8 @@ def status(config_path: str, *, as_json: bool = False) -> None:
         )
         return
 
+    if config_error:
+        click.echo(f"{_warn('Warning:')} {_CONFIG_INVALID_WARNING}: {config_error}")
     click.echo(f"Config : {resolved}")
     click.echo(f"Enabled: {'yes' if enabled else 'no'}")
     click.echo(f"Servers: {len(servers)}")
@@ -3994,6 +4027,7 @@ def health(
     data = _load(path)
     servers: dict[str, Any] = data.get("upstream_servers", {})
     surfacing_status = _surfacing_bootstrap_status(float(timeout))
+    config_error = _schema_validation_error(data)
 
     # JSON output format matches ``status --json`` / ``list --json`` (indent=2,
     # ensure_ascii=False) so scripts piping the three commands through the
@@ -4002,12 +4036,19 @@ def health(
         if as_json:
             click.echo(
                 json.dumps(
-                    {"servers": {}, "surfacing": surfacing_status},
+                    {
+                        "servers": {},
+                        "config_valid": config_error is None,
+                        "config_error": config_error,
+                        "surfacing": surfacing_status,
+                    },
                     indent=2,
                     ensure_ascii=False,
                 )
             )
         else:
+            if config_error:
+                click.echo(f"{_warn('Warning:')} {_CONFIG_INVALID_WARNING}: {config_error}")
             click.echo("No upstream servers configured.")
             click.echo("")
             for line in _format_surfacing_bootstrap(surfacing_status):
@@ -4019,13 +4060,20 @@ def health(
     if as_json:
         click.echo(
             json.dumps(
-                {"servers": results, "surfacing": surfacing_status},
+                {
+                    "servers": results,
+                    "config_valid": config_error is None,
+                    "config_error": config_error,
+                    "surfacing": surfacing_status,
+                },
                 indent=2,
                 ensure_ascii=False,
             )
         )
         return
 
+    if config_error:
+        click.echo(f"{_warn('Warning:')} {_CONFIG_INVALID_WARNING}: {config_error}")
     click.echo(_hdr("Upstream Server Health"))
     click.echo("=" * 30)
     for name, info in results.items():
@@ -4067,3 +4115,7 @@ cli.add_command(_hook_command)
 # `mms daemon ...` — manage the local surfacing daemon (Stage 2 warm LTM
 # connection for `mms hook`); lives in src/memtomem_stm/cli/daemon_cmd.py.
 cli.add_command(_daemon_group)
+
+# `mms config ...` — strict config-file linting (#611); lives in
+# src/memtomem_stm/cli/config_cmd.py.
+cli.add_command(_config_group)

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -77,6 +77,25 @@ def _permissive_mode(resolved: Path) -> int | None:
     return mode if mode & 0o077 else None
 
 
+def _sanitized_load_error(exc: Exception) -> str:
+    """Error summary safe to surface beyond the local process log.
+
+    ``str(ValidationError)`` embeds ``input_value=...`` — for a mistyped
+    secret-bearing field (``headers``/``env``) that is the secret itself, and
+    ``ConfigLoadResult.error`` flows to the MCP client via
+    ``stm_proxy_health``. Rebuild from ``errors(include_input=False)``
+    (location + message only). Non-pydantic errors (``json.JSONDecodeError``,
+    the non-object-root ``ValueError``) describe positions/types, not values.
+    """
+    if isinstance(exc, ValidationError):
+        parts = []
+        for err in exc.errors(include_url=False, include_input=False):
+            loc = ".".join(str(part) for part in err["loc"])
+            parts.append(f"{loc}: {err['msg']}" if loc else err["msg"])
+        return "; ".join(parts)
+    return str(exc)
+
+
 def _env_override_hint(
     exc: Exception,
     env_overrides: dict[str, Any] | None,
@@ -1226,7 +1245,11 @@ class ProxyConfig(BaseModel):
 
     @staticmethod
     def load_from_file(
-        path: Path, env_overrides: dict[str, Any] | None = None, *, missing_ok: bool = True
+        path: Path,
+        env_overrides: dict[str, Any] | None = None,
+        *,
+        missing_ok: bool = True,
+        log_warnings: bool = True,
     ) -> ProxyConfig | None:
         """Load config from *path*. Returns ``None`` on parse/validation error
         (with ``missing_ok=True``, distinct from file-not-found which returns
@@ -1251,12 +1274,16 @@ class ProxyConfig(BaseModel):
         use ``load_from_file_with_status`` instead.
         """
         return ProxyConfig.load_from_file_with_status(
-            path, env_overrides, missing_ok=missing_ok
+            path, env_overrides, missing_ok=missing_ok, log_warnings=log_warnings
         ).config
 
     @staticmethod
     def load_from_file_with_status(
-        path: Path, env_overrides: dict[str, Any] | None = None, *, missing_ok: bool = True
+        path: Path,
+        env_overrides: dict[str, Any] | None = None,
+        *,
+        missing_ok: bool = True,
+        log_warnings: bool = True,
     ) -> ConfigLoadResult:
         """``load_from_file`` with the failure mode preserved in the result.
 
@@ -1267,6 +1294,17 @@ class ProxyConfig(BaseModel):
         ``unknown_keys`` the lenient validation silently dropped, walked over
         the raw file dict *before* the env merge so an env-injected key can
         never be misattributed as a file typo.
+
+        ``error`` is sanitized (location + message, never ``input_value``):
+        it flows to the MCP client via ``stm_proxy_health``, and a mistyped
+        secret-bearing field would otherwise embed the secret itself.
+
+        ``log_warnings=False`` suppresses the advisory warnings (permissive
+        mode, unknown keys) for re-loads of a file some earlier load already
+        warned about — e.g. ``ProxyManager.start()``'s empty-upstreams
+        fallback, which would otherwise duplicate them at startup. Parse
+        *failures* are always logged: a silent ``None`` is the dark-failure
+        mode this module exists to prevent.
         """
         resolved = path.expanduser().resolve()
         if not resolved.exists():
@@ -1287,7 +1325,7 @@ class ProxyConfig(BaseModel):
             return ConfigLoadResult(config=ProxyConfig(), error=None)
         # Warn if config is group/world-readable (may contain API keys)
         mode = _permissive_mode(resolved)
-        if mode is not None:
+        if mode is not None and log_warnings:
             logger.warning(
                 "Proxy config %s has permissive mode %o — consider restricting to 0600",
                 resolved,
@@ -1307,7 +1345,7 @@ class ProxyConfig(BaseModel):
             unknown_keys = tuple(find_unknown_keys(ProxyConfig, file_data))
             data = _deep_merge(file_data, env_overrides) if env_overrides else file_data
             config = ProxyConfig.model_validate(data)
-            if unknown_keys:
+            if unknown_keys and log_warnings:
                 # One aggregated line, not one per key: the hot-reload loader
                 # re-runs this on every mtime change.
                 logger.warning(
@@ -1327,7 +1365,9 @@ class ProxyConfig(BaseModel):
                 exc,
                 _env_override_hint(exc, env_overrides, file_data),
             )
-            return ConfigLoadResult(config=None, error=str(exc), unknown_keys=unknown_keys)
+            return ConfigLoadResult(
+                config=None, error=_sanitized_load_error(exc), unknown_keys=unknown_keys
+            )
 
 
 class ProxyConfigLoader:

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -80,19 +80,27 @@ def _permissive_mode(resolved: Path) -> int | None:
 def _sanitized_load_error(exc: Exception) -> str:
     """Error summary safe to surface beyond the local process log.
 
-    ``str(ValidationError)`` embeds ``input_value=...`` — for a mistyped
-    secret-bearing field (``headers``/``env``) that is the secret itself, and
     ``ConfigLoadResult.error`` flows to the MCP client via
-    ``stm_proxy_health``. Rebuild from ``errors(include_input=False)``
-    (location + message only). Non-pydantic errors (``json.JSONDecodeError``,
-    the non-object-root ``ValueError``) describe positions/types, not values.
+    ``stm_proxy_health``, so it must not echo config *values*. Pydantic
+    smuggles them in two ways: ``input_value=...`` (dropped via
+    ``include_input=False``) and the rendered ``msg`` of a custom
+    model-validator — e.g. the duplicate-prefix check embeds the prefix
+    string, which is the secret itself if someone typos a token into a
+    ``prefix`` field. So the summary uses ``loc`` + the machine-readable
+    ``type`` code (``dict_type`` / ``value_error`` / ``missing`` …) only,
+    never ``msg``. Full messages stay in the local stderr log and in
+    ``mms config validate``, which reads the raw errors directly.
+
+    Non-pydantic errors (``json.JSONDecodeError``, the non-object-root
+    ``ValueError``) describe positions/types, not config values.
     """
     if isinstance(exc, ValidationError):
         parts = []
         for err in exc.errors(include_url=False, include_input=False):
             loc = ".".join(str(part) for part in err["loc"])
-            parts.append(f"{loc}: {err['msg']}" if loc else err["msg"])
-        return "; ".join(parts)
+            parts.append(f"{loc} ({err['type']})" if loc else err["type"])
+        summary = "; ".join(parts)
+        return f"{exc.error_count()} validation error(s): {summary}"
     return str(exc)
 
 

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+import types
+from collections.abc import Mapping
+from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Literal, Self
+from typing import Annotated, Any, Literal, Self, Union, get_args, get_origin
 
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
@@ -59,6 +62,19 @@ def _deep_merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, An
         else:
             out[k] = v
     return out
+
+
+def _permissive_mode(resolved: Path) -> int | None:
+    """Mode bits of *resolved* when it is group/world-accessible, else ``None``.
+
+    Shared by the load path and ``mms config validate`` so the two warnings
+    can't drift apart. ``None`` also covers a failed ``stat`` (best-effort).
+    """
+    try:
+        mode = resolved.stat().st_mode & 0o777
+    except OSError:
+        return None
+    return mode if mode & 0o077 else None
 
 
 def _env_override_hint(
@@ -953,6 +969,134 @@ class RelevanceScorerConfig(BaseModel):
         return self
 
 
+def _model_arms(annotation: Any) -> list[type[BaseModel]] | None:
+    """BaseModel arms of *annotation* after unwrapping ``Annotated``/unions.
+
+    Returns ``None`` when descending would risk false positives: a non-model
+    leaf, a mixed union (model | free-form), or anything else where key
+    existence isn't defined by a model schema. The classification is read off
+    the annotation itself — no name allowlist — so it stays correct as the
+    config models evolve.
+    """
+    if get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    origin = get_origin(annotation)
+    if origin in (Union, types.UnionType):
+        arms: list[type[BaseModel]] = []
+        for arm in get_args(annotation):
+            if arm is type(None):
+                continue
+            sub = _model_arms(arm)
+            if sub is None:  # mixed union — don't guess, don't descend
+                return None
+            arms.extend(sub)
+        return arms or None
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return [annotation]
+    return None
+
+
+def _container_value_arms(annotation: Any) -> tuple[str, list[type[BaseModel]]] | None:
+    """Classify a container annotation whose *values* are models.
+
+    Returns ``("dict", arms)`` for ``dict[str, Model]`` (user-defined keys —
+    descend into values only) or ``("list", arms)`` for ``list[Model]``;
+    ``None`` for free-form containers (``dict[str, str]``, ``dict[str, Any]``)
+    and everything else.
+    """
+    if get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    origin = get_origin(annotation)
+    if origin is dict:
+        args = get_args(annotation)
+        if len(args) == 2 and (arms := _model_arms(args[1])) is not None:
+            return ("dict", arms)
+    elif origin in (list, tuple, set):
+        args = get_args(annotation)
+        if args and (arms := _model_arms(args[0])) is not None:
+            return ("list", arms)
+    return None
+
+
+def _unknown_keys_via_arms(
+    arms: list[type[BaseModel]], data: Mapping[str, Any], prefix: str
+) -> list[str]:
+    """Unknown keys under a (possibly multi-arm) model annotation.
+
+    With several model arms (none in today's tree), only keys unknown to
+    *every* arm are flagged — conservative, no false positives.
+    """
+    per_arm = [find_unknown_keys(arm, data, prefix) for arm in arms]
+    common = set(per_arm[0])
+    for other in per_arm[1:]:
+        common &= set(other)
+    return sorted(common)
+
+
+def find_unknown_keys(
+    model_cls: type[BaseModel], data: Mapping[str, Any], prefix: str = ""
+) -> list[str]:
+    """Dotted paths in *data* that no field of *model_cls* (recursively) accepts.
+
+    The proxy config models deliberately keep pydantic's default
+    ``extra="ignore"`` for forward compatibility (older binaries must ignore
+    fields written by newer CLIs — see ``UpstreamServerConfig.origin``), which
+    means a typo'd key is silently dropped at load time. This walker gives the
+    load path and ``mms config validate`` a way to *name* those dropped keys
+    without giving up the lenient validation.
+
+    Key-existence only: a value of the wrong runtime type (a string where a
+    model object belongs) is skipped silently — ``model_validate`` owns type
+    errors. ``dict[str, Model]`` fields (``upstream_servers``,
+    ``tool_overrides``) have user-defined keys, so only their values are
+    descended; free-form leaves (``env``, ``headers``, ``origin.original``,
+    ``server_name_map``) are never descended.
+    """
+    unknown: list[str] = []
+    known: dict[str, Any] = {}
+    for name, field in model_cls.model_fields.items():
+        known[name] = field.annotation
+        if field.alias:
+            known[field.alias] = field.annotation
+    for key, value in data.items():
+        path = f"{prefix}{key}"
+        if key not in known:
+            unknown.append(path)
+            continue
+        annotation = known[key]
+        if (arms := _model_arms(annotation)) is not None:
+            if isinstance(value, Mapping):
+                unknown.extend(_unknown_keys_via_arms(arms, value, f"{path}."))
+        elif (container := _container_value_arms(annotation)) is not None:
+            kind, arms = container
+            if kind == "dict" and isinstance(value, Mapping):
+                for sub_key, sub_value in value.items():
+                    if isinstance(sub_value, Mapping):
+                        unknown.extend(
+                            _unknown_keys_via_arms(arms, sub_value, f"{path}.{sub_key}.")
+                        )
+            elif kind == "list" and isinstance(value, list):
+                for i, item in enumerate(value):
+                    if isinstance(item, Mapping):
+                        unknown.extend(_unknown_keys_via_arms(arms, item, f"{path}[{i}]."))
+    return sorted(unknown)
+
+
+@dataclass(frozen=True)
+class ConfigLoadResult:
+    """Outcome of ``ProxyConfig.load_from_file_with_status``.
+
+    ``error`` is set iff the file exists but failed to parse or validate —
+    the case a running server silently papers over by falling back to
+    env/default config. A missing file is not an error (``config`` may still
+    carry the env-only/defaults rebuild under ``missing_ok=True``).
+    """
+
+    config: ProxyConfig | None
+    error: str | None
+    unknown_keys: tuple[str, ...] = ()
+
+
 class ProxyConfig(BaseModel):
     enabled: bool = False
     config_path: Path = Path("~/.memtomem/stm_proxy.json")
@@ -1102,34 +1246,55 @@ class ProxyConfig(BaseModel):
         pre-check that races with file deletion. A file deleted between the
         existence check and the read also lands on ``None`` here, so every
         disappearance mode converges on "do not swap".
+
+        Callers that need to distinguish "missing" from "present but broken"
+        use ``load_from_file_with_status`` instead.
+        """
+        return ProxyConfig.load_from_file_with_status(
+            path, env_overrides, missing_ok=missing_ok
+        ).config
+
+    @staticmethod
+    def load_from_file_with_status(
+        path: Path, env_overrides: dict[str, Any] | None = None, *, missing_ok: bool = True
+    ) -> ConfigLoadResult:
+        """``load_from_file`` with the failure mode preserved in the result.
+
+        Same loading semantics and logging; additionally reports (a) an
+        ``error`` string when the file exists but fails to parse/validate —
+        so the server can surface "running defaults because the file is
+        broken" in health output instead of only a stderr line — and (b) the
+        ``unknown_keys`` the lenient validation silently dropped, walked over
+        the raw file dict *before* the env merge so an env-injected key can
+        never be misattributed as a file typo.
         """
         resolved = path.expanduser().resolve()
         if not resolved.exists():
             logger.debug("Proxy config file not found: %s", resolved)
             if not missing_ok:
-                return None
+                return ConfigLoadResult(config=None, error=None)
             if env_overrides:
                 try:
-                    return ProxyConfig.model_validate(env_overrides)
+                    return ConfigLoadResult(
+                        config=ProxyConfig.model_validate(env_overrides), error=None
+                    )
                 except Exception as exc:
                     logger.warning(
                         "Env-only proxy config failed validation: %s%s — using defaults",
                         exc,
                         _env_override_hint(exc, env_overrides),
                     )
-            return ProxyConfig()
+            return ConfigLoadResult(config=ProxyConfig(), error=None)
         # Warn if config is group/world-readable (may contain API keys)
-        try:
-            mode = resolved.stat().st_mode & 0o777
-            if mode & 0o077:
-                logger.warning(
-                    "Proxy config %s has permissive mode %o — consider restricting to 0600",
-                    resolved,
-                    mode,
-                )
-        except OSError:
-            pass
+        mode = _permissive_mode(resolved)
+        if mode is not None:
+            logger.warning(
+                "Proxy config %s has permissive mode %o — consider restricting to 0600",
+                resolved,
+                mode,
+            )
         file_data: dict[str, Any] | None = None
+        unknown_keys: tuple[str, ...] = ()
         try:
             loaded = json.loads(resolved.read_text(encoding="utf-8"))
             if not isinstance(loaded, dict):
@@ -1139,16 +1304,30 @@ class ProxyConfig(BaseModel):
                 # silently accepting an invalid config file.
                 raise ValueError(f"config root must be a JSON object, got {type(loaded).__name__}")
             file_data = loaded
+            unknown_keys = tuple(find_unknown_keys(ProxyConfig, file_data))
             data = _deep_merge(file_data, env_overrides) if env_overrides else file_data
-            return ProxyConfig.model_validate(data)
+            config = ProxyConfig.model_validate(data)
+            if unknown_keys:
+                # One aggregated line, not one per key: the hot-reload loader
+                # re-runs this on every mtime change.
+                logger.warning(
+                    "Proxy config %s has %d unknown key(s) (ignored — possible typo): %s",
+                    resolved,
+                    len(unknown_keys),
+                    ", ".join(unknown_keys),
+                )
+            return ConfigLoadResult(config=config, error=None, unknown_keys=unknown_keys)
         except (json.JSONDecodeError, Exception) as exc:
+            # The parse-failure warning dominates; the unknown-keys warning is
+            # suppressed here but the paths stay in the result for `mms
+            # config validate` to report alongside the errors.
             logger.warning(
                 "Failed to parse proxy config %s: %s%s",
                 resolved,
                 exc,
                 _env_override_hint(exc, env_overrides, file_data),
             )
-            return None
+            return ConfigLoadResult(config=None, error=str(exc), unknown_keys=unknown_keys)
 
 
 class ProxyConfigLoader:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -411,7 +411,12 @@ class ProxyManager:
 
         servers = self._config.upstream_servers
         if not servers:
-            loaded = ProxyConfig.load_from_file(self._config.config_path)
+            # Fallback re-load of a file the server startup path typically
+            # already loaded (env-enabled proxy, upstreams only in the file).
+            # log_warnings=False so the advisory permissive-mode /
+            # unknown-key warnings don't fire twice per startup (#611);
+            # a parse *failure* still logs.
+            loaded = ProxyConfig.load_from_file(self._config.config_path, log_warnings=False)
             servers = loaded.upstream_servers if loaded else {}
 
         # Warn about dangerous config: compression active but auto_index disabled

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -63,13 +63,23 @@ class STMContext:
     feedback_tracker: FeedbackTracker | None
     compression_feedback_tracker: CompressionFeedbackTracker | None
     progressive_reads_tracker: ProgressiveReadsTracker | None
+    proxy_config_error: str | None = None
+    """Set when the proxy config file exists but failed to parse/validate at
+    startup (#611): the server is running env/default config — typically with
+    the proxy off — and only a buried stderr warning says why. Surfaced by
+    ``stm_proxy_health`` so the failure is visible from inside the client."""
 
 
 CtxType = Context[ServerSession, STMContext]
 
 
-def _apply_proxy_file_config(config: STMConfig, proxy_env_overrides: dict[str, Any]) -> None:
+def _apply_proxy_file_config(config: STMConfig, proxy_env_overrides: dict[str, Any]) -> str | None:
     """Load the JSON config file and overlay env vars on top of it, in place.
+
+    Returns the load error when the file exists but failed to parse/validate
+    (``None`` otherwise — including the deliberate missing-file no-swap), so
+    the lifespan can pin it on ``STMContext.proxy_config_error`` instead of
+    the failure living only in a stderr warning (#611).
 
     The documented precedence (env > file > defaults) is enforced by
     ``load_from_file``'s deep-merge: every ``MEMTOMEM_STM_PROXY__*`` var —
@@ -95,20 +105,21 @@ def _apply_proxy_file_config(config: STMConfig, proxy_env_overrides: dict[str, A
     but never surfacing's model-aware budgets
     (``effective_max_injection_chars`` / ``effective_max_results``).
     """
-    file_cfg = ProxyConfig.load_from_file(
+    result = ProxyConfig.load_from_file_with_status(
         config.proxy.config_path, env_overrides=proxy_env_overrides, missing_ok=False
     )
-    if file_cfg is not None:
-        config.proxy = file_cfg
+    if result.config is not None:
+        config.proxy = result.config
     if config.proxy.consumer_model and not config.surfacing.consumer_model:
         config.surfacing.consumer_model = config.proxy.consumer_model
+    return result.error
 
 
 @asynccontextmanager
 async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
     config = STMConfig()
     proxy_env_overrides = collect_proxy_env_overrides()
-    _apply_proxy_file_config(config, proxy_env_overrides)
+    proxy_config_error = _apply_proxy_file_config(config, proxy_env_overrides)
 
     # Shared state — populated only when proxy is enabled
     from memtomem_stm.proxy.cache import ProxyCache
@@ -360,6 +371,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
             feedback_tracker=feedback_tracker,
             compression_feedback_tracker=compression_feedback_tracker,
             progressive_reads_tracker=progressive_reads_tracker,
+            proxy_config_error=proxy_config_error,
         )
         yield ctx
     finally:
@@ -776,12 +788,21 @@ async def stm_proxy_health(
 
     bootstrap_lines = _surfacing_bootstrap_lines(app)
 
+    # A broken config file is the likeliest cause of the "No upstream
+    # servers configured." symptom below — lead with it in both branches.
+    config_warning = []
+    if app.proxy_config_error:
+        config_warning.append(
+            "WARNING: proxy config file present but failed to parse — "
+            f"running env/default config: {app.proxy_config_error}"
+        )
+
     health = pm.get_upstream_health()
     if not health:
         head = "No upstream servers configured."
-        return "\n".join([head, *bootstrap_lines]) if bootstrap_lines else head
+        return "\n".join([*config_warning, head, *bootstrap_lines])
 
-    lines = ["Upstream Server Health", "====================="]
+    lines = [*config_warning, "Upstream Server Health", "====================="]
     for name, info in health.items():
         status = "connected" if info["connected"] else "DISCONNECTED"
         lines.append(

--- a/tests/cli/test_mms_config_validate.py
+++ b/tests/cli/test_mms_config_validate.py
@@ -1,0 +1,145 @@
+"""Tests for ``mms config validate`` (#611).
+
+Strict linting of the config file as written: parse errors, schema
+validation errors, unknown keys (silently ignored at runtime), and a
+missing file all exit non-zero; the permissive-file-mode case is a
+warning only. Uses ``CliRunner`` + a tmp config path — no real home
+directory is touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem_stm.cli.proxy import cli
+from helpers import set_home
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_home(monkeypatch, tmp_path: Path) -> Path:
+    home = tmp_path / "hermetic-home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    return home
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> Path:
+    return tmp_path / "stm_proxy.json"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _validate(runner: CliRunner, config: Path, *extra: str):
+    return runner.invoke(cli, ["config", "validate", "--config", str(config), *extra])
+
+
+class TestConfigValidate:
+    def test_clean_config_exits_zero(self, runner, config):
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "upstream_servers": {"gh": {"prefix": "gh", "command": "gh-server"}},
+                }
+            )
+        )
+        config.chmod(0o600)
+        result = _validate(runner, config)
+        assert result.exit_code == 0, result.output
+        assert "OK" in result.output
+
+    def test_unknown_keys_exit_one_with_dotted_paths(self, runner, config):
+        config.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "max_result_char": 4000,
+                    "upstream_servers": {"gh": {"prefix": "gh", "tool_overides": {}}},
+                }
+            )
+        )
+        config.chmod(0o600)
+        result = _validate(runner, config)
+        assert result.exit_code == 1
+        assert "max_result_char" in result.output
+        assert "upstream_servers.gh.tool_overides" in result.output
+        assert "unknown key" in result.output
+
+    def test_invalid_json_exits_one(self, runner, config):
+        config.write_text("{ not valid json")
+        result = _validate(runner, config)
+        assert result.exit_code == 1
+        assert "invalid JSON" in result.output
+
+    def test_non_object_root_exits_one(self, runner, config):
+        config.write_text("[]")
+        result = _validate(runner, config)
+        assert result.exit_code == 1
+        assert "JSON object" in result.output
+
+    def test_validation_error_exits_one_with_location(self, runner, config):
+        # Duplicate prefixes trip the ProxyConfig model validator.
+        config.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "a": {"prefix": "dup", "command": "a"},
+                        "b": {"prefix": "dup", "command": "b"},
+                    }
+                }
+            )
+        )
+        config.chmod(0o600)
+        result = _validate(runner, config)
+        assert result.exit_code == 1
+        assert "Duplicate upstream prefixes" in result.output
+
+    def test_missing_file_exits_one(self, runner, config):
+        result = _validate(runner, config)
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+    def test_permissive_mode_warns_but_exits_zero(self, runner, config):
+        config.write_text(json.dumps({"enabled": True}))
+        config.chmod(0o644)
+        result = _validate(runner, config)
+        assert result.exit_code == 0, result.output
+        assert "permissive mode 644" in result.output
+        assert "OK" in result.output
+
+    def test_json_output_shape(self, runner, config):
+        config.write_text(json.dumps({"enabled": True, "cache": {"ttl_secondz": 60}}))
+        config.chmod(0o600)
+        result = _validate(runner, config, "--json")
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["status"] == "invalid"
+        assert payload["unknown_keys"] == ["cache.ttl_secondz"]
+        assert payload["errors"] == []
+        assert payload["config_path"].endswith("stm_proxy.json")
+
+    def test_json_output_missing(self, runner, config):
+        result = _validate(runner, config, "--json")
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["status"] == "missing"
+        assert payload["errors"]
+
+    def test_env_vars_deliberately_ignored(self, runner, config, monkeypatch):
+        # The command lints the file as written; a bogus env var must not
+        # taint the verdict, and an env-only "fix" must not mask a file typo.
+        monkeypatch.setenv("MEMTOMEM_STM_PROXY__BOGUS_ENV_KEY", "1")
+        config.write_text(json.dumps({"enabled": True}))
+        config.chmod(0o600)
+        result = _validate(runner, config)
+        assert result.exit_code == 0, result.output

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -456,6 +456,52 @@ class TestStatus:
         data = json.loads(result.output)
         assert data["error"] == "config_not_found"
 
+    def test_valid_json_invalid_schema_warns_exit_zero(self, runner, config):
+        """#611: valid JSON that fails model validation is exactly what a
+        running server silently degrades on — ``status`` must warn (but stay
+        exit 0; strictness lives in ``mms config validate``)."""
+        config.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "a": {"prefix": "dup", "command": "a"},
+                        "b": {"prefix": "dup", "command": "b"},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["status", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "fails validation" in result.output
+        assert "falls back to env/defaults" in result.output
+
+    def test_valid_json_invalid_schema_flagged_in_json(self, runner, config):
+        config.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "a": {"prefix": "dup", "command": "a"},
+                        "b": {"prefix": "dup", "command": "b"},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["status", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["config_valid"] is False
+        assert "Duplicate upstream prefixes" in data["config_error"]
+
+    def test_valid_config_marked_valid_in_json(self, runner, config):
+        config.write_text(json.dumps({"enabled": True, "upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["status", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["config_valid"] is True
+        assert data["config_error"] is None
+
     def test_json_redacts_origin_original(self, runner, config):
         """``origin.original`` is the verbatim host entry and may carry
         secrets — ``status --json`` must emit only the provenance summary
@@ -5867,12 +5913,45 @@ class TestHealth:
         assert "Surfacing Bootstrap" in result.output
         assert "feedback tables: missing" in result.output
 
+    def test_health_no_servers_from_invalid_schema_names_cause(self, runner, config):
+        """#611: a schema-invalid config is the classic cause of the
+        "No upstream servers" symptom on a running server — ``health`` must
+        lead with the cause (exit code unchanged)."""
+        config.write_text(
+            json.dumps(
+                {
+                    "upstream_servers": {
+                        "a": {"prefix": "dup", "command": "a"},
+                        "b": {"prefix": "dup", "command": "b"},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["config_valid"] is False
+        assert "Duplicate upstream prefixes" in data["config_error"]
+
+    def test_health_warns_on_invalid_schema_text(self, runner, config):
+        config.write_text(
+            json.dumps({"upstream_servers": {}, "default_max_result_chars": -1}),
+            encoding="utf-8",
+        )
+        result = runner.invoke(cli, ["health", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "fails validation" in result.output
+        assert "No upstream servers configured" in result.output
+
     def test_health_json_no_servers(self, runner, config):
         config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
         result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data["servers"] == {}
+        assert data["config_valid"] is True
+        assert data["config_error"] is None
         assert data["surfacing"]["enabled"] is True
         assert data["surfacing"]["feedback_enabled"] is True
         assert data["surfacing"]["feedback_db"]["exists"] is False

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -201,6 +201,50 @@ class TestLoadFromFileWithStatus:
         assert result.unknown_keys == ()
         assert not [r for r in caplog.records if "unknown key" in r.getMessage()]
 
+    def test_error_never_carries_input_values(self, tmp_path):
+        """codex review of #611: str(ValidationError) embeds input_value=...,
+        and a mistyped secret-bearing field (headers/env) would flow to the
+        MCP client via stm_proxy_health. The error must carry location +
+        message only."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({
+            "upstream_servers": {
+                "gh": {"prefix": "gh", "headers": "Bearer SECRET_TOKEN_ABC"}
+            }
+        }))
+        result = ProxyConfig.load_from_file_with_status(cfg_file)
+        assert result.config is None
+        assert result.error is not None
+        assert "SECRET_TOKEN_ABC" not in result.error
+        assert "upstream_servers.gh.headers" in result.error
+
+    def test_log_warnings_false_suppresses_advisory_warnings(self, tmp_path, caplog):
+        """codex review of #611: ProxyManager.start()'s empty-upstreams
+        fallback re-loads a file the server startup already loaded — advisory
+        warnings (permissive mode, unknown keys) must not fire twice, while
+        the unknown_keys stay in the result and parse failures still log."""
+        import logging
+
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"enabled": True, "max_result_char": 1}))
+        cfg_file.chmod(0o644)
+        with caplog.at_level(logging.WARNING):
+            result = ProxyConfig.load_from_file_with_status(cfg_file, log_warnings=False)
+        assert result.config is not None
+        assert result.unknown_keys == ("max_result_char",)
+        assert not [
+            r
+            for r in caplog.records
+            if "unknown key" in r.getMessage() or "permissive mode" in r.getMessage()
+        ]
+
+        caplog.clear()
+        cfg_file.write_text("{ broken")
+        with caplog.at_level(logging.WARNING):
+            result = ProxyConfig.load_from_file_with_status(cfg_file, log_warnings=False)
+        assert result.config is None
+        assert [r for r in caplog.records if "Failed to parse" in r.getMessage()]
+
     def test_load_from_file_delegate_contract_unchanged(self, tmp_path):
         good = tmp_path / "good.json"
         good.write_text(json.dumps({"enabled": True}))

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -157,7 +157,8 @@ class TestLoadFromFileWithStatus:
         }))
         result = ProxyConfig.load_from_file_with_status(cfg_file)
         assert result.config is None
-        assert result.error is not None and "Duplicate upstream prefixes" in result.error
+        # loc + type, not the raw validator message (which embeds prefixes).
+        assert result.error is not None and "value_error" in result.error
         assert result.unknown_keys == ("bogus_key",)
 
     def test_missing_file_is_not_an_error(self, tmp_path):
@@ -217,6 +218,25 @@ class TestLoadFromFileWithStatus:
         assert result.error is not None
         assert "SECRET_TOKEN_ABC" not in result.error
         assert "upstream_servers.gh.headers" in result.error
+
+    def test_error_never_carries_custom_validator_values(self, tmp_path):
+        """Round-2 codex: pydantic input_value was only one leak channel —
+        a custom model-validator renders raw values into its message too
+        (the duplicate-prefix check embeds the prefix string). A secret
+        typo'd into a `prefix` field must not reach ConfigLoadResult.error,
+        which flows to the MCP client via stm_proxy_health."""
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({
+            "upstream_servers": {
+                "a": {"prefix": "SECRET_TOKEN_ABC", "command": "a"},
+                "b": {"prefix": "SECRET_TOKEN_ABC", "command": "b"},
+            }
+        }))
+        result = ProxyConfig.load_from_file_with_status(cfg_file)
+        assert result.config is None
+        assert result.error is not None
+        assert "SECRET_TOKEN_ABC" not in result.error
+        assert "value_error" in result.error
 
     def test_log_warnings_false_suppresses_advisory_warnings(self, tmp_path, caplog):
         """codex review of #611: ProxyManager.start()'s empty-upstreams

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -124,6 +124,96 @@ class TestProxyConfigLoader:
         assert "gh2" not in reloaded.upstream_servers
 
 
+# ── load_from_file_with_status / unknown-key warning (#611) ──────────────
+
+
+class TestLoadFromFileWithStatus:
+    def test_valid_file_no_error(self, tmp_path):
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"enabled": True}))
+        result = ProxyConfig.load_from_file_with_status(cfg_file)
+        assert result.config is not None and result.config.enabled is True
+        assert result.error is None
+        assert result.unknown_keys == ()
+
+    def test_parse_failure_sets_error(self, tmp_path):
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text("{ not valid json")
+        result = ProxyConfig.load_from_file_with_status(cfg_file)
+        assert result.config is None
+        assert result.error is not None
+
+    def test_validation_failure_sets_error_and_keeps_unknown_keys(self, tmp_path):
+        # Duplicate prefixes fail the model validator; the typo'd key found
+        # before validation must survive into the result for `mms config
+        # validate` to report both.
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({
+            "bogus_key": 1,
+            "upstream_servers": {
+                "a": {"prefix": "dup", "command": "a"},
+                "b": {"prefix": "dup", "command": "b"},
+            },
+        }))
+        result = ProxyConfig.load_from_file_with_status(cfg_file)
+        assert result.config is None
+        assert result.error is not None and "Duplicate upstream prefixes" in result.error
+        assert result.unknown_keys == ("bogus_key",)
+
+    def test_missing_file_is_not_an_error(self, tmp_path):
+        missing = tmp_path / "nonexistent.json"
+        strict = ProxyConfig.load_from_file_with_status(missing, missing_ok=False)
+        assert strict.config is None and strict.error is None
+        lenient = ProxyConfig.load_from_file_with_status(missing)
+        assert lenient.config is not None and lenient.error is None
+
+    def test_unknown_keys_warned_once_aggregated(self, tmp_path, caplog):
+        import logging
+
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({
+            "enabled": True,
+            "max_result_char": 4000,
+            "cache": {"ttl_secondz": 60},
+        }))
+        with caplog.at_level(logging.WARNING):
+            result = ProxyConfig.load_from_file_with_status(cfg_file)
+        assert result.config is not None
+        assert result.unknown_keys == ("cache.ttl_secondz", "max_result_char")
+        warnings = [r for r in caplog.records if "unknown key" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "cache.ttl_secondz" in warnings[0].getMessage()
+        assert "max_result_char" in warnings[0].getMessage()
+
+    def test_env_injected_keys_not_flagged_as_file_typos(self, tmp_path, caplog):
+        import logging
+
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"enabled": True}))
+        # An env overlay carrying a key the file doesn't have (even a bogus
+        # one — extra="ignore" accepts it) must not surface as a file typo:
+        # the walk runs on the raw file dict before the merge.
+        overrides = {"default_max_result_chars": "9000", "bogus_env_key": "1"}
+        with caplog.at_level(logging.WARNING):
+            result = ProxyConfig.load_from_file_with_status(cfg_file, overrides)
+        assert result.config is not None
+        assert result.config.default_max_result_chars == 9000
+        assert result.unknown_keys == ()
+        assert not [r for r in caplog.records if "unknown key" in r.getMessage()]
+
+    def test_load_from_file_delegate_contract_unchanged(self, tmp_path):
+        good = tmp_path / "good.json"
+        good.write_text(json.dumps({"enabled": True}))
+        broken = tmp_path / "broken.json"
+        broken.write_text("{ nope")
+        missing = tmp_path / "missing.json"
+
+        assert ProxyConfig.load_from_file(good).enabled is True
+        assert ProxyConfig.load_from_file(broken) is None
+        assert ProxyConfig.load_from_file(missing).enabled is False  # defaults
+        assert ProxyConfig.load_from_file(missing, missing_ok=False) is None
+
+
 # ── MetricsStore persistence ─────────────────────────────────────────────
 
 

--- a/tests/test_config_unknown_keys.py
+++ b/tests/test_config_unknown_keys.py
@@ -1,0 +1,139 @@
+"""Tests for the unknown-key walker over the proxy config models (#611).
+
+The models keep pydantic's default ``extra="ignore"`` on purpose (forward
+compat — older binaries must ignore fields written by newer CLIs), so a
+typo'd key vanishes silently at load time. ``find_unknown_keys`` names those
+dropped keys; these tests pin the walker's classification of every container
+shape in the tree, plus a full-clean-config canary that fails loudly if a
+future pydantic version changes the ``model_fields`` annotation surface the
+walker reads.
+"""
+
+from __future__ import annotations
+
+from memtomem_stm.proxy.config import ProxyConfig, find_unknown_keys
+
+
+def test_top_level_unknown_key_flagged():
+    assert find_unknown_keys(ProxyConfig, {"enabld": True}) == ["enabld"]
+
+
+def test_nested_block_unknown_key_flagged():
+    data = {"cache": {"enabled": True, "ttl_secondz": 60}}
+    assert find_unknown_keys(ProxyConfig, data) == ["cache.ttl_secondz"]
+
+
+def test_upstream_server_typo_flagged_under_user_key():
+    data = {
+        "upstream_servers": {
+            "gh": {"prefix": "gh", "command": "gh-server", "max_result_char": 4000}
+        }
+    }
+    assert find_unknown_keys(ProxyConfig, data) == ["upstream_servers.gh.max_result_char"]
+
+
+def test_two_dict_hops_via_tool_overrides():
+    data = {
+        "upstream_servers": {
+            "gh": {
+                "prefix": "gh",
+                "tool_overrides": {"list_issues": {"max_result_charz": 1}},
+            }
+        }
+    }
+    assert find_unknown_keys(ProxyConfig, data) == [
+        "upstream_servers.gh.tool_overrides.list_issues.max_result_charz"
+    ]
+
+
+def test_free_form_dict_leaves_never_descended():
+    data = {
+        "upstream_servers": {
+            "gh": {
+                "prefix": "gh",
+                "env": {"ANYTHING_GOES": "1", "another_key": "x"},
+                "headers": {"X-Custom-Header": "y"},
+                "origin": {
+                    "source": {"kind": "mcp-json"},
+                    "original": {"verbatim": {"host": "entry"}, "weird-key": 1},
+                },
+            }
+        },
+        "toolgraph": {"server_name_map": {"gh": "github-crawled"}},
+    }
+    assert find_unknown_keys(ProxyConfig, data) == []
+
+
+def test_optional_model_field_descended():
+    data = {
+        "upstream_servers": {"gh": {"prefix": "gh", "llm": {"modell": "x"}}},
+    }
+    assert find_unknown_keys(ProxyConfig, data) == ["upstream_servers.gh.llm.modell"]
+
+
+def test_list_of_models_descended_with_index():
+    data = {
+        "upstream_servers": {
+            "gh": {
+                "prefix": "gh",
+                "origin": {
+                    "source": {"kind": "mcp-json"},
+                    "duplicates": [{"kind": "claude-user"}, {"kind": "mcp-json", "badkey": 1}],
+                },
+            }
+        }
+    }
+    assert find_unknown_keys(ProxyConfig, data) == [
+        "upstream_servers.gh.origin.duplicates[1].badkey"
+    ]
+
+
+def test_wrong_type_value_skipped_not_crashed():
+    # Key existence is the walker's only concern; model_validate owns type
+    # errors. A scalar where a model/dict belongs must neither crash nor flag.
+    data = {
+        "cache": "not-a-dict",
+        "upstream_servers": "also-not-a-dict",
+        "toolgraph": {"env": "not-a-dict-either"},
+    }
+    assert find_unknown_keys(ProxyConfig, data) == []
+
+
+def test_multiple_unknown_keys_sorted():
+    data = {"zz_bogus": 1, "aa_bogus": 2, "cache": {"bogus": 3}}
+    assert find_unknown_keys(ProxyConfig, data) == ["aa_bogus", "cache.bogus", "zz_bogus"]
+
+
+def test_full_clean_config_yields_nothing():
+    # Canary: exercises every nested-container classification against a
+    # realistic config. If a pydantic upgrade changes the annotation surface
+    # (model_fields / FieldInfo.annotation), this fails loudly.
+    data = {
+        "enabled": True,
+        "default_max_result_chars": 16000,
+        "consumer_model": "claude-sonnet-4",
+        "relevance_scorer": {"scorer": "bm25"},
+        "cache": {"enabled": True, "default_ttl_seconds": 3600.0},
+        "auto_index": {},
+        "metrics": {},
+        "toolgraph": {"enabled": False, "server_name_map": {"gh": "github"}},
+        "upstream_servers": {
+            "gh": {
+                "prefix": "gh",
+                "command": "gh-server",
+                "env": {"TOKEN": "x"},
+                "headers": {"X-H": "y"},
+                "llm": None,
+                "tool_overrides": {"list_issues": {"max_result_chars": 4000}},
+                "origin": {
+                    "source": {"kind": "mcp-json", "path": "/p/.mcp.json"},
+                    "duplicates": [{"kind": "claude-user"}],
+                    "original": {"command": "gh-server", "anything": [1, 2]},
+                },
+            }
+        },
+    }
+    assert find_unknown_keys(ProxyConfig, data) == []
+    # And the same payload actually validates — the walker and the validator
+    # must agree on what a clean config is.
+    assert ProxyConfig.model_validate(data).enabled is True

--- a/tests/test_proxy_manager_lifecycle.py
+++ b/tests/test_proxy_manager_lifecycle.py
@@ -67,6 +67,32 @@ class TestStart:
         assert mock_conn.call_count == 1
         assert mock_conn.call_args_list[0].args[0] == "file_srv"
 
+    async def test_start_fallback_load_does_not_duplicate_advisory_warnings(
+        self, tmp_path, caplog
+    ):
+        """codex review of #611: the empty-upstreams fallback re-loads a file
+        the server startup path already loaded and warned about — start()
+        must not emit the advisory unknown-key / permissive-mode warnings a
+        second time."""
+        import json
+        import logging
+
+        cfg_file = tmp_path / "proxy.json"
+        cfg_file.write_text(json.dumps({"enabled": True, "max_result_char": 1}))
+        cfg_file.chmod(0o644)
+        mgr = _make_manager(servers={}, tmp_path=tmp_path)
+        with (
+            caplog.at_level(logging.WARNING),
+            patch.object(mgr, "_connect_server", new_callable=AsyncMock),
+        ):
+            await mgr.start()
+        assert not [
+            r
+            for r in caplog.records
+            if "unknown key" in r.getMessage() or "permissive mode" in r.getMessage()
+        ]
+        await mgr.stop()
+
     async def test_start_empty_servers_no_file_noop(self, tmp_path):
         """No servers configured and no file — start() completes without error."""
         mgr = _make_manager(servers={}, tmp_path=tmp_path)

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -6,7 +6,7 @@ import sqlite3
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from memtomem_stm.proxy.config import ProxyConfig, UpstreamServerConfig
+from memtomem_stm.proxy.config import ConfigLoadResult, ProxyConfig, UpstreamServerConfig
 from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
 from memtomem_stm.proxy.metrics import TokenTracker
 from memtomem_stm.server import (
@@ -43,6 +43,7 @@ def _make_ctx(
     compression_feedback_tracker: object | None = None,
     progressive_reads_tracker: object | None = None,
     config: STMConfig | None = None,
+    proxy_config_error: str | None = None,
 ) -> SimpleNamespace:
     """Build a fake CtxType that _get_ctx() can unwrap.
 
@@ -65,6 +66,7 @@ def _make_ctx(
         feedback_tracker=feedback_tracker,
         compression_feedback_tracker=compression_feedback_tracker,
         progressive_reads_tracker=progressive_reads_tracker,
+        proxy_config_error=proxy_config_error,
     )
     return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
 
@@ -412,6 +414,36 @@ class TestHealth:
         ctx = _make_ctx(proxy_manager=pm)
         result = await stm_proxy_health(ctx=ctx)
         assert "No upstream servers configured" in result
+        assert "failed to parse" not in result
+
+    async def test_config_error_shown_without_upstreams(self):
+        """#611: a broken config file typically manifests as zero upstreams —
+        the warning must lead the 'No upstream servers' branch, naming the
+        cause of the symptom."""
+        pm = _make_proxy_manager()
+        ctx = _make_ctx(proxy_manager=pm, proxy_config_error="Expecting value: line 1")
+        result = await stm_proxy_health(ctx=ctx)
+        lines = result.splitlines()
+        assert lines[0] == (
+            "WARNING: proxy config file present but failed to parse — "
+            "running env/default config: Expecting value: line 1"
+        )
+        assert "No upstream servers configured" in result
+
+    async def test_config_error_shown_with_upstreams(self):
+        """The warning also leads the populated branch (env-configured
+        upstreams can coexist with a broken file)."""
+        pm = _make_proxy_manager()
+        pm._connections["srv"] = UpstreamConnection(
+            name="srv",
+            config=UpstreamServerConfig(prefix="test"),
+            session=AsyncMock(),
+            tools=[MagicMock()],
+        )
+        ctx = _make_ctx(proxy_manager=pm, proxy_config_error="boom")
+        result = await stm_proxy_health(ctx=ctx)
+        assert result.splitlines()[0].startswith("WARNING: proxy config file present")
+        assert "srv: connected" in result
 
     async def test_with_servers(self):
         """Reports connection status with discovered vs advertised counts —
@@ -1840,7 +1872,10 @@ class TestLifespan:
             # Prevent the file-load block at the top of app_lifespan from
             # overwriting our mocked ProxyConfig with the real on-disk one
             # (or its defaults when the file is missing).
-            patch("memtomem_stm.server.ProxyConfig.load_from_file", return_value=None),
+            patch(
+                "memtomem_stm.server.ProxyConfig.load_from_file_with_status",
+                return_value=ConfigLoadResult(config=None, error=None),
+            ),
         ):
             mock_cfg = MockConfig.return_value
             mock_cfg.proxy = MagicMock()
@@ -1870,7 +1905,7 @@ class TestLifespan:
         JSON file load entirely — the proxy started enabled but with zero
         upstreams (``upstream_servers`` is a file-only field in practice).
         An existing file must be loaded regardless of the env var; env wins
-        through the ``load_from_file`` overlay instead of a bypass."""
+        through the ``load_from_file_with_status`` overlay instead of a bypass."""
         from memtomem_stm.server import app_lifespan, mcp
 
         monkeypatch.setenv("MEMTOMEM_STM_PROXY__ENABLED", "1")
@@ -1885,7 +1920,10 @@ class TestLifespan:
         with (
             patch("memtomem_stm.server.STMConfig") as MockConfig,
             patch("memtomem_stm.server.ProxyManager", return_value=mock_pm_instance),
-            patch("memtomem_stm.server.ProxyConfig.load_from_file", return_value=None) as mock_load,
+            patch(
+                "memtomem_stm.server.ProxyConfig.load_from_file_with_status",
+                return_value=ConfigLoadResult(config=None, error=None),
+            ) as mock_load,
         ):
             mock_cfg = MockConfig.return_value
             mock_cfg.proxy = MagicMock()
@@ -2009,6 +2047,37 @@ class TestApplyProxyFileConfig:
 
         assert config.proxy.enabled is True
         assert set(config.proxy.upstream_servers) == {"gh"}
+
+    def test_returns_error_when_file_present_but_broken(self, tmp_path, monkeypatch):
+        """#611: the helper reports "present but broken" so the lifespan can
+        pin it on STMContext instead of the failure living only in stderr."""
+        from memtomem_stm.server import _apply_proxy_file_config
+
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text("{ not valid json", encoding="utf-8")
+        config = self._config(monkeypatch)
+        config.proxy.config_path = cfg_file
+        default_enabled = config.proxy.enabled
+
+        error = _apply_proxy_file_config(config, {})
+
+        assert error is not None
+        assert config.proxy.enabled is default_enabled  # fell back, no swap
+
+    def test_returns_none_for_good_and_missing_files(self, tmp_path, monkeypatch):
+        import json
+
+        from memtomem_stm.server import _apply_proxy_file_config
+
+        cfg_file = tmp_path / "stm_proxy.json"
+        cfg_file.write_text(json.dumps({"enabled": True}), encoding="utf-8")
+        config = self._config(monkeypatch)
+        config.proxy.config_path = cfg_file
+        assert _apply_proxy_file_config(config, {}) is None
+
+        config2 = self._config(monkeypatch)
+        config2.proxy.config_path = tmp_path / "nonexistent.json"
+        assert _apply_proxy_file_config(config2, {}) is None
 
 
 # ── advertise_observability_tools flag ──────────────────────────────────


### PR DESCRIPTION
Fixes #611.

Two compounding dark-failure modes from the 2026-07-04 service review: typo'd config keys vanish silently (the models deliberately keep pydantic's default `extra="ignore"` for forward compat — see `UpstreamServerConfig.origin`), and a config file that exists but fails to parse degrades to env/default config (proxy typically off) with only a stderr warning an MCP client buries.

## What

- **`find_unknown_keys(model_cls, data)`** (`proxy/config.py`): annotation-driven recursive walk naming every silently-dropped key as a dotted path (`upstream_servers.gh.tool_overides`). `dict[str, Model]` fields with user-defined keys (`upstream_servers`, `tool_overrides`) descend into values only; free-form dict leaves (`env`, `headers`, `server_name_map`, `origin.original`) are never descended. Classification is read off `model_fields` annotations — no name allowlist to drift as models evolve. `extra="ignore"` stays untouched on the models.
- **`load_from_file_with_status`** returns `ConfigLoadResult(config, error, unknown_keys)`; `error` is set iff the file exists but failed to parse/validate. `load_from_file` delegates to it — signature and behavior unchanged for existing callers. Unknown keys are walked on the raw file dict *before* the env merge (an env-injected key can never be misattributed as a file typo) and logged as one aggregated warning per load (per-key lines would multiply under hot reload).
- **Server surfacing**: `_apply_proxy_file_config` returns the error; `app_lifespan` pins it on the new defaulted `STMContext.proxy_config_error`; `stm_proxy_health` leads with `WARNING: proxy config file present but failed to parse — running env/default config: <error>` in both the empty and populated upstream branches.
- **`mms config validate [--config] [--json]`** (new `cli/config_cmd.py`): strict linting of the file as written — no env overlay (it lints the artifact you edit, not the runtime composite). Parse errors, schema errors, unknown keys, and a missing file all exit 1 (CI-gateable); the permissive-file-mode check (shared `_permissive_mode`, extracted from the load path) is a warning only.
- **`mms status` / `mms health`** warn on valid-JSON-but-invalid-schema configs and expose `config_valid` / `config_error` in `--json`. Exit codes unchanged — inspection commands stay lenient, strictness lives in `validate`.

## Behavior change

- `stm_proxy_health` output gains a leading `WARNING:` line when the config file is present but broken (previously the symptom `No upstream servers configured.` appeared with no cause).
- `mms status` / `mms health` print a new warning line for schema-invalid configs and add `config_valid` / `config_error` keys to their `--json` payloads (existing keys unchanged).
- The load path emits one new aggregated `unknown key(s)` warning per load when the file carries unrecognized keys. Load semantics (lenient, `extra="ignore"`) are unchanged.

## Doesn't hot reload already handle this?

`ProxyConfigLoader` still keeps last-known-good on reload failure (tests untouched); this PR covers what that path cannot: first startup and silently-ignored keys.

## Tests

- New `tests/test_config_unknown_keys.py` — walker classification per container shape (both `dict[str, Model]` hops, free-form leaves, `Optional[Model]`, `list[Model]` with `[i]` paths, wrong-type skip) plus a full-clean-config canary that also `model_validate`s the same payload so walker and validator can't disagree.
- `tests/test_config_persistence.py` — `with_status` triples (valid / parse-failed / validation-failed / missing), aggregated-warning content, env-injected-keys-not-flagged, and a `load_from_file` delegate-contract pin.
- `tests/test_server_tools.py` — `_apply_proxy_file_config` return values; `stm_proxy_health` warning with and without upstreams.
- New `tests/cli/test_mms_config_validate.py` — all exit-code cases incl. `--json` shapes; `tests/cli/test_proxy_cli.py` — status/health warn lines + JSON flags.

`uv run pytest -m "not ollama"`: 4208 passed. Verified end-to-end against throwaway configs: planted-typo file → exit 1 with both dotted paths; broken JSON → exit 1; clean file → exit 0; duplicate-prefix file → `mms status` warning line + `validate --json` reports the model error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)