### PR TITLE
feat(server): opt-in rotating file log under ~/.memtomem/ (#612)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -748,6 +748,20 @@ Log level is controlled via environment variable (no CLI flag):
 export MEMTOMEM_STM_LOG_LEVEL=DEBUG   # DEBUG | INFO | WARNING | ERROR | CRITICAL
 ```
 
+By default the server logs to **stderr**, which the launching MCP client
+captures (or drops) — hard to find when you're diagnosing why the proxy did
+nothing. Set `MEMTOMEM_STM_LOG_FILE` to also write to a rotating file:
+
+```bash
+export MEMTOMEM_STM_LOG_FILE=~/.memtomem/stm.log
+```
+
+The file is created `0o600` (parent dir `0o700`) and rotates at 2 MiB with 3
+backups. It's opt-in and additive — stderr logging is unchanged. `mms health`
+prints the active destination (`Logging: stderr only …` or `Logging: stderr +
+file <path> …`) so you know where to look. If the file can't be opened
+(read-only path), the server logs a warning to stderr and keeps running.
+
 See [Configuration → General](configuration.md#general) for details.
 
 ## Trimming the advertised MCP tool surface

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -758,8 +758,11 @@ export MEMTOMEM_STM_LOG_FILE=~/.memtomem/stm.log
 
 The file is created `0o600` (parent dir `0o700`) and rotates at 2 MiB with 3
 backups. It's opt-in and additive — stderr logging is unchanged. `mms health`
-prints the active destination (`Logging: stderr only …` or `Logging: stderr +
-file <path> …`) so you know where to look. If the file can't be opened
+prints where a newly started server would log (the configured, probed
+destination — it runs in a separate process and can't see a live server's
+handler): `Logging: stderr only …`, or `Logging: stderr + file <path> …` when
+the path is writable, or a `stderr only — configured log file <path> is not
+writable` warning when it isn't. If the file can't be opened at startup
 (read-only path), the server logs a warning to stderr and keeps running.
 
 See [Configuration → General](configuration.md#general) for details.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,17 @@ loggers.  Default `WARNING`.  Read once at startup — restart to
 apply changes.
 
 ```bash
+export MEMTOMEM_STM_LOG_FILE=~/.memtomem/stm.log   # opt-in rotating file log
+```
+
+Adds a rotating file handler alongside stderr (the server otherwise
+logs to stderr only, which an MCP client captures or drops). File
+created `0o600`, parent dir `0o700`; rotates at 2 MiB with 3 backups.
+Unset (default) keeps stderr-only logging. `mms health` prints the
+active destination. A path that can't be opened degrades to a
+stderr warning, not a crash.
+
+```bash
 export MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true   # opt in
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,9 +37,11 @@ export MEMTOMEM_STM_LOG_FILE=~/.memtomem/stm.log   # opt-in rotating file log
 Adds a rotating file handler alongside stderr (the server otherwise
 logs to stderr only, which an MCP client captures or drops). File
 created `0o600`, parent dir `0o700`; rotates at 2 MiB with 3 backups.
-Unset (default) keeps stderr-only logging. `mms health` prints the
-active destination. A path that can't be opened degrades to a
-stderr warning, not a crash.
+Unset (default) keeps stderr-only logging. `mms health` prints where a
+newly started server would log (the configured, probed destination —
+not the running server's live handler) and flags a configured path that
+isn't writable. A path that can't be opened degrades to a stderr
+warning, not a crash.
 
 ```bash
 export MEMTOMEM_STM_ADVERTISE_OBSERVABILITY_TOOLS=true   # opt in

--- a/src/memtomem_stm/cli/daemon_cmd.py
+++ b/src/memtomem_stm/cli/daemon_cmd.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from memtomem_stm.logging_setup import FILE_FORMAT, open_private_log_handler
+
 if TYPE_CHECKING:
     from memtomem_stm.config import STMConfig
 
@@ -145,19 +147,25 @@ def _live_foreign_daemons(config: STMConfig) -> list[dict[str, Any]]:
 
 def _configure_logging(config: STMConfig, *, detached: bool) -> None:
     """Route daemon logs to a file under ``data_dir`` when detached (its stdio
-    is ``DEVNULL``), otherwise to stderr for foreground debugging."""
+    is ``DEVNULL``), otherwise to stderr for foreground debugging.
+
+    The detached file goes through the shared #612 handler: 0o600 file /
+    0o700 parent per the data-at-rest convention, and size rotation so the
+    #581 crash-trace guarantee doesn't eventually drown in an unbounded log.
+    A failure to open it propagates — with stdio devnulled, a daemon that
+    cannot log its crashes must not run. (The server path degrades to
+    stderr instead; see ``configure_server_logging``.)
+    """
     level = getattr(logging, config.log_level, logging.WARNING)
     handler: logging.Handler
     if detached:
-        logpath = (config.data_dir / "stm-daemon.log").expanduser()
-        logpath.parent.mkdir(parents=True, exist_ok=True)
-        handler = logging.FileHandler(logpath, encoding="utf-8")
+        handler = open_private_log_handler((config.data_dir / "stm-daemon.log").expanduser())
     else:
         handler = logging.StreamHandler(sys.stderr)
     logging.basicConfig(
         level=level,
         handlers=[handler],
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        format=FILE_FORMAT,
         force=True,
     )
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -188,13 +188,20 @@ def _logging_destination_status() -> dict[str, Any]:
 
 def _format_logging_destination(status: dict[str, Any]) -> str:
     """One ``Logging:`` line — always printed, so users learn the file-log
-    option exists even while running stderr-only."""
+    option exists even while running stderr-only. When a configured log file
+    isn't writable, name stderr as the real destination (the server degrades
+    to it) instead of pointing at a file that receives nothing."""
     if "error" in status:
         return f"{_warn('Logging:')} {status['error']}"
     if status["log_file"]:
+        if status.get("writable"):
+            return (
+                f"Logging: stderr + file {status['log_file']} "
+                f"(level {status['log_level']}, rotating)"
+            )
         return (
-            f"Logging: stderr + file {status['log_file']} "
-            f"(level {status['log_level']}, rotating)"
+            f"{_warn('Logging:')} stderr only — configured log file {status['log_file']} "
+            "is not writable; the server falls back to stderr"
         )
     return "Logging: stderr only (set MEMTOMEM_STM_LOG_FILE for a persistent log)"
 

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -170,6 +170,35 @@ _CONFIG_INVALID_WARNING = (
 )
 
 
+def _logging_destination_status() -> dict[str, Any]:
+    """Active log destination for ``mms health`` (#612) — the point of the
+    opt-in file log is diagnosability, so health says where to look.
+    ValidationError-guarded: a bad ``MEMTOMEM_STM_*`` env value must not
+    break a diagnostics command."""
+    from pydantic import ValidationError
+
+    from memtomem_stm.config import STMConfig
+    from memtomem_stm.logging_setup import describe_log_destination
+
+    try:
+        return describe_log_destination(STMConfig())
+    except ValidationError as exc:
+        return {"error": f"invalid MEMTOMEM_STM_* environment ({exc.error_count()} error(s))"}
+
+
+def _format_logging_destination(status: dict[str, Any]) -> str:
+    """One ``Logging:`` line — always printed, so users learn the file-log
+    option exists even while running stderr-only."""
+    if "error" in status:
+        return f"{_warn('Logging:')} {status['error']}"
+    if status["log_file"]:
+        return (
+            f"Logging: stderr + file {status['log_file']} "
+            f"(level {status['log_level']}, rotating)"
+        )
+    return "Logging: stderr only (set MEMTOMEM_STM_LOG_FILE for a persistent log)"
+
+
 def _save(config_path: Path, data: dict[str, Any]) -> None:
     """Write the proxy config atomically.
 
@@ -4028,6 +4057,7 @@ def health(
     servers: dict[str, Any] = data.get("upstream_servers", {})
     surfacing_status = _surfacing_bootstrap_status(float(timeout))
     config_error = _schema_validation_error(data)
+    logging_status = _logging_destination_status()
 
     # JSON output format matches ``status --json`` / ``list --json`` (indent=2,
     # ensure_ascii=False) so scripts piping the three commands through the
@@ -4041,6 +4071,7 @@ def health(
                         "config_valid": config_error is None,
                         "config_error": config_error,
                         "surfacing": surfacing_status,
+                        "logging": logging_status,
                     },
                     indent=2,
                     ensure_ascii=False,
@@ -4053,6 +4084,7 @@ def health(
             click.echo("")
             for line in _format_surfacing_bootstrap(surfacing_status):
                 click.echo(line)
+            click.echo(_format_logging_destination(logging_status))
         return
 
     results = asyncio.run(_probe_servers(servers, timeout))
@@ -4065,6 +4097,7 @@ def health(
                     "config_valid": config_error is None,
                     "config_error": config_error,
                     "surfacing": surfacing_status,
+                    "logging": logging_status,
                 },
                 indent=2,
                 ensure_ascii=False,
@@ -4096,6 +4129,7 @@ def health(
     click.echo("")
     for line in _format_surfacing_bootstrap(surfacing_status):
         click.echo(line)
+    click.echo(_format_logging_destination(logging_status))
 
 
 # `mms project ...` — RFC §7.1, lives in src/memtomem_stm/cli/mms_project.py

--- a/src/memtomem_stm/config.py
+++ b/src/memtomem_stm/config.py
@@ -187,6 +187,14 @@ class STMConfig(BaseSettings):
     )
 
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "WARNING"
+    log_file: Path | None = None
+    """Opt-in rotating file log (#612), e.g. ``~/.memtomem/stm.log`` — set via
+    ``MEMTOMEM_STM_LOG_FILE``. For an MCP-launched stdio server, stderr is
+    captured (or dropped) by the client, so this is the diagnosable trail.
+    Written in addition to stderr via a size-rotating handler (2 MiB × 3
+    backups), file ``0o600`` / parent ``0o700`` per the data-at-rest
+    convention. ``None`` (default) keeps stderr-only logging. Stored raw;
+    ``expanduser()`` happens at the use site (like ``data_dir``)."""
     proxy: ProxyConfig = Field(default_factory=ProxyConfig)
     surfacing: SurfacingConfig = Field(default_factory=SurfacingConfig)
     langfuse: LangfuseConfig = Field(default_factory=LangfuseConfig)

--- a/src/memtomem_stm/logging_setup.py
+++ b/src/memtomem_stm/logging_setup.py
@@ -120,17 +120,34 @@ def log_file_writable(path: Path) -> bool:
 
     ``mms health`` runs in a separate process from the server, so it cannot
     observe the live handler — it can only tell whether the configured path
-    *would* open. Mirrors the handler's needs (create parent dirs, then the
-    file) without any side effect: an existing file must be writable; a
-    missing one needs its nearest existing ancestor writable + traversable.
+    *would* open. This mirrors what the handler actually needs — ``mkdir(
+    parents=True)`` on the parent then ``os.open(file, O_WRONLY|O_CREAT|
+    O_APPEND)`` — without side effects, so it rejects the cases that pass a
+    naive "exists and writable" test but still fail the real open:
+
+    - an existing directory / symlink-to-directory / special file (can't be
+      opened ``O_WRONLY``): the terminal path must resolve to a regular file;
+    - a broken symlink (``O_CREAT`` would chase a missing target);
+    - a non-directory ancestor (``mkdir(parents=True)`` fails on it).
+
+    A symlink to a regular writable file is accepted. Point-in-time: like any
+    probe it races the real open, but for a diagnostic that is acceptable.
     """
     resolved = path.expanduser()
+    # Broken symlink: exists() follows it and returns False, but the server's
+    # O_CREAT open would chase the missing target — not usable.
+    if resolved.is_symlink() and not resolved.exists():
+        return False
     if resolved.exists():
-        return os.access(resolved, os.W_OK)
+        # Must be a regular file (is_file follows symlinks) openable for
+        # append — a directory / special file cannot be O_WRONLY'd.
+        return resolved.is_file() and os.access(resolved, os.W_OK)
+    # Missing file: mkdir(parents=True) needs the nearest existing ancestor to
+    # be a writable, traversable *directory* (it fails on a non-directory).
     ancestor = resolved.parent
     while not ancestor.exists() and ancestor != ancestor.parent:
         ancestor = ancestor.parent
-    return os.access(ancestor, os.W_OK | os.X_OK)
+    return ancestor.is_dir() and os.access(ancestor, os.W_OK | os.X_OK)
 
 
 def describe_log_destination(config: STMConfig) -> dict[str, Any]:

--- a/src/memtomem_stm/logging_setup.py
+++ b/src/memtomem_stm/logging_setup.py
@@ -1,0 +1,124 @@
+"""Shared logging configuration for the server and daemon entry points (#612).
+
+The MCP stdio server logs to stderr, which the launching client captures (or
+drops) — diagnosing "why did my proxy do nothing" means hunting per-client
+log locations. ``MEMTOMEM_STM_LOG_FILE`` / ``STMConfig.log_file`` opt into a
+rotating file log *in addition to* stderr. The daemon's detached mode routes
+its fixed ``stm-daemon.log`` through the same handler (its stdio is DEVNULL —
+the file is the only crash trace, #581).
+
+Hardening matches the data-at-rest convention (``utils/fileio.py``,
+``proxy/selection_log.py``): file ``0o600``, parent directory created
+``0o700`` (a pre-existing directory keeps its mode). Credential redaction
+needs no handler-level hook — it happens at message-construction time
+(``proxy/manager.py:_redacted_error``), so every handler receives already-
+redacted records.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from memtomem_stm.config import STMConfig
+
+STDERR_FORMAT = "%(levelname)s %(name)s: %(message)s"
+"""Server stderr format — unchanged from the pre-#612 ``basicConfig``."""
+
+FILE_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+"""File format carries timestamps: a persistent log spans restarts."""
+
+LOG_FILE_MAX_BYTES = 2 * 1024 * 1024
+LOG_FILE_BACKUP_COUNT = 3
+"""2 MiB × (1 current + 3 backups) caps the worst-case footprint at 8 MiB
+while keeping enough history to cover a crash discovered a few days late."""
+
+
+class PrivateRotatingFileHandler(RotatingFileHandler):
+    """RotatingFileHandler whose files are created ``0o600``.
+
+    ``FileHandler`` has no ``opener=`` hook, so ``_open`` is overridden with
+    the create-private-then-tighten idiom from ``proxy/selection_log.py``:
+    ``os.open(..., 0o600)`` covers creation (umask-permitting) and the
+    ``fchmod`` tightens a pre-existing permissive file. ``doRollover``
+    re-invokes ``_open`` for the recreated base file, so post-rotation files
+    get the same mode; rotated backups are ``os.rename``d (mode travels with
+    the inode) and need nothing extra.
+    """
+
+    def _open(self):  # type: ignore[override]
+        fd = os.open(self.baseFilename, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+        except OSError:
+            pass
+        return os.fdopen(fd, "a", encoding="utf-8")
+
+
+def open_private_log_handler(
+    path: Path,
+    *,
+    max_bytes: int = LOG_FILE_MAX_BYTES,
+    backup_count: int = LOG_FILE_BACKUP_COUNT,
+) -> logging.Handler:
+    """Rotating 0o600 file handler at *path*, parent created 0o700.
+
+    Raises ``OSError`` when the file or directory cannot be created — the
+    caller decides whether that is fatal (daemon detached mode: yes, the file
+    is the only output) or degradable (server: stderr still works).
+    """
+    resolved = path.expanduser()
+    resolved.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    handler = PrivateRotatingFileHandler(
+        resolved, maxBytes=max_bytes, backupCount=backup_count, encoding="utf-8"
+    )
+    handler.setFormatter(logging.Formatter(FILE_FORMAT))
+    return handler
+
+
+def configure_server_logging(config: STMConfig) -> Path | None:
+    """Root logging for the MCP server: stderr always, plus the opt-in file.
+
+    Returns the active log-file path, or ``None`` when running stderr-only
+    (unset ``log_file`` or a file that could not be opened — an opt-in
+    diagnostic aid must not take the server down with it; the failure is
+    logged to stderr instead).
+    """
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(STDERR_FORMAT))
+    handlers: list[logging.Handler] = [stderr_handler]
+    active_path: Path | None = None
+    file_error: str | None = None
+    if config.log_file is not None:
+        try:
+            handlers.append(open_private_log_handler(config.log_file))
+            active_path = config.log_file.expanduser()
+        except OSError as exc:
+            file_error = str(exc)  # logged once basicConfig installs stderr
+    logging.basicConfig(
+        level=getattr(logging, config.log_level, logging.WARNING),
+        handlers=handlers,
+        force=True,
+    )
+    if file_error is not None:
+        logging.getLogger(__name__).warning(
+            "log_file %s could not be opened (%s); continuing with stderr only",
+            config.log_file,
+            file_error,
+        )
+    return active_path
+
+
+def describe_log_destination(config: STMConfig) -> dict[str, Any]:
+    """Shared payload for ``mms health`` text and ``--json`` output."""
+    log_file = str(config.log_file.expanduser()) if config.log_file is not None else None
+    return {
+        "log_level": config.log_level,
+        "log_file": log_file,
+        "destination": "stderr+file" if log_file else "stderr",
+    }

--- a/src/memtomem_stm/logging_setup.py
+++ b/src/memtomem_stm/logging_setup.py
@@ -114,11 +114,39 @@ def configure_server_logging(config: STMConfig) -> Path | None:
     return active_path
 
 
+def log_file_writable(path: Path) -> bool:
+    """Best-effort, non-mutating check that ``open_private_log_handler`` would
+    succeed for *path*.
+
+    ``mms health`` runs in a separate process from the server, so it cannot
+    observe the live handler — it can only tell whether the configured path
+    *would* open. Mirrors the handler's needs (create parent dirs, then the
+    file) without any side effect: an existing file must be writable; a
+    missing one needs its nearest existing ancestor writable + traversable.
+    """
+    resolved = path.expanduser()
+    if resolved.exists():
+        return os.access(resolved, os.W_OK)
+    ancestor = resolved.parent
+    while not ancestor.exists() and ancestor != ancestor.parent:
+        ancestor = ancestor.parent
+    return os.access(ancestor, os.W_OK | os.X_OK)
+
+
 def describe_log_destination(config: STMConfig) -> dict[str, Any]:
-    """Shared payload for ``mms health`` text and ``--json`` output."""
+    """Shared payload for ``mms health`` text and ``--json`` output.
+
+    ``writable`` reflects whether the configured ``log_file`` can be opened
+    right now (``None`` when unset). It is deliberately *configured*, not
+    *active*: a separate ``mms health`` process cannot see the running
+    server's handler, so an unwritable path means the server would fall back
+    to stderr — which the health text then says explicitly rather than
+    pointing at a file that receives nothing.
+    """
     log_file = str(config.log_file.expanduser()) if config.log_file is not None else None
     return {
         "log_level": config.log_level,
         "log_file": log_file,
         "destination": "stderr+file" if log_file else "stderr",
+        "writable": log_file_writable(config.log_file) if config.log_file is not None else None,
     }

--- a/src/memtomem_stm/logging_setup.py
+++ b/src/memtomem_stm/logging_setup.py
@@ -17,6 +17,7 @@ redacted records.
 
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import sys
@@ -39,6 +40,30 @@ LOG_FILE_BACKUP_COUNT = 3
 while keeping enough history to cover a crash discovered a few days late."""
 
 
+def _unsafe_log_target_reason(target: Path) -> str | None:
+    """Why *target* can't be a hardened log file, or ``None`` if it's fine.
+
+    A single source of truth for the terminal-path rule, shared by the write
+    probe (``log_file_writable``) and the real open (``_open``) so the two
+    can't diverge: a 0o600 append log must resolve to a regular file, so a
+    dangling symlink (``os.open(O_CREAT)`` would silently create the target,
+    redirecting the log) and an existing non-regular target (directory /
+    special file / symlink to one) are refused. A symlink to an existing
+    regular file is allowed.
+    """
+    if target.is_symlink() and not target.exists():
+        return f"log path is a dangling symlink: {target}"
+    if target.exists() and not target.is_file():
+        return f"log path is not a regular file: {target}"
+    return None
+
+
+def _reject_unsafe_log_target(target: Path) -> None:
+    reason = _unsafe_log_target_reason(target)
+    if reason is not None:
+        raise OSError(errno.ELOOP, reason)
+
+
 class PrivateRotatingFileHandler(RotatingFileHandler):
     """RotatingFileHandler whose files are created ``0o600``.
 
@@ -52,6 +77,7 @@ class PrivateRotatingFileHandler(RotatingFileHandler):
     """
 
     def _open(self):  # type: ignore[override]
+        _reject_unsafe_log_target(Path(self.baseFilename))
         fd = os.open(self.baseFilename, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
         try:
             os.fchmod(fd, 0o600)
@@ -134,14 +160,13 @@ def log_file_writable(path: Path) -> bool:
     probe it races the real open, but for a diagnostic that is acceptable.
     """
     resolved = path.expanduser()
-    # Broken symlink: exists() follows it and returns False, but the server's
-    # O_CREAT open would chase the missing target — not usable.
-    if resolved.is_symlink() and not resolved.exists():
+    # Terminal-path rule, shared with the real open so they can't disagree:
+    # dangling symlink or existing non-regular target → not usable.
+    if _unsafe_log_target_reason(resolved) is not None:
         return False
     if resolved.exists():
-        # Must be a regular file (is_file follows symlinks) openable for
-        # append — a directory / special file cannot be O_WRONLY'd.
-        return resolved.is_file() and os.access(resolved, os.W_OK)
+        # A regular file (possibly via symlink) must be writable for append.
+        return os.access(resolved, os.W_OK)
     # Missing file: mkdir(parents=True) needs the nearest existing ancestor to
     # be a writable, traversable *directory* (it fails on a non-directory).
     ancestor = resolved.parent

--- a/src/memtomem_stm/logging_setup.py
+++ b/src/memtomem_stm/logging_setup.py
@@ -146,6 +146,11 @@ def log_file_writable(path: Path) -> bool:
     # be a writable, traversable *directory* (it fails on a non-directory).
     ancestor = resolved.parent
     while not ancestor.exists() and ancestor != ancestor.parent:
+        # A broken symlink in the parent chain reads as "missing" via exists()
+        # (which follows links), but mkdir(parents=True) raises FileExistsError
+        # on it rather than creating through it — so it's not usable.
+        if ancestor.is_symlink():
+            return False
         ancestor = ancestor.parent
     return ancestor.is_dir() and os.access(ancestor, os.W_OK | os.X_OK)
 

--- a/src/memtomem_stm/logging_setup.py
+++ b/src/memtomem_stm/logging_setup.py
@@ -79,10 +79,14 @@ class PrivateRotatingFileHandler(RotatingFileHandler):
     def _open(self):  # type: ignore[override]
         _reject_unsafe_log_target(Path(self.baseFilename))
         fd = os.open(self.baseFilename, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
-        try:
-            os.fchmod(fd, 0o600)
-        except OSError:
-            pass
+        # Race-free tighten of a pre-existing permissive file. os.fchmod is
+        # POSIX-only; Windows has no fchmod (and ignores POSIX modes anyway),
+        # so guard it — the sibling stores' perm-assertion tests skip Windows.
+        if hasattr(os, "fchmod"):
+            try:
+                os.fchmod(fd, 0o600)
+            except OSError:
+                pass
         return os.fdopen(fd, "a", encoding="utf-8")
 
 

--- a/src/memtomem_stm/server.py
+++ b/src/memtomem_stm/server.py
@@ -15,6 +15,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 
 from memtomem_stm.config import STMConfig
+from memtomem_stm.logging_setup import STDERR_FORMAT, configure_server_logging
 from memtomem_stm.proxy.compression_feedback import CompressionFeedbackTracker
 from memtomem_stm.proxy.config import ProxyConfig, collect_proxy_env_overrides
 from memtomem_stm.proxy.manager import ProxyManager
@@ -1878,11 +1879,18 @@ async def stm_tuning_recommendations(
 
 def main() -> None:
     """Run the STM MCP server."""
-    level = os.environ.get("MEMTOMEM_STM_LOG_LEVEL", "WARNING").upper()
-    logging.basicConfig(
-        level=getattr(logging, level, logging.WARNING),
-        format="%(levelname)s %(name)s: %(message)s",
-    )
+    # STMConfig folds MEMTOMEM_STM_LOG_LEVEL and MEMTOMEM_STM_LOG_FILE into
+    # one env surface (#612). A bad env value used to fall back to WARNING
+    # silently here while the lifespan's own STMConfig() raised the same
+    # ValidationError moments later WITHOUT any logging configured — failing
+    # here, after a plain stderr basicConfig, is the readable version.
+    try:
+        startup_config = STMConfig()
+    except Exception:
+        logging.basicConfig(level=logging.WARNING, format=STDERR_FORMAT)
+        logger.exception("Invalid MEMTOMEM_STM_* environment configuration")
+        raise
+    configure_server_logging(startup_config)
     # Exception barrier (#209): without this, an unhandled exception from
     # ``mcp.run()`` (e.g. a background task crashing the event loop) ends the
     # process with only stderr output — operators get no ERROR-level log, and

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -5972,6 +5972,29 @@ class TestHealth:
         logging_status = json.loads(result.output)["logging"]
         assert logging_status["log_file"] == str(logf)
         assert logging_status["destination"] == "stderr+file"
+        assert logging_status["writable"] is True
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+    def test_health_logging_line_unwritable_file_names_stderr(
+        self, runner, config, tmp_path, monkeypatch
+    ):
+        """codex review of #612: mms health runs in a separate process and
+        cannot see the server's live handler. When the configured log file
+        can't be opened, the server degrades to stderr — health must say so,
+        not point at a file that receives nothing."""
+        locked = tmp_path / "locked"
+        locked.mkdir(mode=0o500)
+        try:
+            monkeypatch.setenv("MEMTOMEM_STM_LOG_FILE", str(locked / "sub" / "stm.log"))
+            config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+            result = runner.invoke(cli, ["health", *_cfg_args(config)])
+            assert result.exit_code == 0
+            assert "stderr only — configured log file" in result.output
+            assert "not writable" in result.output
+            json_result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
+            assert json.loads(json_result.output)["logging"]["writable"] is False
+        finally:
+            locked.chmod(0o700)
 
     def test_health_json_no_servers(self, runner, config, monkeypatch):
         monkeypatch.delenv("MEMTOMEM_STM_LOG_FILE", raising=False)

--- a/tests/cli/test_proxy_cli.py
+++ b/tests/cli/test_proxy_cli.py
@@ -5944,7 +5944,37 @@ class TestHealth:
         assert "fails validation" in result.output
         assert "No upstream servers configured" in result.output
 
-    def test_health_json_no_servers(self, runner, config):
+    def test_health_logging_line_stderr_only(self, runner, config, monkeypatch):
+        """#612: health always prints where logs go, so users learn the
+        file-log option exists even while running stderr-only."""
+        monkeypatch.delenv("MEMTOMEM_STM_LOG_FILE", raising=False)
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["health", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert "Logging: stderr only" in result.output
+        assert "MEMTOMEM_STM_LOG_FILE" in result.output
+
+    def test_health_logging_line_with_file(self, runner, config, tmp_path, monkeypatch):
+        logf = tmp_path / "stm.log"
+        monkeypatch.setenv("MEMTOMEM_STM_LOG_FILE", str(logf))
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["health", *_cfg_args(config)])
+        assert result.exit_code == 0
+        assert f"stderr + file {logf}" in result.output
+        assert "rotating" in result.output
+
+    def test_health_json_logging_key(self, runner, config, tmp_path, monkeypatch):
+        logf = tmp_path / "stm.log"
+        monkeypatch.setenv("MEMTOMEM_STM_LOG_FILE", str(logf))
+        config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
+        result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
+        assert result.exit_code == 0
+        logging_status = json.loads(result.output)["logging"]
+        assert logging_status["log_file"] == str(logf)
+        assert logging_status["destination"] == "stderr+file"
+
+    def test_health_json_no_servers(self, runner, config, monkeypatch):
+        monkeypatch.delenv("MEMTOMEM_STM_LOG_FILE", raising=False)
         config.write_text(json.dumps({"upstream_servers": {}}), encoding="utf-8")
         result = runner.invoke(cli, ["health", "--json", *_cfg_args(config)])
         assert result.exit_code == 0
@@ -5952,6 +5982,7 @@ class TestHealth:
         assert data["servers"] == {}
         assert data["config_valid"] is True
         assert data["config_error"] is None
+        assert data["logging"]["destination"] == "stderr"
         assert data["surfacing"]["enabled"] is True
         assert data["surfacing"]["feedback_enabled"] is True
         assert data["surfacing"]["feedback_db"]["exists"] is False

--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -125,6 +125,72 @@ def test_iter_foreign_handshakes_missing_dir(tmp_path: Path):
     assert discovery.iter_foreign_handshakes(tmp_path / "nope", "cur") == []
 
 
+# ── daemon logging (#612 convergence) ─────────────────────────────────────
+
+
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX 0o700/0o600 modes are unenforceable on Windows",
+)
+
+
+@pytest.fixture
+def _restore_root_logging():
+    import logging
+
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    yield
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+        try:
+            h.close()
+        except Exception:
+            pass
+    for h in saved_handlers:
+        root.addHandler(h)
+    root.setLevel(saved_level)
+
+
+@_skip_on_windows
+def test_configure_logging_detached_hardens_file(tmp_path, _restore_root_logging):
+    """Detached daemon logs to stm-daemon.log, now via the shared #612 handler:
+    0o600 file / 0o700 parent + rotation, closing the pre-existing gap where
+    the plain FileHandler left the crash-trace log world-readable."""
+    import logging
+
+    from memtomem_stm.cli.daemon_cmd import _configure_logging
+    from memtomem_stm.logging_setup import PrivateRotatingFileHandler
+
+    config = STMConfig(data_dir=tmp_path)
+    _configure_logging(config, detached=True)
+    logging.getLogger("daemon.test").warning("crash trace")
+
+    logpath = tmp_path / "stm-daemon.log"
+    assert logpath.exists()
+    assert logpath.stat().st_mode & 0o777 == 0o600
+    assert logpath.parent.stat().st_mode & 0o777 == 0o700
+    handlers = [
+        h for h in logging.getLogger().handlers if isinstance(h, PrivateRotatingFileHandler)
+    ]
+    assert len(handlers) == 1
+
+
+def test_configure_logging_foreground_uses_stderr(tmp_path, _restore_root_logging):
+    import logging
+
+    from memtomem_stm.cli.daemon_cmd import _configure_logging
+    from memtomem_stm.logging_setup import PrivateRotatingFileHandler
+
+    _configure_logging(STMConfig(data_dir=tmp_path), detached=False)
+    handlers = logging.getLogger().handlers
+    assert len(handlers) == 1
+    assert isinstance(handlers[0], logging.StreamHandler)
+    assert not isinstance(handlers[0], PrivateRotatingFileHandler)
+    assert not (tmp_path / "stm-daemon.log").exists()
+
+
 def test_config_fingerprint_stable_and_broad(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("MEMTOMEM_STM_HOOK_SURFACE_TOOLS", raising=False)
     fp = discovery.config_fingerprint(STMConfig())

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -23,6 +23,7 @@ from memtomem_stm.logging_setup import (
     PrivateRotatingFileHandler,
     configure_server_logging,
     describe_log_destination,
+    log_file_writable,
     open_private_log_handler,
 )
 
@@ -163,10 +164,45 @@ class TestConfigureServerLogging:
             locked.chmod(0o700)
 
 
+class TestLogFileWritable:
+    def test_missing_file_writable_parent(self, tmp_path):
+        assert log_file_writable(tmp_path / "sub" / "stm.log") is True
+
+    @_skip_on_windows
+    def test_missing_file_unwritable_parent(self, tmp_path):
+        locked = tmp_path / "locked"
+        locked.mkdir(mode=0o500)
+        try:
+            assert log_file_writable(locked / "sub" / "stm.log") is False
+        finally:
+            locked.chmod(0o700)
+
+    @_skip_on_windows
+    def test_existing_unwritable_file(self, tmp_path):
+        path = tmp_path / "stm.log"
+        path.touch()
+        path.chmod(0o400)
+        try:
+            assert log_file_writable(path) is False
+        finally:
+            path.chmod(0o600)
+
+    def test_probe_does_not_create_anything(self, tmp_path):
+        path = tmp_path / "sub" / "stm.log"
+        log_file_writable(path)
+        assert not path.exists()
+        assert not path.parent.exists()
+
+
 class TestDescribeLogDestination:
     def test_unset(self):
         d = describe_log_destination(STMConfig(log_file=None, log_level="WARNING"))
-        assert d == {"log_level": "WARNING", "log_file": None, "destination": "stderr"}
+        assert d == {
+            "log_level": "WARNING",
+            "log_file": None,
+            "destination": "stderr",
+            "writable": None,
+        }
 
     def test_set(self, tmp_path):
         path = tmp_path / "stm.log"
@@ -174,6 +210,7 @@ class TestDescribeLogDestination:
         assert d["log_level"] == "DEBUG"
         assert d["log_file"] == str(path.expanduser())
         assert d["destination"] == "stderr+file"
+        assert d["writable"] is True
 
 
 class TestEnvWiring:

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -214,6 +214,15 @@ class TestLogFileWritable:
         assert log_file_writable(link) is False
 
     @_skip_on_windows
+    def test_broken_symlink_intermediate_ancestor_rejected(self, tmp_path):
+        # A dangling symlink used as an intermediate parent: exists() follows
+        # it and reads "missing", but mkdir(parents=True) raises
+        # FileExistsError on it rather than creating through it.
+        broken_parent = tmp_path / "broken_parent"
+        broken_parent.symlink_to(tmp_path / "missing_target")
+        assert log_file_writable(broken_parent / "sub" / "stm.log") is False
+
+    @_skip_on_windows
     def test_symlink_to_regular_writable_file_accepted(self, tmp_path):
         target = tmp_path / "real.log"
         target.touch()

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,187 @@
+"""Tests for the shared logging setup (#612).
+
+Covers the opt-in rotating file log: 0o600 file / 0o700 parent on creation
+and after rollover, tightening a pre-existing permissive file, graceful
+degradation when the file can't be opened (server keeps running on stderr),
+and the format/description surfaces. Root-logger handlers are snapshotted and
+restored per test — ``basicConfig(force=True)`` closes existing handlers
+(including pytest's caplog handler), so leaking them across tests would break
+capture and, on Windows, keep the tmp file open.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+from memtomem_stm.config import STMConfig
+from memtomem_stm.logging_setup import (
+    FILE_FORMAT,
+    STDERR_FORMAT,
+    PrivateRotatingFileHandler,
+    configure_server_logging,
+    describe_log_destination,
+    open_private_log_handler,
+)
+
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX 0o700/0o600 modes are unenforceable on Windows",
+)
+
+
+@pytest.fixture
+def _restore_root_logging():
+    """Snapshot/restore root handlers + level around a test that reconfigures
+    the root logger, so ``basicConfig(force=True)`` can't leak closed handlers
+    into pytest's capture or other tests."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    yield
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+        try:
+            h.close()
+        except Exception:
+            pass
+    for h in saved_handlers:
+        root.addHandler(h)
+    root.setLevel(saved_level)
+
+
+def _emit(name: str = "test.logging") -> None:
+    logging.getLogger(name).warning("a log line")
+
+
+class TestFilePermissions:
+    @_skip_on_windows
+    def test_fresh_file_0600_parent_0700(self, tmp_path):
+        path = tmp_path / "sub" / "stm.log"
+        handler = open_private_log_handler(path)
+        try:
+            handler.emit(logging.makeLogRecord({"msg": "x"}))
+        finally:
+            handler.close()
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert path.parent.stat().st_mode & 0o777 == 0o700
+
+    @_skip_on_windows
+    def test_preexisting_permissive_file_tightened(self, tmp_path):
+        path = tmp_path / "stm.log"
+        path.touch()
+        path.chmod(0o644)
+        handler = open_private_log_handler(path)
+        try:
+            handler.emit(logging.makeLogRecord({"msg": "x"}))
+        finally:
+            handler.close()
+        assert path.stat().st_mode & 0o777 == 0o600
+
+    @_skip_on_windows
+    def test_preexisting_parent_mode_untouched(self, tmp_path):
+        # A pre-existing parent dir keeps its mode (mkdir's mode only applies
+        # on creation) — matches the sibling-store policy.
+        parent = tmp_path / "existing"
+        parent.mkdir(mode=0o755)
+        parent.chmod(0o755)
+        handler = open_private_log_handler(parent / "stm.log")
+        handler.close()
+        assert parent.stat().st_mode & 0o777 == 0o755
+
+    @_skip_on_windows
+    def test_rollover_keeps_0600_on_base_and_backup(self, tmp_path):
+        path = tmp_path / "stm.log"
+        handler = open_private_log_handler(path, max_bytes=1, backup_count=1)
+        try:
+            handler.emit(logging.makeLogRecord({"msg": "first record"}))
+            handler.emit(logging.makeLogRecord({"msg": "second record forces rollover"}))
+        finally:
+            handler.close()
+        backup = path.with_name(path.name + ".1")
+        assert backup.exists()
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert backup.stat().st_mode & 0o777 == 0o600
+
+    def test_handler_is_rotating_subclass(self, tmp_path):
+        handler = open_private_log_handler(tmp_path / "stm.log")
+        try:
+            assert isinstance(handler, PrivateRotatingFileHandler)
+        finally:
+            handler.close()
+
+
+class TestConfigureServerLogging:
+    def test_no_log_file_is_stderr_only(self, _restore_root_logging):
+        active = configure_server_logging(STMConfig(log_file=None, log_level="INFO"))
+        assert active is None
+        handlers = logging.getLogger().handlers
+        assert len(handlers) == 1
+        assert isinstance(handlers[0], logging.StreamHandler)
+        # stderr format is byte-identical to the pre-#612 basicConfig.
+        assert handlers[0].formatter is not None
+        assert handlers[0].formatter._fmt == STDERR_FORMAT
+
+    @_skip_on_windows
+    def test_log_file_adds_second_handler_with_asctime(self, tmp_path, _restore_root_logging):
+        path = tmp_path / "stm.log"
+        active = configure_server_logging(STMConfig(log_file=path, log_level="INFO"))
+        assert active == path.expanduser()
+        handlers = logging.getLogger().handlers
+        assert len(handlers) == 2
+        file_handler = next(h for h in handlers if isinstance(h, PrivateRotatingFileHandler))
+        assert file_handler.formatter is not None
+        assert file_handler.formatter._fmt == FILE_FORMAT
+        _emit()
+        assert path.exists()
+        assert path.stat().st_mode & 0o777 == 0o600
+
+    @_skip_on_windows
+    def test_unwritable_path_degrades_to_stderr(self, tmp_path, _restore_root_logging, capsys):
+        # Parent is a read-only dir → the file can't be created. The server
+        # must keep running on stderr rather than crash on an opt-in aid.
+        # Asserted via capsys, not caplog: basicConfig(force=True) removes
+        # caplog's handler before the warning is emitted, so it only reaches
+        # the freshly-installed stderr handler.
+        locked = tmp_path / "locked"
+        locked.mkdir(mode=0o500)
+        try:
+            cfg = STMConfig(log_file=locked / "sub" / "stm.log", log_level="WARNING")
+            active = configure_server_logging(cfg)
+            logging.getLogger().handlers[0].flush()
+            assert active is None
+            handlers = [
+                h
+                for h in logging.getLogger().handlers
+                if isinstance(h, PrivateRotatingFileHandler)
+            ]
+            assert handlers == []
+            assert "continuing with stderr only" in capsys.readouterr().err
+        finally:
+            locked.chmod(0o700)
+
+
+class TestDescribeLogDestination:
+    def test_unset(self):
+        d = describe_log_destination(STMConfig(log_file=None, log_level="WARNING"))
+        assert d == {"log_level": "WARNING", "log_file": None, "destination": "stderr"}
+
+    def test_set(self, tmp_path):
+        path = tmp_path / "stm.log"
+        d = describe_log_destination(STMConfig(log_file=path, log_level="DEBUG"))
+        assert d["log_level"] == "DEBUG"
+        assert d["log_file"] == str(path.expanduser())
+        assert d["destination"] == "stderr+file"
+
+
+class TestEnvWiring:
+    def test_log_file_from_env(self, monkeypatch, tmp_path):
+        path = tmp_path / "stm.log"
+        monkeypatch.setenv("MEMTOMEM_STM_LOG_FILE", str(path))
+        assert STMConfig().log_file == path
+
+    def test_default_is_none(self, monkeypatch):
+        monkeypatch.delenv("MEMTOMEM_STM_LOG_FILE", raising=False)
+        assert STMConfig().log_file is None

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -113,6 +113,40 @@ class TestFilePermissions:
         finally:
             handler.close()
 
+    @_skip_on_windows
+    def test_open_rejects_dangling_terminal_symlink(self, tmp_path):
+        # The real open must agree with log_file_writable(): os.open(O_CREAT)
+        # would otherwise follow the symlink and create the target, so a probe
+        # that said "not writable" would be contradicted by the server.
+        link = tmp_path / "broken.log"
+        link.symlink_to(tmp_path / "missing_target")
+        with pytest.raises(OSError):
+            open_private_log_handler(link)
+        assert not (tmp_path / "missing_target").exists()  # nothing created
+
+    @_skip_on_windows
+    def test_open_rejects_symlink_to_directory(self, tmp_path):
+        target = tmp_path / "realdir"
+        target.mkdir()
+        link = tmp_path / "link.log"
+        link.symlink_to(target)
+        with pytest.raises(OSError):
+            open_private_log_handler(link)
+
+    @_skip_on_windows
+    def test_open_accepts_symlink_to_regular_file(self, tmp_path):
+        target = tmp_path / "real.log"
+        target.touch()
+        target.chmod(0o600)
+        link = tmp_path / "link.log"
+        link.symlink_to(target)
+        handler = open_private_log_handler(link)
+        try:
+            handler.emit(logging.makeLogRecord({"msg": "through the link"}))
+        finally:
+            handler.close()
+        assert "through the link" in target.read_text()
+
 
 class TestConfigureServerLogging:
     def test_no_log_file_is_stderr_only(self, _restore_root_logging):

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -193,6 +193,41 @@ class TestLogFileWritable:
         assert not path.exists()
         assert not path.parent.exists()
 
+    def test_existing_directory_is_not_writable_target(self, tmp_path):
+        # os.open(dir, O_WRONLY|O_CREAT) fails — health must not report it usable.
+        d = tmp_path / "logdir"
+        d.mkdir()
+        assert log_file_writable(d) is False
+
+    @_skip_on_windows
+    def test_symlink_to_directory_rejected(self, tmp_path):
+        target = tmp_path / "realdir"
+        target.mkdir()
+        link = tmp_path / "link.log"
+        link.symlink_to(target)
+        assert log_file_writable(link) is False
+
+    @_skip_on_windows
+    def test_broken_symlink_rejected(self, tmp_path):
+        link = tmp_path / "broken.log"
+        link.symlink_to(tmp_path / "does_not_exist")
+        assert log_file_writable(link) is False
+
+    @_skip_on_windows
+    def test_symlink_to_regular_writable_file_accepted(self, tmp_path):
+        target = tmp_path / "real.log"
+        target.touch()
+        target.chmod(0o600)
+        link = tmp_path / "link.log"
+        link.symlink_to(target)
+        assert log_file_writable(link) is True
+
+    def test_non_directory_ancestor_rejected(self, tmp_path):
+        # A file used as if it were a parent dir: mkdir(parents=True) fails.
+        notdir = tmp_path / "afile"
+        notdir.write_text("x")
+        assert log_file_writable(notdir / "sub" / "stm.log") is False
+
 
 class TestDescribeLogDestination:
     def test_unset(self):

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -6,6 +6,8 @@ import sqlite3
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from memtomem_stm.proxy.config import ConfigLoadResult, ProxyConfig, UpstreamServerConfig
 from memtomem_stm.proxy.manager import ProxyManager, UpstreamConnection
 from memtomem_stm.proxy.metrics import TokenTracker
@@ -2302,6 +2304,17 @@ class TestMainExceptionBarrier:
     """#209 Part A: unhandled exceptions from ``mcp.run()`` must be logged at
     ERROR level before the process terminates, so operators have a visible
     signal instead of only stderr tail output."""
+
+    @pytest.fixture(autouse=True)
+    def _neutralize_logging_setup(self):
+        """``main()`` now configures root logging via
+        ``configure_server_logging`` (#612), which calls
+        ``basicConfig(force=True)`` — that removes pytest's caplog handler
+        before ``mcp.run()`` raises, so the barrier's ERROR log would never be
+        captured. These tests exercise the barrier, not logging setup, so
+        stub it out (its own behavior is covered in test_logging_setup.py)."""
+        with patch("memtomem_stm.server.configure_server_logging", return_value=None):
+            yield
 
     def test_unhandled_exception_is_logged_then_reraised(self, caplog):
         import logging


### PR DESCRIPTION
Fixes #612. **Stacked on #625** (base branch `fix/611-config-validate`) — merge #625 first, then this rebases onto `main`. The diff below is PR2-only.

## Why

The MCP stdio server logs to stderr only, which the launching client captures or drops. Several dark-failure modes (the silent config fallback in #611, dropped >64-char tool names) are only visible there, and where that stderr lands differs per host. This adds an opt-in rotating file log so there's one predictable place to look.

## What

- **`logging_setup.py`** (new): `PrivateRotatingFileHandler` creates its file `0o600` via `os.open(...O_CREAT, 0o600)` + defensive `fchmod` (the `proxy/selection_log.py` idiom); rollover re-invokes `_open` so post-rotation files stay `0o600`, and `os.rename`d backups inherit the mode. `open_private_log_handler` makes the parent `0o700` (a pre-existing dir keeps its mode). `configure_server_logging` installs stderr always + the opt-in file, and **degrades to stderr-only** (logged warning) if the file can't be opened — an opt-in diagnostic must not take the server down. `describe_log_destination` is the shared source for the health text + JSON.
- **`STMConfig.log_file: Path | None`** — set via `MEMTOMEM_STM_LOG_FILE` (free through the `BaseSettings` env prefix). 2 MiB × 3 backups.
- **`server.main()`** now builds `STMConfig()` (folding `log_level` + `log_file` into one env surface) and routes through `configure_server_logging`.
- **`mms health`** prints the active destination (`Logging: stderr only …` / `Logging: stderr + file <path> …`) and a `"logging"` key in `--json`.
- **Daemon convergence** (`cli/daemon_cmd.py`): the detached branch now uses the shared handler.

Redaction needs no change — it happens at message-construction time (`proxy/manager.py:_redacted_error`), so the second handler inherits already-redacted records.

## Behavior change

- **Daemon detached logging** now goes through the shared handler, **gaining `0o600`/`0o700` hardening it lacked** and 2 MiB rotation. An unbounded `stm-daemon.log` no longer erodes the #581 crash-trace guarantee. A file-open failure there **propagates** (the daemon's stdio is DEVNULL — the file is the only trace), unlike the server path which degrades to stderr.
- A malformed **`MEMTOMEM_STM_LOG_LEVEL`** now raises a logged `ValidationError` at server startup instead of silently falling back to `WARNING`. This is strictly more visible — the lifespan's own `STMConfig()` would have raised the same error moments later with no logging configured at all.

## Tests

- New `tests/test_logging_setup.py`: `0o600`/`0o700` on fresh create, tighten-pre-existing, rollover keeps `0o600` on base + backup, stderr-only default preserves the format, graceful degrade on an unwritable path (asserted via `capsys` — `basicConfig(force=True)` drops caplog's handler), `describe_log_destination`, env wiring.
- `tests/daemon/test_internals.py`: detached path hardens `stm-daemon.log`; foreground stays stderr.
- `tests/cli/test_proxy_cli.py`: health logging line (set/unset) + JSON key.
- `TestMainExceptionBarrier` stubs the new logging setup so its caplog assertions survive `force=True`.

`uv run pytest -m "not ollama"`: 4229 passed. Verified end-to-end: `mms health` prints both line variants; a server run with `MEMTOMEM_STM_LOG_FILE` set writes a `-rw-------` timestamped log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)