### PR TITLE
types: mypy burn-down — fix all 9 errors and re-enable attr-defined (#617)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,4 +92,4 @@ markers = [
 python_version = "3.12"
 warn_unused_configs = true
 ignore_missing_imports = true
-disable_error_code = ["has-type", "attr-defined"]
+disable_error_code = ["has-type"]

--- a/src/memtomem_stm/cli/proxy.py
+++ b/src/memtomem_stm/cli/proxy.py
@@ -2630,7 +2630,11 @@ def _remove_eject_hint(name: str, entry: Any) -> str | None:
     origin = entry.get("origin")
     if not _origin_fully_pruned(origin):
         return None
+    if not isinstance(origin, dict):  # unreachable — narrows for mypy
+        return None
     source = origin.get("source")
+    if not isinstance(source, dict):  # unreachable — narrows for mypy
+        return None
     kind = source.get("kind")
     spec = _SOURCE_BY_KIND.get(kind) if isinstance(kind, str) else None
     label = spec.label if spec else (kind if isinstance(kind, str) else "its host client")

--- a/src/memtomem_stm/daemon/locking.py
+++ b/src/memtomem_stm/daemon/locking.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -102,7 +103,7 @@ def single_owner_lock(path: Path) -> Iterator[bool]:
 
 
 def _try_lock(fd: int) -> bool:
-    if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+    if sys.platform == "win32":  # pragma: no cover - exercised on Windows CI only
         import msvcrt
 
         try:
@@ -121,7 +122,7 @@ def _try_lock(fd: int) -> bool:
 
 def _unlock(fd: int) -> None:
     try:
-        if os.name == "nt":  # pragma: no cover - exercised on Windows CI only
+        if sys.platform == "win32":  # pragma: no cover - exercised on Windows CI only
             import msvcrt
 
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -11,7 +11,10 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+if TYPE_CHECKING:
+    from memtomem_stm.proxy.pending_store import PendingStore
 
 try:
     import httpx
@@ -839,7 +842,7 @@ class SelectiveCompressor:
         pending_ttl_seconds: float = 300.0,
         json_depth: int = 1,
         min_section_chars: int = 50,
-        store: object | None = None,
+        store: PendingStore | None = None,
         scorer: RelevanceScorer | None = None,
     ) -> None:
         self._max_pending = max_pending
@@ -1866,7 +1869,11 @@ class SchemaPruningCompressor:
             if isinstance(data, dict):
                 # Most compact value form (stubbed nesting + minimal strings) so
                 # as many keys as possible survive before any are dropped.
-                items = list(self._prune(data, max_str=0, max_array=2, max_depth=1).items())
+                # _prune preserves the container kind, so a dict input stays a dict.
+                pruned_dict = cast(
+                    dict[str, Any], self._prune(data, max_str=0, max_array=2, max_depth=1)
+                )
+                items = list(pruned_dict.items())
                 total = len(items)
                 # Collision-safe marker key: never clobber (or repurpose as the
                 # marker) a real top-level "_pruned" field, which would skew the

--- a/src/memtomem_stm/proxy/compression.py
+++ b/src/memtomem_stm/proxy/compression.py
@@ -11,7 +11,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 try:
     import httpx
@@ -115,7 +115,7 @@ def _sanitize_nonfinite(obj: object) -> object:
     return obj
 
 
-def _mm_json_loads(s: str, **kwargs: object) -> object:
+def _mm_json_loads(s: str, **kwargs: Any) -> object:
     """``json.loads`` that scrubs non-finite floats from the parsed result.
 
     Python's ``json.loads`` accepts the ``NaN`` / ``Infinity`` / ``-Infinity``
@@ -1599,13 +1599,13 @@ class FieldExtractCompressor:
         else:
             framing = 0 if base_empty else 2
         room = budget - len(dump(base)) - framing
-        cand = self._fit_monotone(boundary_item, room) if room >= 0 else _MISSING
+        boundary_cand = self._fit_monotone(boundary_item, room) if room >= 0 else _MISSING
         if (
-            cand is not _MISSING
-            and not starved(cand, boundary_item)
-            and len(dump(frame(full_k, cand, omitted_after))) <= budget
+            boundary_cand is not _MISSING
+            and not starved(boundary_cand, boundary_item)
+            and len(dump(frame(full_k, boundary_cand, omitted_after))) <= budget
         ):
-            return frame(full_k, cand, omitted_after)
+            return frame(full_k, boundary_cand, omitted_after)
 
         # No room for a content-bearing boundary: keep the full prefix + a marker
         # for every remaining item.

--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal, Self, Union, get_args, get_origin
 
 from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic_core import ErrorDetails
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +165,7 @@ def _env_override_hint(
                         _PROXY_ENV_PREFIX + "__".join(p.upper() for p in [*prefix, str(key)])
                     )
 
-    def _error_key(e: dict[str, Any]) -> tuple[tuple[Any, ...], str, str]:
+    def _error_key(e: ErrorDetails) -> tuple[tuple[Any, ...], str, str]:
         return (tuple(e.get("loc", ())), str(e.get("type", "")), str(e.get("msg", "")))
 
     file_error_keys: frozenset[tuple[tuple[Any, ...], str, str]] | None = None

--- a/src/memtomem_stm/proxy/progressive.py
+++ b/src/memtomem_stm/proxy/progressive.py
@@ -10,8 +10,12 @@ import json
 import logging
 import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from memtomem_stm.proxy.compression import PendingSelection
+
+if TYPE_CHECKING:
+    from memtomem_stm.proxy.pending_store import PendingStore
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +63,7 @@ class ProgressiveStoreAdapter:
     by encoding ProgressiveResponse into PendingSelection with format="progressive".
     """
 
-    def __init__(self, store: object) -> None:
+    def __init__(self, store: PendingStore) -> None:
         self._store = store
 
     def put(self, key: str, resp: ProgressiveResponse) -> None:

--- a/src/memtomem_stm/surfacing/feedback.py
+++ b/src/memtomem_stm/surfacing/feedback.py
@@ -6,7 +6,11 @@ import logging
 from pathlib import Path
 
 from memtomem_stm.surfacing.config import SurfacingConfig
-from memtomem_stm.surfacing.feedback_store import FeedbackStore, inspect_feedback_db
+from memtomem_stm.surfacing.feedback_store import (
+    FeedbackDbStatus,
+    FeedbackStore,
+    inspect_feedback_db,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +49,7 @@ class FeedbackTracker:
     def store(self) -> FeedbackStore:
         return self._store
 
-    def bootstrap_status(self) -> dict[str, object]:
+    def bootstrap_status(self) -> FeedbackDbStatus:
         return inspect_feedback_db(self._store.db_path)
 
     def close(self) -> None:

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -363,7 +363,7 @@ class FeedbackStore:
             return {}
 
         target_ids = list(dict.fromkeys(str(mid) for mid in memory_ids))
-        event_ids_by_memory = {mid: set() for mid in target_ids}
+        event_ids_by_memory: dict[str, set[str]] = {mid: set() for mid in target_ids}
         target_set = set(target_ids)
 
         placeholders = ", ".join("?" for _ in target_ids)

--- a/src/memtomem_stm/surfacing/feedback_store.py
+++ b/src/memtomem_stm/surfacing/feedback_store.py
@@ -9,6 +9,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from typing import TypedDict
 
 from memtomem_stm.utils.sqlite_private import ensure_private_db_files
 from memtomem_stm.utils.sqlite_tuning import tune_connection
@@ -124,10 +125,20 @@ def _relax_surfacing_events_query_notnull(db: sqlite3.Connection) -> None:
     logger.info("Migrated surfacing_events: relaxed NOT NULL on query column (#352 part 2)")
 
 
-def inspect_feedback_db(db_path: Path) -> dict[str, object]:
+class FeedbackDbStatus(TypedDict):
+    """Read-only schema snapshot returned by :func:`inspect_feedback_db`."""
+
+    path: str
+    exists: bool
+    initialized: bool
+    missing_tables: list[str]
+    error: str | None
+
+
+def inspect_feedback_db(db_path: Path) -> FeedbackDbStatus:
     """Inspect surfacing feedback DB schema without creating or migrating it."""
     resolved = db_path.expanduser().resolve()
-    status: dict[str, object] = {
+    status: FeedbackDbStatus = {
         "path": str(resolved),
         "exists": resolved.exists(),
         "initialized": False,


### PR DESCRIPTION
Closes #617.

## What

Two commits, both type-only:

1. **Fix the 9 baseline mypy errors** (4 files):
   - `surfacing/feedback_store.py` — annotate `event_ids_by_memory` (empty `set()` defeats inference).
   - `proxy/config.py` — `_error_key` now takes `pydantic_core.ErrorDetails`, the TypedDict that `ValidationError.errors()` actually returns; a TypedDict is not assignable to `dict[str, Any]`.
   - `proxy/compression.py` — forward `**kwargs` to `json.loads` as `Any`; rename the second, object-typed rebinding of `cand` in `_fit_monotone` to `boundary_cand` so it no longer collides with the earlier `str` binding.
   - `cli/proxy.py` — `isinstance` narrowing for `origin`/`source` after the `_origin_fully_pruned` guard (the helper already rejects non-dicts at runtime; mypy can't see through a bool-returning helper).

2. **Re-enable `attr-defined`** (drop it from `disable_error_code`; `has-type` stays) and fix the 19 errors it surfaced:
   - `daemon/locking.py` — gate the `msvcrt` branches on `sys.platform == "win32"` instead of `os.name == "nt"` (mypy narrows on `sys.platform`; runtime-equivalent).
   - `proxy/compression.py` / `proxy/progressive.py` — the pending-store params were typed `object`; reuse the existing `PendingStore` Protocol via `TYPE_CHECKING`-only imports (preserves the lazy-import pattern around the `compression` ↔ `pending_store` cycle).
   - `proxy/compression.py` — `cast` the dict-in-dict-out `_prune` result before `.items()`.
   - `surfacing/feedback_store.py` — `inspect_feedback_db` returns a new `FeedbackDbStatus` TypedDict (propagated through `FeedbackTracker.bootstrap_status`), fixing `server.py`'s iteration over `missing_tables`.
   - The pre-existing narrow `# type: ignore[attr-defined]`s in `proxy/manager.py` (`exc._stm_*`) remain appropriate and are untouched.

`uv run mypy src` is now **0 errors**.

## Behavior change

None intended — types, annotations, casts, and one runtime-equivalent platform-guard rewrite (`os.name == "nt"` → `sys.platform == "win32"`; `sys.platform` is `"win32"` exactly when `os.name` is `"nt"` on CPython) plus two runtime-redundant isinstance guards on paths `_origin_fully_pruned` already rejects. The full-suite green run below is the no-op proof.

## Not in this PR

Flipping CI mypy from advisory (`continue-on-error`) to required is #617's proposal step 3 and a merge-gate decision — deferred; see the issue.

## Verification

- `uv run mypy src` — Success: no issues found in 82 source files (with `attr-defined` re-enabled)
- `uv run ruff check src && uv run ruff format --check src` — clean
- `uv run pytest -m "not ollama" -q` — 4264 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)