### PR TITLE
tests: fill direct-coverage gaps — tracing, relevance embedding paths, daemon run_cmd (#619)

### DIFF
--- a/tests/daemon/test_internals.py
+++ b/tests/daemon/test_internals.py
@@ -1212,3 +1212,113 @@ class TestDaemonRestartCli:
 
         assert result.exit_code == 0, result.output
         assert "still shutting down" in result.output
+
+
+# ── daemon run + handshake coercion helpers ─────────────────────────────────
+
+
+class TestRunCmd:
+    """``mms daemon run`` — the long-lived entry point had no direct test.
+
+    ``run_cmd`` is three load-bearing lines: load config, route logging by
+    ``--detached``, and exit with the server loop's return code. The server
+    loop itself is covered in ``tests/daemon/test_server.py``; here it is
+    stubbed so only the command layer is under test.
+    """
+
+    def _invoke_run(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, args: list[str], rc: int
+    ):
+        from click.testing import CliRunner
+
+        monkeypatch.setenv("MEMTOMEM_STM_DATA_DIR", str(tmp_path))
+        seen: dict = {}
+
+        def fake_run(config):
+            seen["config"] = config
+            return rc
+
+        def fake_configure_logging(config, *, detached):
+            seen["detached"] = detached
+
+        # run_cmd imports memtomem_stm.daemon.server.run lazily at call time,
+        # so patching the source module attribute is sufficient.
+        monkeypatch.setattr("memtomem_stm.daemon.server.run", fake_run)
+        monkeypatch.setattr(
+            "memtomem_stm.cli.daemon_cmd._configure_logging", fake_configure_logging
+        )
+        return CliRunner().invoke(_cli(), ["daemon", "run", *args]), seen
+
+    def test_exit_code_is_server_return_code(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        result, seen = self._invoke_run(monkeypatch, tmp_path, [], rc=3)
+        assert result.exit_code == 3
+        assert isinstance(seen["config"], STMConfig)
+
+    def test_foreground_default_routes_logging_to_stderr_handler(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        result, seen = self._invoke_run(monkeypatch, tmp_path, [], rc=0)
+        assert result.exit_code == 0
+        assert seen["detached"] is False
+
+    def test_detached_flag_routes_logging_to_file_handler(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        result, seen = self._invoke_run(monkeypatch, tmp_path, ["--detached"], rc=0)
+        assert result.exit_code == 0
+        assert seen["detached"] is True
+
+
+class TestHandshakeCoercionHelpers:
+    """Direct unit table for ``_as_int`` / ``_as_float``.
+
+    The stop/status corrupted-handshake tests above exercise these only
+    through full CLI invocations; this pins each rejection branch —
+    bool-reject (JSON ``true`` must not become pid 1), TypeError,
+    ValueError, and OverflowError — at the helper level.
+    """
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (42, 42),
+            ("42", 42),
+            (42.9, 42),
+            (True, -1),  # bool-reject: JSON true would coerce to pid 1
+            (False, -1),
+            (None, -1),  # TypeError
+            ("junk", -1),  # ValueError
+            (float("inf"), -1),  # OverflowError (JSON Infinity)
+            (float("-inf"), -1),
+            (float("nan"), -1),  # ValueError
+        ],
+    )
+    def test_as_int(self, value, expected):
+        from memtomem_stm.cli.daemon_cmd import _as_int
+
+        assert _as_int(value, default=-1) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (1.5, 1.5),
+            ("1.5", 1.5),
+            (7, 7.0),
+            (True, 0.0),  # bool-reject
+            (False, 0.0),
+            (None, 0.0),  # TypeError
+            ("junk", 0.0),  # ValueError
+            (10**400, 0.0),  # OverflowError: huge int -> float
+        ],
+    )
+    def test_as_float(self, value, expected):
+        from memtomem_stm.cli.daemon_cmd import _as_float
+
+        assert _as_float(value, default=0.0) == expected
+
+    def test_as_float_passes_through_infinity(self):
+        """float('inf') IS a valid float — _as_float guards conversion
+        failures only; range/semantic checks belong to the call sites."""
+        from memtomem_stm.cli.daemon_cmd import _as_float
+
+        assert _as_float(float("inf"), default=0.0) == float("inf")

--- a/tests/test_query_aware.py
+++ b/tests/test_query_aware.py
@@ -8,7 +8,7 @@ budget allocation behavior.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -385,6 +385,118 @@ class TestEmbeddingOpenAIResponseParsing:
         with patch("httpx.post", return_value=self._mock_response({"data": []})):
             result = scorer._embed_openai(None, [])
         assert result == []
+
+
+class TestEmbeddingProviderPaths:
+    """Non-network branches of ``EmbeddingScorer`` (#619): the Ollama
+    ``/api/embed`` parsing, provider dispatch, error mapping into the BM25
+    fallback, and the empty-input short-circuit — all with a mocked transport.
+    """
+
+    def _make_scorer(self, provider: str = "ollama"):
+        from memtomem_stm.proxy.relevance import EmbeddingScorer
+
+        return EmbeddingScorer(
+            provider=provider, model="test-model", base_url="http://ollama:11434"
+        )
+
+    def _mock_response(self, payload: dict):
+        from unittest.mock import MagicMock
+
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json = MagicMock(return_value=payload)
+        return resp
+
+    def test_ollama_success_path_maps_cosine_scores(self):
+        """A successful /api/embed response scores sections by cosine similarity
+        against the query embedding (first element of the batch)."""
+        scorer = self._make_scorer()
+        # query == section A embedding (cos 1.0), orthogonal to section B (cos 0.0)
+        payload = {"embeddings": [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0]]}
+        sections = [("## A", "matches the query"), ("## B", "unrelated")]
+
+        with patch("httpx.post", return_value=self._mock_response(payload)) as post:
+            scores = scorer.score_sections("the query", sections)
+
+        assert scores == pytest.approx([1.0, 0.0])
+        assert scorer.fallback_count == 0
+        url = post.call_args.args[0]
+        assert url == "http://ollama:11434/api/embed"
+        body = post.call_args.kwargs["json"]
+        assert body["model"] == "test-model"
+        assert len(body["input"]) == 3  # query + 2 sections
+        assert body["input"][0] == "the query"
+
+    def test_unknown_provider_raises_and_falls_back(self):
+        """_embed_batch rejects unknown providers loudly; score_sections maps
+        that into the BM25 fallback like any other embedding failure."""
+        scorer = self._make_scorer(provider="cohere")
+
+        with pytest.raises(ValueError, match="Unknown embedding provider: cohere"):
+            scorer._embed_batch(["text"])
+
+        scores = scorer.score_sections("query", [("## A", "body")])
+        assert len(scores) == 1
+        assert scorer.fallback_count == 1
+
+    def test_missing_httpx_raises_runtime_error_and_falls_back(self, monkeypatch):
+        """An unavailable httpx maps to RuntimeError in _embed_batch, and
+        score_sections degrades to BM25 instead of propagating."""
+        import sys
+
+        scorer = self._make_scorer()
+        monkeypatch.setitem(sys.modules, "httpx", None)
+
+        with pytest.raises(RuntimeError, match="httpx required"):
+            scorer._embed_batch(["text"])
+
+        scores = scorer.score_sections("query", [("## A", "body")])
+        assert len(scores) == 1
+        assert scorer.fallback_count == 1
+
+    def test_empty_query_and_sections_short_circuit_without_network(self):
+        scorer = self._make_scorer()
+
+        with patch("httpx.post") as post:
+            assert scorer.score_sections("", [("## A", "body")]) == [0.0]
+            assert scorer.score_sections("query", []) == []
+
+        post.assert_not_called()
+        assert scorer.fallback_count == 0
+
+    def test_http_error_falls_back_with_message_only_warning(self, caplog):
+        """raise_for_status failures fall back to BM25, count once, and log a
+        message-only WARNING (no stack trace per hit)."""
+        import httpx
+
+        scorer = self._make_scorer()
+        resp = self._mock_response({})
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503", request=MagicMock(), response=MagicMock()
+        )
+        sections = [("## Redis", "Cache layer."), ("## Database", "PostgreSQL.")]
+
+        with (
+            patch("httpx.post", return_value=resp),
+            caplog.at_level("WARNING", logger="memtomem_stm.proxy.relevance"),
+        ):
+            scores = scorer.score_sections("Redis", sections)
+
+        assert len(scores) == 2
+        assert scores[0] > scores[1]  # BM25 fallback actually scored
+        assert scorer.fallback_count == 1
+        warning = next(r for r in caplog.records if "falling back to BM25" in r.message)
+        assert warning.levelname == "WARNING"
+        assert warning.exc_info is None  # message-only, no stack
+
+    def test_cosine_similarity_edge_cases(self):
+        from memtomem_stm.proxy.relevance import _cosine_similarity
+
+        assert _cosine_similarity([0.0, 0.0], [1.0, 0.0]) == 0.0  # zero norm
+        assert _cosine_similarity([1.0, 0.0], [0.0, 0.0]) == 0.0
+        assert _cosine_similarity([1.0, 2.0], [1.0, 2.0]) == pytest.approx(1.0)
+        assert _cosine_similarity([1.0, 0.0], [0.0, 1.0]) == 0.0  # orthogonal
 
 
 # ── TruncateCompressor with context_query ─────────────────────────────

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,174 @@
+"""Direct tests for ``memtomem_stm.observability.tracing`` (#619).
+
+``traced()`` happy paths (delegation, sampling, proxy integration) are already
+covered in ``tests/test_observability.py::TestLangfuseTracing`` — this file
+pins the remaining contracts: ``init_langfuse`` construction/degrade behavior,
+``_SafeObservation``'s never-break-the-traced-call guarantee, the one-shot
+log escalation, and ``shutdown_langfuse``.
+"""
+
+import os
+import sys
+import types
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from memtomem_stm.observability import tracing
+from memtomem_stm.observability.tracing import (
+    _SafeObservation,
+    init_langfuse,
+    shutdown_langfuse,
+    traced,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracing_globals(monkeypatch):
+    """Isolate the module-level singleton state per test (auto-restored)."""
+    monkeypatch.setattr(tracing, "_langfuse_client", None)
+    monkeypatch.setattr(tracing, "_sampling_rate", 1.0)
+    monkeypatch.setattr(tracing, "_warned_observation_failure", False)
+
+
+def _fake_langfuse_module(ctor):
+    """A stand-in ``langfuse`` module whose ``Langfuse`` is *ctor*."""
+    mod = types.ModuleType("langfuse")
+    mod.Langfuse = ctor
+    return mod
+
+
+class TestInitLangfuse:
+    def test_disabled_returns_none_and_leaves_globals_untouched(self, monkeypatch):
+        sentinel = object()
+        monkeypatch.setattr(tracing, "_langfuse_client", sentinel)
+        monkeypatch.setattr(tracing, "_sampling_rate", 0.25)
+
+        assert init_langfuse(SimpleNamespace(enabled=False)) is None
+
+        assert tracing._langfuse_client is sentinel
+        assert tracing._sampling_rate == 0.25
+
+    def test_import_failure_degrades_to_none(self, monkeypatch):
+        # ``sys.modules["langfuse"] = None`` makes ``from langfuse import …``
+        # raise ImportError regardless of whether the SDK is installed.
+        monkeypatch.setitem(sys.modules, "langfuse", None)
+
+        assert init_langfuse(SimpleNamespace(enabled=True)) is None
+        assert tracing._langfuse_client is None
+
+    def test_forwards_only_nonempty_credentials(self, monkeypatch):
+        captured: dict = {}
+
+        def ctor(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setitem(sys.modules, "langfuse", _fake_langfuse_module(ctor))
+        config = SimpleNamespace(
+            enabled=True, sampling_rate=0.5, public_key="pk", secret_key="", host="http://lf"
+        )
+
+        client = init_langfuse(config)
+
+        assert client is not None
+        assert tracing._langfuse_client is client
+        assert captured == {"public_key": "pk", "host": "http://lf"}  # empty secret_key omitted
+        assert tracing._sampling_rate == 0.5
+
+    def test_otel_service_name_set_only_when_unset(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "langfuse", _fake_langfuse_module(MagicMock()))
+        # setenv-then-delenv (not bare delenv): registers a restore even when
+        # the variable was absent, so the value init_langfuse writes directly
+        # into os.environ cannot leak past this test.
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "placeholder")
+        monkeypatch.delenv("OTEL_SERVICE_NAME")
+
+        init_langfuse(SimpleNamespace(enabled=True), service_name="custom-svc")
+        assert os.environ.get("OTEL_SERVICE_NAME") == "custom-svc"
+
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "pre-existing")
+        init_langfuse(SimpleNamespace(enabled=True), service_name="custom-svc")
+        assert os.environ.get("OTEL_SERVICE_NAME") == "pre-existing"
+
+
+class TestSafeObservation:
+    def test_enter_failure_degrades_and_body_still_runs(self, caplog):
+        inner = MagicMock()
+        inner.__enter__ = MagicMock(side_effect=RuntimeError("exporter down"))
+        ran = False
+
+        with caplog.at_level("DEBUG", logger="memtomem_stm.observability.tracing"):
+            with _SafeObservation(inner) as span:
+                ran = True
+                assert span is None
+        assert ran
+
+    def test_body_exception_propagates(self):
+        inner = MagicMock()
+        inner.__enter__ = MagicMock(return_value="span")
+        inner.__exit__ = MagicMock(return_value=False)
+
+        with pytest.raises(ValueError, match="from the body"):
+            with _SafeObservation(inner):
+                raise ValueError("from the body")
+
+        # The SDK still saw the body's exception (exc_type is ValueError).
+        assert inner.__exit__.call_args.args[0] is ValueError
+
+    def test_exit_failure_swallowed(self):
+        inner = MagicMock()
+        inner.__enter__ = MagicMock(return_value="span")
+        inner.__exit__ = MagicMock(side_effect=RuntimeError("flush failed"))
+
+        with _SafeObservation(inner):
+            pass  # __exit__ raising must not escape
+
+    def test_exit_without_enter_does_not_touch_inner(self):
+        inner = MagicMock()
+        obs = _SafeObservation(inner)
+
+        assert obs.__exit__(None, None, None) is False
+        inner.__exit__.assert_not_called()
+
+
+class TestTracedDegrade:
+    def test_constructor_failure_returns_nullcontext(self, monkeypatch):
+        client = MagicMock()
+        client.start_as_current_observation.side_effect = RuntimeError("bad config")
+        monkeypatch.setattr(tracing, "_langfuse_client", client)
+
+        ctx = traced("proxy_call")
+
+        assert isinstance(ctx, nullcontext)
+        with ctx as span:
+            assert span is None
+
+
+class TestLogObservationFailureEscalation:
+    def test_first_failure_warns_then_repeats_at_debug(self, caplog):
+        with caplog.at_level("DEBUG", logger="memtomem_stm.observability.tracing"):
+            tracing._log_observation_failure("start")
+            tracing._log_observation_failure("start")
+
+        levels = [r.levelname for r in caplog.records]
+        assert levels == ["WARNING", "DEBUG"]
+
+
+class TestShutdownLangfuse:
+    def test_calls_shutdown_on_explicit_client(self):
+        client = MagicMock()
+        shutdown_langfuse(client)
+        client.shutdown.assert_called_once_with()
+
+    def test_falls_back_to_global_client(self, monkeypatch):
+        client = MagicMock()
+        monkeypatch.setattr(tracing, "_langfuse_client", client)
+        shutdown_langfuse()
+        client.shutdown.assert_called_once_with()
+
+    def test_noop_without_shutdown_attr_or_client(self):
+        shutdown_langfuse(object())  # no .shutdown — must not raise
+        shutdown_langfuse(None)  # no client anywhere — must not raise


### PR DESCRIPTION
Closes #619.

## Scope adjustment vs the issue

Before writing anything, each of the five listed modules was re-checked against the current suite. Two of the issue's targets turned out to be **already covered by comprehensive direct test files** and needed no work:

- `mms/secrets.py` → `tests/mms/test_secrets.py` (key-pattern matrix incl. specificity and precedence, value heuristics with boundary cases, redaction keep/mask/override).
- `mms/detect.py` → `tests/mms/test_detect.py` (all three source branches, marker/git walk-up precedence, worktree `.git`-as-file, malformed-marker propagation).

The genuine gaps were narrower than the issue implied; this PR fills them in three test-only commits.

## What

1. **New `tests/test_tracing.py`** — `observability/tracing.py` degrades silently by design, which is exactly what deserves pinning. `traced()` happy paths were already in `test_observability.py::TestLangfuseTracing`; this adds `init_langfuse` (disabled/import-failure degrade, credential kwargs assembly, `OTEL_SERVICE_NAME` only-when-unset), `_SafeObservation` (SDK enter/exit failures swallowed, body exceptions propagate), `traced()` constructor-failure → `nullcontext`, the one-shot WARNING→DEBUG log escalation, and `shutdown_langfuse`.

2. **`tests/test_query_aware.py` +`TestEmbeddingProviderPaths`** — the `_embed_ollama` `/api/embed` success path had zero direct coverage (existing tests covered the OpenAI parsing matrix and the dead-port fallback only). Adds, all with a mocked transport: Ollama success → cosine mapping with the request shape pinned; unknown-provider `ValueError` and missing-httpx `RuntimeError`, both degrading to BM25 (+`fallback_count`) through `score_sections`; the empty-input short-circuit making no network call; HTTP-error fallback with a message-only WARNING (no stack per hit); `_cosine_similarity` edges.

3. **`tests/daemon/test_internals.py` +`TestRunCmd`/`TestHandshakeCoercionHelpers`** — `run_cmd` had no test (exit code = server rc; `--detached` logging routing, server loop stubbed), and `_as_int`/`_as_float` get a direct parametrized table pinning the bool-reject / TypeError / ValueError / OverflowError branches previously exercised only through full stop/status invocations.

No production code changes — the new tests flushed out no bugs.

Note (out of scope, will follow up separately): the `ollama` pytest marker declared in pyproject.toml has zero usages and no auto-skip hook, so none of the above needed gating.

## Verification

- `uv run pytest -m "not ollama" -q` — 4305 passed, 3 skipped (41 new tests)
- `uv run ruff check` / `ruff format` clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)