### PR TITLE
tests: retire the dead ollama pytest marker (#637)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           version: "latest"
       - run: uv sync --frozen
-      - run: uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf" --tb=short -q
+      - run: uv run pytest -m "not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf" --tb=short -q
 
   notebooks:
     runs-on: ubuntu-latest
@@ -223,7 +223,7 @@ jobs:
     # non-blocking; promote to required (flip to false + branch protection)
     # after an observation window, mirroring #482.
     #
-    # NB: the pytest -m filter here must NOT contain "not ollama" — the
+    # NB: the pytest -m filter here must NOT contain "not bench_qa_meta" — the
     # docs-sync test (test_contributing_pytest_command_matches_ci) requires
     # exactly one such filter (the `test` job's); a second would red it.
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,15 +11,17 @@ Requires Python 3.12+ and `uv`.
 
 ```bash
 uv sync                                                    # install deps
-uv run pytest -m "not ollama"                              # tests (CI filter)
+uv run pytest -m "not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf"  # tests (CI filter)
 uv run ruff check src && uv run ruff format --check src    # lint (required)
 uv run mypy src                                            # typecheck (required)
 ```
 
-The `ollama` marker auto-skips when Ollama isn't running; CI always uses
-`-m "not ollama"`. `ruff`, `mypy`, and tests must pass to merge. mypy must be
-clean on Windows too — CI typechecks both platforms, so POSIX-only stdlib
-usage (`fcntl`, `os.killpg`, …) needs a `sys.platform` guard mypy can narrow.
+The filter excludes only the `bench_qa_*` markers CI runs in separate jobs;
+live-Ollama tests are out of scope — Ollama code paths are tested with mocked
+transport / dead ports only (#637). `ruff`, `mypy`, and tests must pass to
+merge. mypy must be clean on Windows too — CI typechecks both platforms, so
+POSIX-only stdlib usage (`fcntl`, `os.killpg`, …) needs a `sys.platform` guard
+mypy can narrow.
 
 ## Invariants when editing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ cd memtomem-stm
 uv sync
 
 # Run tests (same filter CI uses)
-uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf"
+uv run pytest -m "not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf"
 
 # Lint and format
 uv run ruff check src
@@ -45,7 +45,7 @@ The LTM core lives in a separate repository: [memtomem/memtomem](https://github.
 2. Keep changes focused — one feature or fix per PR
 3. Add tests for new functionality
 4. Ensure `uv run ruff check src` and `uv run ruff format --check src` pass
-5. Ensure `uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf"` passes
+5. Ensure `uv run pytest -m "not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf"` passes
 6. Ensure `uv run mypy src` passes (required in CI on both Linux and Windows)
 7. Write a clear commit message describing the "why"
 8. Sign the CLA on your first pull request (see below)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ operator tools.
 
 ```bash
 uv sync                                                    # install dev deps
-uv run pytest -m "not ollama and not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf"   # tests (CI filter)
+uv run pytest -m "not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf"   # tests (CI filter)
 uv run ruff check src && uv run ruff format --check src    # lint (required)
 uv run mypy src                                            # typecheck (required)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ line-length = 100
 asyncio_mode = "auto"
 testpaths = ["tests"]
 markers = [
-    "ollama: requires a running Ollama instance (auto-skipped when unavailable)",
     "bench_qa: end-to-end compression/surfacing regression gate (fake upstream, deterministic)",
     "bench_qa_meta: self-test probes for bench_qa — intentional failures, NOT CI-safe",
     "bench_qa_llm_judge: LLM-as-judge advisory scoring — requires OPENAI_API_KEY or ANTHROPIC_API_KEY, off in default CI",

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -22,11 +22,12 @@ def _read(relative: str) -> str:
 
 
 def _canonical_ci_test_filter() -> str:
-    """The single CI ``test``-job ``pytest -m`` filter (the one with ``not ollama``).
+    """The single CI ``test``-job ``pytest -m`` filter (the one with ``not bench_qa_meta``).
 
-    Shared source of truth for the README + CONTRIBUTING pins below: both
-    quickstarts must quote this verbatim, or a contributor runs straight into
-    the ``bench_qa_*`` jobs CI deliberately splits into separate workflows.
+    Shared source of truth for the CLAUDE.md + README + CONTRIBUTING pins
+    below: all three quickstarts must quote this verbatim, or a contributor
+    runs straight into the ``bench_qa_*`` jobs CI deliberately splits into
+    separate workflows.
     """
     ci = _read(".github/workflows/ci.yml")
     # Double-quoted ``pytest -m "…"`` is what the workflow uses today. If the
@@ -34,18 +35,18 @@ def _canonical_ci_test_filter() -> str:
     # this regex falls through to zero matches and we want a loud failure
     # pointing operators back here rather than a cryptic IndexError.
     ci_filters = re.findall(r'pytest -m "([^"]+)"', ci)
-    test_job_filters = [f for f in ci_filters if "not ollama" in f]
+    test_job_filters = [f for f in ci_filters if "not bench_qa_meta" in f]
     if not test_job_filters:
         pytest.fail(
             "Could not locate CI's pytest filter — expected a double-quoted "
-            '`pytest -m "…not ollama…"` in .github/workflows/ci.yml. '
+            '`pytest -m "…not bench_qa_meta…"` in .github/workflows/ci.yml. '
             "The workflow was likely refactored; update this helper and the "
-            "docs that quote it (README.md, CONTRIBUTING.md) together."
+            "docs that quote it (CLAUDE.md, README.md, CONTRIBUTING.md) together."
         )
     if len(test_job_filters) > 1:
         pytest.fail(
-            "Multiple CI jobs now use `not ollama` — this helper picks the "
-            "first match, which may not be the one the docs should mirror. "
+            "Multiple CI jobs now use `not bench_qa_meta` — this helper picks "
+            "the first match, which may not be the one the docs should mirror. "
             f"Filters found: {test_job_filters!r}. Parse by job name or pin "
             "the canonical one explicitly."
         )
@@ -58,8 +59,8 @@ def test_contributing_pytest_command_matches_ci() -> None:
     The CI ``test`` job filters out ``bench_qa_meta`` (intentional-failure
     self-tests — see ``pyproject.toml`` markers table) and
     ``bench_qa_llm_judge`` (requires ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY``)
-    in addition to ``ollama``. A shorter filter in CONTRIBUTING leads new
-    contributors straight into those expected failures.
+    among others. A shorter filter in CONTRIBUTING leads new contributors
+    straight into those expected failures.
     """
     canonical = _canonical_ci_test_filter()
     contributing_filters = re.findall(r'pytest -m "([^"]+)"', _read("CONTRIBUTING.md"))
@@ -85,6 +86,24 @@ def test_readme_pytest_command_matches_ci() -> None:
         f"README.md must quote the CI pytest filter verbatim.\n"
         f"  CI uses: {canonical!r}\n"
         f"  README has: {readme_filters!r}"
+    )
+
+
+def test_claude_md_pytest_command_matches_ci() -> None:
+    """CLAUDE.md's Commands ``pytest -m`` filter must match CI's verbatim.
+
+    CLAUDE.md quoted the short ``-m "not ollama"`` form until #637 — a
+    no-op filter (the marker had zero usages) that also under-filtered:
+    it didn't exclude ``bench_qa_meta``, whose tests fail by design. Pin
+    CLAUDE.md to the same source of truth as README/CONTRIBUTING so the
+    command Claude Code runs from context is always the CI command.
+    """
+    canonical = _canonical_ci_test_filter()
+    claude_md_filters = re.findall(r'pytest -m "([^"]+)"', _read("CLAUDE.md"))
+    assert canonical in claude_md_filters, (
+        f"CLAUDE.md must quote the CI pytest filter verbatim.\n"
+        f"  CI uses: {canonical!r}\n"
+        f"  CLAUDE.md has: {claude_md_filters!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Closes #637. The `ollama` marker declared in `pyproject.toml` had **zero `@pytest.mark.ollama` usages** and **no auto-skip hook** — CI's `-m "not ollama"` filter was a no-op, and CLAUDE.md described auto-skip behavior that was never implemented. Every Ollama code path (`proxy/relevance.py`, `proxy/extraction.py`, `proxy/compression.py`) is already tested with mocked transport or dead ports (`localhost:99999`), so this takes the issue's option 2: retire the promise and state that live-Ollama tests are out of scope. The marker + skip hook can return together if live e2e tests are ever wanted.

## Changes

- **`pyproject.toml`** — drop the `ollama` marker declaration.
- **`.github/workflows/ci.yml`** — drop `not ollama and ` from the `test` job's filter; re-key the perf-job NB comment from `"not ollama"` to `"not bench_qa_meta"` (the new unique identifier of the test job's filter — other jobs use `bench_qa and not bench_qa_sweep` / `bench_qa_drift` / `bench_qa_perf`).
- **`tests/test_docs_sync.py`** — re-key `_canonical_ci_test_filter()` to `"not bench_qa_meta"`; add `test_claude_md_pytest_command_matches_ci` pinning CLAUDE.md's quoted command to the CI filter (same pattern as the existing README/CONTRIBUTING pins).
- **`README.md` / `CONTRIBUTING.md` / `CLAUDE.md`** — quote the new filter verbatim.

## Behavior change

**None in what CI runs**: no test was ever marked `ollama`, so removing the filter term deselects nothing (4284 passed / 22 deselected before and after — the deselected are all `bench_qa_*`).

One doc-command fix worth calling out: CLAUDE.md's test command was the short `-m "not ollama"` form, which — beyond the dead marker — was under-filtered: it didn't exclude `bench_qa_meta`, whose self-tests fail by design. It now quotes the full CI filter, and the new docs-sync test pins it so it can't drift again (negative-checked: reverting the CLAUDE.md command reds the new test).

## Testing

- `uv run pytest tests/test_docs_sync.py -q` — 14 passed (13 existing re-keyed + 1 new).
- `uv run pytest -m "not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf" --tb=short -q` — 4284 passed, 3 skipped, 22 deselected.
- `ruff check` / `ruff format --check` / `mypy src` — clean.
- `grep -rn 'not ollama'` over md/yml/toml/py — only the intentional historical mention in the new test's docstring and CHANGELOG's historical entry remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)