### PR TITLE
feat(proxy): warn at startup when an LLM path runs with privacy scan disabled (#610)

### DIFF
--- a/src/memtomem_stm/proxy/config.py
+++ b/src/memtomem_stm/proxy/config.py
@@ -7,6 +7,7 @@ import logging
 import os
 import types
 from collections.abc import Mapping
+from urllib.parse import urlparse
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -270,6 +271,12 @@ class LLMProvider(StrEnum):
     OLLAMA = "ollama"
 
 
+# Hosts whose traffic never leaves the machine — a scan-off LLM path pointed
+# here does not cross a trust boundary, so the #610 startup warning stays
+# silent for them.
+_LOCAL_LLM_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", ""})
+
+
 class LLMCompressorConfig(BaseModel):
     provider: LLMProvider = LLMProvider.OPENAI
     model: str = "gpt-4.1-mini"
@@ -295,6 +302,19 @@ class LLMCompressorConfig(BaseModel):
     # body is known to be sensitive-free or you are using a self-hosted
     # provider you trust (e.g. local Ollama). See #289.
     privacy_scan_enabled: bool = True
+
+    def is_external_destination(self) -> bool:
+        """True when this LLM path sends text off the machine.
+
+        OpenAI / Anthropic are always external. Ollama is treated as local only
+        when its ``base_url`` host is loopback (the common self-hosted case);
+        an Ollama endpoint on a remote host still crosses the boundary. Used by
+        the #610 startup warning to avoid false alarms on local Ollama.
+        """
+        if self.provider in (LLMProvider.OPENAI, LLMProvider.ANTHROPIC):
+            return True
+        host = urlparse(self.base_url).hostname or ""
+        return host not in _LOCAL_LLM_HOSTS
 
     @model_validator(mode="after")
     def _require_api_key_for_hosted_providers(self) -> LLMCompressorConfig:

--- a/src/memtomem_stm/proxy/manager.py
+++ b/src/memtomem_stm/proxy/manager.py
@@ -49,6 +49,7 @@ from memtomem_stm.proxy.config import (
     CleaningConfig,
     CompressionStrategy,
     ExposureProfile,
+    ExtractionStrategy,
     HybridConfig,
     LLMCompressorConfig,
     ProgressiveConfig,
@@ -141,6 +142,31 @@ from memtomem_stm.utils.redact import redact_exception_text
 _NO_RETRY_CODES = {-32600, -32601, -32602, -32603}  # INVALID_REQUEST/METHOD/PARAMS/INTERNAL
 
 logger = logging.getLogger(__name__)
+
+
+def _describe_llm_destination(llm: LLMCompressorConfig) -> str:
+    """Human-readable provider + endpoint for the #610 startup warning."""
+    if llm.base_url:
+        return f"{llm.provider.value} ({llm.base_url})"
+    return llm.provider.value
+
+
+def _llm_compression_leaks(
+    compression: CompressionStrategy, llm: LLMCompressorConfig | None
+) -> bool:
+    """True when an LLM_SUMMARY path will send raw text UNSCANNED off-machine.
+
+    Requires an explicit ``llm_summary`` strategy (``auto`` resolves at runtime
+    and would produce noisy static false positives), an attached LLM config
+    with the privacy scan disabled, and an external destination (#610).
+    """
+    return (
+        compression == CompressionStrategy.LLM_SUMMARY
+        and llm is not None
+        and not llm.privacy_scan_enabled
+        and llm.is_external_destination()
+    )
+
 
 # Errors the tool-graph consult treats as "graph unreachable" → on_unreachable.
 # ``eligible_tools()`` already wraps transport failures into
@@ -459,6 +485,78 @@ class ProxyManager:
                     "config is enabled but inert; extracted facts will not be stored",
                     ", ".join(ext_paths),
                 )
+
+        # #610: warn loudly when an LLM path will send raw upstream responses
+        # UNSCANNED to an external provider (privacy_scan_enabled=false). The
+        # scan is default-on; an operator who flips it off otherwise gets no
+        # signal that credential redaction (#289) is now off. Scoped to
+        # *external* destinations — a local Ollama endpoint never leaves the
+        # machine, so a scan-off local path is not flagged.
+        #
+        # Compression (Stage 2) runs in every deployment, so its warning is
+        # unconditional. Extraction (Stage 4b) only fires when an index engine
+        # is wired (gated at the call site, manager.py ~L3768); the standalone
+        # ``mms`` server has none, so extraction never reaches the provider
+        # there — its warning is gated on the same condition to stay accurate.
+        comp_leak_paths: list[str] = []
+        comp_dests: set[str] = set()
+        default_comp = self._config.default_compression
+        for srv_name, srv_cfg in servers.items():
+            srv_comp = (
+                srv_cfg.compression if "compression" in srv_cfg.model_fields_set else default_comp
+            )
+            srv_llm = srv_cfg.llm
+            srv_leaks = _llm_compression_leaks(srv_comp, srv_llm)
+            if srv_leaks and srv_llm is not None:
+                comp_leak_paths.append(f"server '{srv_name}'")
+                comp_dests.add(_describe_llm_destination(srv_llm))
+            for tool_name, override in srv_cfg.tool_overrides.items():
+                tool_comp = override.compression if override.compression is not None else srv_comp
+                tool_llm = override.llm or srv_llm
+                # A tool that inherits both strategy and llm from the server is
+                # already covered by the server-level entry — don't double-list.
+                inherits = override.compression is None and override.llm is None
+                if (
+                    _llm_compression_leaks(tool_comp, tool_llm)
+                    and tool_llm is not None
+                    and not (srv_leaks and inherits)
+                ):
+                    comp_leak_paths.append(f"server '{srv_name}' tool '{tool_name}'")
+                    comp_dests.add(_describe_llm_destination(tool_llm))
+        if comp_leak_paths:
+            logger.warning(
+                "LLM compression enabled (%s) with privacy_scan_enabled=false — raw "
+                "upstream responses will be sent UNSCANNED to %s; credential "
+                "redaction (#289) is off",
+                ", ".join(comp_leak_paths),
+                ", ".join(sorted(comp_dests)),
+            )
+
+        if self._index_engine is not None:
+            ext_llm = ext_cfg.effective_llm()
+            if (
+                ext_cfg.strategy in (ExtractionStrategy.LLM, ExtractionStrategy.HYBRID)
+                and not ext_llm.privacy_scan_enabled
+                and ext_llm.is_external_destination()
+            ):
+                ext_leak_paths: list[str] = []
+                if ext_cfg.enabled:
+                    ext_leak_paths.append("extraction.enabled")
+                for srv_name, srv_cfg in servers.items():
+                    if srv_cfg.extraction is True:
+                        ext_leak_paths.append(f"server '{srv_name}'")
+                    for tool_name, override in srv_cfg.tool_overrides.items():
+                        if override.extraction is True:
+                            ext_leak_paths.append(f"server '{srv_name}' tool '{tool_name}'")
+                if ext_leak_paths:
+                    logger.warning(
+                        "LLM extraction enabled (%s) with privacy_scan_enabled=false — "
+                        "raw upstream responses will be sent UNSCANNED to %s; credential "
+                        "redaction (#289) is off",
+                        ", ".join(ext_leak_paths),
+                        _describe_llm_destination(ext_llm),
+                    )
+
         for srv_name, srv_cfg in servers.items():
             if (
                 srv_cfg.compression not in (CompressionStrategy.NONE, CompressionStrategy.AUTO)

--- a/tests/test_config_constraints.py
+++ b/tests/test_config_constraints.py
@@ -253,6 +253,42 @@ class TestLLMCompressorApiKey:
             LLMCompressorConfig(provider=LLMProvider.OPENAI)
 
 
+class TestLLMExternalDestination:
+    """``LLMCompressorConfig.is_external_destination`` — powers the #610
+    scan-off startup warning. OpenAI/Anthropic always leave the machine; Ollama
+    only when its ``base_url`` host is non-loopback."""
+
+    def test_openai_is_external(self) -> None:
+        cfg = LLMCompressorConfig(provider=LLMProvider.OPENAI, api_key="sk-x")
+        assert cfg.is_external_destination() is True
+
+    def test_anthropic_is_external(self) -> None:
+        cfg = LLMCompressorConfig(provider=LLMProvider.ANTHROPIC, api_key="ant-x")
+        assert cfg.is_external_destination() is True
+
+    def test_ollama_localhost_is_local(self) -> None:
+        cfg = LLMCompressorConfig(
+            provider=LLMProvider.OLLAMA, base_url="http://localhost:11434"
+        )
+        assert cfg.is_external_destination() is False
+
+    def test_ollama_loopback_ip_is_local(self) -> None:
+        cfg = LLMCompressorConfig(
+            provider=LLMProvider.OLLAMA, base_url="http://127.0.0.1:11434"
+        )
+        assert cfg.is_external_destination() is False
+
+    def test_ollama_empty_base_url_is_local(self) -> None:
+        cfg = LLMCompressorConfig(provider=LLMProvider.OLLAMA, base_url="")
+        assert cfg.is_external_destination() is False
+
+    def test_ollama_remote_host_is_external(self) -> None:
+        cfg = LLMCompressorConfig(
+            provider=LLMProvider.OLLAMA, base_url="http://192.168.1.5:11434"
+        )
+        assert cfg.is_external_destination() is True
+
+
 class TestSurfacingNumericConstraints:
     def test_surfacing_min_score_range(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/test_proxy_manager.py
+++ b/tests/test_proxy_manager.py
@@ -12,6 +12,9 @@ from memtomem_stm.proxy.config import (
     CleaningConfig,
     CompressionStrategy,
     ExtractionConfig,
+    ExtractionStrategy,
+    LLMCompressorConfig,
+    LLMProvider,
     ProxyConfig,
     RelevanceScorerConfig,
     SelectiveConfig,
@@ -295,6 +298,171 @@ class TestAutoIndexStartupWarning:
                 # on fires before the connect loop runs.
                 pass
         assert not any("permanently lost" in r.message for r in caplog.records)
+
+
+# ── Privacy-scan-disabled startup warning tests (#610) ──────────────────
+# When an LLM path (compression / extraction) is enabled with
+# ``privacy_scan_enabled=false`` toward an EXTERNAL provider, raw upstream
+# responses leave the machine without credential redaction (#289). Warn loudly
+# at startup — but stay silent for local Ollama (never leaves the machine).
+
+
+class TestPrivacyScanStartupWarning:
+    @pytest.mark.asyncio
+    async def test_warns_llm_compression_scan_off_external(self, caplog):
+        """compression=llm_summary + privacy_scan_enabled=false + OpenAI → warning."""
+        config = ProxyConfig(
+            enabled=True,
+            upstream_servers={
+                "docs": UpstreamServerConfig(
+                    prefix="dc",
+                    command="echo",
+                    compression=CompressionStrategy.LLM_SUMMARY,
+                    llm=LLMCompressorConfig(
+                        provider=LLMProvider.OPENAI,
+                        api_key="sk-test",
+                        privacy_scan_enabled=False,
+                    ),
+                ),
+            },
+        )
+        mgr = ProxyManager(config, TokenTracker())
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            try:
+                await mgr.start()
+            except (Exception, asyncio.CancelledError):
+                # "echo" upstream exits before the JSON-RPC handshake; the
+                # warning fires before that connect failure.
+                pass
+        assert any(
+            "LLM compression enabled" in r.message
+            and "server 'docs'" in r.message
+            and "privacy_scan_enabled=false" in r.message
+            and "UNSCANNED" in r.message
+            and "openai" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_warns_llm_extraction_scan_off_external(self, caplog):
+        """extraction (LLM, scan off, external) with an index engine → warning."""
+        config = ProxyConfig(
+            enabled=True,
+            extraction=ExtractionConfig(
+                enabled=True,
+                strategy=ExtractionStrategy.LLM,
+                llm=LLMCompressorConfig(
+                    provider=LLMProvider.ANTHROPIC,
+                    api_key="ant-test",
+                    privacy_scan_enabled=False,
+                ),
+            ),
+        )
+        # Extraction only reaches the provider when an index engine is wired
+        # (Stage-4b gate); a sentinel is enough to exercise the warning path.
+        mgr = ProxyManager(config, TokenTracker(), index_engine=object())
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr.start()
+        assert any(
+            "LLM extraction enabled" in r.message
+            and "extraction.enabled" in r.message
+            and "UNSCANNED" in r.message
+            and "anthropic" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_extraction_warning_without_index_engine(self, caplog):
+        """Same scan-off external extraction, but no index engine → no leak, no
+        warning (extraction never runs in the bundled ``mms`` server)."""
+        config = ProxyConfig(
+            enabled=True,
+            extraction=ExtractionConfig(
+                enabled=True,
+                strategy=ExtractionStrategy.LLM,
+                llm=LLMCompressorConfig(
+                    provider=LLMProvider.OPENAI,
+                    api_key="sk-test",
+                    privacy_scan_enabled=False,
+                ),
+            ),
+        )
+        mgr = ProxyManager(config, TokenTracker())  # index_engine=None
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr.start()
+        assert not any("LLM extraction enabled" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_warning_for_local_ollama_scan_off(self, caplog):
+        """Scan off but destination is local Ollama → no warning (never leaves box)."""
+        config = ProxyConfig(
+            enabled=True,
+            extraction=ExtractionConfig(
+                enabled=True,
+                strategy=ExtractionStrategy.LLM,
+                llm=LLMCompressorConfig(
+                    provider=LLMProvider.OLLAMA,
+                    base_url="http://localhost:11434",
+                    privacy_scan_enabled=False,
+                ),
+            ),
+        )
+        mgr = ProxyManager(config, TokenTracker(), index_engine=object())
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            await mgr.start()
+        assert not any("UNSCANNED" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_scan_enabled(self, caplog):
+        """privacy_scan_enabled=true (default) + external LLM → no warning."""
+        config = ProxyConfig(
+            enabled=True,
+            upstream_servers={
+                "docs": UpstreamServerConfig(
+                    prefix="dc",
+                    command="echo",
+                    compression=CompressionStrategy.LLM_SUMMARY,
+                    llm=LLMCompressorConfig(
+                        provider=LLMProvider.OPENAI,
+                        api_key="sk-test",
+                        # privacy_scan_enabled defaults to True
+                    ),
+                ),
+            },
+        )
+        mgr = ProxyManager(config, TokenTracker())
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            try:
+                await mgr.start()
+            except (Exception, asyncio.CancelledError):
+                pass
+        assert not any("UNSCANNED" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_warning_for_auto_compression(self, caplog):
+        """compression=auto (not explicit llm_summary) → not statically flagged."""
+        config = ProxyConfig(
+            enabled=True,
+            upstream_servers={
+                "docs": UpstreamServerConfig(
+                    prefix="dc",
+                    command="echo",
+                    compression=CompressionStrategy.AUTO,
+                    llm=LLMCompressorConfig(
+                        provider=LLMProvider.OPENAI,
+                        api_key="sk-test",
+                        privacy_scan_enabled=False,
+                    ),
+                ),
+            },
+        )
+        mgr = ProxyManager(config, TokenTracker())
+        with caplog.at_level(logging.WARNING, logger="memtomem_stm.proxy.manager"):
+            try:
+                await mgr.start()
+            except (Exception, asyncio.CancelledError):
+                pass
+        assert not any("LLM compression enabled" in r.message for r in caplog.records)
 
 
 class TestToolConfigFrozen:


### PR DESCRIPTION
## Why

Closes #610 (part 1). When `privacy_scan_enabled=false`, `ProxyManager` passes `None` for `privacy_patterns`, so raw upstream responses reach the external LLM provider without the #289 credential redaction. The scan is default-on, but an operator who flips it off got **no signal anywhere** that credentials now leave the machine unscanned — exactly the surprising-consequence config that the #288 `inert` startup warnings already set a precedent for surfacing loudly.

## What

`ProxyManager.start()` now scans the resolved compression and extraction paths and logs a `WARNING` naming each enabled site and the destination provider/endpoint when the scan is off — mirroring the sibling #288 warning block.

Example output:

```
WARNING memtomem_stm.proxy.manager: LLM compression enabled (server 'docs') with privacy_scan_enabled=false — raw upstream responses will be sent UNSCANNED to ollama (http://10.0.0.9:11434); credential redaction (#289) is off
WARNING memtomem_stm.proxy.manager: LLM extraction enabled (extraction.enabled) with privacy_scan_enabled=false — raw upstream responses will be sent UNSCANNED to openai; credential redaction (#289) is off
```

### Scoped to *external* destinations

New `LLMCompressorConfig.is_external_destination()`: OpenAI/Anthropic always qualify; Ollama only on a non-loopback `base_url`. This keeps the common, legitimate local-Ollama scan-off setup silent — text never leaves the machine there, so warning would be a false alarm (extraction defaults to `http://localhost:11434`).

### Correctness notes

- **Compression** (Stage 2) runs in every deployment → its warning is unconditional.
- **Extraction** (Stage 4b) only reaches the provider when an index engine is wired (gated at the call site; the standalone `mms` server has none, per #288/#288). Its warning is gated on `index_engine is not None` so it stays accurate in the bundled server.
- Only an explicit `compression: llm_summary` is flagged, **not** `auto` — `auto` resolves at runtime and a static check would produce false positives.

## Behavior change

Adds two new startup `WARNING` log lines (module logger `memtomem_stm.proxy.manager`) when an LLM compression/extraction path is enabled with `privacy_scan_enabled=false` toward an external provider. No config semantics or default behavior change; scan-on and local-Ollama setups are unaffected (silent).

## Out of scope

Part 2 of #610 (entropy-based unlabeled-token heuristic in `privacy.py`, soft deadline 2026-08-15) is a separate detection-quality design item and not included here.

## Tests

- `tests/test_proxy_manager.py::TestPrivacyScanStartupWarning` — 6 cases: compression scan-off external warns; extraction warns only with an index engine; no warning without an engine, for local Ollama, when scan is on, or for `auto` compression.
- `tests/test_config_constraints.py::TestLLMExternalDestination` — 6 cases pinning the OpenAI/Anthropic/Ollama-local/Ollama-remote/empty-base_url matrix.
- Full CI-filter suite: 4296 passed, 3 skipped. `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)