### PR TITLE
fix: complete #646 policy scope + anchor pins missed by the merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ memtomem-stm is alpha (0.x): behavior and defaults may change between minor
 releases while the design settles — defaults have flipped before (e.g.
 `injection_mode` `prepend` → `append` in 0.1.24). Every such change is flagged
 inline in [CHANGELOG.md](https://github.com/memtomem/memtomem-stm/blob/main/CHANGELOG.md)
-with a `**Behavior change**:` marker and, per release, summarized up front in
-that release's **Upgrade notes** block — skim that block before upgrading.
+with a `**Behavior change**:` marker and — for releases after 0.1.31 — is also
+summarized up front in that release's **Upgrade notes** block; skim that block
+before upgrading (older releases record behavior changes inline only).
 Machine-readable surfaces (`--json` output shapes, exit codes) only change
 with an Upgrade notes entry; additive keys may appear at any time, so parse by
 key, not by shape equality. Deprecated CLI commands or flags keep working with

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -732,7 +732,12 @@ def test_deprecation_policy_and_upgrade_notes_convention_exist() -> None:
     or dropping any one of them silently orphans the other two."""
     readme = _read("README.md")
     contributing = _read("CONTRIBUTING.md")
-    changelog_head = _read("CHANGELOG.md")[:2000]
+    changelog = _read("CHANGELOG.md")
+    # The convention prose lives ABOVE the first release heading; slicing
+    # there means the assertions below cannot be satisfied by the Unreleased
+    # block's own `### Upgrade notes` heading surviving a header deletion.
+    changelog_header = changelog.split("## [Unreleased]", 1)[0]
+    policy_anchor = "README.md#compatibility--deprecation-policy"
 
     assert "## Compatibility & deprecation policy" in readme, (
         "README lost the '## Compatibility & deprecation policy' section — "
@@ -742,14 +747,26 @@ def test_deprecation_policy_and_upgrade_notes_convention_exist() -> None:
         "CONTRIBUTING lost the '## Changelog and upgrade notes' section that "
         "defines when a release block needs an '### Upgrade notes' summary."
     )
+    # Both referrers must carry the exact anchor of the README section —
+    # renaming the heading changes the GitHub anchor and orphans these links.
+    for name, text in (("CHANGELOG.md", changelog_header), ("CONTRIBUTING.md", contributing)):
+        assert policy_anchor in text, (
+            f"{name} no longer links to '{policy_anchor}' — the README policy "
+            "heading and its referrers must move together."
+        )
     # The inline marker string is the convention's join key: CONTRIBUTING
     # tells writers to use it and the README tells readers to look for it.
-    for name, text in (("README.md", readme), ("CONTRIBUTING.md", contributing)):
+    for name, text in (
+        ("README.md", readme),
+        ("CONTRIBUTING.md", contributing),
+        ("CHANGELOG.md header", changelog_header),
+    ):
         assert "**Behavior change**:" in text, (
             f"{name} no longer names the '**Behavior change**:' marker the "
             "upgrade-notes convention aggregates."
         )
-    assert "Upgrade notes" in changelog_head, (
-        "CHANGELOG.md's header prose should tell readers releases with "
-        "behavior changes open with an 'Upgrade notes' block."
+    assert "Upgrade notes" in changelog_header, (
+        "CHANGELOG.md's header prose (before the first release heading) should "
+        "tell readers releases with behavior changes open with an 'Upgrade "
+        "notes' block."
     )


### PR DESCRIPTION
Post-merge codex review of #646 — its two findings:

- **Major**: README's "Compatibility & deprecation policy" said every behavior change is, "per release, summarized up front" in an Upgrade notes block — but the convention starts after 0.1.31 (as the CHANGELOG header states), making the public policy claim false for the 33 already-released versions. The sentence now carries the same "for releases after 0.1.31" scope, with older releases noted as inline-only.
- **Minor**: `test_deprecation_policy_and_upgrade_notes_convention_exist` claimed to protect the cross-file heading links but never asserted them. It now pins the literal `README.md#compatibility--deprecation-policy` anchor in both referrers (CHANGELOG header prose and CONTRIBUTING) and scopes the CHANGELOG assertions to the prose before `## [Unreleased]`, so deleting the header convention text can no longer pass via the Unreleased block's own `### Upgrade notes` heading.

Docs + one test; docs-sync suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)