### PR TITLE
docs: sync docs with v0.1.32 code (privacy_scan_enabled, extraction/toolgraph, stats --source)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -444,12 +444,15 @@ Group/world-readable file permissions produce a warning line but exit 0 on their
 Usage: mms stats [OPTIONS]
 
 Options:
-  --config TEXT  [default: ~/.memtomem/stm_proxy.json]
-  --tool TEXT    Filter to one upstream tool name.
-  --json         Output as JSON for scripting.
+  --config TEXT              [default: ~/.memtomem/stm_proxy.json]
+  --tool TEXT                Filter to one upstream tool name.
+  --source [mcp|hook]        Filter compression rows by provenance: 'mcp'
+                             (proxied upstream tools) or 'hook' (native
+                             built-in tools recorded by 'mms hook').
+  --json                     Output as JSON for scripting.
 ```
 
-Shows proxy compression and surfacing statistics from the persistent databases (`proxy_metrics.db` and `stm_feedback.db`). 
+Shows proxy compression and surfacing statistics from the persistent databases (`proxy_metrics.db` and `stm_feedback.db`). `--source mcp` limits the compression rows to proxied upstream tools, `--source hook` to native built-in tools recorded by `mms hook`; omit it to include both. 
 
 It reads these files read-only (without creating or migrating them) and reports all-time totals. Because the live MCP server keeps additional in-memory counters that a separate CLI process cannot see, the numbers here reflect only what has been successfully flushed/written to disk.
 

--- a/docs/compression.md
+++ b/docs/compression.md
@@ -255,18 +255,22 @@ Routes through an external LLM for intelligent summarization:
     "provider": "openai",
     "model": "gpt-4.1-mini",
     "api_key": "sk-...",
+    "base_url": "",
     "max_tokens": 500,
     "llm_timeout_seconds": 60.0,
+    "privacy_scan_enabled": true,
     "system_prompt": "Summarize concisely, preserving key information. Under {max_chars} chars."
   }
 }
 ```
 
-Providers: `openai`, `anthropic`, `ollama`. `llm_timeout_seconds` (default 60.0) bounds the per-call LLM wait. On timeout, privacy-pattern hit, circuit-breaker open, or any other API failure, compression falls back to `TruncateCompressor` and records the strategy as `llm_summary→{timeout,privacy,circuit_breaker,llm_error}_fallback` in `proxy_metrics` for observability. A successful call whose summary still exceeds `max_chars` is clamped by the same truncation and recorded as `llm_summary→llm_overlength_fallback` — the model overshot the length instruction; the endpoint is fine, so the circuit breaker is unaffected.
+Providers: `openai`, `anthropic`, `ollama`. `base_url` (default `""`) overrides the provider endpoint — required to point `ollama` at a non-default host, and how OpenAI/Anthropic get aimed at a compatible gateway. `llm_timeout_seconds` (default 60.0) bounds the per-call LLM wait. On timeout, privacy-pattern hit, circuit-breaker open, or any other API failure, compression falls back to `TruncateCompressor` and records the strategy as `llm_summary→{timeout,privacy,circuit_breaker,llm_error}_fallback` in `proxy_metrics` for observability. A successful call whose summary still exceeds `max_chars` is clamped by the same truncation and recorded as `llm_summary→llm_overlength_fallback` — the model overshot the length instruction; the endpoint is fine, so the circuit breaker is unaffected.
 
 > **`api_key` is validated eagerly.** Every `llm` block in the config is validated when the config loads — for `provider: openai` / `anthropic`, a missing `api_key` (and missing `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env var) fails the load even if nothing selects the `llm_summary` strategy or the block sits under a disabled `extraction`. This keeps the startup fail-fast for configs that DO use the LLM. Don't leave placeholder `llm` blocks you aren't using — remove them, or point them at `provider: ollama` (no key required).
 
-Credential-bearing content (API keys, passwords, provider tokens, JWTs, private keys) is auto-detected and **never** sent to external LLMs — falls back to local truncation. Email addresses alone do **not** trigger this fallback: they appear in ordinary compressible content (git logs, issue threads, contact pages), and routing on them silently degraded the chosen strategy to truncation. Emails remain protected where storage is at stake — surfacing query persistence hashes any query matching the full sensitive set (credentials *and* emails) before it reaches disk.
+Credential-bearing content (API keys, passwords, provider tokens, JWTs, private keys) is auto-detected and **never** sent to external LLMs — falls back to local truncation. This scan is governed by `privacy_scan_enabled` (default `true`); an operator who flips `compression: llm_summary` gets the protection without remembering a second knob. Email addresses alone do **not** trigger this fallback: they appear in ordinary compressible content (git logs, issue threads, contact pages), and routing on them silently degraded the chosen strategy to truncation. Emails remain protected where storage is at stake — surfacing query persistence hashes any query matching the full sensitive set (credentials *and* emails) before it reaches disk.
+
+> **Disabling the scan (`privacy_scan_enabled: false`) sends raw upstream responses to the LLM provider unscanned.** Set it off only when the response body is known to be sensitive-free, or for a self-hosted provider you trust (e.g. local Ollama). To catch an accidental flip, `ProxyManager.start()` logs a startup **WARNING** naming each enabled LLM site (compression and, in library mode, extraction) and the destination when the scan is off — but only for **external** destinations: OpenAI/Anthropic always qualify, Ollama only on a non-loopback `base_url`, so the common local-Ollama-with-scan-off setup stays silent (`is_external_destination()`, #610). Only an explicit `compression: llm_summary` is flagged, not `auto` (which resolves at runtime).
 
 `LLMCompressor` holds a single `httpx.AsyncClient` for the life of the instance. `ProxyManager` caches one compressor per active `llm` config and swaps it (awaiting `close()` on the old one) whenever the config changes at runtime, so integrators generally do not need to manage it directly. If you construct an `LLMCompressor` standalone, `await compressor.close()` before discarding it to release the client.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,6 +370,24 @@ Full example with all options:
     "health_min_calls": 5,
     "health_error_rate_threshold": 0.95,
     "review_risk_penalty": 0.5
+  },
+  "toolgraph": {
+    "enabled": false,
+    "command": "toolgraph",
+    "args": ["serve"],
+    "env": null,
+    "agent_id": "stm-proxy",
+    "server_name_map": {},
+    "query_profile": "strict",
+    "on_unreachable": "open",
+    "on_agent_not_found": "fail_start",
+    "on_protocol_error": "fail_start",
+    "on_tool_not_found": "open",
+    "risk_penalty_scale": 1.0,
+    "timeout_seconds": 5.0,
+    "consult_cache_enabled": true,
+    "consult_cache_path": "~/.memtomem/toolgraph_consult.db",
+    "consult_cache_max_scopes": 64
   }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,6 +229,8 @@ Full example with all options:
 {
   "enabled": true,
   "default_max_result_chars": 16000,
+  "default_compression": "auto",
+  "max_upstream_chars": 10000000,
   "min_result_retention": 0.65,
   "consumer_model": "",
   "context_budget_ratio": 0.05,
@@ -318,6 +320,18 @@ Full example with all options:
     "memory_dir": "~/.memtomem/proxy_index",
     "namespace": "proxy-{server}"
   },
+  "extraction": {
+    "enabled": false,
+    "strategy": "llm",
+    "llm": null,
+    "max_facts": 10,
+    "min_response_chars": 500,
+    "dedup_threshold": 0.92,
+    "memory_dir": "~/.memtomem/extracted_facts",
+    "namespace": "facts-{server}",
+    "background": true,
+    "max_input_chars": 20000
+  },
   "relevance_scorer": {
     "scorer": "bm25",
     "embedding_provider": "ollama",
@@ -359,6 +373,16 @@ Full example with all options:
   }
 }
 ```
+
+The `auto_index` and `extraction` blocks are **inert in the bundled `mms`
+server** — it constructs `ProxyManager` without an `index_engine`, so Stage 4
+is skipped and the proxy logs a "config is enabled but inert" startup warning
+naming each site (#288). They are valid config and take effect only for library
+callers that wire an `index_engine` themselves (see the auto-indexing note in
+the [env-var section](#environment-variables) above). `extraction.llm` accepts
+the same `LLMCompressorConfig` shape as [LLM compression](compression.md#llm-compression),
+including `privacy_scan_enabled`; leaving it `null` uses the default local
+Ollama extractor.
 
 `circuit_max_failures` / `circuit_reset_seconds` configure the per-upstream
 circuit breaker (#608). The breaker counts **one failure per call** that

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -770,3 +770,150 @@ def test_deprecation_policy_and_upgrade_notes_convention_exist() -> None:
         "tell readers releases with behavior changes open with an 'Upgrade "
         "notes' block."
     )
+
+
+def test_compression_md_llm_section_documents_privacy_scan() -> None:
+    """docs/compression.md's ``## LLM Compression`` section must surface
+    ``privacy_scan_enabled``.
+
+    ``LLMCompressorConfig.privacy_scan_enabled``
+    (``src/memtomem_stm/proxy/config.py``, default ``True``) is the credential
+    scan that keeps API keys / passwords / JWTs out of the outbound LLM call
+    (#289); flipping it off sends raw upstream responses to the provider
+    unscanned, and ``ProxyManager.start()`` logs a startup WARNING for that
+    state on external destinations (#610). Undocumented, the knob and its
+    warning are invisible to anyone not reading the source.
+    """
+    from memtomem_stm.proxy.config import LLMCompressorConfig
+
+    assert "privacy_scan_enabled" in LLMCompressorConfig.model_fields, (
+        "LLMCompressorConfig lost `privacy_scan_enabled` — the knob was "
+        "renamed or removed; update docs/compression.md and this test together."
+    )
+    comp_md = _read("docs/compression.md")
+    section_match = re.search(
+        r"##\s+LLM Compression[^\n]*\n(.*?)(?=\n##\s|\Z)",
+        comp_md,
+        re.DOTALL,
+    )
+    if not section_match:
+        pytest.fail(
+            "docs/compression.md lost its `## LLM Compression` H2 section — "
+            "either restructure the test or restore the section heading."
+        )
+    section_body = section_match.group(1)
+    if "privacy_scan_enabled" not in section_body:
+        pytest.fail(
+            "docs/compression.md `## LLM Compression` section must mention "
+            "`privacy_scan_enabled` — in the JSON example or the credential "
+            "scan prose. Without it, the default-on scan (#289) and the "
+            "scan-disabled startup warning (#610) are undiscoverable."
+        )
+
+
+def test_configuration_full_example_documents_extraction_block() -> None:
+    """docs/configuration.md's full-example must carry an ``extraction`` block
+    whose keys match ``ExtractionConfig``, plus the two top-level knobs
+    ``default_compression`` / ``max_upstream_chars``.
+
+    ``ExtractionConfig`` (``src/memtomem_stm/proxy/config.py``) is a whole
+    config subtree the "Full example with all options" block omitted entirely —
+    it appeared only in the inert-note prose. It is inert in the bundled ``mms``
+    server (#288) but valid config for library callers, and the #610
+    scan-disabled warning walks the extraction path too, so operators need to
+    see its shape. Scoped to the ``## Config File`` section so moving the block
+    into prose cannot satisfy the check.
+    """
+    import json
+
+    from memtomem_stm.proxy.config import ExtractionConfig
+
+    config_md = _read("docs/configuration.md")
+    section_match = re.search(
+        r"##\s+Config File[^\n]*\n(.*?)(?=\n##\s|\Z)",
+        config_md,
+        re.DOTALL,
+    )
+    if not section_match:
+        pytest.fail(
+            "docs/configuration.md lost its `## Config File` H2 section — "
+            "either restructure the test or restore the section heading."
+        )
+    block_match = re.search(r"```json\n(.*?)\n```", section_match.group(1), re.DOTALL)
+    if not block_match:
+        pytest.fail(
+            "docs/configuration.md `## Config File` section lost its ```json "
+            "fenced example — restore the full-example block or update the test."
+        )
+    example = json.loads(block_match.group(1))
+
+    for top_level in ("default_compression", "max_upstream_chars"):
+        if top_level not in example:
+            pytest.fail(
+                f"docs/configuration.md full-example omits top-level "
+                f"`{top_level}` — it exists on ProxyConfig "
+                "(src/memtomem_stm/proxy/config.py). Keep it visible in the "
+                "example so operators discover it without reading CHANGELOG."
+            )
+
+    if "extraction" not in example:
+        pytest.fail(
+            "docs/configuration.md full-example omits the `extraction` block — "
+            "add it mirroring ExtractionConfig. It is inert in the bundled "
+            "server (#288) but valid config for library callers, and the #610 "
+            "scan-disabled warning covers the extraction path."
+        )
+    documented = set(example["extraction"])
+    expected = set(ExtractionConfig.model_fields)
+    missing = expected - documented
+    if missing:
+        pytest.fail(
+            f"docs/configuration.md `extraction` example is missing field(s): "
+            f"{sorted(missing)!r}. Keep it in sync with ExtractionConfig "
+            "(src/memtomem_stm/proxy/config.py)."
+        )
+
+
+def test_cli_md_stats_documents_source_filter() -> None:
+    """docs/cli.md's ``### `stats` `` section must document the ``--source``
+    provenance filter.
+
+    ``mms stats`` grew a ``--source [mcp|hook]`` option (#512) that filters
+    compression rows by provenance — ``mcp`` (proxied upstream tools) vs
+    ``hook`` (native built-in tools recorded by ``mms hook``). It shipped
+    undocumented; without it, an operator comparing hook vs proxied compression
+    has no surface telling them the split exists. Anchored to the live click
+    option so a rename fails here, and scoped to the ``### `stats` `` section.
+    """
+    from memtomem_stm.cli.proxy import cli as mms_cli
+
+    stats_cmd = mms_cli.commands.get("stats")
+    assert stats_cmd is not None, "`mms stats` is gone — update docs/cli.md and this test"
+    source_param = next(
+        (p for p in stats_cmd.params if "--source" in getattr(p, "opts", [])),
+        None,
+    )
+    if source_param is None:
+        pytest.fail(
+            "`mms stats` no longer exposes a `--source` option — it was "
+            "renamed or removed; update docs/cli.md and this test together."
+        )
+    choices = set(getattr(source_param.type, "choices", ()))
+    assert choices == {"mcp", "hook"}, (
+        f"`mms stats --source` choices changed to {sorted(choices)!r} — "
+        "update the docs and this test."
+    )
+
+    cli_md = _read("docs/cli.md")
+    section_match = re.search(r"### `stats`\n(.*?)(?=\n### |\n## |\Z)", cli_md, re.DOTALL)
+    if not section_match:
+        pytest.fail("docs/cli.md must have a ### `stats` section")
+    section = section_match.group(1)
+    for token in ("--source", "mcp", "hook"):
+        if token not in section:
+            pytest.fail(
+                f"docs/cli.md `stats` section must mention {token!r} — the "
+                "`--source` provenance filter (mcp = proxied upstream, hook = "
+                "native built-in tools recorded by `mms hook`) is otherwise "
+                "undiscoverable (#512)."
+            )

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -790,6 +790,14 @@ def test_compression_md_llm_section_documents_privacy_scan() -> None:
         "LLMCompressorConfig lost `privacy_scan_enabled` — the knob was "
         "renamed or removed; update docs/compression.md and this test together."
     )
+    # The docstring/prose claim the scan is default-on; pin that against source
+    # so a flipped default can't leave the docs silently wrong. Read the field
+    # default directly — instantiating LLMCompressorConfig() validates api_key.
+    assert LLMCompressorConfig.model_fields["privacy_scan_enabled"].default is True, (
+        "LLMCompressorConfig.privacy_scan_enabled default is no longer True — "
+        "docs/compression.md says the credential scan is default-on; update "
+        "both together."
+    )
     comp_md = _read("docs/compression.md")
     section_match = re.search(
         r"##\s+LLM Compression[^\n]*\n(.*?)(?=\n##\s|\Z)",
@@ -809,24 +817,41 @@ def test_compression_md_llm_section_documents_privacy_scan() -> None:
             "scan prose. Without it, the default-on scan (#289) and the "
             "scan-disabled startup warning (#610) are undiscoverable."
         )
+    # The token appearing only in the JSON example would leave the #610
+    # scan-disabled behavior undocumented; require the warning prose too so the
+    # operator-facing consequence can't be silently dropped.
+    lowered = section_body.lower()
+    if "warning" not in lowered or "unscanned" not in lowered:
+        pytest.fail(
+            "docs/compression.md `## LLM Compression` section must describe the "
+            "scan-disabled consequence — the startup WARNING and that raw "
+            "responses go to the provider UNSCANNED (#610). Found the "
+            "`privacy_scan_enabled` token but not the warning prose."
+        )
 
 
-def test_configuration_full_example_documents_extraction_block() -> None:
-    """docs/configuration.md's full-example must carry an ``extraction`` block
-    whose keys match ``ExtractionConfig``, plus the two top-level knobs
-    ``default_compression`` / ``max_upstream_chars``.
+def test_configuration_full_example_documents_all_config_blocks() -> None:
+    """docs/configuration.md's "Full example with all options" must carry the
+    ``extraction`` and ``toolgraph`` blocks — with keys AND default values that
+    match ``ExtractionConfig`` / ``ToolgraphConfig`` exactly — plus the two
+    top-level knobs ``default_compression`` / ``max_upstream_chars`` at their
+    ProxyConfig defaults.
 
-    ``ExtractionConfig`` (``src/memtomem_stm/proxy/config.py``) is a whole
-    config subtree the "Full example with all options" block omitted entirely —
-    it appeared only in the inert-note prose. It is inert in the bundled ``mms``
-    server (#288) but valid config for library callers, and the #610
-    scan-disabled warning walks the extraction path too, so operators need to
-    see its shape. Scoped to the ``## Config File`` section so moving the block
-    into prose cannot satisfy the check.
+    ``ExtractionConfig`` and ``ToolgraphConfig``
+    (``src/memtomem_stm/proxy/config.py``) are whole config subtrees the "all
+    options" block omitted while documenting their siblings (``auto_index`` /
+    ``exposure``). Comparing each documented block to ``Model().model_dump(
+    mode="json")`` (rather than just a key-subset check) pins the example to the
+    real defaults — a renamed key, a stray/typo'd key, or a drifted default all
+    fail loudly. Scoped to the ``## Config File`` section so moving a block into
+    prose cannot satisfy the check.
+
+    ``config_path`` is intentionally excluded: it is a runtime-populated field
+    (the path the config was loaded from), not a user-authored config key.
     """
     import json
 
-    from memtomem_stm.proxy.config import ExtractionConfig
+    from memtomem_stm.proxy.config import ExtractionConfig, ProxyConfig, ToolgraphConfig
 
     config_md = _read("docs/configuration.md")
     section_match = re.search(
@@ -847,6 +872,7 @@ def test_configuration_full_example_documents_extraction_block() -> None:
         )
     example = json.loads(block_match.group(1))
 
+    proxy_defaults = ProxyConfig().model_dump(mode="json")
     for top_level in ("default_compression", "max_upstream_chars"):
         if top_level not in example:
             pytest.fail(
@@ -855,23 +881,34 @@ def test_configuration_full_example_documents_extraction_block() -> None:
                 "(src/memtomem_stm/proxy/config.py). Keep it visible in the "
                 "example so operators discover it without reading CHANGELOG."
             )
+        if example[top_level] != proxy_defaults[top_level]:
+            pytest.fail(
+                f"docs/configuration.md full-example shows `{top_level}: "
+                f"{example[top_level]!r}` but the ProxyConfig default is "
+                f"{proxy_defaults[top_level]!r} — the 'all options' example "
+                "should show real defaults."
+            )
 
-    if "extraction" not in example:
-        pytest.fail(
-            "docs/configuration.md full-example omits the `extraction` block — "
-            "add it mirroring ExtractionConfig. It is inert in the bundled "
-            "server (#288) but valid config for library callers, and the #610 "
-            "scan-disabled warning covers the extraction path."
-        )
-    documented = set(example["extraction"])
-    expected = set(ExtractionConfig.model_fields)
-    missing = expected - documented
-    if missing:
-        pytest.fail(
-            f"docs/configuration.md `extraction` example is missing field(s): "
-            f"{sorted(missing)!r}. Keep it in sync with ExtractionConfig "
-            "(src/memtomem_stm/proxy/config.py)."
-        )
+    expected_blocks = {
+        "extraction": ExtractionConfig().model_dump(mode="json"),
+        "toolgraph": ToolgraphConfig().model_dump(mode="json"),
+    }
+    for name, defaults in expected_blocks.items():
+        if name not in example:
+            pytest.fail(
+                f"docs/configuration.md full-example omits the `{name}` block — "
+                f"add it mirroring {name.capitalize()}Config's defaults. The "
+                "'all options' claim (and this test) require every ProxyConfig "
+                "sub-block to appear."
+            )
+        if example[name] != defaults:
+            pytest.fail(
+                f"docs/configuration.md `{name}` example does not match "
+                f"{name.capitalize()}Config defaults.\n"
+                f"  documented: {example[name]!r}\n"
+                f"  defaults:   {defaults!r}\n"
+                "Keep the example in sync with src/memtomem_stm/proxy/config.py."
+            )
 
 
 def test_cli_md_stats_documents_source_filter() -> None:
@@ -917,3 +954,13 @@ def test_cli_md_stats_documents_source_filter() -> None:
                 "native built-in tools recorded by `mms hook`) is otherwise "
                 "undiscoverable (#512)."
             )
+    # A bare token list could pass while mapping the two provenances backwards;
+    # pin the semantics (mcp → proxied upstream, hook → native built-in) so the
+    # prose can't invert without failing.
+    lowered = section.lower()
+    if "proxied" not in lowered or "native" not in lowered:
+        pytest.fail(
+            "docs/cli.md `stats` section must map the `--source` values: `mcp` "
+            "to proxied upstream tools and `hook` to native built-in tools. "
+            "Found the flag tokens but not the provenance mapping prose."
+        )

--- a/tests/test_docs_sync.py
+++ b/tests/test_docs_sync.py
@@ -21,6 +21,25 @@ def _read(relative: str) -> str:
     return (REPO_ROOT / relative).read_text(encoding="utf-8")
 
 
+def _fwd_slash(obj: object) -> object:
+    """Normalize backslashes to forward slashes in every string leaf.
+
+    ``Model().model_dump(mode="json")`` serializes ``Path`` fields with the
+    host separator, so a default like ``Path("~/.memtomem/...")`` dumps to
+    ``~\\.memtomem\\...`` on Windows. Docs always use forward slashes; compare
+    both sides through this normalizer so the config-example pins are
+    cross-platform (CI runs the suite on Windows too). No legitimate config
+    string value carries an intentional backslash, so this is loss-free.
+    """
+    if isinstance(obj, str):
+        return obj.replace("\\", "/")
+    if isinstance(obj, dict):
+        return {k: _fwd_slash(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_fwd_slash(v) for v in obj]
+    return obj
+
+
 def _canonical_ci_test_filter() -> str:
     """The single CI ``test``-job ``pytest -m`` filter (the one with ``not bench_qa_meta``).
 
@@ -901,7 +920,7 @@ def test_configuration_full_example_documents_all_config_blocks() -> None:
                 "'all options' claim (and this test) require every ProxyConfig "
                 "sub-block to appear."
             )
-        if example[name] != defaults:
+        if _fwd_slash(example[name]) != _fwd_slash(defaults):
             pytest.fail(
                 f"docs/configuration.md `{name}` example does not match "
                 f"{name.capitalize()}Config defaults.\n"


### PR DESCRIPTION
## Context

A three-way documentation drift audit against the current v0.1.32 tree found the docs **largely already in sync** — the recent CLI/observability release (#640–#650) updated most docs alongside the code. `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `notebooks/README.md`, `docs/caching.md`, and `docs/selection-telemetry.md` were audited and confirmed accurate (no change). This PR closes the handful of **genuine gaps** where a feature shipped without its doc.

## Changes

**`docs/compression.md`** — document `privacy_scan_enabled` (`LLMCompressorConfig`, default-on credential scan, #289) and its #610 scan-disabled startup WARNING, plus `base_url` in the LLM example. Both were absent from the JSON example and the prose.

**`docs/configuration.md`** — the "Full example with all options" block omitted whole config subtrees. Add:
- the `extraction` block (`ExtractionConfig`, 10 fields) and the top-level `default_compression` / `max_upstream_chars` keys;
- the `toolgraph` block (`ToolgraphConfig`) — it was missing while its sibling `exposure` was documented (caught in review);
- a note that `auto_index` / `extraction` are inert in the bundled `mms` server (#288) but valid for library callers.

(`config_path` stays out of the example: it is a runtime-populated field, not a user-authored key.)

**`docs/cli.md`** — `mms stats` grew a `--source [mcp|hook]` provenance filter (#512, `mcp` = proxied upstream tools, `hook` = native built-ins recorded by `mms hook`) that was undocumented. Add it to the usage block and prose.

## Regression tests

Each fix is pinned in `tests/test_docs_sync.py`, anchored to the source of truth so a future rename/default-change fails loudly instead of silently re-drifting:
- the config-example test compares the `extraction` and `toolgraph` blocks to `Model().model_dump(mode="json")` (exact key **and** value match — catches stray/typo'd keys and drifted defaults) and checks the top-level scalar values against `ProxyConfig` defaults;
- the privacy-scan test pins the default-on value (via `model_fields`, since instantiating `LLMCompressorConfig` validates `api_key`) and requires the scan-disabled WARNING / "unscanned" prose;
- the `stats --source` test is anchored to the live click option and requires the `mcp`→proxied / `hook`→native mapping prose.

## Review

Codex-reviewed; its findings (the `toolgraph` omission and under-pinned tests) are folded into the second commit. No source-fact mismatches were found in the documented facts themselves.

## Verification

`uv run pytest -m "not bench_qa_meta and not bench_qa_llm_judge and not bench_qa_sweep and not bench_qa_drift and not bench_qa_perf"` → **4364 passed, 3 skipped**; `ruff check` / `ruff format --check` clean.

## Out of scope

Low-severity nits (surfacing auto-tune knobs in the controls table, a few local JSON omissions, cosmetic stage-label/issue-number tweaks) and the retroactive CHANGELOG `#646` citation (v0.1.32 is already released; its substance is in the CHANGELOG header note) — deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)